### PR TITLE
Fixes for OpenXR vulkan initialization.

### DIFF
--- a/Gems/OpenXRVk/Code/Include/OpenXRVk/OpenXRVkSession.h
+++ b/Gems/OpenXRVk/Code/Include/OpenXRVk/OpenXRVkSession.h
@@ -75,7 +75,7 @@ namespace OpenXRVk
         XrSessionState m_sessionState = XR_SESSION_STATE_UNKNOWN;
         XrEventDataBuffer m_eventDataBuffer;
         XrInstance m_xrInstance = XR_NULL_HANDLE;
-        XrGraphicsBindingVulkan2KHR m_graphicsBinding{ XR_TYPE_GRAPHICS_BINDING_VULKAN2_KHR };
+        XrGraphicsBindingVulkan2KHR m_graphicsBinding{ XR_TYPE_GRAPHICS_BINDING_VULKAN_KHR };
 
         bool m_sessionRunning = false;
         bool m_exitRenderLoop = false;

--- a/Gems/OpenXRVk/Code/Source/OpenXRVkDevice.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkDevice.cpp
@@ -81,15 +81,11 @@ namespace OpenXRVk
         }
 
         // Now that we have created the device, load the function pointers for it.
-        // NOTE: Passing the xr physical device to LoadProcAddresses causes a crash in glad vulkan
-        //       inside 'glad_vk_find_core_vulkan' function when calling 'context->GetPhysicalDeviceProperties'.
-        //       It's OK to pass VK_NULL_HANDLE at the moment, which means glad vulkan will use only device and instance
-        //       to check for vulkan extensions.
-        if (!xrVkInstance->GetFunctionLoader().LoadProcAddresses(
-            &m_context, xrVkInstance->GetNativeInstance(), VK_NULL_HANDLE/*xrVkInstance->GetActivePhysicalDevice()*/, m_xrVkDevice))
+        bool functionsLoaded = xrVkInstance->GetFunctionLoader().LoadProcAddresses(
+            &xrVkInstance->GetContext(), xrVkInstance->GetNativeInstance(), xrVkInstance->GetActivePhysicalDevice(), m_xrVkDevice);
+        m_context = xrVkInstance->GetContext();
+        if (!functionsLoaded)
         {
-            // Something went wrong loading function pointers, use the glad context from the instance to shut down the device.
-            m_context = xrVkInstance->GetContext();
             ShutdownInternal();
             AZ_Error("OpenXRVk", false, "Failed to initialize function loader for the device.");
             return AZ::RHI::ResultCode::Fail;

--- a/Gems/OpenXRVk/Code/Source/OpenXRVkPhysicalDevice.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkPhysicalDevice.cpp
@@ -13,22 +13,16 @@ namespace OpenXRVk
 {
     AZStd::vector<VkPhysicalDevice> PhysicalDevice::EnumerateDeviceList(XrSystemId xrSystemId, XrInstance xrInstance, VkInstance vkInstance)
     {
-        AZStd::vector<VkPhysicalDevice> physicalDevices;
-		
-        XrVulkanGraphicsDeviceGetInfoKHR deviceGetInfo{ XR_TYPE_VULKAN_GRAPHICS_DEVICE_GET_INFO_KHR };
-        deviceGetInfo.systemId = xrSystemId;
-        deviceGetInfo.vulkanInstance = vkInstance;
-        VkPhysicalDevice vkPhysicalDevice = VK_NULL_HANDLE;
-
         PFN_xrGetVulkanGraphicsDeviceKHR pfnGetVulkanGraphicsDeviceKHR = nullptr;
         XrResult result = xrGetInstanceProcAddr(
-	        xrInstance, "xrGetVulkanGraphicsDeviceKHR", reinterpret_cast<PFN_xrVoidFunction*>(&pfnGetVulkanGraphicsDeviceKHR));
+            xrInstance, "xrGetVulkanGraphicsDeviceKHR", reinterpret_cast<PFN_xrVoidFunction*>(&pfnGetVulkanGraphicsDeviceKHR));
         ASSERT_IF_UNSUCCESSFUL(result);
 
         //TODO::Look into api that can retreive multiple physicall devices if connected
+        VkPhysicalDevice vkPhysicalDevice = VK_NULL_HANDLE;
         result = pfnGetVulkanGraphicsDeviceKHR(xrInstance, xrSystemId, vkInstance, &vkPhysicalDevice);
         ASSERT_IF_UNSUCCESSFUL(result);
-        physicalDevices.push_back(vkPhysicalDevice);
-        return physicalDevices;
+
+        return {vkPhysicalDevice};
     }
 }

--- a/Gems/OpenXRVk/Code/Source/OpenXRVkPhysicalDevice.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkPhysicalDevice.cpp
@@ -18,7 +18,7 @@ namespace OpenXRVk
             xrInstance, "xrGetVulkanGraphicsDeviceKHR", reinterpret_cast<PFN_xrVoidFunction*>(&pfnGetVulkanGraphicsDeviceKHR));
         ASSERT_IF_UNSUCCESSFUL(result);
 
-        //TODO::Look into api that can retreive multiple physicall devices if connected
+        //TODO::Look into api that can retreive multiple physical devices if connected
         VkPhysicalDevice vkPhysicalDevice = VK_NULL_HANDLE;
         result = pfnGetVulkanGraphicsDeviceKHR(xrInstance, xrSystemId, vkInstance, &vkPhysicalDevice);
         ASSERT_IF_UNSUCCESSFUL(result);


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

Fixes https://github.com/o3de/o3de/issues/11254

- Fixed issue when calling to `LoadProcAddresses` using intance, device and physical device.
- Followed the same vulkan flag usage as in hello_xr sample, now using `XR_TYPE_GRAPHICS_BINDING_VULKAN_KHR` flag because we are using the other legacy vulkan flags from the sample too `XR_KHR_VULKAN_ENABLE_EXTENSION_NAME` and `XR_TYPE_SWAPCHAIN_IMAGE_VULKAN_KHR`.
- Simplified `EnumerateDeviceList` function.