### PR TITLE
Added missing DiffuseProbeGrid gem in OpenXRTest.

### DIFF
--- a/Projects/OpenXRTest/Gem/enabled_gems.cmake
+++ b/Projects/OpenXRTest/Gem/enabled_gems.cmake
@@ -21,6 +21,7 @@ set(ENABLED_GEMS
     StartingPointInput
     TextureAtlas
     WhiteBox
+    DiffuseProbeGrid
     XR
     OpenXRVk
 )


### PR DESCRIPTION
Since OpenXRTest was created the `DiffuseProbeGrid` gem was enabled in new projects by default and therefore missing in OpenXRTest  (which is suppose to be a default project + XR gems).

Signed-off-by: moraaar <moraaar@amazon.com>