### PR TITLE
Fix crash when running on Quest 2 with GPU detailed profiling mode enabled

### DIFF
--- a/Gems/OpenXRVk/Code/Include/OpenXRVk/OpenXRVkInstance.h
+++ b/Gems/OpenXRVk/Code/Include/OpenXRVk/OpenXRVkInstance.h
@@ -30,7 +30,6 @@ namespace OpenXRVk
 
         //////////////////////////////////////////////////////////////////////////
         // XR::Instance overrides
-        AZ::RHI::ResultCode InitInstanceInternal(AZ::RHI::ValidationMode validationMode) override;
         AZ::RHI::ResultCode InitNativeInstance(AZ::RHI::XRInstanceDescriptor* instanceDescriptor) override;
         AZ::u32 GetNumPhysicalDevices() const override;
         AZ::RHI::ResultCode GetXRPhysicalDevice(AZ::RHI::XRPhysicalDeviceDescriptor* physicalDeviceDescriptor, int32_t index) override;
@@ -72,10 +71,12 @@ namespace OpenXRVk
         //! Ge the active VkPhysicalDevice.
         VkPhysicalDevice GetActivePhysicalDevice() const;
 
-    private:
-        //! Clean native objects.
+    protected:
+        // XR::Instance overrides...
+        AZ::RHI::ResultCode InitInstanceInternal() override;
         void ShutdownInternal() override;
 
+    private:
         XrInstance m_xrInstance = XR_NULL_HANDLE;
         VkInstance m_xrVkInstance = VK_NULL_HANDLE;
         XrFormFactor m_formFactor = XR_FORM_FACTOR_HEAD_MOUNTED_DISPLAY;

--- a/Gems/OpenXRVk/Code/Source/OpenXRVkDevice.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkDevice.cpp
@@ -94,7 +94,7 @@ namespace OpenXRVk
         // NOTE: When passing a physical device to Vulkan glad loader it uses 'vkEnumerateDeviceExtensionProperties'
         // to obtain device's extension, but that list doesn't match with the list returned by 'xrGetVulkanDeviceExtensionsKHR'
         // which is used for OpenXR. This discrepancy results in the context indicating some extensions are available when they
-        // are really not supporte in OpenXR environment. To surpass this issue we're not passing the physical device.
+        // are really not supported in an OpenXR environment. To surpass this issue we're not passing the physical device.
         bool functionsLoaded = xrVkInstance->GetFunctionLoader().LoadProcAddresses(
             &xrVkInstance->GetContext(), xrVkInstance->GetNativeInstance(), VK_NULL_HANDLE/*xrVkInstance->GetActivePhysicalDevice()*/, m_xrVkDevice);
         m_context = xrVkInstance->GetContext();

--- a/Gems/OpenXRVk/Code/Source/OpenXRVkInstance.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkInstance.cpp
@@ -83,7 +83,7 @@ namespace OpenXRVk
         return layerNames;
     }
 
-    AZ::RHI::ResultCode Instance::InitInstanceInternal(AZ::RHI::ValidationMode validationMode)
+    AZ::RHI::ResultCode Instance::InitInstanceInternal()
     {
         if (!Platform::OpenXRInitializeLoader())
         {
@@ -102,12 +102,18 @@ namespace OpenXRVk
         XR::RawStringList supportedExtensions = FilterList(optionalExtensions, instanceExtensions);
         m_requiredExtensions.insert(m_requiredExtensions.end(), supportedExtensions.begin(), supportedExtensions.end());
 
-        if (validationMode == AZ::RHI::ValidationMode::Enabled)
+        if (m_validationMode == AZ::RHI::ValidationMode::Enabled)
         {
             AZ_Printf("OpenXRVk", "Available Extensions: (%i)\n", instanceExtensions.size());
             for (const AZStd::string& extension : instanceExtensions)
             {
                 AZ_Printf("OpenXRVk", "Name=%s\n", extension.c_str());
+            }
+
+            AZ_Printf("OpenXRVk", "Extensions to enable: (%i)\n", m_requiredExtensions.size());
+            for (const char* extension : m_requiredExtensions)
+            {
+                AZ_Printf("OpenXRVk", "Name=%s\n", extension);
             }
 
             AZ_Printf("OpenXRVk", "Available Layers: (%i)\n", instanceLayerNames.size());
@@ -120,8 +126,8 @@ namespace OpenXRVk
         AZ_Assert(m_xrInstance == XR_NULL_HANDLE, "XR Instance is already initialized");
         XrInstanceCreateInfo createInfo{ XR_TYPE_INSTANCE_CREATE_INFO };
         createInfo.next = nullptr;
-        createInfo.enabledExtensionCount = aznumeric_cast<AZ::u32>(supportedExtensions.size());
-        createInfo.enabledExtensionNames = supportedExtensions.data();
+        createInfo.enabledExtensionCount = aznumeric_cast<AZ::u32>(m_requiredExtensions.size());
+        createInfo.enabledExtensionNames = m_requiredExtensions.data();
         createInfo.enabledApiLayerCount = aznumeric_cast<AZ::u32>(supportedLayers.size());
         createInfo.enabledApiLayerNames = supportedLayers.data();
 
@@ -136,7 +142,7 @@ namespace OpenXRVk
             return AZ::RHI::ResultCode::Fail;
         }
 
-        if (validationMode == AZ::RHI::ValidationMode::Enabled)
+        if (m_validationMode == AZ::RHI::ValidationMode::Enabled)
         {
             XrInstanceProperties instanceProperties{ XR_TYPE_INSTANCE_PROPERTIES };
             result = xrGetInstanceProperties(m_xrInstance, &instanceProperties);
@@ -184,7 +190,7 @@ namespace OpenXRVk
         graphicsRequirements.maxApiVersionSupported = legacyRequirements.maxApiVersionSupported;
         graphicsRequirements.minApiVersionSupported = legacyRequirements.minApiVersionSupported;
 
-        if (validationMode == AZ::RHI::ValidationMode::Enabled)
+        if (m_validationMode == AZ::RHI::ValidationMode::Enabled)
         {
             AZ_Printf("OpenXRVk", "graphicsRequirements.maxApiVersionSupported %d.%d.%d\n",
             XR_VERSION_MAJOR(graphicsRequirements.maxApiVersionSupported),
@@ -316,6 +322,15 @@ namespace OpenXRVk
         for (uint32_t i = 0; i < createInfo.vulkanCreateInfo->enabledExtensionCount; ++i)
         {
             extensions.push_back(createInfo.vulkanCreateInfo->ppEnabledExtensionNames[i]);
+        }
+
+        if (m_validationMode == AZ::RHI::ValidationMode::Enabled)
+        {
+            AZ_Printf("OpenXRVk", "Vulkan instance extensions to enable: (%i)\n", extensions.size());
+            for (const AZStd::string& extension : extensions)
+            {
+                AZ_Printf("OpenXRVk", "Name=%s\n", extension.c_str());
+            }
         }
 
         VkInstanceCreateInfo instInfo{ VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO };

--- a/Gems/XR/Code/Include/XR/XRInstance.h
+++ b/Gems/XR/Code/Include/XR/XRInstance.h
@@ -39,20 +39,21 @@ namespace XR
         //! API to retrieve the native physical device for a specific index.
         virtual AZ::RHI::ResultCode GetXRPhysicalDevice(AZ::RHI::XRPhysicalDeviceDescriptor* physicalDeviceDescriptor, int32_t index) = 0;
 
+    protected:
+        //! API to allow backend object to initialize native xr instance.
+        virtual AZ::RHI::ResultCode InitInstanceInternal() = 0;
+
+        //! Called when the XR instance is being shutdown.
+        virtual void ShutdownInternal() = 0;
+
+        //Cache validation mode in case the backend object needs to use it.
+        AZ::RHI::ValidationMode m_validationMode = AZ::RHI::ValidationMode::Disabled;
+
     private:
         ///////////////////////////////////////////////////////////////////
         // XR::Object
         void Shutdown() override;
         ///////////////////////////////////////////////////////////////////
-
-        //! Called when the XR instance is being shutdown.
-        virtual void ShutdownInternal() = 0;
-
-        //! API to allow backend object to initialize native xr instance.
-        virtual AZ::RHI::ResultCode InitInstanceInternal(AZ::RHI::ValidationMode validationMode) = 0;
-
-        //Cache validation mode in case the backend object needs to use it.
-        AZ::RHI::ValidationMode m_validationMode = AZ::RHI::ValidationMode::Disabled;
     };
 
 } // namespace XR

--- a/Gems/XR/Code/Source/XRInstance.cpp
+++ b/Gems/XR/Code/Source/XRInstance.cpp
@@ -13,7 +13,7 @@ namespace XR
     AZ::RHI::ResultCode Instance::Init(AZ::RHI::ValidationMode validationMode)
     {
         m_validationMode = validationMode;
-        return InitInstanceInternal(validationMode);
+        return InitInstanceInternal();
     }
 
     void Instance::Shutdown()


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

ASV RHI and RPI samples crashed when running on Quest2 with GPU detailed profiling mode enabled (`'adb shell ovrgpuprofiler -e`), which allows the use of `GPU systrace` and `ovrgpuprofiler` tools.

- XR pipeline calling `LoadProcAddresses` passing the physical device leads to vulkan extensions enabled when they are not supported in an XR environment.
- For better debugging now XR Device and Instance now printing their extensions when validation is enabled.

This PR goes in conjunction with this PR in o3de: https://github.com/o3de/o3de/pull/12559

## How was this PR tested?

Run ASV RHI and RPI samples on Quest 2 with GPU detailed profiling mode enabled and disabled.
Able to capture render stage metrics with both `GPU systrace` and `ovrgpuprofiler` tools.