### PR TITLE
Added setting to be able to scale the resolution of OpenXR views

### DIFF
--- a/Gems/OpenXRVk/Code/Source/OpenXRVkSwapChain.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkSwapChain.cpp
@@ -161,10 +161,11 @@ namespace OpenXRVk
             }
 
             double xrViewResolutionScale = 1.0;
-            if (AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get())
+            if (auto* settingsRegistry = AZ::SettingsRegistry::Get();
+                settingsRegistry != nullptr)
             {
                 AZ::SettingsRegistryMergeUtils::PlatformGet(*settingsRegistry, xrViewResolutionScale,
-                    "/O3DE/Atom", "OpenXRViewResolutionScale");
+                    "/O3DE/Atom/OpenXR", "ViewResolutionScale");
             }
 
             // Create a swapchain for each view.

--- a/Gems/OpenXRVk/Code/Source/OpenXRVkSwapChain.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkSwapChain.cpp
@@ -11,6 +11,8 @@
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/std/containers/set.h>
 #include <AzCore/std/containers/vector.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <OpenXRVk/OpenXRVkDevice.h>
 #include <OpenXRVk/OpenXRVkInstance.h>
 #include <OpenXRVk/OpenXRVkSession.h>
@@ -158,10 +160,20 @@ namespace OpenXRVk
                 AZ_Printf("OpenXRVk", "Swapchain Formats: %s\n", swapchainFormatsString.c_str());
             }
 
+            double xrViewResolutionScale = 1.0;
+            if (AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get())
+            {
+                AZ::SettingsRegistryMergeUtils::PlatformGet(*settingsRegistry, xrViewResolutionScale,
+                    "/O3DE/Atom", "OpenXRViewResolutionScale");
+            }
+
             // Create a swapchain for each view.
             for (uint32_t i = 0; i < m_numViews; i++)
             {
-                const XrViewConfigurationView& configView = m_configViews[i];
+                XrViewConfigurationView& configView = m_configViews[i];
+
+                configView.recommendedImageRectWidth = static_cast<uint32_t>(static_cast<double>(configView.recommendedImageRectWidth) * xrViewResolutionScale);
+                configView.recommendedImageRectHeight = static_cast<uint32_t>(static_cast<double>(configView.recommendedImageRectHeight) * xrViewResolutionScale);
 
                 if (GetDescriptor().m_validationMode == AZ::RHI::ValidationMode::Enabled)
                 {

--- a/Gems/XR/Code/Source/XRSystemComponent.cpp
+++ b/Gems/XR/Code/Source/XRSystemComponent.cpp
@@ -16,7 +16,7 @@
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/CommandLine/CommandLine.h>
 
-static constexpr char OpenXREnableSetting[] = "/O3DE/Atom/OpenXREnable";
+static constexpr char OpenXREnableSetting[] = "/O3DE/Atom/OpenXR/Enable";
 
 namespace XR
 {


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

The setting can make use of platform prefixes to only target one platform, for example:

````
{
    "O3DE": {
        "Atom": {
            "OpenXR": {
                "android_ViewResolutionScale": 0.5
            }
        }
    }
}
````

NOTE: This setting is a temporary measure that will help to control the performance when running on Quest 2 by lowering the resolution. Further optimizations to make the VR pipeline more performant overall will be done in the future.