### PR TITLE
Fix crash running editor/launcher on Quest 2 over link cable

### DIFF
--- a/Gems/OpenXRVk/Code/Source/OpenXRVkDevice.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkDevice.cpp
@@ -91,12 +91,17 @@ namespace OpenXRVk
         }
 
         // Now that we have created the device, load the function pointers for it.
+#if AZ_TRAIT_OS_IS_HOST_OS_PLATFORM
+        bool functionsLoaded = xrVkInstance->GetFunctionLoader().LoadProcAddresses(
+            &xrVkInstance->GetContext(), xrVkInstance->GetNativeInstance(), xrVkInstance->GetActivePhysicalDevice(), m_xrVkDevice);
+#else
         // NOTE: When passing a physical device to Vulkan glad loader it uses 'vkEnumerateDeviceExtensionProperties'
         // to obtain device's extension, but that list doesn't match with the list returned by 'xrGetVulkanDeviceExtensionsKHR'
         // which is used for OpenXR. This discrepancy results in the context indicating some extensions are available when they
         // are really not supported in an OpenXR environment. To surpass this issue we're not passing the physical device.
         bool functionsLoaded = xrVkInstance->GetFunctionLoader().LoadProcAddresses(
-            &xrVkInstance->GetContext(), xrVkInstance->GetNativeInstance(), VK_NULL_HANDLE/*xrVkInstance->GetActivePhysicalDevice()*/, m_xrVkDevice);
+            &xrVkInstance->GetContext(), xrVkInstance->GetNativeInstance(), VK_NULL_HANDLE, m_xrVkDevice);
+#endif
         m_context = xrVkInstance->GetContext();
         if (!functionsLoaded)
         {

--- a/Gems/OpenXRVk/Code/Source/OpenXRVkDevice.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkDevice.cpp
@@ -90,24 +90,27 @@ namespace OpenXRVk
             return AZ::RHI::ResultCode::Fail;
         }
 
-        // Now that we have created the device, load the function pointers for it.
-#if AZ_TRAIT_OS_IS_HOST_OS_PLATFORM
-        bool functionsLoaded = xrVkInstance->GetFunctionLoader().LoadProcAddresses(
-            &xrVkInstance->GetContext(), xrVkInstance->GetNativeInstance(), xrVkInstance->GetActivePhysicalDevice(), m_xrVkDevice);
-#else
-        // NOTE: When passing a physical device to Vulkan glad loader it uses 'vkEnumerateDeviceExtensionProperties'
-        // to obtain device's extension, but that list doesn't match with the list returned by 'xrGetVulkanDeviceExtensionsKHR'
-        // which is used for OpenXR. This discrepancy results in the context indicating some extensions are available when they
-        // are really not supported in an OpenXR environment. To surpass this issue we're not passing the physical device.
-        bool functionsLoaded = xrVkInstance->GetFunctionLoader().LoadProcAddresses(
-            &xrVkInstance->GetContext(), xrVkInstance->GetNativeInstance(), VK_NULL_HANDLE, m_xrVkDevice);
-#endif
-        m_context = xrVkInstance->GetContext();
-        if (!functionsLoaded)
         {
-            ShutdownInternal();
-            AZ_Error("OpenXRVk", false, "Failed to initialize function loader for the device.");
-            return AZ::RHI::ResultCode::Fail;
+#if AZ_TRAIT_OS_IS_HOST_OS_PLATFORM
+            VkPhysicalDevice xrVkPhysicalDevice = xrVkInstance->GetActivePhysicalDevice();
+#else
+            // NOTE: When passing a physical device to Vulkan glad loader it uses 'vkEnumerateDeviceExtensionProperties'
+            // to obtain device's extension, but that list doesn't match with the list returned by 'xrGetVulkanDeviceExtensionsKHR'
+            // which is used for OpenXR. This discrepancy results in the context indicating some extensions are available when they
+            // are really not supported in an OpenXR environment. To surpass this issue we're not passing the physical device.
+            VkPhysicalDevice xrVkPhysicalDevice = VK_NULL_HANDLE;
+#endif
+
+            // Now that we have created the device, load the function pointers for it.
+            const bool functionsLoaded = xrVkInstance->GetFunctionLoader().LoadProcAddresses(
+                &xrVkInstance->GetContext(), xrVkInstance->GetNativeInstance(), xrVkPhysicalDevice, m_xrVkDevice);
+            m_context = xrVkInstance->GetContext();
+            if (!functionsLoaded)
+            {
+                ShutdownInternal();
+                AZ_Error("OpenXRVk", false, "Failed to initialize function loader for the device.");
+                return AZ::RHI::ResultCode::Fail;
+            }
         }
 
         //Populate the output data of the descriptor


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

Running OpenXR on host platforms, where the rendering in done over the PC's GPU, the vulkan context created from XR will be used for the PC version and it needs to to gather its features' functions supported by the physics devices features. It was crashing because although its physical device reported raytracing support, the context didn't load the vulkan ray tracing functions.