### PR TITLE
Added functions to Xr Sytem to query if default rendered is needed

### DIFF
--- a/Gems/XR/Code/Include/XR/XRSystem.h
+++ b/Gems/XR/Code/Include/XR/XRSystem.h
@@ -95,6 +95,8 @@ namespace XR
         void BeginFrame() override;
         void EndFrame() override;
         void PostFrame() override;
+        bool IsDefaultRenderPipelineNeeded() const override;
+        bool IsDefaultRenderPipelineEnabledOnHost() const override;
         ///////////////////////////////////////////////////////////////////
 
     private:

--- a/Gems/XR/Code/Include/XR/XRSystemComponent.h
+++ b/Gems/XR/Code/Include/XR/XRSystemComponent.h
@@ -23,7 +23,7 @@ namespace XR
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void Reflect(AZ::ReflectContext* context);
 
-        SystemComponent();
+        SystemComponent() = default;
         ~SystemComponent() override = default;
 
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/XR/Code/Source/XRSystem.cpp
+++ b/Gems/XR/Code/Source/XRSystem.cpp
@@ -8,12 +8,24 @@
 
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Debug/Profiler.h>
+#include <AzCore/Console/IConsole.h>
 #include <XR/XRFactory.h>
 #include <XR/XRSystem.h>
 #include <XR/XRUtils.h>
 
 namespace XR
 {
+#if AZ_TRAIT_OS_IS_HOST_OS_PLATFORM
+    AZ_CVAR(
+        bool,
+        r_EnableHostRenderPipelineOnXR,
+        true,
+        nullptr,
+        AZ::ConsoleFunctorFlags::Null,
+        "When an XR system is present in a host platform, this will enable the regular render pipeline on the host PC as well "
+        "(true by default).");
+#endif
+
     void System::Init(const System::Descriptor& descriptor)
     {
         m_validationMode = descriptor.m_validationMode;
@@ -334,5 +346,25 @@ namespace XR
         AZ::SystemTickBus::Handler::BusDisconnect();
         m_instance = nullptr;
         m_device = nullptr;
+    }
+
+    bool System::IsDefaultRenderPipelineNeeded() const
+    {
+        // While there is an XR system the default render pipeline is only needed on host platforms,
+        // in case we also render on PC as well as in the XR device.
+#if AZ_TRAIT_OS_IS_HOST_OS_PLATFORM
+        return true;
+#else
+        return false;
+#endif
+    }
+
+    bool System::IsDefaultRenderPipelineEnabledOnHost() const
+    {
+#if AZ_TRAIT_OS_IS_HOST_OS_PLATFORM
+        return r_EnableHostRenderPipelineOnXR;
+#else
+        return false;
+#endif
     }
 }

--- a/Gems/XR/Code/Source/XRSystemComponent.cpp
+++ b/Gems/XR/Code/Source/XRSystemComponent.cpp
@@ -33,11 +33,6 @@ namespace XR
         }
     }
 
-    SystemComponent::SystemComponent()
-    {
-        m_xrSystem = aznew System();
-    }
-
     void SystemComponent::Activate()
     {
         // Register XR system interface if openxr is enabled via command line or settings registry
@@ -50,6 +45,7 @@ namespace XR
             //Init the XRSystem
             System::Descriptor descriptor;
             descriptor.m_validationMode = validationMode;
+            m_xrSystem = aznew System();
             m_xrSystem->Init(descriptor);
 
             //Register xr system with RPI
@@ -59,7 +55,11 @@ namespace XR
 
     void SystemComponent::Deactivate()
     {
-        m_xrSystem->Shutdown();
+        if (m_xrSystem)
+        {
+            m_xrSystem->Shutdown();
+            m_xrSystem.reset();
+        }
     }
 
     bool SystemComponent::IsOpenXREnabled()


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

Also fixed crash when shutting down launcher, the xr system needs to be destroyed on the xr system component deactivation, holding it until its destructor is too late.