### PR TITLE
Fixes an issue with camera movement in Launcher

### DIFF
--- a/Gems/OpenXRVk/Code/CMakeLists.txt
+++ b/Gems/OpenXRVk/Code/CMakeLists.txt
@@ -79,9 +79,13 @@ ly_add_target(
             Gem::OpenXRVk.Static
 )
 
-# use the OpenXRVk module in clients and tools:
+# use the OpenXRVk module in all aliases:
 ly_create_alias(NAME OpenXRVk.Clients NAMESPACE Gem TARGETS Gem::OpenXRVk)
-ly_create_alias(NAME OpenXRVk.Tools NAMESPACE Gem TARGETS Gem::OpenXRVk)
+
+if(PAL_TRAIT_BUILD_HOST_TOOLS)
+    ly_create_alias(NAME OpenXRVk.Tools NAMESPACE Gem TARGETS Gem::OpenXRVk)
+    ly_create_alias(NAME OpenXRVk.Builders NAMESPACE Gem TARGETS Gem::OpenXRVk)
+endif()
 
 ################################################################################
 # Tests

--- a/Gems/OpenXRVk/Code/Source/XRCameraMovementComponent.cpp
+++ b/Gems/OpenXRVk/Code/Source/XRCameraMovementComponent.cpp
@@ -55,17 +55,17 @@ namespace OpenXRVk
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<XRCameraMovementComponent>("XRCameraMovementComponent", "[Description of functionality provided by this component]")
+                editContext->Class<XRCameraMovementComponent>("XR Camera Movement", "Provides XR controller input to control the camera")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Category, "ComponentCategory")
+                    ->Attribute(AZ::Edit::Attributes::Category, "Gameplay")
                     ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/Component_Placeholder.svg")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
                     ->DataElement(AZ::Edit::UIHandlers::Default, &XRCameraMovementComponent::m_moveSpeed, "Move Speed", "Speed of camera movement")
-                    ->Attribute(AZ::Edit::Attributes::Min, 1.f)
-                    ->Attribute(AZ::Edit::Attributes::Max, 100.f)
+                        ->Attribute(AZ::Edit::Attributes::Min, 1.f)
+                        ->Attribute(AZ::Edit::Attributes::Max, 50.f)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &XRCameraMovementComponent::m_movementSensitivity, "Move Sensitivity", "Fine movement sensitivity factor")
-                    ->Attribute(AZ::Edit::Attributes::Min, 0.f)
-                    ->Attribute(AZ::Edit::Attributes::Max, 1.f)
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                        ->Attribute(AZ::Edit::Attributes::Max, 1.f)
                     ;
             }
         }

--- a/Projects/OpenXRTest/Levels/XR_Office/XR_Office.prefab
+++ b/Projects/OpenXRTest/Levels/XR_Office/XR_Office.prefab
@@ -165,7 +165,7 @@
                     "Controller": {
                         "Configuration": {
                             "Field of View": 80.0,
-                            "EditorEntityId": 16589391527782614938
+                            "EditorEntityId": 8220845441310131755
                         }
                     }
                 },
@@ -342,6 +342,20 @@
                                 "assetHint": "lightingpresets/lowcontrast/royal_esplanade_2k_iblskyboxcm_iblspecular.exr.streamingimage"
                             }
                         }
+                    },
+                    "diffuseImageAsset": {
+                        "assetId": {
+                            "guid": "{74988A00-9ED5-5F1C-8EBC-E2B8A2CE40AF}",
+                            "subId": 2000
+                        },
+                        "assetHint": "lightingpresets/lowcontrast/royal_esplanade_2k_iblskyboxcm_iblspecular.exr.streamingimage"
+                    },
+                    "specularImageAsset": {
+                        "assetId": {
+                            "guid": "{74988A00-9ED5-5F1C-8EBC-E2B8A2CE40AF}",
+                            "subId": 2000
+                        },
+                        "assetHint": "lightingpresets/lowcontrast/royal_esplanade_2k_iblskyboxcm_iblspecular.exr.streamingimage"
                     }
                 },
                 "Component_[14994774102579326069]": {
@@ -2038,7 +2052,7 @@
                                 },
                                 "assetHint": "assets/textures/reflectionprobes/refprobmain__5671e21b-ba4c-48c7-8e30-8f8a0428ab82__iblspecularcm256.dds.streamingimage"
                             },
-                            "EntityId": 6969507080663320545,
+                            "EntityId": 14136586257618404771,
                             "ShowVisualization": false,
                             "RenderExposure": 1.0
                         }


### PR DESCRIPTION
- Asset Processor was processing the XRCameraMovement component, but with a warning.  This caused the Camera entity to not have this component when spawned at runtime.
- The issue was that the OpenXRVk Gem's cmake didn't declar an alias for the .Builders variant.
- Also fixed some stuff on the Edit Context and re-saved the XR_Office level.
