### PR TITLE
New VR pipeline related changes

### DIFF
--- a/Gems/XR/Code/Source/XRSystem.cpp
+++ b/Gems/XR/Code/Source/XRSystem.cpp
@@ -146,7 +146,10 @@ namespace XR
 
     void System::OnSystemTick()
     {
-        m_session->PollEvents();
+        if (m_session)
+        {
+            m_session->PollEvents();
+        }
     }
     
     void System::BeginFrame()

--- a/Projects/OpenXRTest/Registry/OpenXR.setreg
+++ b/Projects/OpenXRTest/Registry/OpenXR.setreg
@@ -2,8 +2,8 @@
     "O3DE": {
         "Atom": {
             "OpenXR": {
-                "Enable": false,
-                "android_ViewResolutionScale": 0.5
+                "Enable": true,
+                "android_ViewResolutionScale": 1.0
             }
         }
     }


### PR DESCRIPTION
- Part of the fix to allow the Gamelauncher to function if a device is not connected but OpenXR is enabled
- Enable OpenXR by default
- Set resolution scale to 1.0 by default


Signed-off-by: moudgils <47460854+moudgils@users.noreply.github.com>