### PR TITLE
Multiplayer Template: Include NetworkRigidBodyCube.prefab 

### DIFF
--- a/Templates/Multiplayer/template.json
+++ b/Templates/Multiplayer/template.json
@@ -1062,6 +1062,10 @@
             "isTemplated": true
         },
         {
+            "file": "Prefabs/NetworkRigidBodyCube.prefab",
+            "isTemplated": true
+        },
+        {
             "file": "Prefabs/Player.prefab",
             "isTemplated": true
         },


### PR DESCRIPTION
Adding NetworkRigidBodyCube.prefab to the template.json so that it's captured when making a new project
Fixes #63

Signed-off-by: Gene Walters <genewalt@amazon.com>