### PR TITLE
Open XR Editor Crash Fix

### DIFF
--- a/Gems/XR/Code/Source/XRSystem.cpp
+++ b/Gems/XR/Code/Source/XRSystem.cpp
@@ -187,7 +187,12 @@ namespace XR
 
     AZ::u32 System::GetNumViews() const
     {
-        return m_swapChain->GetNumViews();
+        if (m_swapChain)
+        {
+            return m_swapChain->GetNumViews();
+        }
+        AZ_Warning("XRSystem", false, "SwapChain is null");
+        return 0;
     }
 
     AZ::u32 System::GetCurrentImageIndex(AZ::u32 viewIndex) const
@@ -198,7 +203,7 @@ namespace XR
 
     bool System::ShouldRender() const
     {
-        if (m_session->IsSessionRunning())
+        if (m_session && m_session->IsSessionRunning())
         { 
             return m_device->ShouldRender();
         }

--- a/Gems/XR/Code/Source/XRSystem.cpp
+++ b/Gems/XR/Code/Source/XRSystem.cpp
@@ -191,6 +191,7 @@ namespace XR
         {
             return m_swapChain->GetNumViews();
         }
+
         AZ_Warning("XRSystem", false, "SwapChain is null");
         return 0;
     }


### PR DESCRIPTION
Checking for null to avoid an editor and level crash when opening the OpenXRTest project.

Fixes #82

_Note: Maybe the warnings should actual be an error since I'm guessing some feature is fundamentally broken if these are null. although not yet sure how to properly fix the issue. A better error/warning should include more information; I'll defer to the experts._