### PR TITLE
Add lidar modularity for ROS2 Gem

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Math/Transform.h>
+#include <AzCore/Math/Vector3.h>
+
+namespace ROS2
+{
+    class LidarRaycasterRequests
+    {
+    public:
+        AZ_RTTI(LidarRaycasterRequests, "{253a02c8-b6cb-493c-b16f-012ccf9db226}");
+        virtual ~LidarRaycasterRequests() = default;
+
+        //! Configures ray orientations.
+        //! @param orientations Vector of orientations as Euler angles in radians. Each ray direction is computed by transforming a unit
+        //! vector in the positive z direction first by the y, next by the z axis. The x axis is currently not included in calculations.
+        virtual void ConfigureRayOrientations(const AZStd::vector<AZ::Vector3>& orientations) = 0;
+
+        //! Configures ray maximum travel distance.
+        //! @param range Ray range in meters.
+        virtual void ConfigureRayRange(float range) = 0;
+
+        //! Schedules a raycast that originates from the point described by the lidarTransform.
+        //! @param lidarTransform Current transform from global to lidar reference frame.
+        //! @return Results of the raycast in form of coordinates in 3D space.
+        //! The returned vector size can be anything between zero and size of directions. No hits further than distance will be reported.
+        virtual AZStd::vector<AZ::Vector3> PerformRaycast(const AZ::Transform& lidarTransform) = 0;
+
+        //! Configures ray Gaussian Noise parameters.
+        //! @param angularNoiseStdDev Standard deviation of angular noise.
+        //! @param distanceNoiseStdDevBase Base value for standard deviation of distance noise
+        //! @param distanceNoiseStdDevRisePerMeter Value by which standard deviation of distance noise increases per meter distance from
+        //! the lidar.
+        // TODO - different starting points for rays, distance from reference point, noise models, rotating mirror sim, other
+        // TODO - customized settings. Encapsulate in lidar definition and pass in constructor, update transform.
+        virtual void ConfigureNoiseParameters(
+            float angularNoiseStdDev, float distanceNoiseStdDevBase, float distanceNoiseStdDevRisePerMeter)
+        {
+            AZ_Assert(false, "This Lidar Implementation does not support noise!");
+        }
+
+        //! Configures Layer ignoring parameters
+        //! @param ignoreLayer Should a specified collision layer be ignored?
+        //! @param layerIndex Index of collision layer to be ignored.
+        virtual void ConfigureLayerIgnoring(bool ignoreLayer, unsigned int layerIndex)
+        {
+            AZ_Assert(false, "This Lidar Implementation does not support collision layer configurations!");
+        }
+
+        //! Configures max range point addition.
+        //! @param includeMaxRange Should the raycaster add points at max range for rays that exceeded their range?
+        virtual void ConfigureMaxRangePointAddition(bool addMaxRangePoints)
+        {
+            AZ_Assert(false, "This Lidar Implementation does not support Max range point addition configuration!");
+        }
+
+    protected:
+        static void ValidateRayRange(float range)
+        {
+            AZ_Assert(range > 0.0f, "Provided ray range was of incorrect value: Ray range value must be greater than zero.")
+        }
+
+        static void ValidateRayOrientations(const AZStd::vector<AZ::Vector3>& orientations)
+        {
+            AZ_Assert(!orientations.empty(), "Provided ray orientations were of incorrect value: Ray orientations must not be empty.")
+        }
+    };
+
+    class LidarRaycasterBusTraits : public AZ::EBusTraits
+    {
+    public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        using BusIdType = AZ::Uuid;
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+        //////////////////////////////////////////////////////////////////////////
+    };
+
+    using LidarRaycasterRequestBus = AZ::EBus<LidarRaycasterRequests, LidarRaycasterBusTraits>;
+} // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
@@ -63,6 +63,13 @@ namespace ROS2
             AZ_Assert(false, "This Lidar Implementation does not support collision layer configurations!");
         }
 
+        //! Excludes entities with given EntityIds from raycasting.
+        //! @param excludedEntities list of entities marked for exclusion.
+        virtual void ExcludeEntities(const AZStd::vector<AZ::EntityId>& excludedEntities)
+        {
+            AZ_Assert(false, "This Lidar Implementation does not support entity exclusion!");
+        }
+
         //! Configures max range point addition.
         //! @param includeMaxRange Should the raycaster add points at max range for rays that exceeded their range?
         virtual void ConfigureMaxRangePointAddition(bool addMaxRangePoints)

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
@@ -14,11 +14,11 @@
 
 namespace ROS2
 {
+    //! Interface class that allows for communication with a single Lidar instance.
     class LidarRaycasterRequests
     {
     public:
         AZ_RTTI(LidarRaycasterRequests, "{253a02c8-b6cb-493c-b16f-012ccf9db226}");
-        virtual ~LidarRaycasterRequests() = default;
 
         //! Configures ray orientations.
         //! @param orientations Vector of orientations as Euler angles in radians. Each ray direction is computed by transforming a unit
@@ -37,7 +37,7 @@ namespace ROS2
 
         //! Configures ray Gaussian Noise parameters.
         //! Each call overrides the previous configuration.
-        //! This type of noise is especially useful when trying to simulate real-life lidars, since it noise mimics
+        //! This type of noise is especially useful when trying to simulate real-life lidars, since its noise mimics
         //! the imperfections arising due to various physical factors e.g. fluctuations in rotary motion of the lidar (angular noise) or
         //! distance accuracy (distance noise).
         //! For the the details about Gaussian noise, please refer to https://en.wikipedia.org/wiki/Gaussian_noise.
@@ -47,10 +47,10 @@ namespace ROS2
         //! @param distanceNoiseStdDevBase Base value for Distance noise standard deviation.
         //! @param distanceNoiseStdDevRisePerMeter Value by which the distance noise standard deviation increases per meter length from
         //! the lidar.
-        // TODO - different starting points for rays, distance from reference point, noise models, rotating mirror sim, other
-        // TODO - customized settings. Encapsulate in lidar definition and pass in constructor, update transform.
         virtual void ConfigureNoiseParameters(
-            float angularNoiseStdDev, float distanceNoiseStdDevBase, float distanceNoiseStdDevRisePerMeter)
+            [[maybe_unused]] float angularNoiseStdDev,
+            [[maybe_unused]] float distanceNoiseStdDevBase,
+            [[maybe_unused]] float distanceNoiseStdDevRisePerMeter)
         {
             AZ_Assert(false, "This Lidar Implementation does not support noise!");
         }
@@ -58,32 +58,36 @@ namespace ROS2
         //! Configures Layer ignoring parameters
         //! @param ignoreLayer Should a specified collision layer be ignored?
         //! @param layerIndex Index of collision layer to be ignored.
-        virtual void ConfigureLayerIgnoring(bool ignoreLayer, unsigned int layerIndex)
+        virtual void ConfigureLayerIgnoring([[maybe_unused]] bool ignoreLayer, [[maybe_unused]] AZ::u32 layerIndex)
         {
             AZ_Assert(false, "This Lidar Implementation does not support collision layer configurations!");
         }
 
         //! Excludes entities with given EntityIds from raycasting.
-        //! @param excludedEntities list of entities marked for exclusion.
-        virtual void ExcludeEntities(const AZStd::vector<AZ::EntityId>& excludedEntities)
+        //! @param excludedEntities List of entities marked for exclusion.
+        virtual void ExcludeEntities([[maybe_unused]] const AZStd::vector<AZ::EntityId>& excludedEntities)
         {
             AZ_Assert(false, "This Lidar Implementation does not support entity exclusion!");
         }
 
         //! Configures max range point addition.
         //! @param includeMaxRange Should the raycaster add points at max range for rays that exceeded their range?
-        virtual void ConfigureMaxRangePointAddition(bool addMaxRangePoints)
+        virtual void ConfigureMaxRangePointAddition([[maybe_unused]] bool addMaxRangePoints)
         {
             AZ_Assert(false, "This Lidar Implementation does not support Max range point addition configuration!");
         }
 
+        using LidarId = AZ::Uuid;
+
     protected:
-        static void ValidateRayRange(float range)
+        ~LidarRaycasterRequests() = default;
+
+        static void ValidateRayRange([[maybe_unused]] float range)
         {
             AZ_Assert(range > 0.0f, "Provided ray range was of incorrect value: Ray range value must be greater than zero.")
         }
 
-        static void ValidateRayOrientations(const AZStd::vector<AZ::Vector3>& orientations)
+        static void ValidateRayOrientations([[maybe_unused]] const AZStd::vector<AZ::Vector3>& orientations)
         {
             AZ_Assert(!orientations.empty(), "Provided ray orientations were of incorrect value: Ray orientations must not be empty.")
         }
@@ -94,7 +98,7 @@ namespace ROS2
     public:
         //////////////////////////////////////////////////////////////////////////
         // EBusTraits overrides
-        using BusIdType = AZ::Uuid;
+        using BusIdType = LidarRaycasterRequests::LidarId;
         static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
         static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
@@ -21,57 +21,57 @@ namespace ROS2
     {
     public:
         StronglyTypedUuid() = default;
-        StronglyTypedUuid(AZ::Uuid value)
+        explicit constexpr StronglyTypedUuid(AZ::Uuid value)
             : m_uuid(value)
         {
         }
 
-        static StronglyTypedUuid CreateNull()
+        constexpr static StronglyTypedUuid CreateNull()
         {
             return StronglyTypedUuid(AZ::Uuid::CreateNull());
         }
 
-        static StronglyTypedUuid CreateRandom()
+        constexpr static StronglyTypedUuid CreateRandom()
         {
             return StronglyTypedUuid(AZ::Uuid::CreateRandom());
         }
 
-        bool IsNull() const
+        constexpr bool IsNull() const
         {
             return m_uuid.IsNull();
         }
 
-        bool operator==(const StronglyTypedUuid& rhs) const
+        constexpr bool operator==(const StronglyTypedUuid& rhs) const
         {
             return m_uuid == rhs.m_uuid;
         }
 
-        bool operator!=(const StronglyTypedUuid& rhs) const
+        constexpr bool operator!=(const StronglyTypedUuid& rhs) const
         {
             return m_uuid != rhs.m_uuid;
         }
 
-        bool operator<(const StronglyTypedUuid& rhs) const
+        constexpr bool operator<(const StronglyTypedUuid& rhs) const
         {
             return m_uuid < rhs.m_uuid;
         }
 
-        bool operator>(const StronglyTypedUuid& rhs) const
+        constexpr bool operator>(const StronglyTypedUuid& rhs) const
         {
             return m_uuid > rhs.m_uuid;
         }
 
-        bool operator<=(const StronglyTypedUuid& rhs) const
+        constexpr bool operator<=(const StronglyTypedUuid& rhs) const
         {
             return m_uuid <= rhs.m_uuid;
         }
 
-        bool operator>=(const StronglyTypedUuid& rhs) const
+        constexpr bool operator>=(const StronglyTypedUuid& rhs) const
         {
             return m_uuid >= rhs.m_uuid;
         }
 
-        size_t GetHash() const
+        constexpr size_t GetHash() const
         {
             return m_uuid.GetHash();
         }

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
@@ -36,9 +36,16 @@ namespace ROS2
         virtual AZStd::vector<AZ::Vector3> PerformRaycast(const AZ::Transform& lidarTransform) = 0;
 
         //! Configures ray Gaussian Noise parameters.
-        //! @param angularNoiseStdDev Standard deviation of angular noise.
-        //! @param distanceNoiseStdDevBase Base value for standard deviation of distance noise
-        //! @param distanceNoiseStdDevRisePerMeter Value by which standard deviation of distance noise increases per meter distance from
+        //! Each call overrides the previous configuration.
+        //! This type of noise is especially useful when trying to simulate real-life lidars, since it noise mimics
+        //! the imperfections arising due to various physical factors e.g. fluctuations in rotary motion of the lidar (angular noise) or
+        //! distance accuracy (distance noise).
+        //! For the the details about Gaussian noise, please refer to https://en.wikipedia.org/wiki/Gaussian_noise.
+        //! You can also check-out the RobotecGPULidar (integrated in the RobotecGPULidar Gem) docs concerning these types of lidar noise at
+        //! https://github.com/RobotecAI/RobotecGPULidar/blob/v11/docs/GaussianNoise.md.
+        //! @param angularNoiseStdDev Angular noise standard deviation.
+        //! @param distanceNoiseStdDevBase Base value for Distance noise standard deviation.
+        //! @param distanceNoiseStdDevRisePerMeter Value by which the distance noise standard deviation increases per meter length from
         //! the lidar.
         // TODO - different starting points for rays, distance from reference point, noise models, rotating mirror sim, other
         // TODO - customized settings. Encapsulate in lidar definition and pass in constructor, update transform.

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
@@ -13,48 +13,52 @@
 
 namespace ROS2
 {
-    //! Structure used to describe LidarSystem's feature support.
-    struct LidarSystemFeatures
+    //! Enum bitwise flags used to describe LidarSystem's feature support.
+    enum LidarSystemFeatures : uint8_t
     {
-    public:
-        bool m_noise{ false };
-        bool m_collisionLayers{ false };
-        bool m_entityExclusion{ false };
-        bool m_maxRangePoints{ false };
+        None                = 0b00000000,
+        Noise               = 0b00000001,
+        CollisionLayers     = 0b00000010,
+        EntityExclusion     = 0b00000100,
+        MaxRangePoints      = 0b00001000,
+        All                 = 0b00001111
     };
 
     //! Structure used to hold LidarSystem's metadata.
     struct LidarSystemMetaData
     {
-    public:
         AZStd::string m_name;
         AZStd::string m_description;
         LidarSystemFeatures m_features;
     };
 
+    //! Interface class that allows for communication with the LidarRegistrarSystemComponent.
     class LidarRegistrarRequests
     {
     public:
         AZ_RTTI(LidarRegistrarRequests, "{22030dc7-a1db-43bd-b748-0fb9ec43ce2e}");
-        virtual ~LidarRegistrarRequests() = default;
 
         //! Registers a new lidar system under the provided name.
         //! To obtain the busId of a lidarSystem use the AZ_CRC macro as follows.
         //! @code
         //! AZ::Crc32 busId = AZ_CRC(<lidarSystemName>);
         //! @endcode
-        //! @param name name of the newly registered lidar system.
-        //! @param description further information about the lidar system.
+        //! @param name Name of the newly registered lidar system.
+        //! @param description Further information about the lidar system.
         virtual void RegisterLidarSystem(const char* name, const char* description, const LidarSystemFeatures& features) = 0;
 
-        //! Returns a list of all registered lidar systems.
-        //! @return a vector of registered lidar systems' names.
-        virtual const AZStd::vector<AZStd::string> GetRegisteredLidarSystems() = 0;
+        //! Returns A list of all registered lidar systems.
+        //! @return A vector of registered lidar systems' names.
+        virtual AZStd::vector<AZStd::string> GetRegisteredLidarSystems() const = 0;
 
         //! Returns metadata of a registered lidar system.
-        //! @param name name of a registered lidar system.
-        //! @return metadata of a lidar system with the provided name.
-        virtual const LidarSystemMetaData& GetLidarSystemMetaData(const AZStd::string& name) = 0;
+        //! If no lidar system with provided name was found returns nullptr.
+        //! @param name Name of a registered lidar system.
+        //! @return Pointer to the metadata of a lidar system with the provided name.
+        virtual const LidarSystemMetaData* GetLidarSystemMetaData(const AZStd::string& name) const = 0;
+
+    protected:
+        ~LidarRegistrarRequests() = default;
     };
 
     class LidarRegistrarBusTraits : public AZ::EBusTraits

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
@@ -14,14 +14,14 @@
 namespace ROS2
 {
     //! Enum bitwise flags used to describe LidarSystem's feature support.
-    enum LidarSystemFeatures : uint8_t
+    enum LidarSystemFeatures : uint16_t
     {
-        None                = 0b00000000,
-        Noise               = 0b00000001,
-        CollisionLayers     = 0b00000010,
-        EntityExclusion     = 0b00000100,
-        MaxRangePoints      = 0b00001000,
-        All                 = 0b00001111
+        None                = 0b0000000000000000,
+        Noise               = 0b0000000000000001,
+        CollisionLayers     = 0b0000000000000010,
+        EntityExclusion     = 0b0000000000000100,
+        MaxRangePoints      = 0b0000000000001000,
+        All                 = 0b1111111111111111
     };
 
     //! Structure used to hold LidarSystem's metadata.

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
@@ -19,6 +19,7 @@ namespace ROS2
     public:
         bool m_noise{ false };
         bool m_collisionLayers{ false };
+        bool m_entityExclusion{ false };
         bool m_maxRangePoints{ false };
     };
 

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/std/string/string.h>
+
+namespace ROS2
+{
+    //! Structure used to describe LidarSystem's feature support.
+    struct LidarSystemFeatures
+    {
+    public:
+        bool m_noise{ false };
+        bool m_collisionLayers{ false };
+        bool m_maxRangePoints{ false };
+    };
+
+    //! Structure used to hold LidarSystem's metadata.
+    struct LidarSystemMetaData
+    {
+    public:
+        AZStd::string m_name;
+        AZStd::string m_description;
+        LidarSystemFeatures m_features;
+    };
+
+    class LidarRegistrarRequests
+    {
+    public:
+        AZ_RTTI(LidarRegistrarRequests, "{22030dc7-a1db-43bd-b748-0fb9ec43ce2e}");
+        virtual ~LidarRegistrarRequests() = default;
+
+        //! Registers a new lidar system under the provided name.
+        //! To obtain the busId of a lidarSystem use the AZ_CRC macro as follows.
+        //! @code
+        //! AZ::Crc32 busId = AZ_CRC(<lidarSystemName>);
+        //! @endcode
+        //! @param name name of the newly registered lidar system.
+        //! @param description further information about the lidar system.
+        virtual void RegisterLidarSystem(const char* name, const char* description, const LidarSystemFeatures& features) = 0;
+
+        //! Returns a list of all registered lidar systems.
+        //! @return a vector of registered lidar systems' names.
+        virtual const AZStd::vector<AZStd::string> GetRegisteredLidarSystems() = 0;
+
+        //! Returns metadata of a registered lidar system.
+        //! @param name name of a registered lidar system.
+        //! @return metadata of a lidar system with the provided name.
+        virtual const LidarSystemMetaData& GetLidarSystemMetaData(const AZStd::string& name) = 0;
+    };
+
+    class LidarRegistrarBusTraits : public AZ::EBusTraits
+    {
+    public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        //////////////////////////////////////////////////////////////////////////
+    };
+
+    using LidarRegistrarRequestBus = AZ::EBus<LidarRegistrarRequests, LidarRegistrarBusTraits>;
+    using LidarRegistrarInterface = AZ::Interface<LidarRegistrarRequests>;
+} // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarSystemBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarSystemBus.h
@@ -22,7 +22,7 @@ namespace ROS2
         //! Creates a new Lidar.
         //! @param lidarEntityId EntityId holding the ROS2LidarSensorComponent.
         //! @return A unique Id of the newly created Lidar.
-        virtual LidarRaycasterRequests::LidarId CreateLidar(AZ::EntityId lidarEntityId) = 0;
+        virtual LidarId CreateLidar(AZ::EntityId lidarEntityId) = 0;
 
     protected:
         ~LidarSystemRequests() = default;

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarSystemBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarSystemBus.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/EBus/EBus.h>
+
+namespace ROS2
+{
+    //! Structure used to describe LidarSystem features support.
+    struct LidarImplementationFeatures
+    {
+    public:
+        bool m_noise{ false };
+        bool m_collisionLayers{ false };
+        bool m_maxRangePoints{ false };
+    };
+
+    class LidarSystemRequests
+    {
+    public:
+        AZ_RTTI(LidarSystemRequests, "{007871d1-2783-4382-977b-558f436c54a5}");
+        virtual ~LidarSystemRequests() = default;
+
+        //! Creates a new Lidar.
+        //! @param lidarEntityId EntityId holding the ROS2LidarSensorComponent.
+        //! @return A unique Id of the newly created Lidar.
+        virtual AZ::Uuid CreateLidar(const AZ::EntityId& lidarEntityId) = 0;
+
+        //! Returns a structure describing this implementation's feature availability.
+        virtual LidarImplementationFeatures GetSupportedFeatures() = 0;
+    };
+
+    class LidarSystemBusTraits : public AZ::EBusTraits
+    {
+    public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        using BusIdType = int;
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+        //////////////////////////////////////////////////////////////////////////
+    };
+
+    using LidarSystemRequestBus = AZ::EBus<LidarSystemRequests, LidarSystemBusTraits>;
+} // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarSystemBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarSystemBus.h
@@ -12,15 +12,6 @@
 
 namespace ROS2
 {
-    //! Structure used to describe LidarSystem features support.
-    struct LidarImplementationFeatures
-    {
-    public:
-        bool m_noise{ false };
-        bool m_collisionLayers{ false };
-        bool m_maxRangePoints{ false };
-    };
-
     class LidarSystemRequests
     {
     public:
@@ -31,9 +22,6 @@ namespace ROS2
         //! @param lidarEntityId EntityId holding the ROS2LidarSensorComponent.
         //! @return A unique Id of the newly created Lidar.
         virtual AZ::Uuid CreateLidar(const AZ::EntityId& lidarEntityId) = 0;
-
-        //! Returns a structure describing this implementation's feature availability.
-        virtual LidarImplementationFeatures GetSupportedFeatures() = 0;
     };
 
     class LidarSystemBusTraits : public AZ::EBusTraits
@@ -41,7 +29,7 @@ namespace ROS2
     public:
         //////////////////////////////////////////////////////////////////////////
         // EBusTraits overrides
-        using BusIdType = int;
+        using BusIdType = AZ::Crc32;
         static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
         static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarSystemBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarSystemBus.h
@@ -9,19 +9,23 @@
 
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/EBus/EBus.h>
+#include <ROS2/Lidar/LidarRaycasterBus.h>
 
 namespace ROS2
 {
+    //! Interface class that allows for communication with a given Lidar System (implementation).
     class LidarSystemRequests
     {
     public:
         AZ_RTTI(LidarSystemRequests, "{007871d1-2783-4382-977b-558f436c54a5}");
-        virtual ~LidarSystemRequests() = default;
 
         //! Creates a new Lidar.
         //! @param lidarEntityId EntityId holding the ROS2LidarSensorComponent.
         //! @return A unique Id of the newly created Lidar.
-        virtual AZ::Uuid CreateLidar(const AZ::EntityId& lidarEntityId) = 0;
+        virtual LidarRaycasterRequests::LidarId CreateLidar(AZ::EntityId lidarEntityId) = 0;
+
+    protected:
+        ~LidarSystemRequests() = default;
     };
 
     class LidarSystemBusTraits : public AZ::EBusTraits

--- a/Gems/ROS2/Code/Include/ROS2/ROS2Bus.h
+++ b/Gems/ROS2/Code/Include/ROS2/ROS2Bus.h
@@ -9,6 +9,7 @@
 
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Interface/Interface.h>
+#include <AzCore/std/string/string.h>
 #include <builtin_interfaces/msg/time.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <rclcpp/node.hpp>
@@ -50,6 +51,15 @@ namespace ROS2
         //! @note Transforms are already published by each ROS2FrameComponent.
         //! Use this function directly only when default behavior of ROS2FrameComponent is not sufficient.
         virtual void BroadcastTransform(const geometry_msgs::msg::TransformStamped& t, bool isDynamic) const = 0;
+
+        //! Registers a new lidar system under the provided name.
+        //! @param lidarSystemName name of the newly registered lidar system.
+        //! @return id of this lidar system (id that the lidar system bus handler should connect with).
+        virtual int RegisterLidarSystem(const char* lidarSystemName) = 0;
+
+        //! Gets a list of all registered lidar systems.
+        //! @return a vector of id - name pairs representing registered lidar systems.
+        virtual AZStd::vector<AZStd::pair<int, AZStd::string>> GetRegisteredLidarSystems() = 0;
     };
 
     class ROS2BusTraits : public AZ::EBusTraits

--- a/Gems/ROS2/Code/Include/ROS2/ROS2Bus.h
+++ b/Gems/ROS2/Code/Include/ROS2/ROS2Bus.h
@@ -9,7 +9,6 @@
 
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Interface/Interface.h>
-#include <AzCore/std/string/string.h>
 #include <builtin_interfaces/msg/time.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <rclcpp/node.hpp>

--- a/Gems/ROS2/Code/Include/ROS2/ROS2Bus.h
+++ b/Gems/ROS2/Code/Include/ROS2/ROS2Bus.h
@@ -51,15 +51,6 @@ namespace ROS2
         //! @note Transforms are already published by each ROS2FrameComponent.
         //! Use this function directly only when default behavior of ROS2FrameComponent is not sufficient.
         virtual void BroadcastTransform(const geometry_msgs::msg::TransformStamped& t, bool isDynamic) const = 0;
-
-        //! Registers a new lidar system under the provided name.
-        //! @param lidarSystemName name of the newly registered lidar system.
-        //! @return id of this lidar system (id that the lidar system bus handler should connect with).
-        virtual int RegisterLidarSystem(const char* lidarSystemName) = 0;
-
-        //! Gets a list of all registered lidar systems.
-        //! @return a vector of id - name pairs representing registered lidar systems.
-        virtual AZStd::vector<AZStd::pair<int, AZStd::string>> GetRegisteredLidarSystems() = 0;
     };
 
     class ROS2BusTraits : public AZ::EBusTraits

--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
@@ -29,15 +29,15 @@ namespace ROS2
         return lidarPhysicsSceneHandle;
     }
 
-    LidarRaycaster::LidarRaycaster(const LidarRaycasterRequestBus::BusIdType& busId, AZ::EntityId sceneEntityId)
-        : m_lidarId{ busId }
+    LidarRaycaster::LidarRaycaster(LidarId busId, AZ::EntityId sceneEntityId)
+        : m_busId{ busId }
         , m_sceneEntityId{ sceneEntityId }
     {
         ROS2::LidarRaycasterRequestBus::Handler::BusConnect(busId);
     }
 
     LidarRaycaster::LidarRaycaster(LidarRaycaster&& lidarRaycaster)
-        : m_lidarId{ lidarRaycaster.m_lidarId }
+        : m_busId{ lidarRaycaster.m_busId }
         , m_sceneEntityId{ lidarRaycaster.m_sceneEntityId }
         , m_sceneHandle{ lidarRaycaster.m_sceneHandle }
         , m_range{ lidarRaycaster.m_range }
@@ -47,9 +47,9 @@ namespace ROS2
         , m_ignoredLayerIndex{ lidarRaycaster.m_ignoredLayerIndex }
     {
         lidarRaycaster.BusDisconnect();
-        lidarRaycaster.m_lidarId = AZ::Uuid::CreateNull();
+        lidarRaycaster.m_busId = LidarId::CreateNull();
 
-        ROS2::LidarRaycasterRequestBus::Handler::BusConnect(m_lidarId);
+        ROS2::LidarRaycasterRequestBus::Handler::BusConnect(m_busId);
     }
 
     LidarRaycaster::~LidarRaycaster()

--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
@@ -17,10 +17,10 @@
 
 namespace ROS2
 {
-    LidarRaycaster::LidarRaycaster(const AZ::Uuid& uuid)
-        : m_uuid{ uuid }
+    LidarRaycaster::LidarRaycaster(const LidarRaycasterRequestBus::BusIdType& busId)
+        : m_uuid{ busId }
     {
-        ROS2::LidarRaycasterRequestBus::Handler::BusConnect(uuid);
+        ROS2::LidarRaycasterRequestBus::Handler::BusConnect(busId);
     }
 
     LidarRaycaster::LidarRaycaster(LidarRaycaster&& lidarRaycaster) noexcept

--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.h
@@ -7,43 +7,35 @@
  */
 #pragma once
 
-#include "ROS2/Lidar/LidarRaycasterBus.h"
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzFramework/Physics/PhysicsScene.h>
+#include <ROS2/Lidar/LidarRaycasterBus.h>
 
 namespace ROS2
 {
     class LidarRaycaster : protected LidarRaycasterRequestBus::Handler
     {
     public:
-        explicit LidarRaycaster(const LidarRaycasterRequestBus::BusIdType& busId);
-        LidarRaycaster(LidarRaycaster&& lidarSystem) noexcept;
-        LidarRaycaster(const LidarRaycaster& lidarSystem) = delete;
+        explicit LidarRaycaster(const LidarRaycasterRequestBus::BusIdType& busId, AZ::EntityId sceneEntityId);
+        LidarRaycaster(LidarRaycaster&& lidarSystem);
+        LidarRaycaster(const LidarRaycaster& lidarSystem) = default;
         ~LidarRaycaster() override;
 
-        //! Set the Scene for the ray-casting.
-        //! This should be the scene with the Entity that holds the sensor.
-        //! @code
-        //! auto sceneHandle = AZ::RPI::Scene::GetSceneForEntityId(GetEntityId());
-        //! @endcode
-        //! @param handle Scene that will be subject to ray-casting.
-        void SetRaycasterScene(const AzPhysics::SceneHandle& handle);
-
     protected:
-        ////////////////////////////////////////////////////////////////////////
-        // LidarRaycasterRequestBus::Handler interface implementation
+        // LidarRaycasterRequestBus overrides
         void ConfigureRayOrientations(const AZStd::vector<AZ::Vector3>& orientations) override;
         void ConfigureRayRange(float range) override;
         AZStd::vector<AZ::Vector3> PerformRaycast(const AZ::Transform& lidarTransform) override;
-        void ConfigureLayerIgnoring(bool ignoreLayer, unsigned int layerIndex) override;
+        void ConfigureLayerIgnoring(bool ignoreLayer, AZ::u32 layerIndex) override;
         void ConfigureMaxRangePointAddition(bool addMaxRangePoints) override;
-        ////////////////////////////////////////////////////////////////////////
 
     private:
-        AZ::Uuid m_uuid;
+        LidarRaycasterRequestBus::BusIdType m_lidarId;
+        //! EntityId that is used to acquire the physics scene handle.
+        AZ::EntityId m_sceneEntityId;
         AzPhysics::SceneHandle m_sceneHandle{ AzPhysics::InvalidSceneHandle };
 
         float m_range{ 1.0f };
@@ -51,6 +43,6 @@ namespace ROS2
         AZStd::vector<AZ::Vector3> m_rayRotations{ { AZ::Vector3::CreateZero() } };
 
         bool m_ignoreLayer{ false };
-        unsigned int m_ignoredLayerIndex{ 0 };
+        AZ::u32 m_ignoredLayerIndex{ 0 };
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.h
@@ -19,7 +19,7 @@ namespace ROS2
     class LidarRaycaster : protected LidarRaycasterRequestBus::Handler
     {
     public:
-        explicit LidarRaycaster(const LidarRaycasterRequestBus::BusIdType& busId, AZ::EntityId sceneEntityId);
+        LidarRaycaster(LidarId busId, AZ::EntityId sceneEntityId);
         LidarRaycaster(LidarRaycaster&& lidarSystem);
         LidarRaycaster(const LidarRaycaster& lidarSystem) = default;
         ~LidarRaycaster() override;
@@ -33,7 +33,7 @@ namespace ROS2
         void ConfigureMaxRangePointAddition(bool addMaxRangePoints) override;
 
     private:
-        LidarRaycasterRequestBus::BusIdType m_lidarId;
+        LidarId m_busId;
         //! EntityId that is used to acquire the physics scene handle.
         AZ::EntityId m_sceneEntityId;
         AzPhysics::SceneHandle m_sceneHandle{ AzPhysics::InvalidSceneHandle };

--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.h
@@ -16,11 +16,10 @@
 
 namespace ROS2
 {
-    //! A simple implementation of Lidar operation in terms of raycasting.
     class LidarRaycaster : protected LidarRaycasterRequestBus::Handler
     {
     public:
-        explicit LidarRaycaster(const AZ::Uuid& uuid);
+        explicit LidarRaycaster(const LidarRaycasterRequestBus::BusIdType& busId);
         LidarRaycaster(LidarRaycaster&& lidarSystem) noexcept;
         LidarRaycaster(const LidarRaycaster& lidarSystem) = delete;
         ~LidarRaycaster() override;

--- a/Gems/ROS2/Code/Source/Lidar/LidarRegistrarEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRegistrarEditorSystemComponent.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "LidarRegistrarEditorSystemComponent.h"
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace ROS2
+{
+    void LidarRegistrarEditorSystemComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<LidarRegistrarEditorSystemComponent, LidarRegistrarSystemComponent>()->Version(0);
+        }
+    }
+
+    void LidarRegistrarEditorSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        BaseSystemComponent::GetProvidedServices(provided);
+        provided.push_back(AZ_CRC_CE("LidarRegistrarEditorService"));
+    }
+
+    void LidarRegistrarEditorSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        BaseSystemComponent::GetIncompatibleServices(incompatible);
+        incompatible.push_back(AZ_CRC_CE("LidarRegistrarEditorService"));
+    }
+
+    void LidarRegistrarEditorSystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        BaseSystemComponent::GetRequiredServices(required);
+    }
+
+    void LidarRegistrarEditorSystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+        BaseSystemComponent::GetDependentServices(dependent);
+    }
+
+    void LidarRegistrarEditorSystemComponent::Activate()
+    {
+        LidarRegistrarSystemComponent::Activate();
+    }
+
+    void LidarRegistrarEditorSystemComponent::Deactivate()
+    {
+        LidarRegistrarSystemComponent::Deactivate();
+    }
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarRegistrarEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRegistrarEditorSystemComponent.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include "LidarRegistrarEditorSystemComponent.h"
 #include <AzCore/Serialization/SerializeContext.h>
+#include <Lidar/LidarRegistrarEditorSystemComponent.h>
 
 namespace ROS2
 {
@@ -21,24 +21,24 @@ namespace ROS2
 
     void LidarRegistrarEditorSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
     {
-        BaseSystemComponent::GetProvidedServices(provided);
+        LidarRegistrarSystemComponent::GetProvidedServices(provided);
         provided.push_back(AZ_CRC_CE("LidarRegistrarEditorService"));
     }
 
     void LidarRegistrarEditorSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
     {
-        BaseSystemComponent::GetIncompatibleServices(incompatible);
+        LidarRegistrarSystemComponent::GetIncompatibleServices(incompatible);
         incompatible.push_back(AZ_CRC_CE("LidarRegistrarEditorService"));
     }
 
     void LidarRegistrarEditorSystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
-        BaseSystemComponent::GetRequiredServices(required);
+        LidarRegistrarSystemComponent::GetRequiredServices(required);
     }
 
     void LidarRegistrarEditorSystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
     {
-        BaseSystemComponent::GetDependentServices(dependent);
+        LidarRegistrarSystemComponent::GetDependentServices(dependent);
     }
 
     void LidarRegistrarEditorSystemComponent::Activate()

--- a/Gems/ROS2/Code/Source/Lidar/LidarRegistrarEditorSystemComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRegistrarEditorSystemComponent.h
@@ -8,15 +8,13 @@
 
 #pragma once
 
-#include "Lidar/LidarRegistrarSystemComponent.h"
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
+#include <Lidar/LidarRegistrarSystemComponent.h>
 
 namespace ROS2
 {
     class LidarRegistrarEditorSystemComponent : public LidarRegistrarSystemComponent
     {
-        using BaseSystemComponent = LidarRegistrarSystemComponent;
-
     public:
         AZ_COMPONENT(LidarRegistrarEditorSystemComponent, "{7f11b599-5ace-4498-a9a4-ad280c92bacc}", LidarRegistrarSystemComponent);
         static void Reflect(AZ::ReflectContext* context);

--- a/Gems/ROS2/Code/Source/Lidar/LidarRegistrarEditorSystemComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRegistrarEditorSystemComponent.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "Lidar/LidarRegistrarSystemComponent.h"
+#include <AzToolsFramework/Entity/EditorEntityContextBus.h>
+
+namespace ROS2
+{
+    class LidarRegistrarEditorSystemComponent : public LidarRegistrarSystemComponent
+    {
+        using BaseSystemComponent = LidarRegistrarSystemComponent;
+
+    public:
+        AZ_COMPONENT(LidarRegistrarEditorSystemComponent, "{7f11b599-5ace-4498-a9a4-ad280c92bacc}", LidarRegistrarSystemComponent);
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+        LidarRegistrarEditorSystemComponent() = default;
+        ~LidarRegistrarEditorSystemComponent() = default;
+
+    private:
+        void Activate() override;
+        void Deactivate() override;
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarRegistrarSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRegistrarSystemComponent.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "LidarRegistrarSystemComponent.h"
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace ROS2
+{
+    LidarRegistrarSystemComponent::LidarRegistrarSystemComponent()
+    {
+        if (LidarRegistrarInterface::Get() == nullptr)
+        {
+            LidarRegistrarInterface::Register(this);
+        }
+    }
+
+    LidarRegistrarSystemComponent::~LidarRegistrarSystemComponent()
+    {
+        if (LidarRegistrarInterface::Get() == this)
+        {
+            LidarRegistrarInterface::Unregister(this);
+        }
+    }
+
+    void LidarRegistrarSystemComponent::Init()
+    {
+    }
+
+    void LidarRegistrarSystemComponent::Activate()
+    {
+        m_physxLidarSystem.Activate();
+    }
+
+    void LidarRegistrarSystemComponent::Deactivate()
+    {
+    }
+
+    void LidarRegistrarSystemComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<LidarRegistrarSystemComponent, AZ::Component>()->Version(0);
+
+            if (AZ::EditContext* ec = serializeContext->GetEditContext())
+            {
+                ec->Class<LidarRegistrarSystemComponent>(
+                      "Lidar Registrar", "Manages the LidarSystem registration and stores their metadata.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System"))
+                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
+            }
+        }
+    }
+
+    void LidarRegistrarSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("LidarRegistrarService"));
+    }
+
+    void LidarRegistrarSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("LidarRegistrarService"));
+    }
+
+    void LidarRegistrarSystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC_CE("ROS2Service"));
+    }
+
+    void LidarRegistrarSystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+    }
+
+    void LidarRegistrarSystemComponent::RegisterLidarSystem(const char* name, const char* description, const LidarSystemFeatures& features)
+    {
+        AZ_Assert(
+            !m_registeredLidarSystems.contains(AZ_CRC(name)),
+            "A lidar system with the provided name already exists. Please choose a different name.");
+        m_registeredLidarSystems.emplace(AZ_CRC(name), LidarSystemMetaData{ name, description, features });
+    }
+
+    const AZStd::vector<AZStd::string> LidarRegistrarSystemComponent::GetRegisteredLidarSystems()
+    {
+        AZStd::vector<AZStd::string> lidarSystemList;
+        lidarSystemList.reserve(m_registeredLidarSystems.size());
+        for (auto lidarSystem : m_registeredLidarSystems)
+        {
+            lidarSystemList.push_back(lidarSystem.second.m_name);
+        }
+
+        return lidarSystemList;
+    }
+
+    const LidarSystemMetaData& LidarRegistrarSystemComponent::GetLidarSystemMetaData(const AZStd::string& name)
+    {
+        auto lidarSystem = m_registeredLidarSystems.find(AZ_CRC(name));
+        AZ_Assert(lidarSystem != m_registeredLidarSystems.end(), "No registered lidar system matches the provided name.");
+        return lidarSystem->second;
+    }
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarRegistrarSystemComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRegistrarSystemComponent.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include "Lidar/LidarSystem.h"
-#include "ROS2/Lidar/LidarRegistrarBus.h"
 #include <AzCore/Component/Component.h>
+#include <Lidar/LidarSystem.h>
+#include <ROS2/Lidar/LidarRegistrarBus.h>
 
 namespace ROS2
 {
@@ -36,11 +36,10 @@ namespace ROS2
         void Activate() override;
         void Deactivate() override;
 
-        ////////////////////////////////////////////////////////////////////////
+        // LidarRegistrarRequestBus overrides
         void RegisterLidarSystem(const char* name, const char* description, const LidarSystemFeatures& features) override;
-        const AZStd::vector<AZStd::string> GetRegisteredLidarSystems() override;
-        const LidarSystemMetaData& GetLidarSystemMetaData(const AZStd::string& name) override;
-        ////////////////////////////////////////////////////////////////////////
+        AZStd::vector<AZStd::string> GetRegisteredLidarSystems() const override;
+        const LidarSystemMetaData* GetLidarSystemMetaData(const AZStd::string& name) const override;
 
     private:
         LidarSystem m_physxLidarSystem;

--- a/Gems/ROS2/Code/Source/Lidar/LidarRegistrarSystemComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRegistrarSystemComponent.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "Lidar/LidarSystem.h"
+#include "ROS2/Lidar/LidarRegistrarBus.h"
+#include <AzCore/Component/Component.h>
+
+namespace ROS2
+{
+    //! A Component that manages LidarSystems' registration and storage of their metadata.
+    class LidarRegistrarSystemComponent
+        : public AZ::Component
+        , protected LidarRegistrarRequestBus::Handler
+    {
+    public:
+        AZ_COMPONENT(LidarRegistrarSystemComponent, "{78cba3f1-db2c-46de-9c3d-c40dd72f2f1e}");
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+        LidarRegistrarSystemComponent();
+        virtual ~LidarRegistrarSystemComponent();
+
+    protected:
+        void Init() override;
+        void Activate() override;
+        void Deactivate() override;
+
+        ////////////////////////////////////////////////////////////////////////
+        void RegisterLidarSystem(const char* name, const char* description, const LidarSystemFeatures& features) override;
+        const AZStd::vector<AZStd::string> GetRegisteredLidarSystems() override;
+        const LidarSystemMetaData& GetLidarSystemMetaData(const AZStd::string& name) override;
+        ////////////////////////////////////////////////////////////////////////
+
+    private:
+        LidarSystem m_physxLidarSystem;
+        AZStd::unordered_map<AZ::Crc32, LidarSystemMetaData> m_registeredLidarSystems;
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarSystem.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSystem.cpp
@@ -16,6 +16,12 @@ namespace ROS2
         lidarSystem.BusDisconnect();
     }
 
+    LidarSystem& LidarSystem::operator=(LidarSystem&& lidarSystem)
+    {
+        lidarSystem.BusDisconnect();
+        return lidarSystem;
+    }
+
     void LidarSystem::Activate()
     {
         static constexpr const char* Description = "Collider-based lidar implementation that uses the PhysX engine's raycasting.";

--- a/Gems/ROS2/Code/Source/Lidar/LidarSystem.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSystem.cpp
@@ -41,9 +41,9 @@ namespace ROS2
         }
     }
 
-    LidarRaycasterRequests::LidarId LidarSystem::CreateLidar(AZ::EntityId lidarEntityId)
+    LidarId LidarSystem::CreateLidar(AZ::EntityId lidarEntityId)
     {
-        LidarRaycasterRequests::LidarId lidarId = LidarRaycasterRequests::LidarId::CreateRandom();
+        LidarId lidarId = LidarId::CreateRandom();
         m_lidars.emplace_back(lidarId, lidarEntityId);
         return lidarId;
     }

--- a/Gems/ROS2/Code/Source/Lidar/LidarSystem.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSystem.cpp
@@ -6,6 +6,7 @@
  *
  */
 #include "LidarSystem.h"
+#include "ROS2/Lidar/LidarRegistrarBus.h"
 
 namespace ROS2
 {
@@ -24,14 +25,26 @@ namespace ROS2
         return lidarPhysicsSceneHandle;
     }
 
-    void LidarSystem::Activate(int handlerId)
+    void LidarSystem::Activate()
     {
-        ROS2::LidarSystemRequestBus::Handler::BusConnect(handlerId);
+        const char* name = "PhysX";
+        const char* description = "Collider-based lidar implementation that uses the PhysX engine's raycasting.";
+        const LidarSystemFeatures supportedFeatures = {
+            /* .m_noise =                   */ false,
+            /* .m_collisionLayers =         */ true,
+            /* .m_MaxRangeHitPointConfig =  */ true,
+        };
+
+        LidarSystemRequestBus::Handler::BusConnect(AZ_CRC(name));
+
+        auto* lidarSystemManagerInterface = ROS2::LidarRegistrarInterface::Get();
+        AZ_Assert(lidarSystemManagerInterface != nullptr, "The LidarSystem Manager interface was inaccessible.");
+        lidarSystemManagerInterface->RegisterLidarSystem(name, description, supportedFeatures);
     }
 
     void LidarSystem::Deactivate()
     {
-        ROS2::LidarSystemRequestBus::Handler::BusDisconnect();
+        LidarSystemRequestBus::Handler::BusDisconnect();
     }
 
     AZ::Uuid LidarSystem::CreateLidar(const AZ::EntityId& lidarEntityId)
@@ -40,16 +53,5 @@ namespace ROS2
         m_lidars.emplace_back(lidarUuid);
         m_lidars.back().SetRaycasterScene(GetPhysicsSceneFromEntityId(lidarEntityId));
         return lidarUuid;
-    }
-
-    LidarImplementationFeatures LidarSystem::GetSupportedFeatures()
-    {
-        static LidarImplementationFeatures supportedFeatures = {
-            /* .m_noise =                   */ false,
-            /* .m_collisionLayers =         */ true,
-            /* .m_MaxRangeHitPointConfig =  */ true,
-        };
-
-        return supportedFeatures;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarSystem.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSystem.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include "LidarSystem.h"
+
+namespace ROS2
+{
+    AzPhysics::SceneHandle GetPhysicsSceneFromEntityId(const AZ::EntityId& entityId)
+    {
+        auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
+        auto foundBody = physicsSystem->FindAttachedBodyHandleFromEntityId(entityId);
+        AzPhysics::SceneHandle lidarPhysicsSceneHandle = foundBody.first;
+        if (foundBody.first == AzPhysics::InvalidSceneHandle)
+        {
+            auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+            lidarPhysicsSceneHandle = sceneInterface->GetSceneHandle(AzPhysics::DefaultPhysicsSceneName);
+        }
+
+        AZ_Assert(lidarPhysicsSceneHandle != AzPhysics::InvalidSceneHandle, "Invalid physics scene handle for entity");
+        return lidarPhysicsSceneHandle;
+    }
+
+    void LidarSystem::Activate(int handlerId)
+    {
+        ROS2::LidarSystemRequestBus::Handler::BusConnect(handlerId);
+    }
+
+    void LidarSystem::Deactivate()
+    {
+        ROS2::LidarSystemRequestBus::Handler::BusDisconnect();
+    }
+
+    AZ::Uuid LidarSystem::CreateLidar(const AZ::EntityId& lidarEntityId)
+    {
+        AZ::Uuid lidarUuid = AZ::Uuid::CreateRandom();
+        m_lidars.emplace_back(lidarUuid);
+        m_lidars.back().SetRaycasterScene(GetPhysicsSceneFromEntityId(lidarEntityId));
+        return lidarUuid;
+    }
+
+    LidarImplementationFeatures LidarSystem::GetSupportedFeatures()
+    {
+        static LidarImplementationFeatures supportedFeatures = {
+            /* .m_noise =                   */ false,
+            /* .m_collisionLayers =         */ true,
+            /* .m_MaxRangeHitPointConfig =  */ true,
+        };
+
+        return supportedFeatures;
+    }
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarSystem.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSystem.cpp
@@ -32,6 +32,7 @@ namespace ROS2
         const LidarSystemFeatures supportedFeatures = {
             /* .m_noise =                   */ false,
             /* .m_collisionLayers =         */ true,
+            /* .m_entityExclusion =         */ false,
             /* .m_MaxRangeHitPointConfig =  */ true,
         };
 

--- a/Gems/ROS2/Code/Source/Lidar/LidarSystem.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSystem.cpp
@@ -5,54 +5,46 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include "LidarSystem.h"
-#include "ROS2/Lidar/LidarRegistrarBus.h"
+#include <Lidar/LidarSystem.h>
+#include <ROS2/Lidar/LidarRegistrarBus.h>
 
 namespace ROS2
 {
-    AzPhysics::SceneHandle GetPhysicsSceneFromEntityId(const AZ::EntityId& entityId)
+    LidarSystem::LidarSystem(LidarSystem&& lidarSystem)
+        : m_lidars{ AZStd::move(lidarSystem.m_lidars) }
     {
-        auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
-        auto foundBody = physicsSystem->FindAttachedBodyHandleFromEntityId(entityId);
-        AzPhysics::SceneHandle lidarPhysicsSceneHandle = foundBody.first;
-        if (foundBody.first == AzPhysics::InvalidSceneHandle)
-        {
-            auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-            lidarPhysicsSceneHandle = sceneInterface->GetSceneHandle(AzPhysics::DefaultPhysicsSceneName);
-        }
-
-        AZ_Assert(lidarPhysicsSceneHandle != AzPhysics::InvalidSceneHandle, "Invalid physics scene handle for entity");
-        return lidarPhysicsSceneHandle;
+        lidarSystem.BusDisconnect();
     }
 
     void LidarSystem::Activate()
     {
-        const char* name = "PhysX";
-        const char* description = "Collider-based lidar implementation that uses the PhysX engine's raycasting.";
-        const LidarSystemFeatures supportedFeatures = {
-            /* .m_noise =                   */ false,
-            /* .m_collisionLayers =         */ true,
-            /* .m_entityExclusion =         */ false,
-            /* .m_MaxRangeHitPointConfig =  */ true,
-        };
+        static constexpr const char* Description = "Collider-based lidar implementation that uses the PhysX engine's raycasting.";
+        static constexpr auto SupportedFeatures =
+            aznumeric_cast<LidarSystemFeatures>(LidarSystemFeatures::CollisionLayers | LidarSystemFeatures::MaxRangePoints);
 
-        LidarSystemRequestBus::Handler::BusConnect(AZ_CRC(name));
+        LidarSystemRequestBus::Handler::BusConnect(AZ_CRC(SystemName));
 
-        auto* lidarSystemManagerInterface = ROS2::LidarRegistrarInterface::Get();
-        AZ_Assert(lidarSystemManagerInterface != nullptr, "The LidarSystem Manager interface was inaccessible.");
-        lidarSystemManagerInterface->RegisterLidarSystem(name, description, supportedFeatures);
+        auto* lidarRegistrarInterface = ROS2::LidarRegistrarInterface::Get();
+        AZ_Assert(lidarRegistrarInterface != nullptr, "The Lidar Registrar interface was inaccessible.");
+
+        if (!lidarRegistrarInterface->GetLidarSystemMetaData(SystemName))
+        {
+            lidarRegistrarInterface->RegisterLidarSystem(SystemName, Description, SupportedFeatures);
+        }
     }
 
     void LidarSystem::Deactivate()
     {
-        LidarSystemRequestBus::Handler::BusDisconnect();
+        if (LidarSystemRequestBus::Handler::BusIsConnectedId(AZ_CRC(SystemName)))
+        {
+            LidarSystemRequestBus::Handler::BusDisconnect();
+        }
     }
 
-    AZ::Uuid LidarSystem::CreateLidar(const AZ::EntityId& lidarEntityId)
+    LidarRaycasterRequests::LidarId LidarSystem::CreateLidar(AZ::EntityId lidarEntityId)
     {
-        AZ::Uuid lidarUuid = AZ::Uuid::CreateRandom();
-        m_lidars.emplace_back(lidarUuid);
-        m_lidars.back().SetRaycasterScene(GetPhysicsSceneFromEntityId(lidarEntityId));
-        return lidarUuid;
+        LidarRaycasterRequests::LidarId lidarId = LidarRaycasterRequests::LidarId::CreateRandom();
+        m_lidars.emplace_back(lidarId, lidarEntityId);
+        return lidarId;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
@@ -17,14 +17,18 @@ namespace ROS2
     public:
         LidarSystem() = default;
         LidarSystem(LidarSystem&& lidarSystem);
+        LidarSystem& operator=(LidarSystem&& lidarSystem);
         LidarSystem(const LidarSystem& lidarSystem) = default;
+        LidarSystem& operator=(const LidarSystem& lidarSystem) = default;
+
+
         ~LidarSystem() = default;
 
         void Activate();
         void Deactivate();
 
     private:
-        static constexpr const char* SystemName = "PhysX";
+        static constexpr const char* SystemName = "Scene Queries";
 
         // LidarSystemRequestBus overrides
         LidarId CreateLidar(AZ::EntityId lidarEntityId) override;

--- a/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "LidarRaycaster.h"
+#include "ROS2/Lidar/LidarSystemBus.h"
+
+namespace ROS2
+{
+    class LidarSystem : protected ROS2::LidarSystemRequestBus::Handler
+    {
+    public:
+        LidarSystem() = default;
+        LidarSystem(LidarSystem&& lidarSystem) = delete;
+        LidarSystem(const LidarSystem& lidarSystem) = delete;
+        ~LidarSystem() = default;
+
+        void Activate(int handlerId);
+        void Deactivate();
+
+    protected:
+        ////////////////////////////////////////////////////////////////////////
+        // LidarSystemRequestBus::Handler interface implementation
+        AZ::Uuid CreateLidar(const AZ::EntityId& lidarEntityId) override;
+        LidarImplementationFeatures GetSupportedFeatures() override;
+        ////////////////////////////////////////////////////////////////////////
+    private:
+        AZStd::vector<LidarRaycaster> m_lidars;
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
@@ -27,7 +27,7 @@ namespace ROS2
         static constexpr const char* SystemName = "PhysX";
 
         // LidarSystemRequestBus overrides
-        LidarRaycasterRequests::LidarId CreateLidar(AZ::EntityId lidarEntityId) override;
+        LidarId CreateLidar(AZ::EntityId lidarEntityId) override;
 
         AZStd::vector<LidarRaycaster> m_lidars;
     };

--- a/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
@@ -20,16 +20,15 @@ namespace ROS2
         LidarSystem(const LidarSystem& lidarSystem) = delete;
         ~LidarSystem() = default;
 
-        void Activate(int handlerId);
+        void Activate();
         void Deactivate();
 
-    protected:
+    private:
         ////////////////////////////////////////////////////////////////////////
         // LidarSystemRequestBus::Handler interface implementation
         AZ::Uuid CreateLidar(const AZ::EntityId& lidarEntityId) override;
-        LidarImplementationFeatures GetSupportedFeatures() override;
         ////////////////////////////////////////////////////////////////////////
-    private:
+
         AZStd::vector<LidarRaycaster> m_lidars;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
@@ -7,8 +7,8 @@
  */
 #pragma once
 
-#include "LidarRaycaster.h"
-#include "ROS2/Lidar/LidarSystemBus.h"
+#include <Lidar/LidarRaycaster.h>
+#include <ROS2/Lidar/LidarSystemBus.h>
 
 namespace ROS2
 {
@@ -16,18 +16,18 @@ namespace ROS2
     {
     public:
         LidarSystem() = default;
-        LidarSystem(LidarSystem&& lidarSystem) = delete;
-        LidarSystem(const LidarSystem& lidarSystem) = delete;
+        LidarSystem(LidarSystem&& lidarSystem);
+        LidarSystem(const LidarSystem& lidarSystem) = default;
         ~LidarSystem() = default;
 
         void Activate();
         void Deactivate();
 
     private:
-        ////////////////////////////////////////////////////////////////////////
-        // LidarSystemRequestBus::Handler interface implementation
-        AZ::Uuid CreateLidar(const AZ::EntityId& lidarEntityId) override;
-        ////////////////////////////////////////////////////////////////////////
+        static constexpr const char* SystemName = "PhysX";
+
+        // LidarSystemRequestBus overrides
+        LidarRaycasterRequests::LidarId CreateLidar(AZ::EntityId lidarEntityId) override;
 
         AZStd::vector<LidarRaycaster> m_lidars;
     };

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplate.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplate.cpp
@@ -89,7 +89,7 @@ namespace ROS2
                     ->Attribute(AZ::Edit::Attributes::Min, -180.0f)
                     ->Attribute(AZ::Edit::Attributes::Max, 180.0f)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &LidarTemplate::m_maxRange, "Max range", "Maximum beam range [m]")
-                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.001f)
                     ->Attribute(AZ::Edit::Attributes::Max, 1000.0f)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplate.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplate.cpp
@@ -6,9 +6,7 @@
  *
  */
 
-#include "LidarTemplate.h"
-#include <AzCore/Serialization/EditContext.h>
-#include <AzCore/Serialization/EditContextConstants.inl>
+#include <Lidar/LidarTemplate.h>
 
 namespace ROS2
 {
@@ -22,9 +20,9 @@ namespace ROS2
                 ->Field("Distance noise standard deviation base", &NoiseParameters::m_distanceNoiseStdDevBase)
                 ->Field("Distance noise standard deviation slope", &NoiseParameters::m_distanceNoiseStdDevRisePerMeter);
 
-            if (AZ::EditContext* ec = serializeContext->GetEditContext())
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
-                ec->Class<NoiseParameters>("Noise Parameters", "Noise Parameters")
+                editContext->Class<NoiseParameters>("Noise Parameters", "Noise Parameters")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &NoiseParameters::m_angularNoiseStdDev,

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplate.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplate.cpp
@@ -12,8 +12,45 @@
 
 namespace ROS2
 {
+    void LidarTemplate::NoiseParameters::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<NoiseParameters>()
+                ->Version(1)
+                ->Field("Angular noise standard deviation", &NoiseParameters::m_angularNoiseStdDev)
+                ->Field("Distance noise standard deviation base", &NoiseParameters::m_distanceNoiseStdDevBase)
+                ->Field("Distance noise standard deviation slope", &NoiseParameters::m_distanceNoiseStdDevRisePerMeter);
+
+            if (AZ::EditContext* ec = serializeContext->GetEditContext())
+            {
+                ec->Class<NoiseParameters>("Noise Parameters", "Noise Parameters")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &NoiseParameters::m_angularNoiseStdDev,
+                        "Angular noise std dev [Deg]",
+                        "Angular noise standard deviation")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->Attribute(AZ::Edit::Attributes::Max, 180.0f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &NoiseParameters::m_distanceNoiseStdDevBase,
+                        "Distance noise std dev base [m]",
+                        "Distance noise standard deviation base")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &NoiseParameters::m_distanceNoiseStdDevRisePerMeter,
+                        "Distance noise std dev slope [m]",
+                        "Distance noise standard deviation slope")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f);
+            }
+        }
+    }
+
     void LidarTemplate::Reflect(AZ::ReflectContext* context)
     {
+        NoiseParameters::Reflect(context);
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<LidarTemplate>()
@@ -26,7 +63,7 @@ namespace ROS2
                 ->Field("Min vertical angle", &LidarTemplate::m_minVAngle)
                 ->Field("Max vertical angle", &LidarTemplate::m_maxVAngle)
                 ->Field("Max range", &LidarTemplate::m_maxRange)
-                ->Field("Max range add points", &LidarTemplate::m_addPointsAtMax);
+                ->Field("Noise Parameters", &LidarTemplate::m_noiseParameters);
 
             if (AZ::EditContext* ec = serializeContext->GetEditContext())
             {
@@ -56,9 +93,10 @@ namespace ROS2
                     ->Attribute(AZ::Edit::Attributes::Max, 1000.0f)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &LidarTemplate::m_addPointsAtMax,
-                        "Points at Max",
-                        "If set true LiDAR will produce points at max range for free space");
+                        &LidarTemplate::m_noiseParameters,
+                        "Noise parameters",
+                        "Parameters for Noise Configuration")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &LidarTemplate::m_showNoiseConfig);
             }
         }
     }

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplate.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplate.h
@@ -25,7 +25,26 @@ namespace ROS2
 
         enum class LidarModel
         {
-            Generic3DLidar
+            Custom3DLidar,
+            Ouster_OS0_64,
+            Ouster_OS1_64,
+            Ouster_OS2_64,
+            Velodyne_Puck,
+            Velodyne_HDL_32E,
+        };
+
+        struct NoiseParameters
+        {
+        public:
+            AZ_TYPE_INFO(LidarNoiseParameters, "{58c007ad-320f-49df-bc20-6419159ee176}");
+            static void Reflect(AZ::ReflectContext* context);
+
+            //! Angular noise standard deviation, in degrees
+            float m_angularNoiseStdDev = 0.0f;
+            //! Distance noise standard deviation base value, in meters
+            float m_distanceNoiseStdDevBase = 0.0f;
+            //! Distance noise standard deviation increase per meter distance travelled, in meters
+            float m_distanceNoiseStdDevRisePerMeter = 0.0f;
         };
 
         LidarModel m_model;
@@ -45,7 +64,8 @@ namespace ROS2
         unsigned int m_numberOfIncrements = 0;
         //! Maximum range of simulated LiDAR
         float m_maxRange = 0.0f;
-        //! Adds point with maximum range when ray does not hit obstacle
-        bool m_addPointsAtMax = false;
+
+        NoiseParameters m_noiseParameters;
+        bool m_showNoiseConfig = false;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.cpp
@@ -18,21 +18,128 @@ namespace ROS2
 {
     LidarTemplate LidarTemplateUtils::GetTemplate(LidarTemplate::LidarModel model)
     {
-        static AZStd::unordered_map<LidarTemplate::LidarModel, LidarTemplate> templates;
-
-        if (templates.empty())
-        {
-            LidarTemplate generic3DLidar = { /*.m_model = */ LidarTemplate::LidarModel::Generic3DLidar,
-                                             /*.m_name = */ "GenericLidar",
-                                             /*.m_minHAngle = */ -180.0f,
-                                             /*.m_maxHAngle = */ 180.0f,
-                                             /*.m_minVAngle = */ 35.0f,
-                                             /*.m_maxVAngle = */ -35.0f,
-                                             /*.m_layers = */ 24,
-                                             /*.m_numberOfIncrements = */ 924,
-                                             /*.m_maxRange = */ 100.0f };
-            templates[LidarTemplate::LidarModel::Generic3DLidar] = generic3DLidar;
-        }
+        static std::unordered_map<LidarTemplate::LidarModel, LidarTemplate> templates = {
+            {
+                LidarTemplate::LidarModel::Custom3DLidar,
+                {
+                    /*.m_model = */ LidarTemplate::LidarModel::Custom3DLidar,
+                    /*.m_name = */ "CustomLidar",
+                    /*.m_minHAngle = */ -180.0f,
+                    /*.m_maxHAngle = */ 180.0f,
+                    /*.m_minVAngle = */ -35.0f,
+                    /*.m_maxVAngle = */ 35.0f,
+                    /*.m_layers = */ 24,
+                    /*.m_numberOfIncrements = */ 924,
+                    /*.m_maxRange = */ 100.0f,
+                    /*.m_noiseParameters = */
+                    {
+                        /*.m_angularNoiseStdDev = */ 0.0f,
+                        /*.m_distanceNoiseStdDevBase = */ 0.01f,
+                        /*.m_distanceNoiseStdDevRisePerMeter = */ 0.001f,
+                    },
+                },
+            },
+            {
+                LidarTemplate::LidarModel::Ouster_OS0_64,
+                {
+                    /*.m_model = */ LidarTemplate::LidarModel::Ouster_OS0_64,
+                    /*.m_name = */ "Ouster OS0-64",
+                    /*.m_minHAngle = */ -180.0f,
+                    /*.m_maxHAngle = */ 180.0f,
+                    /*.m_minVAngle = */ -45.0f,
+                    /*.m_maxVAngle = */ 45.0f,
+                    /*.m_layers = */ 64,
+                    /*.m_numberOfIncrements = */ 2048,
+                    /*.m_maxRange = */ 47.5f,
+                    /*.m_noiseParameters = */
+                    {
+                        /*.m_angularNoiseStdDev = */ 0.0f,
+                        /*.m_distanceNoiseStdDevBase = */ 0.0f,
+                        /*.m_distanceNoiseStdDevRisePerMeter = */ 0.002f,
+                    },
+                },
+            },
+            {
+                LidarTemplate::LidarModel::Ouster_OS1_64,
+                {
+                    /*.m_model = */ LidarTemplate::LidarModel::Ouster_OS1_64,
+                    /*.m_name = */ "Ouster OS1-64",
+                    /*.m_minHAngle = */ -180.0f,
+                    /*.m_maxHAngle = */ 180.0f,
+                    /*.m_minVAngle = */ 22.5f,
+                    /*.m_maxVAngle = */ -22.5f,
+                    /*.m_layers = */ 64,
+                    /*.m_numberOfIncrements = */ 2048,
+                    /*.m_maxRange = */ 120.0f,
+                    /*.m_noiseParameters = */
+                    {
+                        /*.m_angularNoiseStdDev = */ 0.0f,
+                        /*.m_distanceNoiseStdDevBase = */ 0.002f,
+                        /*.m_distanceNoiseStdDevRisePerMeter = */ 0.0008f,
+                    },
+                },
+            },
+            {
+                LidarTemplate::LidarModel::Ouster_OS2_64,
+                {
+                    /*.m_model = */ LidarTemplate::LidarModel::Ouster_OS1_64,
+                    /*.m_name = */ "Ouster OS1-64",
+                    /*.m_minHAngle = */ -180.0f,
+                    /*.m_maxHAngle = */ 180.0f,
+                    /*.m_minVAngle = */ 11.25f,
+                    /*.m_maxVAngle = */ -11.25f,
+                    /*.m_layers = */ 64,
+                    /*.m_numberOfIncrements = */ 2048,
+                    /*.m_maxRange = */ 225.0f,
+                    /*.m_noiseParameters = */
+                    {
+                        /*.m_angularNoiseStdDev = */ 0.0f,
+                        /*.m_distanceNoiseStdDevBase = */ 0.006f,
+                        /*.m_distanceNoiseStdDevRisePerMeter = */ 0.001f,
+                    },
+                },
+            },
+            {
+                LidarTemplate::LidarModel::Velodyne_Puck,
+                {
+                    /*.m_model = */ LidarTemplate::LidarModel::Velodyne_Puck,
+                    /*.m_name = */ "Velodyne Puck (VLP-16)",
+                    /*.m_minHAngle = */ -180.0f,
+                    /*.m_maxHAngle = */ 180.0f,
+                    /*.m_minVAngle = */ 15.0f,
+                    /*.m_maxVAngle = */ -15.0f,
+                    /*.m_layers = */ 16,
+                    /*.m_numberOfIncrements = */ 1800, // For 0.2 angular resolution
+                    /*.m_maxRange = */ 100.0f,
+                    /*.m_noiseParameters = */
+                    {
+                        /*.m_angularNoiseStdDev = */ 0.0f,
+                        /*.m_distanceNoiseStdDevBase = */ 0.03f,
+                        /*.m_distanceNoiseStdDevRisePerMeter = */ 0.001f,
+                    },
+                },
+            },
+            {
+                LidarTemplate::LidarModel::Velodyne_HDL_32E,
+                {
+                    /*.m_model = */ LidarTemplate::LidarModel::Velodyne_HDL_32E,
+                    /*.m_name = */ "Velodyne HDL-32E",
+                    /*.m_minHAngle = */ -180.0f,
+                    /*.m_maxHAngle = */ 180.0f,
+                    /*.m_minVAngle = */ 10.67f,
+                    /*.m_maxVAngle = */ -30.67f,
+                    /*.m_layers = */ 32,
+                    /*.m_numberOfIncrements = */ 1800, // For 0.2 angular resolution
+                    /*.m_maxRange = */ 100.0f,
+                    /*.m_noiseParameters = */
+                    {
+                        /*.m_angularNoiseStdDev = */ 0.0f,
+                        /*.m_distanceNoiseStdDevBase = */ 0.02f,
+                        /*.m_distanceNoiseStdDevRisePerMeter = */ 0.001f,
+                    },
+                },
+            },
+        };
 
         auto it = templates.find(model);
         if (it == templates.end())
@@ -48,8 +155,7 @@ namespace ROS2
         return t.m_layers * t.m_numberOfIncrements;
     }
 
-    AZStd::vector<AZ::Vector3> LidarTemplateUtils::PopulateRayDirections(
-        const LidarTemplate& lidarTemplate, const AZ::Vector3& rootRotation)
+    AZStd::vector<AZ::Vector3> LidarTemplateUtils::PopulateRayRotations(const LidarTemplate& lidarTemplate)
     {
         const float minVertAngle = AZ::DegToRad(lidarTemplate.m_minVAngle);
         const float maxVertAngle = AZ::DegToRad(lidarTemplate.m_maxVAngle);
@@ -59,21 +165,36 @@ namespace ROS2
         const float verticalStep = (maxVertAngle - minVertAngle) / static_cast<float>(lidarTemplate.m_layers);
         const float horizontalStep = (maxHorAngle - minHorAngle) / static_cast<float>(lidarTemplate.m_numberOfIncrements);
 
-        AZStd::vector<AZ::Vector3> directions;
-
+        AZStd::vector<AZ::Vector3> rotations;
         for (int incr = 0; incr < lidarTemplate.m_numberOfIncrements; incr++)
         {
             for (int layer = 0; layer < lidarTemplate.m_layers; layer++)
             {
-                const float pitch = minVertAngle + layer * verticalStep + rootRotation.GetY();
-                const float yaw = minHorAngle + incr * horizontalStep + rootRotation.GetZ();
+                const float pitch = minVertAngle + layer * verticalStep;
+                const float yaw = minHorAngle + incr * horizontalStep + (AZ::Constants::Pi / 2.0f);
 
-                const float x = AZ::Cos(yaw) * AZ::Cos(pitch);
-                const float y = AZ::Sin(yaw) * AZ::Cos(pitch);
-                const float z = AZ::Sin(pitch);
-
-                directions.push_back(AZ::Vector3(x, y, z));
+                rotations.emplace_back(AZ::Vector3(0, pitch, yaw));
             }
+        }
+
+        return rotations;
+    }
+
+    AZStd::vector<AZ::Vector3> LidarTemplateUtils::RotationsToDirections(
+        const AZStd::vector<AZ::Vector3>& rotations, const AZ::Vector3& rootRotation)
+    {
+        AZStd::vector<AZ::Vector3> directions;
+        directions.reserve(rotations.size());
+        for (auto angle : rotations)
+        {
+            const float pitchTransformed = angle.GetY() + rootRotation.GetY();
+            const float yawTransformed = angle.GetZ() + rootRotation.GetZ();
+
+            const float x = AZ::Cos(yawTransformed) * AZ::Cos(pitchTransformed);
+            const float y = AZ::Sin(yawTransformed) * AZ::Cos(pitchTransformed);
+            const float z = AZ::Sin(pitchTransformed);
+
+            directions.emplace_back(x, y, z);
         }
 
         return directions;

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.cpp
@@ -179,9 +179,9 @@ namespace ROS2
     {
         AZStd::vector<AZ::Vector3> directions;
         directions.reserve(rotations.size());
-        for (auto angle : rotations)
+        for (const auto& angle : rotations)
         {
-            const AZ::Quaternion rotation = AZ::Quaternion::CreateFromEulerRadiansZYX(
+            const auto rotation = AZ::Quaternion::CreateFromEulerRadiansZYX(
                 { 0.0f, -(angle.GetY() + rootRotation.GetY()), angle.GetZ() + rootRotation.GetZ() });
 
             directions.emplace_back(rotation.TransformVector(AZ::Vector3::CreateAxisX()));

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.h
@@ -7,9 +7,9 @@
  */
 #pragma once
 
-#include "LidarTemplate.h"
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/containers/vector.h>
+#include <Lidar/LidarTemplate.h>
 
 namespace ROS2
 {
@@ -34,8 +34,7 @@ namespace ROS2
         //! Compute ray directions from rotations.
         //! @param rotations Rotations as Euler angles in radians to compute directions from.
         //! @param rootRotation Root rotation as Euler angles in radians.
-        //! @return Ray directions constructed using provided rotations.
-        AZStd::vector<AZ::Vector3> RotationsToDirections(
-            const AZStd::vector<AZ::Vector3>& rotations, const AZ::Vector3& rootRotation);
-    };
+        //! @return Ray directions constructed by transforming an X axis unit vector by the provided rotations.
+        AZStd::vector<AZ::Vector3> RotationsToDirections(const AZStd::vector<AZ::Vector3>& rotations, const AZ::Vector3& rootRotation);
+    }; // namespace LidarTemplateUtils
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.h
@@ -26,10 +26,16 @@ namespace ROS2
         //! @return total count of points that the lidar specified by the template would produce on each scan.
         size_t TotalPointCount(const LidarTemplate& t);
 
-        //! Compute ray directions based on lidar model and rotation.
-        //! @param model Lidar model to use. Note that different models will produce different number of rays.
+        //! Compute ray Rotation angles based on lidar model.
+        //! @param lidarTemplate Lidar model to use. Note that different models will produce different number of rays.
+        //! @return Ray rotations angles as Euler angles in radians.
+        AZStd::vector<AZ::Vector3> PopulateRayRotations(const LidarTemplate& lidarTemplate);
+
+        //! Compute ray directions from rotations.
+        //! @param rotations Rotations as Euler angles in radians to compute directions from.
         //! @param rootRotation Root rotation as Euler angles in radians.
-        //! @return All ray directions which can be used to perform ray-casting simulation of lidar operation.
-        AZStd::vector<AZ::Vector3> PopulateRayDirections(const LidarTemplate& lidarTemplate, const AZ::Vector3& rootRotation);
-    }; // namespace LidarTemplateUtils
+        //! @return Ray directions constructed using provided rotations.
+        AZStd::vector<AZ::Vector3> RotationsToDirections(
+            const AZStd::vector<AZ::Vector3>& rotations, const AZ::Vector3& rootRotation);
+    };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -141,7 +141,7 @@ namespace ROS2
             return;
         }
 
-        m_lidarRaycasterId = LidarRaycasterRequests::LidarId::CreateNull();
+        m_lidarRaycasterId = LidarId::CreateNull();
         LidarSystemRequestBus::EventResult(
             m_lidarRaycasterId, AZ_CRC(m_lidarSystem), &LidarSystemRequestBus::Events::CreateLidar, GetEntityId());
         AZ_Assert(!m_lidarRaycasterId.IsNull(), "Could not access selected Lidar System.");

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -7,14 +7,13 @@
  */
 #pragma once
 
-#include "LidarRaycaster.h"
-#include "LidarTemplate.h"
-#include "LidarTemplateUtils.h"
-#include <ROS2/Lidar/LidarRaycasterBus.h>
-#include <ROS2/Lidar/LidarRegistrarBus.h>
-#include <ROS2/Lidar/LidarSystemBus.h>
 #include <Atom/RPI.Public/AuxGeom/AuxGeomDraw.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <Lidar/LidarRaycaster.h>
+#include <Lidar/LidarTemplate.h>
+#include <Lidar/LidarTemplateUtils.h>
+#include <ROS2/Lidar/LidarRegistrarBus.h>
+#include <ROS2/Lidar/LidarSystemBus.h>
 #include <ROS2/Sensor/ROS2SensorComponent.h>
 #include <rclcpp/publisher.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -44,14 +43,15 @@ namespace ROS2
         void FrequencyTick() override;
         void Visualise() override;
 
-        AZ::Crc32 OnLidarModelSelected();
-        AZ::Crc32 OnLidarImplementationSelected();
-        void FetchLidarImplementationFeatures();
         bool IsConfigurationVisible() const;
         bool IsIgnoredLayerConfigurationVisible() const;
         bool IsEntityExclusionVisible() const;
         bool IsMaxPointsConfigurationVisible() const;
-        AZStd::vector<AZStd::string> GetLidarSystemList();
+
+        AZ::Crc32 OnLidarModelSelected();
+        AZ::Crc32 OnLidarImplementationSelected();
+        void FetchLidarImplementationFeatures();
+        AZStd::vector<AZStd::string> FetchLidarSystemList();
         void ConnectToLidarRaycaster();
         void ConfigureLidarRaycaster();
 
@@ -62,8 +62,8 @@ namespace ROS2
 
         AZStd::string m_lidarSystem;
         // A structure that maps each lidar implementation busId to the busId of a raycaster created by this LidarSensorComponent.
-        AZStd::unordered_map<AZStd::string, AZ::Uuid> m_implementationToRaycasterMap;
-        AZ::Uuid m_lidarRaycasterUuid;
+        AZStd::unordered_map<AZStd::string, LidarRaycasterRequests::LidarId> m_implementationToRaycasterMap;
+        LidarRaycasterRequests::LidarId m_lidarRaycasterId;
         std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointCloudPublisher;
 
         // Used only when visualisation is on - points differ since they are in global transform as opposed to local
@@ -72,7 +72,7 @@ namespace ROS2
 
         AZStd::vector<AZ::Vector3> m_lastScanResults;
 
-        unsigned int m_ignoredLayerIndex = 0;
+        AZ::u32 m_ignoredLayerIndex = 0;
         bool m_ignoreLayer = false;
         AZStd::vector<AZ::EntityId> m_excludedEntities;
 

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -10,6 +10,7 @@
 #include "LidarRaycaster.h"
 #include "LidarTemplate.h"
 #include "LidarTemplateUtils.h"
+#include <ROS2/Lidar/LidarRaycasterBus.h>
 #include <Atom/RPI.Public/AuxGeom/AuxGeomDraw.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <ROS2/Sensor/ROS2SensorComponent.h>
@@ -40,15 +41,25 @@ namespace ROS2
         // ROS2SensorComponent overrides
         void FrequencyTick() override;
         void Visualise() override;
-        //////////////////////////////////////////////////////////////////////////
-        void SetPhysicsScene();
 
         AZ::Crc32 OnLidarModelSelected();
+        AZ::Crc32 OnLidarImplementationSelected();
+        void FetchLidarImplementationFeatures();
         bool IsConfigurationVisible() const;
+        bool IsIgnoredLayerConfigurationVisible() const;
+        bool IsMaxPointsConfigurationVisible() const;
+        AZStd::vector<AZStd::pair<int, AZStd::string>> GetRegisteredLidarSystems();
+        void ConnectToLidarRaycaster();
+        void ConfigureLidarRaycaster();
 
-        LidarTemplate::LidarModel m_lidarModel = LidarTemplate::LidarModel::Generic3DLidar;
-        LidarTemplate m_lidarParameters = LidarTemplateUtils::GetTemplate(LidarTemplate::LidarModel::Generic3DLidar);
-        LidarRaycaster m_lidarRaycaster;
+        LidarImplementationFeatures m_lidarImplementationFeatures;
+        LidarTemplate::LidarModel m_lidarModel = LidarTemplate::LidarModel::Custom3DLidar;
+        LidarTemplate m_lidarParameters = LidarTemplateUtils::GetTemplate(LidarTemplate::LidarModel::Custom3DLidar);
+        AZStd::vector<AZ::Vector3> m_lastRotations;
+
+        int m_lidarSystemId;
+        AZStd::unordered_map<int, AZ::Uuid> m_lidarRaycasterIds;
+        AZ::Uuid m_lidarRaycasterUuid;
         std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointCloudPublisher;
 
         // Used only when visualisation is on - points differ since they are in global transform as opposed to local
@@ -59,5 +70,6 @@ namespace ROS2
 
         unsigned int m_ignoredLayerIndex = 0;
         bool m_ignoreLayer = false;
+        bool m_addPointsAtMax = false;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -62,8 +62,8 @@ namespace ROS2
 
         AZStd::string m_lidarSystem;
         // A structure that maps each lidar implementation busId to the busId of a raycaster created by this LidarSensorComponent.
-        AZStd::unordered_map<AZStd::string, LidarRaycasterRequests::LidarId> m_implementationToRaycasterMap;
-        LidarRaycasterRequests::LidarId m_lidarRaycasterId;
+        AZStd::unordered_map<AZStd::string, LidarId> m_implementationToRaycasterMap;
+        LidarId m_lidarRaycasterId;
         std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointCloudPublisher;
 
         // Used only when visualisation is on - points differ since they are in global transform as opposed to local

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -11,6 +11,8 @@
 #include "LidarTemplate.h"
 #include "LidarTemplateUtils.h"
 #include <ROS2/Lidar/LidarRaycasterBus.h>
+#include <ROS2/Lidar/LidarRegistrarBus.h>
+#include <ROS2/Lidar/LidarSystemBus.h>
 #include <Atom/RPI.Public/AuxGeom/AuxGeomDraw.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <ROS2/Sensor/ROS2SensorComponent.h>
@@ -48,17 +50,18 @@ namespace ROS2
         bool IsConfigurationVisible() const;
         bool IsIgnoredLayerConfigurationVisible() const;
         bool IsMaxPointsConfigurationVisible() const;
-        AZStd::vector<AZStd::pair<int, AZStd::string>> GetRegisteredLidarSystems();
+        AZStd::vector<AZStd::string> GetLidarSystemList();
         void ConnectToLidarRaycaster();
         void ConfigureLidarRaycaster();
 
-        LidarImplementationFeatures m_lidarImplementationFeatures;
+        LidarSystemFeatures m_lidarSystemFeatures;
         LidarTemplate::LidarModel m_lidarModel = LidarTemplate::LidarModel::Custom3DLidar;
         LidarTemplate m_lidarParameters = LidarTemplateUtils::GetTemplate(LidarTemplate::LidarModel::Custom3DLidar);
         AZStd::vector<AZ::Vector3> m_lastRotations;
 
-        int m_lidarSystemId;
-        AZStd::unordered_map<int, AZ::Uuid> m_lidarRaycasterIds;
+        AZStd::string m_lidarSystem;
+        // A structure that maps each lidar implementation busId to the busId of a raycaster created by this LidarSensorComponent.
+        AZStd::unordered_map<AZStd::string, AZ::Uuid> m_implementationToRaycasterMap;
         AZ::Uuid m_lidarRaycasterUuid;
         std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointCloudPublisher;
 

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -49,6 +49,7 @@ namespace ROS2
         void FetchLidarImplementationFeatures();
         bool IsConfigurationVisible() const;
         bool IsIgnoredLayerConfigurationVisible() const;
+        bool IsEntityExclusionVisible() const;
         bool IsMaxPointsConfigurationVisible() const;
         AZStd::vector<AZStd::string> GetLidarSystemList();
         void ConnectToLidarRaycaster();
@@ -73,6 +74,8 @@ namespace ROS2
 
         unsigned int m_ignoredLayerIndex = 0;
         bool m_ignoreLayer = false;
+        AZStd::vector<AZ::EntityId> m_excludedEntities;
+
         bool m_addPointsAtMax = false;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/ROS2EditorModule.cpp
+++ b/Gems/ROS2/Code/Source/ROS2EditorModule.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <Lidar/LidarRegistrarEditorSystemComponent.h>
 #include <ROS2EditorSystemComponent.h>
 #include <ROS2ModuleInterface.h>
 #include <RobotImporter/ROS2RobotImporterEditorSystemComponent.h>
@@ -25,7 +26,11 @@ namespace ROS2
             // EditContext. This happens through the [MyComponent]::Reflect() function.
             m_descriptors.insert(
                 m_descriptors.end(),
-                { ROS2EditorSystemComponent::CreateDescriptor(), ROS2RobotImporterEditorSystemComponent::CreateDescriptor() });
+                {
+                    ROS2EditorSystemComponent::CreateDescriptor(),
+                    LidarRegistrarEditorSystemComponent::CreateDescriptor(),
+                    ROS2RobotImporterEditorSystemComponent::CreateDescriptor(),
+                });
         }
 
         /**
@@ -36,6 +41,7 @@ namespace ROS2
         {
             return AZ::ComponentTypeList{
                 azrtti_typeid<ROS2EditorSystemComponent>(),
+                azrtti_typeid<LidarRegistrarEditorSystemComponent>(),
                 azrtti_typeid<ROS2RobotImporterEditorSystemComponent>(),
             };
         }

--- a/Gems/ROS2/Code/Source/ROS2ModuleInterface.h
+++ b/Gems/ROS2/Code/Source/ROS2ModuleInterface.h
@@ -7,13 +7,13 @@
  */
 #pragma once
 
-#include "Lidar/LidarRegistrarSystemComponent.h"
 #include "ROS2SystemComponent.h"
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
 #include <Camera/ROS2CameraSensorComponent.h>
 #include <GNSS/ROS2GNSSSensorComponent.h>
 #include <Imu/ROS2ImuSensorComponent.h>
+#include <Lidar/LidarRegistrarSystemComponent.h>
 #include <Lidar/ROS2LidarSensorComponent.h>
 #include <Odometry/ROS2OdometrySensorComponent.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>

--- a/Gems/ROS2/Code/Source/ROS2ModuleInterface.h
+++ b/Gems/ROS2/Code/Source/ROS2ModuleInterface.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "Lidar/LidarRegistrarSystemComponent.h"
 #include "ROS2SystemComponent.h"
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
@@ -47,6 +48,7 @@ namespace ROS2
             m_descriptors.insert(
                 m_descriptors.end(),
                 { ROS2SystemComponent::CreateDescriptor(),
+                  LidarRegistrarSystemComponent::CreateDescriptor(),
                   ROS2RobotImporterSystemComponent::CreateDescriptor(),
                   ROS2SensorComponent::CreateDescriptor(),
                   ROS2ImuSensorComponent::CreateDescriptor(),
@@ -71,7 +73,11 @@ namespace ROS2
         //! Add required SystemComponents to the SystemEntity.
         AZ::ComponentTypeList GetRequiredSystemComponents() const override
         {
-            return AZ::ComponentTypeList{ azrtti_typeid<ROS2SystemComponent>(), azrtti_typeid<ROS2RobotImporterSystemComponent>() };
+            return AZ::ComponentTypeList{
+                azrtti_typeid<ROS2SystemComponent>(),
+                azrtti_typeid<LidarRegistrarSystemComponent>(),
+                azrtti_typeid<ROS2RobotImporterSystemComponent>(),
+            };
         }
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/ROS2SystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/ROS2SystemComponent.cpp
@@ -104,6 +104,8 @@ namespace ROS2
 
         ROS2RequestBus::Handler::BusConnect();
         AZ::TickBus::Handler::BusConnect();
+
+        m_lidarSystem.Activate(RegisterLidarSystem("PhysX"));
     }
 
     void ROS2SystemComponent::Deactivate()
@@ -113,6 +115,27 @@ namespace ROS2
         m_loadTemplatesHandler.Disconnect();
         m_dynamicTFBroadcaster.reset();
         m_staticTFBroadcaster.reset();
+    }
+
+    int ROS2SystemComponent::RegisterLidarSystem(const char* raycasterName)
+    {
+        m_raycasters.emplace_back(raycasterName);
+        return static_cast<int>(m_raycasters.size()) - 1;
+    }
+
+    AZStd::vector<AZStd::pair<int, AZStd::string>> ROS2SystemComponent::GetRegisteredLidarSystems()
+    {
+        AZStd::vector<AZStd::pair<int, AZStd::string>> registeredLidarSystems;
+        registeredLidarSystems.reserve(m_raycasters.size());
+        for (int lidarSystemIndex = 0; lidarSystemIndex != static_cast<int>(m_raycasters.size()); ++lidarSystemIndex)
+        {
+            registeredLidarSystems.push_back({
+                lidarSystemIndex,
+                m_raycasters[lidarSystemIndex],
+            });
+        }
+
+        return registeredLidarSystems;
     }
 
     builtin_interfaces::msg::Time ROS2SystemComponent::GetROSTimestamp() const

--- a/Gems/ROS2/Code/Source/ROS2SystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/ROS2SystemComponent.cpp
@@ -104,8 +104,6 @@ namespace ROS2
 
         ROS2RequestBus::Handler::BusConnect();
         AZ::TickBus::Handler::BusConnect();
-
-        m_lidarSystem.Activate(RegisterLidarSystem("PhysX"));
     }
 
     void ROS2SystemComponent::Deactivate()
@@ -115,27 +113,6 @@ namespace ROS2
         m_loadTemplatesHandler.Disconnect();
         m_dynamicTFBroadcaster.reset();
         m_staticTFBroadcaster.reset();
-    }
-
-    int ROS2SystemComponent::RegisterLidarSystem(const char* raycasterName)
-    {
-        m_raycasters.emplace_back(raycasterName);
-        return static_cast<int>(m_raycasters.size()) - 1;
-    }
-
-    AZStd::vector<AZStd::pair<int, AZStd::string>> ROS2SystemComponent::GetRegisteredLidarSystems()
-    {
-        AZStd::vector<AZStd::pair<int, AZStd::string>> registeredLidarSystems;
-        registeredLidarSystems.reserve(m_raycasters.size());
-        for (int lidarSystemIndex = 0; lidarSystemIndex != static_cast<int>(m_raycasters.size()); ++lidarSystemIndex)
-        {
-            registeredLidarSystems.push_back({
-                lidarSystemIndex,
-                m_raycasters[lidarSystemIndex],
-            });
-        }
-
-        return registeredLidarSystems;
     }
 
     builtin_interfaces::msg::Time ROS2SystemComponent::GetROSTimestamp() const

--- a/Gems/ROS2/Code/Source/ROS2SystemComponent.h
+++ b/Gems/ROS2/Code/Source/ROS2SystemComponent.h
@@ -7,7 +7,7 @@
  */
 #pragma once
 
-#include "Lidar/LidarSystem.h"
+#include <Lidar/LidarSystem.h>
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
@@ -25,8 +25,8 @@ namespace ROS2
     //! Central singleton-like System Component for ROS2 Gem.
     class ROS2SystemComponent
         : public AZ::Component
-        , protected ROS2RequestBus::Handler
         , public AZ::TickBus::Handler
+        , protected ROS2RequestBus::Handler
     {
     public:
         AZ_COMPONENT(ROS2SystemComponent, "{cb28d486-afa4-4a9f-a237-ac5eb42e1c87}");
@@ -48,10 +48,6 @@ namespace ROS2
         void BroadcastTransform(const geometry_msgs::msg::TransformStamped& t, bool isDynamic) const override;
         //////////////////////////////////////////////////////////////////////////
 
-        int RegisterLidarSystem(const char* raycasterName) override;
-
-        AZStd::vector<AZStd::pair<int, AZStd::string>> GetRegisteredLidarSystems() override;
-
     protected:
         ////////////////////////////////////////////////////////////////////////
         // AZ::Component interface implementation
@@ -64,10 +60,7 @@ namespace ROS2
         // AZTickBus interface implementation
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
         ////////////////////////////////////////////////////////////////////////
-
     private:
-        LidarSystem m_lidarSystem;
-        AZStd::vector<AZStd::string> m_raycasters;
         std::shared_ptr<rclcpp::Node> m_ros2Node;
         AZStd::shared_ptr<rclcpp::executors::SingleThreadedExecutor> m_executor;
         AZStd::unique_ptr<tf2_ros::TransformBroadcaster> m_dynamicTFBroadcaster;

--- a/Gems/ROS2/Code/Source/ROS2SystemComponent.h
+++ b/Gems/ROS2/Code/Source/ROS2SystemComponent.h
@@ -7,12 +7,12 @@
  */
 #pragma once
 
-#include <Lidar/LidarSystem.h>
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <Clock/SimulationClock.h>
+#include <Lidar/LidarSystem.h>
 #include <ROS2/ROS2Bus.h>
 #include <builtin_interfaces/msg/time.hpp>
 #include <memory>

--- a/Gems/ROS2/Code/Source/ROS2SystemComponent.h
+++ b/Gems/ROS2/Code/Source/ROS2SystemComponent.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "Lidar/LidarSystem.h"
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
@@ -38,7 +39,7 @@ namespace ROS2
         static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
 
         ROS2SystemComponent();
-        ~ROS2SystemComponent();
+        ~ROS2SystemComponent() override;
 
         //////////////////////////////////////////////////////////////////////////
         // ROS2RequestBus::Handler overrides
@@ -46,6 +47,10 @@ namespace ROS2
         builtin_interfaces::msg::Time GetROSTimestamp() const override;
         void BroadcastTransform(const geometry_msgs::msg::TransformStamped& t, bool isDynamic) const override;
         //////////////////////////////////////////////////////////////////////////
+
+        int RegisterLidarSystem(const char* raycasterName) override;
+
+        AZStd::vector<AZStd::pair<int, AZStd::string>> GetRegisteredLidarSystems() override;
 
     protected:
         ////////////////////////////////////////////////////////////////////////
@@ -61,6 +66,8 @@ namespace ROS2
         ////////////////////////////////////////////////////////////////////////
 
     private:
+        LidarSystem m_lidarSystem;
+        AZStd::vector<AZStd::string> m_raycasters;
         std::shared_ptr<rclcpp::Node> m_ros2Node;
         AZStd::shared_ptr<rclcpp::executors::SingleThreadedExecutor> m_executor;
         AZStd::unique_ptr<tf2_ros::TransformBroadcaster> m_dynamicTFBroadcaster;

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -6,6 +6,8 @@
 set(FILES
     ../Assets/Editor/Images/Icons/Resources.qrc
     ../Assets/Editor/Images/Icons/ROS_import_icon.svg
+    Source/Lidar/LidarRegistrarEditorSystemComponent.cpp
+    Source/Lidar/LidarRegistrarEditorSystemComponent.h
     Source/RobotImporter/Pages/CheckAssetPage.cpp
     Source/RobotImporter/Pages/CheckAssetPage.h
     Source/RobotImporter/Pages/CheckUrdfPage.cpp

--- a/Gems/ROS2/Code/ros2_files.cmake
+++ b/Gems/ROS2/Code/ros2_files.cmake
@@ -28,6 +28,8 @@ set(FILES
         Source/Imu/ROS2ImuSensorComponent.h
         Source/Lidar/LidarRaycaster.cpp
         Source/Lidar/LidarRaycaster.h
+        Source/Lidar/LidarSystem.cpp
+        Source/Lidar/LidarSystem.h
         Source/Lidar/LidarTemplate.cpp
         Source/Lidar/LidarTemplate.h
         Source/Lidar/LidarTemplateUtils.cpp

--- a/Gems/ROS2/Code/ros2_files.cmake
+++ b/Gems/ROS2/Code/ros2_files.cmake
@@ -30,6 +30,8 @@ set(FILES
         Source/Lidar/LidarRaycaster.h
         Source/Lidar/LidarSystem.cpp
         Source/Lidar/LidarSystem.h
+        Source/Lidar/LidarRegistrarSystemComponent.cpp
+        Source/Lidar/LidarRegistrarSystemComponent.h
         Source/Lidar/LidarTemplate.cpp
         Source/Lidar/LidarTemplate.h
         Source/Lidar/LidarTemplateUtils.cpp

--- a/Gems/ROS2/Code/ros2_files.cmake
+++ b/Gems/ROS2/Code/ros2_files.cmake
@@ -28,10 +28,10 @@ set(FILES
         Source/Imu/ROS2ImuSensorComponent.h
         Source/Lidar/LidarRaycaster.cpp
         Source/Lidar/LidarRaycaster.h
-        Source/Lidar/LidarSystem.cpp
-        Source/Lidar/LidarSystem.h
         Source/Lidar/LidarRegistrarSystemComponent.cpp
         Source/Lidar/LidarRegistrarSystemComponent.h
+        Source/Lidar/LidarSystem.cpp
+        Source/Lidar/LidarSystem.h
         Source/Lidar/LidarTemplate.cpp
         Source/Lidar/LidarTemplate.h
         Source/Lidar/LidarTemplateUtils.cpp

--- a/Gems/ROS2/Code/ros2_header_files.cmake
+++ b/Gems/ROS2/Code/ros2_header_files.cmake
@@ -13,6 +13,7 @@ set(FILES
         Include/ROS2/RobotControl/ControlSubscriptionHandler.h
         Include/ROS2/Lidar/LidarRaycasterBus.h
         Include/ROS2/Lidar/LidarSystemBus.h
+        Include/ROS2/Lidar/LidarRegistrarBus.h
         Include/ROS2/ROS2Bus.h
         Include/ROS2/ROS2GemUtilities.h
         Include/ROS2/Sensor/ROS2SensorComponent.h

--- a/Gems/ROS2/Code/ros2_header_files.cmake
+++ b/Gems/ROS2/Code/ros2_header_files.cmake
@@ -11,6 +11,8 @@ set(FILES
         Include/ROS2/Manipulator/MotorizedJointComponent.h
         Include/ROS2/RobotControl/ControlConfiguration.h
         Include/ROS2/RobotControl/ControlSubscriptionHandler.h
+        Include/ROS2/Lidar/LidarRaycasterBus.h
+        Include/ROS2/Lidar/LidarSystemBus.h
         Include/ROS2/ROS2Bus.h
         Include/ROS2/ROS2GemUtilities.h
         Include/ROS2/Sensor/ROS2SensorComponent.h


### PR DESCRIPTION
This pull request introduces lidar implementation modularity by allowing for multiple LiDAR implementations to be added and used by the ROS2LidarSensor. This can be done by implementing the Lidar System and Raycaster interfaces either in the form of a new Gem or within the ROS Gem.  

Only manual tests of the new Lidar functionalities have been done.