### PR TITLE
Split ROS2CameraSensorComponent to Game and Editor component.

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -113,7 +113,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
         FILES_CMAKE
-            ros2_editor_files.cmake
             ros2_editor_shared_files.cmake
         PLATFORM_INCLUDE_FILES
             ${CMAKE_CURRENT_LIST_DIR}/Platform/Common/${PAL_TRAIT_COMPILER_ID}/ros2_static_editor_${PAL_TRAIT_COMPILER_ID_LOWERCASE}.cmake

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
@@ -28,7 +28,7 @@ namespace ROS2
         int height,
         bool colorCamera,
         bool depthCamera)
-        : m_VerticalFieldOfViewDeg(verticalFieldOfViewDeg)
+        : m_verticalFieldOfViewDeg(verticalFieldOfViewDeg)
         , m_width(width)
         , m_height(height)
         , m_colorCamera(colorCamera)
@@ -44,7 +44,7 @@ namespace ROS2
         {
             serialize->Class<ROS2CameraSensorComponent, ROS2SensorComponent>()
                 ->Version(3)
-                ->Field("VerticalFieldOfViewDeg", &ROS2CameraSensorComponent::m_VerticalFieldOfViewDeg)
+                ->Field("VerticalFieldOfViewDeg", &ROS2CameraSensorComponent::m_verticalFieldOfViewDeg)
                 ->Field("Width", &ROS2CameraSensorComponent::m_width)
                 ->Field("Height", &ROS2CameraSensorComponent::m_height)
                 ->Field("Depth", &ROS2CameraSensorComponent::m_depthCamera)
@@ -66,7 +66,7 @@ namespace ROS2
             ros2Node->create_publisher<sensor_msgs::msg::CameraInfo>(cameraInfoFullTopic.data(), cameraInfoPublisherConfig.GetQoS());
 
         const CameraSensorDescription description{
-            GetCameraNameFromFrame(GetEntity()), m_VerticalFieldOfViewDeg, m_width, m_height
+            GetCameraNameFromFrame(GetEntity()), m_verticalFieldOfViewDeg, m_width, m_height
         };
         if (m_colorCamera)
         {

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
@@ -127,8 +127,14 @@ namespace ROS2
     AZStd::string ROS2CameraSensorComponent::GetCameraNameFromFrame(const AZ::Entity* entity) const
     {
         const auto* component = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(entity);
-        AZStd::string cameraName = component->GetFrameID();
-        AZStd::replace(cameraName.begin(), cameraName.end(), '/', '_');
-        return cameraName;
+        AZ_Assert(component, "Entity %s has no ROS2CameraSensorComponent", entity->GetName().c_str());
+        if (component)
+        {
+            AZStd::string cameraName = component->GetFrameID();
+            AZStd::replace(cameraName.begin(), cameraName.end(), '/', '_');
+            return cameraName;
+        }
+        return AZStd::string{};
+
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.h
@@ -22,6 +22,15 @@
 
 namespace ROS2
 {
+    namespace CameraConstants
+    {
+        const char* const ImageMessageType = "sensor_msgs::msg::Image";
+        const char* const DepthImageConfig = "Depth Image";
+        const char* const ColorImageConfig = "Color Image";
+        const char* const InfoConfig = "Camera Info";
+        const char* const CameraInfoMessageType = "sensor_msgs::msg::CameraInfo";
+    } // namespace CameraConstants
+
     //! ROS2 Camera sensor component class
     //! Allows turning an entity into a camera sensor
     //! Can be parametrized with following values:
@@ -32,7 +41,16 @@ namespace ROS2
     class ROS2CameraSensorComponent : public ROS2SensorComponent
     {
     public:
-        ROS2CameraSensorComponent();
+        ROS2CameraSensorComponent() = default;
+
+        ROS2CameraSensorComponent(
+            const SensorConfiguration& sensorConfiguration,
+            float verticalFieldOfViewDeg,
+            int width,
+            int height,
+            bool colorCamera,
+            bool depthCamera);
+
         ~ROS2CameraSensorComponent() override = default;
         AZ_COMPONENT(ROS2CameraSensorComponent, "{3C6B8AE6-9721-4639-B8F9-D8D28FD7A071}", ROS2SensorComponent);
         static void Reflect(AZ::ReflectContext* context);
@@ -50,7 +68,7 @@ namespace ROS2
         //! Type that combines pointer to ROS2 publisher and CameraSensor
         using PublisherSensorPtrPair = AZStd::pair<ImagePublisherPtrType, AZStd::shared_ptr<CameraSensor>>;
 
-        //! Helper to construct a PublisherSensorPtrPair with a pointer to ROS2 publisher and intrinsic calibration
+        //! Helper to construct a PublisherSensorPtrPair with a pointer to ROS2 publisher and intrinsic calibration.
         //! @tparam CameraType type of camera sensor (eg 'CameraColorSensor')
         //! @param publisher pointer to ROS2 image publisher
         //! @param description CameraSensorDescription with intrinsic calibration
@@ -60,6 +78,11 @@ namespace ROS2
         {
             return { publisher, AZStd::make_shared<CameraType>(description) };
         }
+
+        //! Retrieve camera name from ROS2FrameComponent's FrameID.
+        //! @param entity pointer entity that has ROS2FrameComponent
+        //! @returns FrameID from ROS2FrameComponent
+        AZStd::string GetCameraNameFromFrame(const AZ::Entity* entity) const;
 
         float m_VerticalFieldOfViewDeg = 90.0f;
         int m_width = 640;

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.h
@@ -84,7 +84,7 @@ namespace ROS2
         //! @returns FrameID from ROS2FrameComponent
         AZStd::string GetCameraNameFromFrame(const AZ::Entity* entity) const;
 
-        float m_VerticalFieldOfViewDeg = 90.0f;
+        float m_verticalFieldOfViewDeg = 90.0f;
         int m_width = 640;
         int m_height = 480;
         bool m_colorCamera = true;

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.h
@@ -24,11 +24,11 @@ namespace ROS2
 {
     namespace CameraConstants
     {
-        const char* const ImageMessageType = "sensor_msgs::msg::Image";
-        const char* const DepthImageConfig = "Depth Image";
-        const char* const ColorImageConfig = "Color Image";
-        const char* const InfoConfig = "Camera Info";
-        const char* const CameraInfoMessageType = "sensor_msgs::msg::CameraInfo";
+        inline constexpr char ImageMessageType[] = "sensor_msgs::msg::Image";
+        inline constexpr char DepthImageConfig[] = "Depth Image";
+        inline constexpr char ColorImageConfig[] = "Color Image";
+        inline constexpr char InfoConfig[] = "Camera Info";
+        inline constexpr char CameraInfoMessageType[] = "sensor_msgs::msg::CameraInfo";
     } // namespace CameraConstants
 
     //! ROS2 Camera sensor component class

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ROS2CameraSensorEditorComponent.h"
+#include "ROS2CameraSensorComponent.h"
+#include <AzCore/Component/TransformBus.h>
+#include <ROS2/Frame/ROS2FrameComponent.h>
+namespace ROS2
+{
+    ROS2CameraSensorEditorComponent::ROS2CameraSensorEditorComponent()
+    {
+        m_sensorConfiguration.m_frequency = 10;
+        m_sensorConfiguration.m_publishersConfigurations.insert(
+            MakeTopicConfigurationPair("camera_image_color", CameraConstants::ImageMessageType, CameraConstants::ColorImageConfig));
+        m_sensorConfiguration.m_publishersConfigurations.insert(
+            MakeTopicConfigurationPair("camera_image_depth", CameraConstants::ImageMessageType, CameraConstants::DepthImageConfig));
+        m_sensorConfiguration.m_publishersConfigurations.insert(
+            MakeTopicConfigurationPair("camera_info", CameraConstants::CameraInfoMessageType, CameraConstants::InfoConfig));
+    }
+
+    void ROS2CameraSensorEditorComponent::Reflect(AZ::ReflectContext* context)
+    {
+        auto* serialize = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serialize)
+        {
+            serialize->Class<ROS2CameraSensorEditorComponent, AzToolsFramework::Components::EditorComponentBase>()
+                ->Version(4)
+                ->Field("VerticalFieldOfViewDeg", &ROS2CameraSensorEditorComponent::m_VerticalFieldOfViewDeg)
+                ->Field("Width", &ROS2CameraSensorEditorComponent::m_width)
+                ->Field("Height", &ROS2CameraSensorEditorComponent::m_height)
+                ->Field("Depth", &ROS2CameraSensorEditorComponent::m_depthCamera)
+                ->Field("Color", &ROS2CameraSensorEditorComponent::m_colorCamera)
+                ->Field("SensorConfig", &ROS2CameraSensorEditorComponent::m_sensorConfiguration);
+
+            AZ::EditContext* ec = serialize->GetEditContext();
+            if (ec)
+            {
+                ec->Class<ROS2CameraSensorEditorComponent>("ROS2 Camera Sensor", "[Camera component]")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2CameraSensorEditorComponent::m_sensorConfiguration,
+                        "Sensor configuration",
+                        "Sensor configuration")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2CameraSensorEditorComponent::m_VerticalFieldOfViewDeg,
+                        "Vertical field of view",
+                        "Camera's vertical (y axis) field of view in degrees.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2CameraSensorEditorComponent::m_width, "Image width", "Image width")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2CameraSensorEditorComponent::m_height, "Image height", "Image height")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &ROS2CameraSensorEditorComponent::m_colorCamera, "Color Camera", "Color Camera")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &ROS2CameraSensorEditorComponent::m_depthCamera, "Depth Camera", "Depth Camera");
+            }
+        }
+    }
+
+    void ROS2CameraSensorEditorComponent::Activate()
+    {
+        AzFramework::EntityDebugDisplayEventBus::Handler::BusConnect(this->GetEntityId());
+        AzToolsFramework::Components::EditorComponentBase::Activate();
+    }
+
+    void ROS2CameraSensorEditorComponent::Deactivate()
+    {
+        AzFramework::EntityDebugDisplayEventBus::Handler::BusDisconnect();
+        AzToolsFramework::Components::EditorComponentBase::Deactivate();
+    }
+
+    void ROS2CameraSensorEditorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC("ROS2Frame"));
+    }
+
+    void ROS2CameraSensorEditorComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("ROS2SensorCamera"));
+    }
+
+    void ROS2CameraSensorEditorComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC_CE("ROS2SensorCamera"));
+    }
+
+    void ROS2CameraSensorEditorComponent::BuildGameEntity(AZ::Entity* gameEntity)
+    {
+        gameEntity->CreateComponent<ROS2::ROS2CameraSensorComponent>(
+            m_sensorConfiguration, m_VerticalFieldOfViewDeg, m_width, m_height, m_colorCamera, m_depthCamera);
+    }
+
+    void ROS2CameraSensorEditorComponent::DisplayEntityViewport(
+        const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay)
+    {
+        if (!m_sensorConfiguration.m_visualise)
+        {
+            return;
+        }
+        AZ_UNUSED(viewportInfo);
+        const AZ::u32 stateBefore = debugDisplay.GetState();
+        AZ::Transform transform = GetEntity()->GetTransform()->GetWorldTM();
+
+        // dimension of drawing
+        const float arrowRise = 1.1f;
+        const float arrowSize = 0.5f;
+        const float frustumScale = 0.1f;
+
+        transform.SetUniformScale(frustumScale);
+        debugDisplay.DepthTestOff();
+        const float ver = 0.5f * AZStd::tan((AZ::DegToRad(m_VerticalFieldOfViewDeg * 0.5f)));
+        const float hor = m_height * ver / m_width;
+
+        // frustum drawing
+        const AZ::Vector3 p1(-ver, -hor, 1.f);
+        const AZ::Vector3 p2(ver, -hor, 1.f);
+        const AZ::Vector3 p3(ver, hor, 1.f);
+        const AZ::Vector3 p4(-ver, hor, 1.f);
+        const AZ::Vector3 p0(0, 0, 0);
+        const AZ::Vector3 py(0.1, 0, 0);
+
+        const auto pt1 = transform.TransformPoint(p1);
+        const auto pt2 = transform.TransformPoint(p2);
+        const auto pt3 = transform.TransformPoint(p3);
+        const auto pt4 = transform.TransformPoint(p4);
+        const auto pt0 = transform.TransformPoint(p0);
+        const auto ptz = transform.TransformPoint(AZ::Vector3::CreateAxisZ(0.2f));
+        const auto pty = transform.TransformPoint(AZ::Vector3::CreateAxisY(0.2f));
+        const auto ptx = transform.TransformPoint(AZ::Vector3::CreateAxisX(0.2f));
+
+        debugDisplay.SetColor(AZ::Color(0.f, 1.f, 1.f, 1.f));
+        debugDisplay.SetLineWidth(1);
+        debugDisplay.DrawLine(pt1, pt2);
+        debugDisplay.DrawLine(pt2, pt3);
+        debugDisplay.DrawLine(pt3, pt4);
+        debugDisplay.DrawLine(pt4, pt1);
+        debugDisplay.DrawLine(pt1, pt0);
+        debugDisplay.DrawLine(pt2, pt0);
+        debugDisplay.DrawLine(pt3, pt0);
+        debugDisplay.DrawLine(pt4, pt0);
+
+        // up-arrow drawing
+        const AZ::Vector3 pa1(-arrowSize * ver, -arrowRise * hor, 1.f);
+        const AZ::Vector3 pa2(arrowSize * ver, -arrowRise * hor, 1.f);
+        const AZ::Vector3 pa3(0, (-arrowRise - arrowSize) * hor, 1.f);
+        const auto pat1 = transform.TransformPoint(pa1);
+        const auto pat2 = transform.TransformPoint(pa2);
+        const auto pat3 = transform.TransformPoint(pa3);
+
+        debugDisplay.SetColor(AZ::Color(0.f, 0.6f, 1.f, 1.f));
+        debugDisplay.SetLineWidth(1);
+        debugDisplay.DrawLine(pat1, pat2);
+        debugDisplay.DrawLine(pat2, pat3);
+        debugDisplay.DrawLine(pat3, pat1);
+
+        // coordinate system drawing
+        debugDisplay.SetColor(AZ::Color(1.f, 0.f, 0.f, 1.f));
+        debugDisplay.SetLineWidth(2);
+        debugDisplay.DrawLine(ptx, pt0);
+
+        debugDisplay.SetColor(AZ::Color(0.f, 1.f, 0.f, 1.f));
+        debugDisplay.SetLineWidth(2);
+        debugDisplay.DrawLine(pty, pt0);
+
+        debugDisplay.SetColor(AZ::Color(0.f, 0.f, 1.f, 1.f));
+        debugDisplay.SetLineWidth(2);
+        debugDisplay.DrawLine(ptz, pt0);
+
+        debugDisplay.SetState(stateBefore);
+    }
+
+    AZStd::pair<AZStd::string, TopicConfiguration> ROS2CameraSensorEditorComponent::MakeTopicConfigurationPair(
+        const AZStd::string& topic, const AZStd::string& messageType, const AZStd::string& configName) const
+    {
+        TopicConfiguration config;
+        config.m_topic = topic;
+        config.m_type = messageType;
+        return AZStd::make_pair(configName, config);
+    }
+
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
@@ -10,6 +10,7 @@
 #include "ROS2CameraSensorComponent.h"
 #include <AzCore/Component/TransformBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
+
 namespace ROS2
 {
     ROS2CameraSensorEditorComponent::ROS2CameraSensorEditorComponent()
@@ -25,8 +26,7 @@ namespace ROS2
 
     void ROS2CameraSensorEditorComponent::Reflect(AZ::ReflectContext* context)
     {
-        auto* serialize = azrtti_cast<AZ::SerializeContext*>(context);
-        if (serialize)
+        if (auto* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<ROS2CameraSensorEditorComponent, AzToolsFramework::Components::EditorComponentBase>()
                 ->Version(4)
@@ -37,10 +37,9 @@ namespace ROS2
                 ->Field("Color", &ROS2CameraSensorEditorComponent::m_colorCamera)
                 ->Field("SensorConfig", &ROS2CameraSensorEditorComponent::m_sensorConfiguration);
 
-            AZ::EditContext* ec = serialize->GetEditContext();
-            if (ec)
+            if (AZ::EditContext* editContext = serialize->GetEditContext())
             {
-                ec->Class<ROS2CameraSensorEditorComponent>("ROS2 Camera Sensor", "[Camera component]")
+                editContext->Class<ROS2CameraSensorEditorComponent>("ROS2 Camera Sensor", "[Camera component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
@@ -72,8 +71,8 @@ namespace ROS2
 
     void ROS2CameraSensorEditorComponent::Deactivate()
     {
-        AzFramework::EntityDebugDisplayEventBus::Handler::BusDisconnect();
         AzToolsFramework::Components::EditorComponentBase::Deactivate();
+        AzFramework::EntityDebugDisplayEventBus::Handler::BusDisconnect();
     }
 
     void ROS2CameraSensorEditorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
@@ -98,13 +97,12 @@ namespace ROS2
     }
 
     void ROS2CameraSensorEditorComponent::DisplayEntityViewport(
-        const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay)
+        [[maybe_unused]] const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay)
     {
         if (!m_sensorConfiguration.m_visualise)
         {
             return;
         }
-        AZ_UNUSED(viewportInfo);
         const AZ::u32 stateBefore = debugDisplay.GetState();
         AZ::Transform transform = GetEntity()->GetTransform()->GetWorldTM();
 

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.h
@@ -19,7 +19,6 @@
 
 namespace ROS2
 {
-
     //! ROS2 Camera Editor sensor component class
     //! Allows turning an entity into a camera sensor in Editor
     //! Component draws camera frustrum in the Editor
@@ -44,7 +43,7 @@ namespace ROS2
         void BuildGameEntity(AZ::Entity* gameEntity) override;
 
     private:
-        //! EntityDebugDisplayEventBus::Handler override
+        // EntityDebugDisplayEventBus::Handler overrides
         void DisplayEntityViewport(const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay) override;
 
         AZStd::pair<AZStd::string, TopicConfiguration> MakeTopicConfigurationPair(

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <ROS2/Frame/NamespaceConfiguration.h>
+#include <ROS2/Frame/ROS2Transform.h>
+#include <ROS2/Sensor/SensorConfiguration.h>
+
+#include <AzToolsFramework/API/ComponentEntitySelectionBus.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
+
+#include "CameraSensor.h"
+
+namespace ROS2
+{
+
+    //! ROS2 Camera Editor sensor component class
+    //! Allows turning an entity into a camera sensor in Editor
+    //! Component draws camera frustrum in the Editor
+    class ROS2CameraSensorEditorComponent
+        : public AzToolsFramework::Components::EditorComponentBase
+        , protected AzFramework::EntityDebugDisplayEventBus::Handler
+    {
+    public:
+        ROS2CameraSensorEditorComponent();
+        ~ROS2CameraSensorEditorComponent() override = default;
+        AZ_EDITOR_COMPONENT(ROS2CameraSensorEditorComponent, "{3C2A86B2-AD58-4BF1-A5EF-71E0F94A2B42}");
+        static void Reflect(AZ::ReflectContext* context);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+
+        static void GetPr(AZ::ComponentDescriptor::DependencyArrayType& required);
+        void Activate() override;
+        void Deactivate() override;
+
+        //! AzToolsFramework::Components::EditorComponentBase override
+        void BuildGameEntity(AZ::Entity* gameEntity) override;
+
+    private:
+        //! EntityDebugDisplayEventBus::Handler override
+        void DisplayEntityViewport(const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay) override;
+
+        AZStd::pair<AZStd::string, TopicConfiguration> MakeTopicConfigurationPair(
+            const AZStd::string& topic, const AZStd::string& messageType, const AZStd::string& configName) const;
+        SensorConfiguration m_sensorConfiguration;
+        float m_VerticalFieldOfViewDeg = 90.0f;
+        int m_width = 640;
+        int m_height = 480;
+        bool m_colorCamera = true;
+        bool m_depthCamera = true;
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/ROS2EditorModule.cpp
+++ b/Gems/ROS2/Code/Source/ROS2EditorModule.cpp
@@ -8,6 +8,7 @@
 #include <Lidar/LidarRegistrarEditorSystemComponent.h>
 #include <ROS2EditorSystemComponent.h>
 #include <ROS2ModuleInterface.h>
+#include <Camera/ROS2CameraSensorEditorComponent.h>
 #include <RobotImporter/ROS2RobotImporterEditorSystemComponent.h>
 
 namespace ROS2
@@ -30,6 +31,7 @@ namespace ROS2
                     ROS2EditorSystemComponent::CreateDescriptor(),
                     LidarRegistrarEditorSystemComponent::CreateDescriptor(),
                     ROS2RobotImporterEditorSystemComponent::CreateDescriptor(),
+                    ROS2CameraSensorEditorComponent::CreateDescriptor(),
                 });
         }
 

--- a/Gems/ROS2/Code/Source/ROS2ModuleInterface.h
+++ b/Gems/ROS2/Code/Source/ROS2ModuleInterface.h
@@ -11,7 +11,6 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
 #include <Camera/ROS2CameraSensorComponent.h>
-#include <Camera/ROS2CameraSensorEditorComponent.h>
 #include <GNSS/ROS2GNSSSensorComponent.h>
 #include <Imu/ROS2ImuSensorComponent.h>
 #include <Lidar/LidarRegistrarSystemComponent.h>
@@ -62,7 +61,6 @@ namespace ROS2
                   AckermannControlComponent::CreateDescriptor(),
                   RigidBodyTwistControlComponent::CreateDescriptor(),
                   SkidSteeringControlComponent::CreateDescriptor(),
-                  ROS2CameraSensorEditorComponent::CreateDescriptor(),
                   ROS2SpawnerComponent::CreateDescriptor(),
                   ROS2SpawnPointComponent::CreateDescriptor(),
                   VehicleDynamics::AckermannVehicleModelComponent::CreateDescriptor(),

--- a/Gems/ROS2/Code/Source/ROS2ModuleInterface.h
+++ b/Gems/ROS2/Code/Source/ROS2ModuleInterface.h
@@ -11,6 +11,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
 #include <Camera/ROS2CameraSensorComponent.h>
+#include <Camera/ROS2CameraSensorEditorComponent.h>
 #include <GNSS/ROS2GNSSSensorComponent.h>
 #include <Imu/ROS2ImuSensorComponent.h>
 #include <Lidar/LidarRegistrarSystemComponent.h>
@@ -61,7 +62,7 @@ namespace ROS2
                   AckermannControlComponent::CreateDescriptor(),
                   RigidBodyTwistControlComponent::CreateDescriptor(),
                   SkidSteeringControlComponent::CreateDescriptor(),
-                  ROS2CameraSensorComponent::CreateDescriptor(),
+                  ROS2CameraSensorEditorComponent::CreateDescriptor(),
                   ROS2SpawnerComponent::CreateDescriptor(),
                   ROS2SpawnPointComponent::CreateDescriptor(),
                   VehicleDynamics::AckermannVehicleModelComponent::CreateDescriptor(),

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -6,6 +6,8 @@
 set(FILES
     ../Assets/Editor/Images/Icons/Resources.qrc
     ../Assets/Editor/Images/Icons/ROS_import_icon.svg
+    Source/Camera/ROS2CameraSensorEditorComponent.cpp
+    Source/Camera/ROS2CameraSensorEditorComponent.h
     Source/Lidar/LidarRegistrarEditorSystemComponent.cpp
     Source/Lidar/LidarRegistrarEditorSystemComponent.h
     Source/RobotImporter/Pages/CheckAssetPage.cpp

--- a/Gems/RosRobotSample/Assets/ROSbot.prefab
+++ b/Gems/RosRobotSample/Assets/ROSbot.prefab
@@ -51,6 +51,83 @@
         }
     },
     "Entities": {
+        "Entity_[454274520747]": {
+            "Id": "Entity_[454274520747]",
+            "Name": "Entity1",
+            "Components": {
+                "Component_[10139607700692707664]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10139607700692707664
+                },
+                "Component_[1383110072770318712]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1383110072770318712
+                },
+                "Component_[1459662396467092780]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 1459662396467092780,
+                    "Parent Entity": "Entity_[7507839849146]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.0,
+                            0.0,
+                            0.1079680398106575
+                        ]
+                    }
+                },
+                "Component_[14778984575904365834]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 14778984575904365834
+                },
+                "Component_[16777570562481809460]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16777570562481809460
+                },
+                "Component_[2002554278096027045]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2002554278096027045
+                },
+                "Component_[5063108489464047545]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 5063108489464047545,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent"
+                    }
+                },
+                "Component_[525588079965327013]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 525588079965327013
+                },
+                "Component_[6441665647641943511]": {
+                    "$type": "ROS2CameraSensorEditorComponent",
+                    "Id": 6441665647641943511,
+                    "SensorConfig": {
+                        "Publishers": {
+                            "Camera Info": {
+                                "Type": "sensor_msgs::msg::CameraInfo",
+                                "Topic": "camera_info"
+                            },
+                            "Color Image": {
+                                "Type": "sensor_msgs::msg::Image",
+                                "Topic": "camera_image_color"
+                            },
+                            "Depth Image": {
+                                "Type": "sensor_msgs::msg::Image",
+                                "Topic": "camera_image_depth"
+                            }
+                        }
+                    }
+                },
+                "Component_[7827113227536758757]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 7827113227536758757
+                },
+                "Component_[9064086166682384563]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9064086166682384563
+                }
+            }
+        },
         "Entity_[7477775078074]": {
             "Id": "Entity_[7477775078074]",
             "Name": "rl_wheel_link_visual",
@@ -870,7 +947,8 @@
                         "Entity_[7486365012666]",
                         "Entity_[7482070045370]",
                         "Entity_[7512134816442]",
-                        "Entity_[8141757523394]"
+                        "Entity_[8141757523394]",
+                        "Entity_[454274520747]"
                     ]
                 },
                 "Component_[6615492099568417181]": {


### PR DESCRIPTION
The ROS2CameraSensorEditorComponent has Editor-only features:
 - visualization of frustrum.

Signed-off-by: Michał Pełka <michal.pelka@robotec.ai>