### PR TITLE
Add sensor profiling to ROS2 Gem

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -42,6 +42,8 @@ ly_add_target(
             Gem::Atom_Component_DebugCamera.Static
             Gem::StartingPointInput
             Gem::PhysX.Static
+            Gem::ImGui
+            Gem::ImGui.ImGuiLYUtils
 )
 
 target_depends_on_ros2_packages(${gem_name}.Static rclcpp builtin_interfaces std_msgs sensor_msgs nav_msgs urdfdom tf2_ros ackermann_msgs gazebo_msgs control_toolbox)

--- a/Gems/ROS2/Code/Include/ROS2/Sensor/ROS2SensorComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Sensor/ROS2SensorComponent.h
@@ -12,6 +12,11 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <ROS2/ROS2GemUtilities.h>
+#include <ImGuiBus.h>
+#include <ImGui/ImGuiPass.h>
+#include <fstream>
+#include <imgui/imgui.h>
+#include <LYImGuiUtils/HistogramContainer.h>
 
 namespace ROS2
 {
@@ -21,6 +26,7 @@ namespace ROS2
     class ROS2SensorComponent
         : public AZ::Component
         , public AZ::TickBus::Handler
+        , public ImGui::ImGuiUpdateListenerBus::Handler
     {
     public:
         ROS2SensorComponent() = default;
@@ -43,6 +49,9 @@ namespace ROS2
 
         SensorConfiguration m_sensorConfiguration;
 
+        // ImGui::ImGuiUpdateListenerBus::Handler
+        void OnImGuiUpdate() override;
+
     private:
         //! Executes the sensor action (acquire data -> publish) according to frequency.
         //! Override to implement a specific sensor behavior.
@@ -54,5 +63,13 @@ namespace ROS2
         virtual void Visualise(){};
 
         float m_timeElapsedSinceLastTick = 0.0f;
+        double m_timeElapsedSinceLastFrequencyTick = 0.0f;
+        float m_effectiveFps = 0.0f;
+        ImGui::LYImGuiUtils::HistogramContainer m_deltaTimeHistogram;
+        AZStd::vector<float> m_aggregateFps;
+        bool m_benchmarkGoing = false;
+        float m_benchmarkElapsedChrono = 0;
+        AZStd::chrono::time_point<AZStd::chrono::system_clock> m_start;
+
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
@@ -112,11 +112,6 @@ namespace ROS2
     void CameraSensor::SetupPasses()
     {
         AZ_TracePrintf("CameraSensor", "Initializing pipeline for %s\n", m_cameraSensorDescription.m_cameraName.c_str());
-        const auto & m =m_cameraSensorDescription.m_cameraIntrinsics;
-        AZ_TracePrintf("CameraSensor", "Camera matrix\n");
-        AZ_TracePrintf("CameraSensor", "%f %f %f",m[0],m[1],m[2]);
-        AZ_TracePrintf("CameraSensor", "%f %f %f",m[3],m[4],m[5]);
-        AZ_TracePrintf("CameraSensor", "%f %f %f",m[6],m[7],m[8]);
 
         const AZ::Name viewName = AZ::Name("MainCamera");
         m_view = AZ::RPI::View::CreateView(viewName, AZ::RPI::View::UsageCamera);

--- a/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
@@ -22,6 +22,8 @@
 #include <PostProcess/PostProcessFeatureProcessor.h>
 
 #include <Atom/RPI.Public/Pass/PassFactory.h>
+#include <AzCore/Time/ITime.h>
+
 
 namespace ROS2
 {
@@ -110,6 +112,11 @@ namespace ROS2
     void CameraSensor::SetupPasses()
     {
         AZ_TracePrintf("CameraSensor", "Initializing pipeline for %s\n", m_cameraSensorDescription.m_cameraName.c_str());
+        const auto & m =m_cameraSensorDescription.m_cameraIntrinsics;
+        AZ_TracePrintf("CameraSensor", "Camera matrix\n");
+        AZ_TracePrintf("CameraSensor", "%f %f %f",m[0],m[1],m[2]);
+        AZ_TracePrintf("CameraSensor", "%f %f %f",m[3],m[4],m[5]);
+        AZ_TracePrintf("CameraSensor", "%f %f %f",m[6],m[7],m[8]);
 
         const AZ::Name viewName = AZ::Name("MainCamera");
         m_view = AZ::RPI::View::CreateView(viewName, AZ::RPI::View::UsageCamera);

--- a/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
@@ -11,6 +11,8 @@
 #include <AzCore/XML/rapidxml.h>
 #include <AzFramework/Process/ProcessCommunicator.h>
 #include <AzFramework/Process/ProcessWatcher.h>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <QString>
 namespace ROS2::Utils::xacro
 {
 

--- a/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -22,7 +22,8 @@ namespace ROS2
     T ComputeMean(const AZStd::vector<T>& vec)
     {
         const size_t size = vec.size();
-        if (size == 0 )return 0;
+        if (size == 0)
+            return 0;
         return std::accumulate(vec.begin(), vec.end(), 0.0) / size;
     }
 
@@ -30,7 +31,8 @@ namespace ROS2
     T ComputeVariance(const AZStd::vector<T>& vec, T mean)
     {
         const size_t size = vec.size();
-        if (size == 0 )return 0;
+        if (size == 0)
+            return 0;
         auto variance_computer = [&mean, &size](T acc, const T& val)
         {
             return acc + ((val - mean) * (val - mean) / (size - 1));
@@ -39,14 +41,12 @@ namespace ROS2
         return std::accumulate(vec.begin(), vec.end(), 0.0, variance_computer);
     }
 
-
     void ROS2SensorComponent::Activate()
     {
         AZ::TickBus::Handler::BusConnect();
         AZStd::string s = AZStd::string::format("Sensor %s [%llu] onFrequencyTick FPS ", GetEntity()->GetName().c_str(), GetId());
         m_deltaTimeHistogram.Init(s.c_str(), 250, ImGui::LYImGuiUtils::HistogramContainer::ViewType::Histogram, true, 0.0f, 80.0f);
         ImGui::ImGuiUpdateListenerBus::Handler::BusConnect();
-
     }
 
     void ROS2SensorComponent::Deactivate()
@@ -133,25 +133,28 @@ namespace ROS2
             m_aggregateFps.push_back(m_effectiveFps);
         }
         FrequencyTick();
-
     }
 
-    void ROS2SensorComponent::OnImGuiUpdate(){
-        AZStd::string s = AZStd::string::format("Benchmark##%s %llu ",GetEntity()->GetName().c_str(),GetId());
+    void ROS2SensorComponent::OnImGuiUpdate()
+    {
+        AZStd::string s = AZStd::string::format("Benchmark##%s %llu ", GetEntity()->GetName().c_str(), GetId());
         ImGui::Text("======== Sensor %s [%llu] ========================", GetEntity()->GetName().c_str(), GetId());
         ImGui::BulletText("FrameRate : %f / %f", m_effectiveFps, m_sensorConfiguration.m_frequency);
-        if (m_benchmarkGoing){
+        if (m_benchmarkGoing)
+        {
             ImGui::BulletText("Benchmarking %f", m_benchmarkElapsedChrono);
-        }else{
+        }
+        else
+        {
             if (ImGui::Button(s.c_str()))
             {
                 m_benchmarkGoing = true;
                 m_aggregateFps.clear();
                 m_start = AZStd::chrono::system_clock::now();
             }
-            if(m_aggregateFps.size() > 2)
+            if (m_aggregateFps.size() > 2)
             {
-                auto minmax = AZStd::minmax_element(m_aggregateFps.begin(),m_aggregateFps.end());
+                auto minmax = AZStd::minmax_element(m_aggregateFps.begin(), m_aggregateFps.end());
                 ImGui::BulletText("Benchmark result : ");
                 ImGui::BulletText("Max / Min : %f / %f", *minmax.first, *minmax.second);
                 float mean = ComputeMean(m_aggregateFps);
@@ -162,7 +165,5 @@ namespace ROS2
         }
         m_deltaTimeHistogram.Draw(ImGui::GetColumnWidth(), 100.0f);
         ImGui::End();
-
     }
-
 } // namespace ROS2


### PR DESCRIPTION
This change allows to display and benchmark update times in simulated ROS2 sensors.
![image](https://user-images.githubusercontent.com/3209244/216029947-50ac2976-9d70-46e9-b3af-a6b74e3e8978.png)
