### PR TITLE
Updated prefabs to follow new pattern that colliders require a rigid body.

### DIFF
--- a/Gems/WarehouseSample/Assets/O3DEScene/Prefabs/Warehouse.prefab
+++ b/Gems/WarehouseSample/Assets/O3DEScene/Prefabs/Warehouse.prefab
@@ -1515,6 +1515,10 @@
                     "Id": 3579789965580572662,
                     "Parent Entity": "ContainerEntity"
                 },
+                "Component_[5398237697833321121]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5398237697833321121
+                },
                 "Component_[6126526996710685532]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 6126526996710685532,

--- a/Projects/OpenXRTest/Levels/DefaultLevel/DefaultLevel.prefab
+++ b/Projects/OpenXRTest/Levels/DefaultLevel/DefaultLevel.prefab
@@ -142,6 +142,10 @@
                     "Id": 16578565737331764849,
                     "Parent Entity": "Entity_[1176639161715]"
                 },
+                "Component_[1677504652583565519]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1677504652583565519
+                },
                 "Component_[16919232076966545697]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 16919232076966545697

--- a/Templates/Multiplayer/Template/Levels/Demo/Demo.prefab
+++ b/Templates/Multiplayer/Template/Levels/Demo/Demo.prefab
@@ -10726,6 +10726,10 @@
                 "Component_[3412423409421084023]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 3412423409421084023
+                },
+                "Component_[522094586563106095]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 522094586563106095
                 }
             }
         },


### PR DESCRIPTION
**IMPORTANT: Please approve but DO NOT merge this PR yet!** 

@moraaar will merge it once the work in [PhysX_StaticRigidBody_Staging](https://github.com/aws-lumberyard-dev/o3de/tree/PhysX_StaticRigidBody_Staging) branch is in o3de/development.

More information about this update here: https://github.com/o3de/o3de/pull/14261

What's been updated:
- Prefabs in OpenXRTest project.
- Prefabs in WarehouseSample gem.
- Prefabs in Multiplayer template.

Signed-off-by: moraaar <moraaar@amazon.com>