### PR TITLE
Add that the Gem does not work with the Release

### DIFF
--- a/Gems/ROS2/README.md
+++ b/Gems/ROS2/README.md
@@ -5,7 +5,7 @@ This Gem enables users to develop robotic simulations through ROS2 tools and com
 ## Requirements
 
 * Ubuntu 20.04 or 22.04. Other Ubuntu versions and Linux distros could also work as long as they can support ROS 2.
-* [O3DE](https://www.o3de.org/)
+* [O3DE](https://www.o3de.org/) development branch. The Gem does not work with a release version of O3DE yet.
 * Modern version of ROS 2. This instruction assumes that the `desktop` version is installed. Otherwise some packages might be missing. We support and tested with:
   * [ROS 2 Galactic](https://docs.ros.org/en/galactic/Installation.html) with Ubuntu 20.04.
   * [ROS 2 Humble](https://docs.ros.org/en/humble/Installation.html) with Ubuntu 22.04.


### PR DESCRIPTION
Signed-off-by: Adam Dąbrowski <adam.dabrowski@robotec.ai>
Clarify that the Gem does not work with a release (installed) O3DE.

The goal of this change is to help users to avoid running into issues such as https://github.com/o3de/o3de-extras/issues/115.