### PR TITLE
Adjust ROS2 Gem to recent changes in PhysX Gem.

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -267,8 +267,8 @@ namespace ROS2
             component->SetFrameID(AZStd::string(link->name.c_str(), link->name.size()));
         }
         m_visualsMaker.AddVisuals(link, entityId);
-        m_collidersMaker.AddColliders(link, entityId);
         m_inertialsMaker.AddInertial(link->inertial, entityId);
+        m_collidersMaker.AddColliders(link, entityId);
         return AZ::Success(entityId);
     }
 


### PR DESCRIPTION
The `EditorColliderComponent` in PhysX Gem requires PhysicsRigidBodyService. I have changed the order of component creation to entertain the abovementioned requirement.
Fixes #166 .
Signed-off-by: Michał Pełka <michal.pelka@robotec.ai>