### PR TITLE
Migrate issue templates from main O3DE repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/ar_bug_report.md.txt
+++ b/.github/ISSUE_TEMPLATE/ar_bug_report.md.txt
@@ -1,0 +1,20 @@
+---
+name: Automated Review bug report
+about: Create a bug for a an issue found in the Automated Review
+title: 'AR Bug Report'
+labels: 'needs-triage,kind/bug,kind/automation'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Failed Jenkins Job Information:**
+The name of the job that failed, job build number, and code snippit of the failure.
+
+**Attachments**
+Attach the Jenkins job log as a .txt file and any other relevant information.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/ar_bug_report.md.txt
+++ b/.github/ISSUE_TEMPLATE/ar_bug_report.md.txt
@@ -1,6 +1,6 @@
 ---
 name: Automated Review bug report
-about: Create a bug for a an issue found in the Automated Review
+about: Create an issue for a bug found in the Automated Review
 title: 'AR Bug Report'
 labels: 'needs-triage,kind/bug,kind/automation'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/bug_template.md.txt
+++ b/.github/ISSUE_TEMPLATE/bug_template.md.txt
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'Bug Report'
+labels: 'needs-triage,needs-sig,kind/bug'
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is. Try to isolate the issue to help the community to reproduce it easily and increase chances for a fast fix.
+
+**Assets required**
+[!Important!] Please provide sample assets needed to reproduce the issue, either as an [attachment](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/attaching-files) or as a link to a public asset in Github.
+
+**Steps to reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Select attached asset '...'
+4. Scroll down to '...'
+5. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+A clear and concise description of what actually happened.
+
+**Screenshots/Video**
+If applicable, add screenshots and/or a video to help explain your problem.
+
+**Found in Branch**
+Name of or link to the branch where the issue occurs.
+
+**Commit ID from [o3de/o3de](https://github.com/o3de/o3de) Repository**
+Please provide the SHA/hash that identifies the latest commit from the o3de/o3de repository if the issue is reproducible in the development or other official branches. 
+You can get the commit ID by running the `git rev-parse HEAD` command on your current branch.
+
+**Desktop/Device (please complete the following information):**
+ - Device: [e.g. PC, Mac, iPhone, Samsung] 
+ - OS: [e.g. Windows, macOS, iOS, Android]
+ - Version [e.g. 10, Monterey, Oreo]
+ - CPU [e.g. Intel I9-9900k , Ryzen 5900x, ]
+ - GPU [AMD 6800 XT, NVidia RTX 3090]
+ - Memory [e.g. 16GB]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_template.md.txt
+++ b/.github/ISSUE_TEMPLATE/bug_template.md.txt
@@ -39,7 +39,8 @@ You can get the commit ID by running the `git rev-parse HEAD` command on your cu
 
 **Desktop/Device (please complete the following information):**
  - Device: [e.g. PC, Mac, iPhone, Samsung] 
- - OS: [e.g. Windows, macOS, iOS, Android]
+ - OS: [e.g. Windows, macOS, iOS, Android, Linux, including distribution and version (e. g. Ubuntu 22.04 / Windows 11 22H2)]
+
  - Version [e.g. 10, Monterey, Oreo]
  - CPU [e.g. Intel I9-9900k , Ryzen 5900x, ]
  - GPU [AMD 6800 XT, NVidia RTX 3090]

--- a/.github/ISSUE_TEMPLATE/bug_template.md.txt
+++ b/.github/ISSUE_TEMPLATE/bug_template.md.txt
@@ -32,9 +32,10 @@ If applicable, add screenshots and/or a video to help explain your problem.
 **Found in Branch**
 Name of or link to the branch where the issue occurs.
 
-**Commit ID from [o3de/o3de](https://github.com/o3de/o3de) Repository**
-Please provide the SHA/hash that identifies the latest commit from the o3de/o3de repository if the issue is reproducible in the development or other official branches. 
+**Commit ID from [o3de/o3de](https://github.com/o3de/o3de) and [o3de/o3de-extras](https://github.com/o3de/o3de-extras) repositories**
+Please provide the SHA/hash that identifies the latest commit from the o3de/o3de and o3de/o3de-extras repository if the issue is reproducible in the development or other official branches. 
 You can get the commit ID by running the `git rev-parse HEAD` command on your current branch.
+
 
 **Desktop/Device (please complete the following information):**
  - Device: [e.g. PC, Mac, iPhone, Samsung] 

--- a/.github/ISSUE_TEMPLATE/config.yml.txt
+++ b/.github/ISSUE_TEMPLATE/config.yml.txt
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation Issues
+    about: Report issues with the documentation for O3DE
+    url: https://github.com/o3de/o3de.org/issues/new/choose 
+

--- a/.github/ISSUE_TEMPLATE/config.yml.txt
+++ b/.github/ISSUE_TEMPLATE/config.yml.txt
@@ -1,6 +1,6 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation Issues
-    about: Report issues with the documentation for O3DE
+    about: Report issues with the O3DE.org/docs documentation
     url: https://github.com/o3de/o3de.org/issues/new/choose 
 

--- a/.github/ISSUE_TEMPLATE/deprecation_template.md.txt
+++ b/.github/ISSUE_TEMPLATE/deprecation_template.md.txt
@@ -1,0 +1,23 @@
+---
+name: Deprecation Notice
+about: A notice for one or more feature or API deprecations
+title: 'Deprecation Notice'
+labels: 'needs-triage,needs-sig,kind/deprecation'
+
+---
+
+## Deprecated APIs
+List the fully qualified APIs/types. For example, `AZ::Quaternion::SetFromEulerRadians(const Vector3&)`
+
+## Alternatives APIs
+List new or updated APIs to replace deprecated API. 
+For example, use 
+`Quaternion AZ::Quaternion::CreateFromEulerRadiansXYZ(const Vector3&)` 
+to repleace 
+`void AZ::Quaternion::SetFromEulerRadians(const Vector3&)` and `Quaternion AZ::Quaternion::ConvertEulerRadiansToQuaternion(const Vector3&)`
+
+## Last Release
+Describe the last release version before this deprecation. For example: `stabilization/2210`
+
+## Additional Context
+Add some information about the reasons for the deprecations

--- a/.github/ISSUE_TEMPLATE/feature_request.md.txt
+++ b/.github/ISSUE_TEMPLATE/feature_request.md.txt
@@ -1,0 +1,20 @@
+---
+
+name: Feature request
+about: Suggest an idea for this project
+title: 'Feature Request'
+labels: 'needs-triage,needs-sig'
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
The main O3DE repository uses issue templates to guide the structure and contents of issues. This PR introduces these issue templates to the o3de-extras repo as well.