### PR TITLE
A fix for ROS2Frame component

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
@@ -54,10 +54,11 @@ namespace ROS2
         //! @return A complete namespace (including parent namespaces)
         AZStd::string GetNamespace() const;
 
-        //! Get AZ Transform for this frame.
-        //! @return If parent ROS2Frame is found, return its Transform.
+        //! Get a transform between this frame and the next frame up in hierarchy.
+        //! @return If the parent frame is found, return a Transform between this frame and the parent.
         //! Otherwise, return a global Transform.
-        const AZ::Transform& GetFrameTransform() const;
+        //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame components.
+        AZ::Transform GetFrameTransform() const;
 
         //! Global frame name in ros2 ecosystem.
         //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -161,8 +161,8 @@ namespace ROS2
             auto* ancestorTransformInterface = Internal::GetEntityTransformInterface(parentFrame->GetEntity());
             AZ_Assert(ancestorTransformInterface, "No transform interface for an entity with a ROS2Frame component, which requires it!");
 
-            auto ancestorWorldTm = ancestorTransformInterface->GetWorldTM();
-            auto thisWorldTm = transformInterface->GetWorldTM();
+            const auto ancestorWorldTm = ancestorTransformInterface->GetWorldTM();
+            const auto thisWorldTm = transformInterface->GetWorldTM();
             return ancestorWorldTm.GetInverse() * thisWorldTm;
         }
         return transformInterface->GetWorldTM();

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -50,6 +50,7 @@ namespace ROS2
             AZ::Entity* parentEntity = nullptr;
             AZ::ComponentApplicationBus::BroadcastResult(parentEntity, &AZ::ComponentApplicationRequests::FindEntity, parentEntityId);
             AZ_Assert(parentEntity, "No parent entity id : %s", parentEntityId.ToString().c_str());
+
             auto* component = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(parentEntity);
             if (component == nullptr)
             { // Parent entity has no ROS2Frame, but there can still be a ROS2Frame in its ancestors
@@ -152,12 +153,17 @@ namespace ROS2
         return Internal::GetFirstROS2FrameAncestor(GetEntity());
     }
 
-    const AZ::Transform& ROS2FrameComponent::GetFrameTransform() const
+    AZ::Transform ROS2FrameComponent::GetFrameTransform() const
     {
         auto* transformInterface = Internal::GetEntityTransformInterface(GetEntity());
-        if (GetParentROS2FrameComponent() != nullptr)
+        if (const auto* parentFrame = GetParentROS2FrameComponent(); parentFrame != nullptr)
         {
-            return transformInterface->GetLocalTM();
+            auto* ancestorTransformInterface = Internal::GetEntityTransformInterface(parentFrame->GetEntity());
+            AZ_Assert(ancestorTransformInterface, "No transform interface for an entity with a ROS2Frame component, which requires it!");
+
+            auto ancestorWorldTm = ancestorTransformInterface->GetWorldTM();
+            auto thisWorldTm = transformInterface->GetWorldTM();
+            return ancestorWorldTm.GetInverse() * thisWorldTm;
         }
         return transformInterface->GetWorldTM();
     }

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -161,9 +161,10 @@ namespace ROS2
             auto* ancestorTransformInterface = Internal::GetEntityTransformInterface(parentFrame->GetEntity());
             AZ_Assert(ancestorTransformInterface, "No transform interface for an entity with a ROS2Frame component, which requires it!");
 
-            const auto ancestorWorldTm = ancestorTransformInterface->GetWorldTM();
-            const auto thisWorldTm = transformInterface->GetWorldTM();
-            return ancestorWorldTm.GetInverse() * thisWorldTm;
+            const auto worldFromAncestor = ancestorTransformInterface->GetWorldTM();
+            const auto worldFromThis = transformInterface->GetWorldTM();
+            const auto ancestorFromWorld = worldFromAncestor.GetInverse();
+            return ancestorFromWorld * worldFromThis;
         }
         return transformInterface->GetWorldTM();
     }


### PR DESCRIPTION
- Previously, it did not work well with intermediate entities without ROS2Frame component.
- For example, the prefab container entity.
- This resulted in skipping prefab transform and publishing invalid /tf

Fixes #139