### PR TITLE
Using System Allocator to manage small objects used by Vulkan.

### DIFF
--- a/Gems/OpenXRVk/Code/Source/OpenXRVkDevice.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkDevice.cpp
@@ -14,6 +14,7 @@
 #include <OpenXRVk/OpenXRVkUtils.h>
 #include <OpenXRVkCommon.h>
 #include <Atom/RHI.Reflect/Vulkan/XRVkDescriptors.h>
+#include <Atom/RHI.Reflect/VkAllocator.h>
 #include <AzCore/Casting/numeric_cast.h>
 
 namespace OpenXRVk
@@ -32,7 +33,7 @@ namespace OpenXRVk
         xrDeviceCreateInfo.pfnGetInstanceProcAddr = xrVkInstance->GetContext().GetInstanceProcAddr;
         xrDeviceCreateInfo.vulkanCreateInfo = xrDeviceDescriptor->m_inputData.m_deviceCreateInfo;
         xrDeviceCreateInfo.vulkanPhysicalDevice = xrVkInstance->GetActivePhysicalDevice();
-        xrDeviceCreateInfo.vulkanAllocator = nullptr;
+        xrDeviceCreateInfo.vulkanAllocator = AZ::Vulkan::VkSystemAllocator::Get();
 
         PFN_xrGetVulkanDeviceExtensionsKHR pfnGetVulkanDeviceExtensionsKHR = nullptr;
         XrResult result = xrGetInstanceProcAddr(
@@ -306,7 +307,7 @@ namespace OpenXRVk
         m_xrLayers.clear();
         if (m_xrVkDevice != VK_NULL_HANDLE)
         {
-            m_context.DestroyDevice(m_xrVkDevice, nullptr);
+            m_context.DestroyDevice(m_xrVkDevice, AZ::Vulkan::VkSystemAllocator::Get());
             m_xrVkDevice = VK_NULL_HANDLE;
         }
     }

--- a/Gems/OpenXRVk/Code/Source/OpenXRVkInstance.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkInstance.cpp
@@ -9,6 +9,7 @@
 #include <OpenXRVk/OpenXRVkInstance.h>
 #include <OpenXRVk/OpenXRVkUtils.h>
 #include <Atom/RHI.Reflect/Vulkan/XRVkDescriptors.h>
+#include <Atom/RHI.Reflect/VkAllocator.h>
 #include <AzCore/Casting/numeric_cast.h>
 #include <OpenXRVkCommon.h>
 
@@ -339,7 +340,7 @@ namespace OpenXRVk
         instInfo.ppEnabledExtensionNames = extensions.empty() ? nullptr : extensions.data();
 
         auto pfnCreateInstance = (PFN_vkCreateInstance)createInfo.pfnGetInstanceProcAddr(nullptr, "vkCreateInstance");
-        VkResult vkResult = pfnCreateInstance(&instInfo, nullptr, &m_xrVkInstance);
+        VkResult vkResult = pfnCreateInstance(&instInfo, AZ::Vulkan::VkSystemAllocator::Get(), &m_xrVkInstance);
         if (vkResult != VK_SUCCESS)
         {
             ShutdownInternal();
@@ -382,7 +383,7 @@ namespace OpenXRVk
         {
             m_supportedXRDevices.clear();
 
-            m_context.DestroyInstance(m_xrVkInstance, nullptr);
+            m_context.DestroyInstance(m_xrVkInstance, AZ::Vulkan::VkSystemAllocator::Get());
             m_xrVkInstance = VK_NULL_HANDLE;
         }
 


### PR DESCRIPTION
As [comment](https://github.com/o3de/o3de/pull/14526#pullrequestreview-1293626647), use the same allocator to manage small objects.