### PR TITLE
Adjust prefabs and colliders to changes in the o3de PhysX gem

### DIFF
--- a/Gems/ProteusRobot/Assets/Proteus.prefab
+++ b/Gems/ProteusRobot/Assets/Proteus.prefab
@@ -898,52 +898,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10928326798115103880
                 },
-                "Component_[1153232506834696450]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 1153232506834696450,
-                    "ColliderConfiguration": {
-                        "Position": [
-                            0.1837027668952942,
-                            0.0,
-                            -0.06689203530550003
-                        ],
-                        "Rotation": [
-                            0.0,
-                            0.0,
-                            0.7071067690849304,
-                            0.7071067094802856
-                        ],
-                        "MaterialSlots": {
-                            "Slots": [
-                                {
-                                    "Name": "Proteus"
-                                }
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
-                                "assetId": {
-                                    "guid": "{0042012D-310E-5380-8BFB-5B92949DA679}",
-                                    "subId": 1612379007
-                                },
-                                "assetHint": "assets/proteusrobot/proteus_chassis.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{0042012D-310E-5380-8BFB-5B92949DA679}",
-                                        "subId": 1612379007
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/proteusrobot/proteus_chassis.pxmesh"
-                                },
-                                "UseMaterialsFromAsset": false
-                            }
-                        }
-                    }
-                },
                 "Component_[12137189902681906851]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 12137189902681906851,
@@ -1034,6 +988,50 @@
                 "Component_[6615492099568417181]": {
                     "$type": "EditorLockComponent",
                     "Id": 6615492099568417181
+                },
+                "Component_[7263698520419106338]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 7263698520419106338,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.1837027668952942,
+                            0.0,
+                            -0.06689203530550003
+                        ],
+                        "Rotation": [
+                            0.0,
+                            0.0,
+                            0.7071067690849304,
+                            0.7071067094802856
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Proteus"
+                                }
+                            ]
+                        }
+                    },
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{0042012D-310E-5380-8BFB-5B92949DA679}",
+                                "subId": 1612379007
+                            },
+                            "assetHint": "assets/proteusrobot/proteus_chassis.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
+                                "assetId": {
+                                    "guid": "{0042012D-310E-5380-8BFB-5B92949DA679}",
+                                    "subId": 1612379007
+                                },
+                                "loadBehavior": "QueueLoad",
+                                "assetHint": "assets/proteusrobot/proteus_chassis.pxmesh"
+                            },
+                            "UseMaterialsFromAsset": false
+                        }
+                    }
                 },
                 "Component_[7613619815052417776]": {
                     "$type": "EditorRigidBodyComponent",

--- a/Gems/ROS2/Assets/Prefabs/Sensors/CameraOrbbeck.prefab
+++ b/Gems/ROS2/Assets/Prefabs/Sensors/CameraOrbbeck.prefab
@@ -70,40 +70,6 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 14616296837285217185
                 },
-                "Component_[14985514809153430690]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 14985514809153430690,
-                    "ColliderConfiguration": {
-                        "MaterialSlots": {
-                            "Slots": [
-                                {
-                                    "Name": "Entire object"
-                                }
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
-                                "assetId": {
-                                    "guid": "{0E27CF27-5752-5557-B77A-4B29A5870E0E}",
-                                    "subId": 3865077323
-                                },
-                                "assetHint": "models/sensors/camera/cameraorbbeck.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{0E27CF27-5752-5557-B77A-4B29A5870E0E}",
-                                        "subId": 3865077323
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "models/sensors/camera/cameraorbbeck.pxmesh"
-                                }
-                            }
-                        }
-                    }
-                },
                 "Component_[15329441649387498950]": {
                     "$type": "AZ::Render::EditorMeshComponent",
                     "Id": 15329441649387498950,
@@ -152,6 +118,38 @@
                             "SortIndex": 2
                         }
                     ]
+                },
+                "Component_[4036444066756233836]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 4036444066756233836,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{0E27CF27-5752-5557-B77A-4B29A5870E0E}",
+                                "subId": 3865077323
+                            },
+                            "assetHint": "models/sensors/camera/cameraorbbeck.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
+                                "assetId": {
+                                    "guid": "{0E27CF27-5752-5557-B77A-4B29A5870E0E}",
+                                    "subId": 3865077323
+                                },
+                                "loadBehavior": "QueueLoad",
+                                "assetHint": "models/sensors/camera/cameraorbbeck.pxmesh"
+                            }
+                        }
+                    }
                 },
                 "Component_[6578496273892635118]": {
                     "$type": "EditorEntitySortComponent",

--- a/Gems/ROS2/Assets/Prefabs/Sensors/Imu.prefab
+++ b/Gems/ROS2/Assets/Prefabs/Sensors/Imu.prefab
@@ -58,13 +58,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 10340392978555572105
                 },
-                "Component_[11958193181460909696]": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 11958193181460909696
-                },
-                "Component_[12053638524449760314]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 12053638524449760314,
+                "Component_[11750730641353427948]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 11750730641353427948,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
                             "Slots": [
@@ -74,27 +70,29 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{50286487-658B-5B99-99D6-3AB4002EFF73}",
+                                "subId": 3726733934
+                            },
+                            "assetHint": "models/sensors/imu/imu_mti10.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{50286487-658B-5B99-99D6-3AB4002EFF73}",
                                     "subId": 3726733934
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "models/sensors/imu/imu_mti10.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{50286487-658B-5B99-99D6-3AB4002EFF73}",
-                                        "subId": 3726733934
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "models/sensors/imu/imu_mti10.pxmesh"
-                                }
                             }
                         }
                     }
+                },
+                "Component_[11958193181460909696]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11958193181460909696
                 },
                 "Component_[12417918822595867875]": {
                     "$type": "EditorEntitySortComponent",

--- a/Gems/ROS2/Assets/Prefabs/Sensors/LidarOS2.prefab
+++ b/Gems/ROS2/Assets/Prefabs/Sensors/LidarOS2.prefab
@@ -130,6 +130,41 @@
             "Id": "Entity_[417184227077]",
             "Name": "LidarOS2",
             "Components": {
+                "Component_[10290792692497724644]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 10290792692497724644,
+                    "ColliderConfiguration": {
+                        "CollisionGroupId": {
+                            "GroupId": "{DED3A46E-3588-4BB8-BADF-E3114DBA95A6}"
+                        },
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{99D850A3-8E59-5E78-93FE-AE8DB228684D}",
+                                "subId": 2574200790
+                            },
+                            "assetHint": "models/sensors/lidaros2/lidaros2.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
+                                "assetId": {
+                                    "guid": "{99D850A3-8E59-5E78-93FE-AE8DB228684D}",
+                                    "subId": 2574200790
+                                },
+                                "loadBehavior": "QueueLoad",
+                                "assetHint": "models/sensors/lidaros2/lidaros2.pxmesh"
+                            }
+                        }
+                    }
+                },
                 "Component_[10387713135725007135]": {
                     "$type": "AZ::Render::EditorMeshComponent",
                     "Id": 10387713135725007135,
@@ -152,43 +187,6 @@
                 "Component_[13177781661023720894]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 13177781661023720894
-                },
-                "Component_[14535670656735835043]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 14535670656735835043,
-                    "ColliderConfiguration": {
-                        "CollisionGroupId": {
-                            "GroupId": "{DED3A46E-3588-4BB8-BADF-E3114DBA95A6}"
-                        },
-                        "MaterialSlots": {
-                            "Slots": [
-                                {
-                                    "Name": "DefaultMaterial"
-                                }
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
-                                "assetId": {
-                                    "guid": "{99D850A3-8E59-5E78-93FE-AE8DB228684D}",
-                                    "subId": 2574200790
-                                },
-                                "assetHint": "models/sensors/lidaros2/lidaros2.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{99D850A3-8E59-5E78-93FE-AE8DB228684D}",
-                                        "subId": 2574200790
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "models/sensors/lidaros2/lidaros2.pxmesh"
-                                }
-                            }
-                        }
-                    }
                 },
                 "Component_[17075071070477116796]": {
                     "$type": "EditorDisabledCompositionComponent",

--- a/Gems/RosRobotSample/Assets/ROSbot.prefab
+++ b/Gems/RosRobotSample/Assets/ROSbot.prefab
@@ -733,41 +733,6 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10928326798115103880
                 },
-                "Component_[1153232506834696450]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 1153232506834696450,
-                    "ColliderConfiguration": {
-                        "MaterialSlots": {
-                            "Slots": [
-                                {
-                                    "Name": "DefaultMaterial"
-                                }
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
-                                "assetId": {
-                                    "guid": "{7F445A99-8C11-5417-9D63-8BCC7DCA76C8}",
-                                    "subId": 1509562746
-                                },
-                                "assetHint": "robot/rosbot_xl_description/meshes/body_colision.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{7F445A99-8C11-5417-9D63-8BCC7DCA76C8}",
-                                        "subId": 1509562746
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "robot/rosbot_xl_description/meshes/body_colision.pxmesh"
-                                },
-                                "UseMaterialsFromAsset": false
-                            }
-                        }
-                    }
-                },
                 "Component_[117912442323439654]": {
                     "$type": "GenericComponentWrapper",
                     "Id": 117912442323439654,
@@ -854,6 +819,39 @@
                 "Component_[3596110623068228821]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 3596110623068228821
+                },
+                "Component_[5440240886480353994]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 5440240886480353994,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "DefaultMaterial"
+                                }
+                            ]
+                        }
+                    },
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{7F445A99-8C11-5417-9D63-8BCC7DCA76C8}",
+                                "subId": 1509562746
+                            },
+                            "assetHint": "robot/rosbot_xl_description/meshes/body_colision.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
+                                "assetId": {
+                                    "guid": "{7F445A99-8C11-5417-9D63-8BCC7DCA76C8}",
+                                    "subId": 1509562746
+                                },
+                                "loadBehavior": "QueueLoad",
+                                "assetHint": "robot/rosbot_xl_description/meshes/body_colision.pxmesh"
+                            },
+                            "UseMaterialsFromAsset": false
+                        }
+                    }
                 },
                 "Component_[5852749630011233946]": {
                     "$type": "EditorEntityIconComponent",

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseRack.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseRack.prefab
@@ -104,40 +104,6 @@
                     "$type": "EditorEntitySortComponent",
                     "Id": 16403983953216827994
                 },
-                "Component_[2276504649476859699]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 2276504649476859699,
-                    "ColliderConfiguration": {
-                        "MaterialSlots": {
-                            "Slots": [
-                                {
-                                    "Name": "MWarehouseStorage"
-                                }
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
-                                "assetId": {
-                                    "guid": "{665AB396-251A-55E3-83E2-AAB98CB864FB}",
-                                    "subId": 1812650258
-                                },
-                                "assetHint": "assets/warehouse/models/warehouse_rack.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{665AB396-251A-55E3-83E2-AAB98CB864FB}",
-                                        "subId": 1812650258
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_rack.pxmesh"
-                                }
-                            }
-                        }
-                    }
-                },
                 "Component_[365858973221232949]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 365858973221232949
@@ -179,6 +145,38 @@
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 7951809217182138039,
                     "Parent Entity": "ContainerEntity"
+                },
+                "Component_[8857752593320328453]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 8857752593320328453,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "MWarehouseStorage"
+                                }
+                            ]
+                        }
+                    },
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{665AB396-251A-55E3-83E2-AAB98CB864FB}",
+                                "subId": 1812650258
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_rack.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
+                                "assetId": {
+                                    "guid": "{665AB396-251A-55E3-83E2-AAB98CB864FB}",
+                                    "subId": 1812650258
+                                },
+                                "loadBehavior": "QueueLoad",
+                                "assetHint": "assets/warehouse/models/warehouse_rack.pxmesh"
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_front_protector.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_front_protector.prefab
@@ -58,13 +58,9 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 11438438563397133372
                 },
-                "Component_[13395915873594579514]": {
-                    "$type": "EditorLockComponent",
-                    "Id": 13395915873594579514
-                },
-                "Component_[15579174905508719867]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 15579174905508719867,
+                "Component_[11639947535860909332]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 11639947535860909332,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
                             "Slots": [
@@ -74,27 +70,29 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{9928FCBB-9AD8-5B3E-94FF-3516CC574ED1}",
+                                "subId": 4102061829
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_frontrackprotector.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{9928FCBB-9AD8-5B3E-94FF-3516CC574ED1}",
                                     "subId": 4102061829
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "assets/warehouse/models/warehouse_frontrackprotector.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{9928FCBB-9AD8-5B3E-94FF-3516CC574ED1}",
-                                        "subId": 4102061829
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_frontrackprotector.pxmesh"
-                                }
                             }
                         }
                     }
+                },
+                "Component_[13395915873594579514]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13395915873594579514
                 },
                 "Component_[15907735198669368676]": {
                     "$type": "EditorDisabledCompositionComponent",

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_side_protector.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_side_protector.prefab
@@ -155,9 +155,17 @@
                         }
                     }
                 },
-                "Component_[15264405835034640312]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 15264405835034640312,
+                "Component_[16551911944901009126]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 16551911944901009126
+                },
+                "Component_[18146145291811479353]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 18146145291811479353
+                },
+                "Component_[2600525514124264372]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 2600525514124264372,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
                             "Slots": [
@@ -167,35 +175,25 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{663633B0-B67A-5957-BC3A-53FA65F40353}",
+                                "subId": 3163433385
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_siderackprotector.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{663633B0-B67A-5957-BC3A-53FA65F40353}",
                                     "subId": 3163433385
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "assets/warehouse/models/warehouse_siderackprotector.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{663633B0-B67A-5957-BC3A-53FA65F40353}",
-                                        "subId": 3163433385
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_siderackprotector.pxmesh"
-                                }
                             }
                         }
                     }
-                },
-                "Component_[16551911944901009126]": {
-                    "$type": "EditorLockComponent",
-                    "Id": 16551911944901009126
-                },
-                "Component_[18146145291811479353]": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 18146145291811479353
                 },
                 "Component_[4216229295497526239]": {
                     "$type": "EditorEntityIconComponent",

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Floor.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Floor.prefab
@@ -111,9 +111,9 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 13150841160273927131
                 },
-                "Component_[13299402086043239524]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 13299402086043239524,
+                "Component_[16118272851083804668]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 16118272851083804668,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
                             "Slots": [
@@ -123,34 +123,31 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{4687EDB6-F57B-592A-8451-4A41BD678D9A}",
+                                "subId": 2070809848
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_floor.pxmesh"
+                        },
+                        "Configuration": {
+                            "Scale": [
+                                0.9850000143051147,
+                                0.8100000023841858,
+                                1.0
+                            ],
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{4687EDB6-F57B-592A-8451-4A41BD678D9A}",
                                     "subId": 2070809848
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "assets/warehouse/models/warehouse_floor.pxmesh"
-                            },
-                            "Configuration": {
-                                "Scale": [
-                                    0.9850000143051147,
-                                    0.8100000023841858,
-                                    1.0
-                                ],
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{4687EDB6-F57B-592A-8451-4A41BD678D9A}",
-                                        "subId": 2070809848
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_floor.pxmesh"
-                                }
                             }
                         },
                         "HasNonUniformScale": true
-                    },
-                    "HasNonUniformScale": true
+                    }
                 },
                 "Component_[17647558825107464022]": {
                     "$type": "EditorVisibilityComponent",

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Walls.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Walls.prefab
@@ -209,9 +209,9 @@
                     "$type": "EditorInspectorComponent",
                     "Id": 15167189095873685279
                 },
-                "Component_[16809483465388003559]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 16809483465388003559,
+                "Component_[15767425793673148970]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 15767425793673148970,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
                             "Slots": [
@@ -224,24 +224,22 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{9F3790A0-9383-5BBA-BB91-2AD9F04086B3}",
+                                "subId": 675098786
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_gate_closed.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{9F3790A0-9383-5BBA-BB91-2AD9F04086B3}",
                                     "subId": 675098786
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "assets/warehouse/models/warehouse_gate_closed.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{9F3790A0-9383-5BBA-BB91-2AD9F04086B3}",
-                                        "subId": 675098786
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_gate_closed.pxmesh"
-                                }
                             }
                         }
                     }
@@ -332,40 +330,6 @@
                         }
                     }
                 },
-                "Component_[1554132197757752789]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 1554132197757752789,
-                    "ColliderConfiguration": {
-                        "MaterialSlots": {
-                            "Slots": [
-                                {
-                                    "Name": "MWarehouseModules"
-                                }
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
-                                "assetId": {
-                                    "guid": "{34CA9168-D5C7-5554-BE7D-8485A3D67AB6}",
-                                    "subId": 3814177680
-                                },
-                                "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{34CA9168-D5C7-5554-BE7D-8485A3D67AB6}",
-                                        "subId": 3814177680
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.pxmesh"
-                                }
-                            }
-                        }
-                    }
-                },
                 "Component_[18360744952719232820]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 18360744952719232820
@@ -381,6 +345,38 @@
                 "Component_[4932017064714589766]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 4932017064714589766
+                },
+                "Component_[6961914333579766230]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 6961914333579766230,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "MWarehouseModules"
+                                }
+                            ]
+                        }
+                    },
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{34CA9168-D5C7-5554-BE7D-8485A3D67AB6}",
+                                "subId": 3814177680
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
+                                "assetId": {
+                                    "guid": "{34CA9168-D5C7-5554-BE7D-8485A3D67AB6}",
+                                    "subId": 3814177680
+                                },
+                                "loadBehavior": "QueueLoad",
+                                "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.pxmesh"
+                            }
+                        }
+                    }
                 },
                 "Component_[7017245480046407512]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -447,6 +443,38 @@
                         }
                     }
                 },
+                "Component_[1694265098081325918]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 1694265098081325918,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "MWarehouseModules"
+                                }
+                            ]
+                        }
+                    },
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{995CFC9D-3583-51BC-B46E-4554DEF0650E}",
+                                "subId": 2510506373
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_walls_front.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
+                                "assetId": {
+                                    "guid": "{995CFC9D-3583-51BC-B46E-4554DEF0650E}",
+                                    "subId": 2510506373
+                                },
+                                "loadBehavior": "QueueLoad",
+                                "assetHint": "assets/warehouse/models/warehouse_walls_front.pxmesh"
+                            }
+                        }
+                    }
+                },
                 "Component_[18360744952719232820]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 18360744952719232820
@@ -458,40 +486,6 @@
                 "Component_[3149718320647090514]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 3149718320647090514
-                },
-                "Component_[3790789121538053334]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 3790789121538053334,
-                    "ColliderConfiguration": {
-                        "MaterialSlots": {
-                            "Slots": [
-                                {
-                                    "Name": "MWarehouseModules"
-                                }
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
-                                "assetId": {
-                                    "guid": "{995CFC9D-3583-51BC-B46E-4554DEF0650E}",
-                                    "subId": 2510506373
-                                },
-                                "assetHint": "assets/warehouse/models/warehouse_walls_front.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{995CFC9D-3583-51BC-B46E-4554DEF0650E}",
-                                        "subId": 2510506373
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_walls_front.pxmesh"
-                                }
-                            }
-                        }
-                    }
                 },
                 "Component_[4417542793349551988]": {
                     "$type": "EditorStaticRigidBodyComponent",
@@ -575,40 +569,6 @@
                         }
                     }
                 },
-                "Component_[3143867532230487626]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 3143867532230487626,
-                    "ColliderConfiguration": {
-                        "MaterialSlots": {
-                            "Slots": [
-                                {
-                                    "Name": "MWarehouseModules"
-                                }
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
-                                "assetId": {
-                                    "guid": "{1DB458F4-42D7-5377-995B-415257F59549}",
-                                    "subId": 1364068586
-                                },
-                                "assetHint": "assets/warehouse/models/warehouse_walls_side.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{1DB458F4-42D7-5377-995B-415257F59549}",
-                                        "subId": 1364068586
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_walls_side.pxmesh"
-                                }
-                            }
-                        }
-                    }
-                },
                 "Component_[4521756557639722239]": {
                     "$type": "EditorStaticRigidBodyComponent",
                     "Id": 4521756557639722239
@@ -631,6 +591,38 @@
                 "Component_[551333522313100696]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 551333522313100696
+                },
+                "Component_[8947064000995272886]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 8947064000995272886,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "MWarehouseModules"
+                                }
+                            ]
+                        }
+                    },
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{1DB458F4-42D7-5377-995B-415257F59549}",
+                                "subId": 1364068586
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_walls_side.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
+                                "assetId": {
+                                    "guid": "{1DB458F4-42D7-5377-995B-415257F59549}",
+                                    "subId": 1364068586
+                                },
+                                "loadBehavior": "QueueLoad",
+                                "assetHint": "assets/warehouse/models/warehouse_walls_side.pxmesh"
+                            }
+                        }
+                    }
                 },
                 "Component_[921603062043779547]": {
                     "$type": "EditorDisabledCompositionComponent",

--- a/Gems/WarehouseSample/Assets/O3DEScene/Prefabs/Warehouse.prefab
+++ b/Gems/WarehouseSample/Assets/O3DEScene/Prefabs/Warehouse.prefab
@@ -1475,65 +1475,9 @@
                         }
                     ]
                 },
-                "Component_[12194365436668824793]": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 12194365436668824793
-                },
-                "Component_[13823656493018592813]": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 13823656493018592813
-                },
-                "Component_[1545542302497973797]": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 1545542302497973797
-                },
-                "Component_[1836959596730672894]": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 1836959596730672894
-                },
-                "Component_[1976302571202485674]": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 1976302571202485674
-                },
-                "Component_[3130608849925615607]": {
-                    "$type": "AZ::Render::EditorMeshComponent",
-                    "Id": 3130608849925615607,
-                    "Controller": {
-                        "Configuration": {
-                            "ModelAsset": {
-                                "assetId": {
-                                    "guid": "{2B484CB6-8011-5B56-B194-7B3110DA7629}",
-                                    "subId": 280202236
-                                },
-                                "assetHint": "o3descene/warehouse.azmodel"
-                            }
-                        }
-                    }
-                },
-                "Component_[3579789965580572662]": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 3579789965580572662,
-                    "Parent Entity": "ContainerEntity"
-                },
-                "Component_[5398237697833321121]": {
-                    "$type": "EditorStaticRigidBodyComponent",
-                    "Id": 5398237697833321121
-                },
-                "Component_[6126526996710685532]": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 6126526996710685532,
-                    "Child Entity Order": [
-                        "Entity_[716185407570]",
-                        "Entity_[707595472978]"
-                    ]
-                },
-                "Component_[8421478587399964878]": {
-                    "$type": "EditorLockComponent",
-                    "Id": 8421478587399964878
-                },
-                "Component_[9485936813148123686]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 9485936813148123686,
+                "Component_[11628671484290353418]": {
+                    "$type": "EditorMeshColliderComponent",
+                    "Id": 11628671484290353418,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
                             "Slots": [
@@ -1790,27 +1734,81 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{2B484CB6-8011-5B56-B194-7B3110DA7629}",
+                                "subId": 2755884180
+                            },
+                            "assetHint": "o3descene/warehouse.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{2B484CB6-8011-5B56-B194-7B3110DA7629}",
                                     "subId": 2755884180
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "o3descene/warehouse.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{2B484CB6-8011-5B56-B194-7B3110DA7629}",
-                                        "subId": 2755884180
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "o3descene/warehouse.pxmesh"
-                                }
                             }
                         }
                     }
+                },
+                "Component_[12194365436668824793]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12194365436668824793
+                },
+                "Component_[13823656493018592813]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13823656493018592813
+                },
+                "Component_[1545542302497973797]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1545542302497973797
+                },
+                "Component_[1836959596730672894]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1836959596730672894
+                },
+                "Component_[1976302571202485674]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1976302571202485674
+                },
+                "Component_[3130608849925615607]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 3130608849925615607,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{2B484CB6-8011-5B56-B194-7B3110DA7629}",
+                                    "subId": 280202236
+                                },
+                                "assetHint": "o3descene/warehouse.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[3579789965580572662]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3579789965580572662,
+                    "Parent Entity": "ContainerEntity"
+                },
+                "Component_[5398237697833321121]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5398237697833321121
+                },
+                "Component_[6126526996710685532]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6126526996710685532,
+                    "Child Entity Order": [
+                        "Entity_[716185407570]",
+                        "Entity_[707595472978]"
+                    ]
+                },
+                "Component_[8421478587399964878]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8421478587399964878
                 },
                 "Component_[9530788238563717018]": {
                     "$type": "EditorMaterialComponent",


### PR DESCRIPTION
- Updated colliders in prefabs by running 'ed_physxUpdatePrefabsWithColliderComponents' command.
- Adjusted C++ code in URDF importer to changes in PhysX gem API.

**Note**
This is part of the work to separate PhysX Collider into 2 components: https://github.com/o3de/o3de/pull/14725.
This is currently as draft to avoid submitting it too early.

**Reviewers**
Please review and approve this draft and once the main change is submitted into o3de I will merge this as well.

**Testing**
All converted prefabs were processed successfully by the Asset Processor.
Checked updated URDF importer code with : https://gist.github.com/michalpelka/c2a4d31e353a23388f53ae97fb74303b
