### PR TITLE
Adjust prefabs and colliders to changes in the o3de PhysX gem

### DIFF
--- a/Gems/ProteusRobot/Assets/Proteus.prefab
+++ b/Gems/ProteusRobot/Assets/Proteus.prefab
@@ -899,7 +899,7 @@
                     "Id": 10928326798115103880
                 },
                 "Component_[1153232506834696450]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1153232506834696450,
                     "ColliderConfiguration": {
                         "Position": [
@@ -921,26 +921,24 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{0042012D-310E-5380-8BFB-5B92949DA679}",
+                                "subId": 1612379007
+                            },
+                            "assetHint": "assets/proteusrobot/proteus_chassis.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{0042012D-310E-5380-8BFB-5B92949DA679}",
                                     "subId": 1612379007
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "assets/proteusrobot/proteus_chassis.pxmesh"
                             },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{0042012D-310E-5380-8BFB-5B92949DA679}",
-                                        "subId": 1612379007
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/proteusrobot/proteus_chassis.pxmesh"
-                                },
-                                "UseMaterialsFromAsset": false
-                            }
+                            "UseMaterialsFromAsset": false
                         }
                     }
                 },

--- a/Gems/ROS2/Assets/Prefabs/Sensors/CameraOrbbeck.prefab
+++ b/Gems/ROS2/Assets/Prefabs/Sensors/CameraOrbbeck.prefab
@@ -71,7 +71,7 @@
                     "Id": 14616296837285217185
                 },
                 "Component_[14985514809153430690]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14985514809153430690,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -82,24 +82,22 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{0E27CF27-5752-5557-B77A-4B29A5870E0E}",
+                                "subId": 3865077323
+                            },
+                            "assetHint": "models/sensors/camera/cameraorbbeck.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{0E27CF27-5752-5557-B77A-4B29A5870E0E}",
                                     "subId": 3865077323
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "models/sensors/camera/cameraorbbeck.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{0E27CF27-5752-5557-B77A-4B29A5870E0E}",
-                                        "subId": 3865077323
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "models/sensors/camera/cameraorbbeck.pxmesh"
-                                }
                             }
                         }
                     }

--- a/Gems/ROS2/Assets/Prefabs/Sensors/Imu.prefab
+++ b/Gems/ROS2/Assets/Prefabs/Sensors/Imu.prefab
@@ -63,7 +63,7 @@
                     "Id": 11958193181460909696
                 },
                 "Component_[12053638524449760314]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12053638524449760314,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -74,24 +74,22 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{50286487-658B-5B99-99D6-3AB4002EFF73}",
+                                "subId": 3726733934
+                            },
+                            "assetHint": "models/sensors/imu/imu_mti10.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{50286487-658B-5B99-99D6-3AB4002EFF73}",
                                     "subId": 3726733934
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "models/sensors/imu/imu_mti10.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{50286487-658B-5B99-99D6-3AB4002EFF73}",
-                                        "subId": 3726733934
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "models/sensors/imu/imu_mti10.pxmesh"
-                                }
                             }
                         }
                     }

--- a/Gems/ROS2/Assets/Prefabs/Sensors/LidarOS2.prefab
+++ b/Gems/ROS2/Assets/Prefabs/Sensors/LidarOS2.prefab
@@ -154,7 +154,7 @@
                     "Id": 13177781661023720894
                 },
                 "Component_[14535670656735835043]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 14535670656735835043,
                     "ColliderConfiguration": {
                         "CollisionGroupId": {
@@ -168,24 +168,22 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{99D850A3-8E59-5E78-93FE-AE8DB228684D}",
+                                "subId": 2574200790
+                            },
+                            "assetHint": "models/sensors/lidaros2/lidaros2.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{99D850A3-8E59-5E78-93FE-AE8DB228684D}",
                                     "subId": 2574200790
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "models/sensors/lidaros2/lidaros2.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{99D850A3-8E59-5E78-93FE-AE8DB228684D}",
-                                        "subId": 2574200790
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "models/sensors/lidaros2/lidaros2.pxmesh"
-                                }
                             }
                         }
                     }

--- a/Gems/RosRobotSample/Assets/ROSbot.prefab
+++ b/Gems/RosRobotSample/Assets/ROSbot.prefab
@@ -734,7 +734,7 @@
                     "Id": 10928326798115103880
                 },
                 "Component_[1153232506834696450]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1153232506834696450,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -745,26 +745,24 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{7F445A99-8C11-5417-9D63-8BCC7DCA76C8}",
+                                "subId": 1509562746
+                            },
+                            "assetHint": "robot/rosbot_xl_description/meshes/body_colision.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{7F445A99-8C11-5417-9D63-8BCC7DCA76C8}",
                                     "subId": 1509562746
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "robot/rosbot_xl_description/meshes/body_colision.pxmesh"
                             },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{7F445A99-8C11-5417-9D63-8BCC7DCA76C8}",
-                                        "subId": 1509562746
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "robot/rosbot_xl_description/meshes/body_colision.pxmesh"
-                                },
-                                "UseMaterialsFromAsset": false
-                            }
+                            "UseMaterialsFromAsset": false
                         }
                     }
                 },

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseRack.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseRack.prefab
@@ -105,7 +105,7 @@
                     "Id": 16403983953216827994
                 },
                 "Component_[2276504649476859699]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2276504649476859699,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -116,24 +116,22 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{665AB396-251A-55E3-83E2-AAB98CB864FB}",
+                                "subId": 1812650258
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_rack.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{665AB396-251A-55E3-83E2-AAB98CB864FB}",
                                     "subId": 1812650258
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "assets/warehouse/models/warehouse_rack.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{665AB396-251A-55E3-83E2-AAB98CB864FB}",
-                                        "subId": 1812650258
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_rack.pxmesh"
-                                }
                             }
                         }
                     }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_front_protector.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_front_protector.prefab
@@ -63,7 +63,7 @@
                     "Id": 13395915873594579514
                 },
                 "Component_[15579174905508719867]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15579174905508719867,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -74,24 +74,22 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{9928FCBB-9AD8-5B3E-94FF-3516CC574ED1}",
+                                "subId": 4102061829
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_frontrackprotector.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{9928FCBB-9AD8-5B3E-94FF-3516CC574ED1}",
                                     "subId": 4102061829
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "assets/warehouse/models/warehouse_frontrackprotector.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{9928FCBB-9AD8-5B3E-94FF-3516CC574ED1}",
-                                        "subId": 4102061829
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_frontrackprotector.pxmesh"
-                                }
                             }
                         }
                     }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_side_protector.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_side_protector.prefab
@@ -156,7 +156,7 @@
                     }
                 },
                 "Component_[15264405835034640312]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 15264405835034640312,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -167,24 +167,22 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{663633B0-B67A-5957-BC3A-53FA65F40353}",
+                                "subId": 3163433385
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_siderackprotector.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{663633B0-B67A-5957-BC3A-53FA65F40353}",
                                     "subId": 3163433385
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "assets/warehouse/models/warehouse_siderackprotector.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{663633B0-B67A-5957-BC3A-53FA65F40353}",
-                                        "subId": 3163433385
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_siderackprotector.pxmesh"
-                                }
                             }
                         }
                     }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Floor.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Floor.prefab
@@ -112,7 +112,7 @@
                     "Id": 13150841160273927131
                 },
                 "Component_[13299402086043239524]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 13299402086043239524,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -123,34 +123,31 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{4687EDB6-F57B-592A-8451-4A41BD678D9A}",
+                                "subId": 2070809848
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_floor.pxmesh"
+                        },
+                        "Configuration": {
+                            "Scale": [
+                                0.9850000143051147,
+                                0.8100000023841858,
+                                1.0
+                            ],
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{4687EDB6-F57B-592A-8451-4A41BD678D9A}",
                                     "subId": 2070809848
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "assets/warehouse/models/warehouse_floor.pxmesh"
-                            },
-                            "Configuration": {
-                                "Scale": [
-                                    0.9850000143051147,
-                                    0.8100000023841858,
-                                    1.0
-                                ],
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{4687EDB6-F57B-592A-8451-4A41BD678D9A}",
-                                        "subId": 2070809848
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_floor.pxmesh"
-                                }
                             }
                         },
                         "HasNonUniformScale": true
-                    },
-                    "HasNonUniformScale": true
+                    }
                 },
                 "Component_[17647558825107464022]": {
                     "$type": "EditorVisibilityComponent",

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Walls.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Walls.prefab
@@ -210,7 +210,7 @@
                     "Id": 15167189095873685279
                 },
                 "Component_[16809483465388003559]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 16809483465388003559,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -224,24 +224,22 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{9F3790A0-9383-5BBA-BB91-2AD9F04086B3}",
+                                "subId": 675098786
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_gate_closed.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{9F3790A0-9383-5BBA-BB91-2AD9F04086B3}",
                                     "subId": 675098786
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "assets/warehouse/models/warehouse_gate_closed.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{9F3790A0-9383-5BBA-BB91-2AD9F04086B3}",
-                                        "subId": 675098786
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_gate_closed.pxmesh"
-                                }
                             }
                         }
                     }
@@ -333,7 +331,7 @@
                     }
                 },
                 "Component_[1554132197757752789]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1554132197757752789,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -344,24 +342,22 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{34CA9168-D5C7-5554-BE7D-8485A3D67AB6}",
+                                "subId": 3814177680
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{34CA9168-D5C7-5554-BE7D-8485A3D67AB6}",
                                     "subId": 3814177680
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{34CA9168-D5C7-5554-BE7D-8485A3D67AB6}",
-                                        "subId": 3814177680
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.pxmesh"
-                                }
                             }
                         }
                     }
@@ -460,7 +456,7 @@
                     "Id": 3149718320647090514
                 },
                 "Component_[3790789121538053334]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 3790789121538053334,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -471,24 +467,22 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{995CFC9D-3583-51BC-B46E-4554DEF0650E}",
+                                "subId": 2510506373
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_walls_front.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{995CFC9D-3583-51BC-B46E-4554DEF0650E}",
                                     "subId": 2510506373
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "assets/warehouse/models/warehouse_walls_front.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{995CFC9D-3583-51BC-B46E-4554DEF0650E}",
-                                        "subId": 2510506373
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_walls_front.pxmesh"
-                                }
                             }
                         }
                     }
@@ -576,7 +570,7 @@
                     }
                 },
                 "Component_[3143867532230487626]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 3143867532230487626,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -587,24 +581,22 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{1DB458F4-42D7-5377-995B-415257F59549}",
+                                "subId": 1364068586
+                            },
+                            "assetHint": "assets/warehouse/models/warehouse_walls_side.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{1DB458F4-42D7-5377-995B-415257F59549}",
                                     "subId": 1364068586
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "assets/warehouse/models/warehouse_walls_side.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{1DB458F4-42D7-5377-995B-415257F59549}",
-                                        "subId": 1364068586
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_walls_side.pxmesh"
-                                }
                             }
                         }
                     }

--- a/Gems/WarehouseSample/Assets/O3DEScene/Prefabs/Warehouse.prefab
+++ b/Gems/WarehouseSample/Assets/O3DEScene/Prefabs/Warehouse.prefab
@@ -1532,7 +1532,7 @@
                     "Id": 8421478587399964878
                 },
                 "Component_[9485936813148123686]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 9485936813148123686,
                     "ColliderConfiguration": {
                         "MaterialSlots": {
@@ -1790,24 +1790,22 @@
                             ]
                         }
                     },
-                    "ShapeConfiguration": {
-                        "PhysicsAsset": {
-                            "Asset": {
+                    "PhysicsAssetShapeConfiguration": {
+                        "Asset": {
+                            "assetId": {
+                                "guid": "{2B484CB6-8011-5B56-B194-7B3110DA7629}",
+                                "subId": 2755884180
+                            },
+                            "assetHint": "o3descene/warehouse.pxmesh"
+                        },
+                        "Configuration": {
+                            "PhysicsAsset": {
                                 "assetId": {
                                     "guid": "{2B484CB6-8011-5B56-B194-7B3110DA7629}",
                                     "subId": 2755884180
                                 },
+                                "loadBehavior": "QueueLoad",
                                 "assetHint": "o3descene/warehouse.pxmesh"
-                            },
-                            "Configuration": {
-                                "PhysicsAsset": {
-                                    "assetId": {
-                                        "guid": "{2B484CB6-8011-5B56-B194-7B3110DA7629}",
-                                        "subId": 2755884180
-                                    },
-                                    "loadBehavior": "QueueLoad",
-                                    "assetHint": "o3descene/warehouse.pxmesh"
-                                }
                             }
                         }
                     }


### PR DESCRIPTION
- Updated colliders in prefabs by running 'ed_physxUpdatePrefabsWithColliderComponents' command.
- Adjusted C++ code in URDF importer to changes in PhysX gem API.

**Note**
This is part of the work to separate PhysX Collider into 2 components: https://github.com/o3de/o3de/pull/14725.
This is currently as draft to avoid submitting it too early.

**Reviewers**
Please review and approve this draft and once the main change is submitted into o3de I will merge this as well.

**Testing**
All converted prefabs were processed successfully by the Asset Processor.
Checked updated URDF importer code with : https://gist.github.com/michalpelka/c2a4d31e353a23388f53ae97fb74303b
