### PR TITLE
High frequency implementation of odometry sensor.

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -46,6 +46,9 @@ ly_add_target(
 
 target_depends_on_ros2_packages(${gem_name}.Static rclcpp builtin_interfaces std_msgs sensor_msgs nav_msgs urdfdom tf2_ros ackermann_msgs gazebo_msgs control_toolbox)
 
+target_include_directories(${gem_name}.Static PUBLIC "/opt/ros/humble/include/control_toolbox/")
+target_link_libraries(${gem_name}.Static PUBLIC "/opt/ros/humble/lib/libcontrol_toolbox.so")
+
 ly_add_target(
     NAME ${gem_name}.API HEADERONLY
     NAMESPACE Gem

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplate.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplate.h
@@ -36,7 +36,7 @@ namespace ROS2
         struct NoiseParameters
         {
         public:
-            AZ_TYPE_INFO(LidarNoiseParameters, "{58c007ad-320f-49df-bc20-6419159ee176}");
+            AZ_TYPE_INFO(NoiseParameters, "{58c007ad-320f-49df-bc20-6419159ee176}");
             static void Reflect(AZ::ReflectContext* context);
 
             //! Angular noise standard deviation, in degrees

--- a/Gems/ROS2/Code/Source/Odometry/ROS2OdometrySensorComponent.h
+++ b/Gems/ROS2/Code/Source/Odometry/ROS2OdometrySensorComponent.h
@@ -12,6 +12,8 @@
 #include <ROS2/Sensor/ROS2SensorComponent.h>
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/publisher.hpp>
+#include <AzFramework/Physics/PhysicsSystem.h>
+#include <AzFramework/Physics/Common/PhysicsEvents.h>
 
 namespace ROS2
 {
@@ -41,5 +43,7 @@ namespace ROS2
 
         std::shared_ptr<rclcpp::Publisher<nav_msgs::msg::Odometry>> m_odometryPublisher;
         nav_msgs::msg::Odometry m_odometryMsg;
+        AzPhysics::SceneEvents::OnSceneActiveSimulatedBodiesEvent::Handler m_onSceneActiveSimulatedBodiesEvent;
+        AzPhysics::SimulatedBodyHandle m_handle;
     };
 } // namespace ROS2


### PR DESCRIPTION
- [ ] Change the ROS2SensorComponent interface, and remove its ticking loop (e.g. add another base class in between). A ticking loop is not needed, wait for the solution proposed in #155.
- [ ] Add a mechanism to limit output the frequency
- [ ] Profile `m_onSceneActiveSimulatedBodiesEvent` - it performs expensive and redundant 'GetFrameTransform', it can be delegated to TickBus::Handler
- [ ] Rebase and clean unblocking code (covered by #200 and #204)
- [ ] Remove draft status