### PR TITLE
Made ROS2Frame required for ROS2Odometry to prevent possible crash on run

### DIFF
--- a/Gems/ROS2/Code/Source/Odometry/ROS2OdometrySensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Odometry/ROS2OdometrySensorComponent.cpp
@@ -51,6 +51,7 @@ namespace ROS2
     void ROS2OdometrySensorComponent::FrequencyTick()
     {
         auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
+        AZ_Assert(ros2Frame, "ROS2Frame must be present for ROS2OdometrySensorComponent");
         auto transform = ros2Frame->GetFrameTransform();
 
         AZ::Vector3 linearVelocity;
@@ -74,6 +75,7 @@ namespace ROS2
     void ROS2OdometrySensorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
+        required.push_back(AZ_CRC_CE("ROS2Frame"));
     }
 
     void ROS2OdometrySensorComponent::Activate()


### PR DESCRIPTION
Added ROS2Frame as required service for ROS2OdometrySensor.
Added Assert after getting component to prevent segfault without indication to cause.
Fix for Issue 196