### PR TITLE
As part of fixing https://github.com/o3de/o3de-extras/issues/118

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -89,16 +89,35 @@ namespace ROS2
                 if (outcome)
                 {
                     m_parsedUrdf = outcome.m_urdfHandle;
-                    report += "# " + tr("XACRO execution succeed") + "\n";
+                    report += "# " + tr("XACRO execution succeeded") + "\n";
                 }
                 else
                 {
                     report += "# " + tr("XACRO parsing failed") + "\n";
-                    report += "\n\n" + tr("Command called : \n'") + QString::fromUtf8(outcome.m_called.data()) + "'";
+                    report += "\n\n## " + tr("Command called") +  "\n\n`" + QString::fromUtf8(outcome.m_called.data()) + "`";
                     report += "\n\n" + tr("Process failed");
-                    report += "\n\n" + tr("error output") + " :\n\n";
-                    report +=
-                        QString::fromLocal8Bit(outcome.m_logErrorOutput.data(), static_cast<int>(outcome.m_logErrorOutput.size())) + "\n";
+                    report += "\n\n## " + tr("Error output") + "\n\n";
+                    report += "```\n";
+                    if (outcome.m_logErrorOutput.size())
+                    {
+                        report += QString::fromLocal8Bit(outcome.m_logErrorOutput.data(), static_cast<int>(outcome.m_logErrorOutput.size()));
+                    }
+                    else
+                    {
+                        report += tr("(EMPTY)");
+                    }
+                    report += "\n```";
+                    report += "\n\n## " + tr("Standard output") + "\n\n";
+                    report += "```\n";
+                    if (outcome.m_logStandardOutput.size())
+                    {
+                        report += QString::fromLocal8Bit(outcome.m_logStandardOutput.data(), static_cast<int>(outcome.m_logStandardOutput.size()));
+                    }
+                    else
+                    {
+                        report += tr("(EMPTY)");
+                    }
+                    report += "\n```";
                     m_checkUrdfPage->ReportURDFResult(report, false);
                     m_parsedUrdf = nullptr;
                     return;


### PR DESCRIPTION
It was discovered that the error log from xacro is cut off on the first angle bracket, making it impossible to see the actual error problem fully if it occurs.

This change surrounds the error text with a code macro (three backticks) so that it shows up in markdown as the actual literal code, which causes Qt to ignore any angle brackets and other markdown inside the text.

Note that this was discovered during fixing 
https://github.com/o3de/o3de-extras/issues/118
but does not fix 118, only makes it better display when errors occur.

How it looks with these changes

![image](https://user-images.githubusercontent.com/70027408/227027511-d4bf51bd-4259-4a00-b981-fe21d5dd8d09.png)
