### PR TITLE
Blast Gem - Fix python script connect order

### DIFF
--- a/Gems/Blast/Editor/Scripts/blast_chunk_processor.py
+++ b/Gems/Blast/Editor/Scripts/blast_chunk_processor.py
@@ -149,9 +149,9 @@ def on_update_manifest(args):
 try:
     import azlmbr.scene as sceneApi
     sceneJobHandler = sceneApi.ScriptBuildingNotificationBusHandler()
+    sceneJobHandler.connect()
     sceneJobHandler.add_callback('OnUpdateManifest', on_update_manifest)
     sceneJobHandler.add_callback('OnPrepareForExport', on_prepare_for_export)
-    sceneJobHandler.connect()
         
 except:
     sceneJobHandler = None


### PR DESCRIPTION
Fixed an issue with python builder script connecting to an ebus before calling add_callback

Fixes https://github.com/o3de/o3de/issues/14209

Tested by manually running AP and processing the blast FBX files