### PR TITLE
Change way of source asset handling in URDF importer

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -97,6 +97,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         INCLUDE_DIRECTORIES
             PRIVATE
                 Source
+                Source/RobotImporter
             PUBLIC
                 Include
         COMPILE_DEFINITIONS

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
@@ -7,8 +7,11 @@
  */
 
 #include "CheckAssetPage.h"
+#include "RobotImporter/Utils/SourceAssetsStorage.h"
 #include <AzCore/Math/MathStringConversions.h>
+#include <AzFramework/Asset/AssetSystemBus.h>
 #include <QHeaderView>
+#include <QPushButton>
 #include <QVBoxLayout>
 namespace ROS2
 {
@@ -17,19 +20,53 @@ namespace ROS2
         : QWizardPage(parent)
         , m_success(true)
         , m_missingCount(0)
+        , m_failureIcon(QStringLiteral(":/stylesheet/img/logging/failure.svg"))
+        , m_okIcon(QStringLiteral(":/stylesheet/img/logging/valid.svg"))
     {
         m_table = new QTableWidget(parent);
         SetTitle();
         QVBoxLayout* layout = new QVBoxLayout;
         layout->addWidget(m_table);
-        m_table->setColumnCount(4);
-        m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
-        m_table->setShowGrid(true);
-        m_table->setSelectionMode(QAbstractItemView::SingleSelection);
-        m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
-        m_table->setHorizontalHeaderLabels({ tr("URDF mesh path"), tr("CRC"), tr("Type"), tr("Asset source") });
+        m_table->setEnabled(true);
+        m_table->setAlternatingRowColors(true);
+        m_table->setMinimumHeight(500);
+        m_table->setMinimumWidth(1000);
         m_table->horizontalHeader()->setStretchLastSection(true);
+        m_table->setCornerButtonEnabled(false);
+        m_table->setSortingEnabled(false);
+        m_table->setColumnCount(5);
+        m_table->setShowGrid(true);
+        m_table->setMouseTracking(true);
+        m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+        m_table->setSelectionMode(QAbstractItemView::SingleSelection);
+        // Set the header items.
+        QTableWidgetItem* headerItem = new QTableWidgetItem(tr("URDF mesh path"));
+        headerItem->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+        m_table->setHorizontalHeaderItem(0, headerItem);
+        headerItem = new QTableWidgetItem(tr("Resolved mesh from URDF"));
+        headerItem->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+        m_table->setHorizontalHeaderItem(1, headerItem);
+        headerItem = new QTableWidgetItem(tr("Type"));
+        headerItem->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+        m_table->setHorizontalHeaderItem(2, headerItem);
+        headerItem = new QTableWidgetItem(tr("Source asset"));
+        headerItem->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+        m_table->setHorizontalHeaderItem(3, headerItem);
+        headerItem = new QTableWidgetItem(tr("Product asset"));
+        headerItem->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+        m_table->setHorizontalHeaderItem(4, headerItem);
+        m_table->horizontalHeader()->resizeSection(0, 200);
+        m_table->horizontalHeader()->resizeSection(1, 350);
+        m_table->horizontalHeader()->resizeSection(2, 50);
+        m_table->horizontalHeader()->resizeSection(3, 400);
+        m_table->horizontalHeader()->resizeSection(4, 400);
+        m_table->verticalHeader()->hide();
+        connect(m_table, &QTableWidget::cellDoubleClicked, this, &CheckAssetPage::DoubleClickRow);
         this->setLayout(layout);
+        m_refreshTimer = new QTimer(this);
+        m_refreshTimer->setInterval(250);
+        m_refreshTimer->setSingleShot(false);
+        connect(m_refreshTimer, &QTimer::timeout, this, &CheckAssetPage::RefreshTimerElapsed);
     }
 
     void CheckAssetPage::SetTitle()
@@ -50,24 +87,47 @@ namespace ROS2
     };
 
     void CheckAssetPage::ReportAsset(
-        const QString& urdfPath, const QString& type, const QString& assetSourcePath, const AZ::Crc32& crc32, const QString& tooltip)
+        const AZ::Uuid assetUuid,
+        const AZStd::string urdfPath,
+        const QString& type,
+        const AZStd::string assetSourcePath,
+        const AZ::Crc32& crc32,
+        const AZStd::string resolvedUrdfPath)
     {
         int i = m_table->rowCount();
         m_table->setRowCount(i + 1);
 
-        bool isOk = !assetSourcePath.isEmpty();
+        bool isOk = !assetSourcePath.empty();
         if (!isOk)
         {
             m_missingCount++;
         }
         SetTitle();
         AZStd::string crcStr = AZStd::to_string(crc32);
-        QTableWidgetItem* p = createCell(isOk, urdfPath);
-        p->setToolTip(tr("Resolved to : ") + tooltip);
+        QTableWidgetItem* p = createCell(isOk, QString::fromUtf8(urdfPath.data(), urdfPath.size()));
+        p->setToolTip(tr("CRC for file : ") + QString::fromUtf8(crcStr.data(), crcStr.size()));
         m_table->setItem(i, 0, p);
-        m_table->setItem(i, 1, createCell(isOk, QString::fromUtf8(crcStr.data(), crcStr.size())));
+        m_table->setItem(i, 1, createCell(isOk, QString::fromUtf8(resolvedUrdfPath.data(), resolvedUrdfPath.size())));
         m_table->setItem(i, 2, createCell(isOk, type));
-        m_table->setItem(i, 3, createCell(isOk, assetSourcePath));
+        m_table->setItem(i, 3, createCell(isOk, QString::fromUtf8(assetSourcePath.data(), assetSourcePath.size())));
+        if (isOk)
+        {
+            m_table->item(i, 1)->setIcon(m_okIcon);
+        }
+        else
+        {
+            m_table->item(i, 1)->setIcon(m_failureIcon);
+        }
+        if (!assetSourcePath.empty())
+        {
+            m_assetsPaths.push_back(assetSourcePath);
+            m_assetsUuids.push_back(assetUuid);
+        }
+    }
+
+    void CheckAssetPage::StartWatchAsset()
+    {
+        m_refreshTimer->start();
     }
 
     QTableWidgetItem* CheckAssetPage::createCell(bool isOk, const QString& text)
@@ -75,16 +135,101 @@ namespace ROS2
         QTableWidgetItem* p = new QTableWidgetItem(text);
         if (!isOk)
         {
-            p->setBackground(Qt::red);
+            p->setBackground(Qt::darkRed);
         }
-        p->setFlags(Qt::NoItemFlags);
+        p->setToolTip(text);
+        p->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         return p;
     }
 
     void CheckAssetPage::ClearAssetsList()
     {
+        m_assetsUuids.clear();
+        m_assetsUuidsFinished.clear();
+        m_assetsPaths.clear();
         m_table->setRowCount(0);
         m_missingCount = 0;
+        m_failedCount = 0;
+        m_refreshTimer->stop();
     }
 
+    bool CheckAssetPage::IsEmpty() const
+    {
+        return m_assetsUuids.empty();
+    }
+
+    void CheckAssetPage::DoubleClickRow(int row, int col)
+    {
+        AZ_Printf("CheckAssetPage", "Clicked on row", row);
+        if (row < m_assetsPaths.size())
+        {
+            AzFramework::AssetSystemRequestBus::Broadcast(
+                &AzFramework::AssetSystem::AssetSystemRequests::ShowInAssetProcessor, m_assetsPaths[row]);
+        }
+    }
+
+    void CheckAssetPage::RefreshTimerElapsed()
+    {
+        for (int i = 0; i < m_assetsUuids.size(); i++)
+        {
+            const AZ::Uuid& assetUuid = m_assetsUuids[i];
+            const AZStd::string& sourceAssetFullPath = m_assetsPaths[i];
+            if (!m_assetsUuidsFinished.contains(assetUuid))
+            {
+                using namespace AzToolsFramework;
+                using namespace AzToolsFramework::AssetSystem;
+
+                AZ::Outcome<AssetSystem::JobInfoContainer> result = AZ::Failure();
+                AssetSystemJobRequestBus::BroadcastResult(
+                    result, &AssetSystemJobRequestBus::Events::GetAssetJobsInfo, sourceAssetFullPath, true);
+                bool allFinished = true;
+                bool failed = false;
+                JobInfoContainer& allJobs = result.GetValue();
+                for (const JobInfo& job : allJobs)
+                {
+                    if (job.m_status == JobStatus::Queued || job.m_status == JobStatus::InProgress)
+                    {
+                        allFinished = false;
+                    }
+                    if (job.m_status == JobStatus::Failed)
+                    {
+                        failed = true;
+                        m_failedCount++;
+                    }
+                }
+                if (allFinished)
+                {
+                    if (!failed)
+                    {
+                        const AZStd::string productRelPathVisual = Utils::GetModelProductAsset(assetUuid);
+                        const AZStd::string productRelPathCollider = Utils::GetPhysXMeshProductAsset(assetUuid);
+                        QString text = QString::fromUtf8(productRelPathVisual.data(), productRelPathVisual.size()) + " " +
+                            QString::fromUtf8(productRelPathCollider.data(), productRelPathCollider.size());
+                        m_table->setItem(i, 4, createCell(true, text));
+                        m_table->item(i, 4)->setIcon(m_okIcon);
+                    }
+                    else
+                    {
+                        m_table->setItem(i, 4, createCell(false, tr("Failed")));
+                        m_table->item(i, 4)->setIcon(m_failureIcon);
+                    }
+                    m_assetsUuidsFinished.insert(assetUuid);
+                }
+            }
+        }
+        if (m_assetsUuidsFinished.size() == m_assetsUuids.size())
+        {
+            m_refreshTimer->stop();
+            if (m_failedCount == 0 && m_missingCount == 0)
+            {
+                setTitle(tr("All meshes were processed"));
+            }
+            else
+            {
+                setTitle(
+                    tr("There are ") + QString::number(m_missingCount) + tr(" unresolved meshes.") + tr("There are ") +
+                    QString::number(m_failedCount) + tr(" failed asset processor jobs."));
+            }
+        }
+    }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.h
@@ -9,12 +9,17 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
+#include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Math/Crc.h>
+#include <AzCore/std/containers/map.h>
+#include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
 #include <QLabel>
 #include <QString>
 #include <QTableWidget>
 #include <QTableWidgetItem>
+#include <QTimer>
+#include <QVector>
 #include <QWizardPage>
 #endif
 
@@ -25,17 +30,35 @@ namespace ROS2
         Q_OBJECT
     public:
         explicit CheckAssetPage(QWizard* parent);
-        void ReportAsset(
-            const QString& urdfPath, const QString& type, const QString& assetSourcePath, const AZ::Crc32& crc32, const QString& tooltip);
-        void ClearAssetsList();
 
+        //! Function reports assets that are will be processed by asset processor.
+        void ReportAsset(
+            const AZ::Uuid assetUuid,
+            const AZStd::string urdfPath,
+            const QString& type,
+            const AZStd::string assetSourcePath,
+            const AZ::Crc32& crc32,
+            const AZStd::string resolvedUrdfPath);
+        void ClearAssetsList();
+        bool IsEmpty() const;
         bool isComplete() const override;
+        void StartWatchAsset();
 
     private:
         bool m_success;
-        QTableWidget* m_table {};
+        QTimer* m_refreshTimer{};
+        QTableWidget* m_table{};
         QTableWidgetItem* createCell(bool isOk, const QString& text);
-        unsigned int m_missingCount;
+        QLabel* m_numberOfAssetLabel{};
+        unsigned int m_missingCount{ 0 };
+        unsigned int m_failedCount{ 0 };
         void SetTitle();
+        AZStd::vector<AZ::Uuid> m_assetsUuids;
+        AZStd::vector<AZStd::string> m_assetsPaths;
+        AZStd::unordered_set<AZ::Uuid> m_assetsUuidsFinished;
+        void DoubleClickRow(int row, int col);
+        void RefreshTimerElapsed();
+        QIcon m_failureIcon;
+        QIcon m_okIcon;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.cpp
@@ -21,6 +21,8 @@ namespace ROS2
         m_fileDialog->setNameFilter("URDF, XACRO (*.urdf *.xacro)");
         m_button = new QPushButton("...", this);
         m_textEdit = new QLineEdit("", this);
+        m_copyFiles = new QCheckBox(tr("Import meshes during URDF load"), this);
+        m_copyFiles->setCheckState(Qt::CheckState::Checked);
         setTitle(tr("Load URDF file"));
         QVBoxLayout* layout = new QVBoxLayout;
         layout->addStretch();
@@ -29,6 +31,7 @@ namespace ROS2
         layout_in->addWidget(m_button);
         layout_in->addWidget(m_textEdit);
         layout->addLayout(layout_in);
+        layout->addWidget(m_copyFiles);
         layout->addStretch();
         this->setLayout(layout);
         connect(m_button, &QPushButton::pressed, this, &FileSelectionPage::onLoadButtonPressed);
@@ -56,5 +59,10 @@ namespace ROS2
     bool FileSelectionPage::isComplete() const
     {
         return m_fileExists;
-    };
+    }
+
+    bool FileSelectionPage::getIfCopyAssetsDuringUrdfImport() const
+    {
+        return m_copyFiles->isChecked();
+    }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
+#include <QCheckBox>
 #include <QFileDialog>
 #include <QLabel>
 #include <QLineEdit>
@@ -36,12 +37,13 @@ namespace ROS2
             }
             return "";
         }
+        bool getIfCopyAssetsDuringUrdfImport() const;
 
     private:
         QFileDialog* m_fileDialog;
         QPushButton* m_button;
         QLineEdit* m_textEdit;
-
+        QCheckBox* m_copyFiles;
         void onLoadButtonPressed();
 
         void onFileSelected(const QString& file);

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -41,7 +41,6 @@ namespace ROS2
         connect(this, &QWizard::currentIdChanged, this, &RobotImporterWidget::onCurrentIdChanged);
         connect(m_prefabMakerPage, &QWizardPage::completeChanged, this, &RobotImporterWidget::OnUrdfCreated);
         connect(m_prefabMakerPage, &PrefabMakerPage::onCreateButtonPressed, this, &RobotImporterWidget::onCreateButtonPressed);
-        connect(this, &RobotImporterWidget::SignalFinalizeURDFCreation, this, &RobotImporterWidget::FinalizeURDFCreation);
         connect(
             this,
             &QWizard::customButtonClicked,
@@ -90,17 +89,19 @@ namespace ROS2
                 {
                     m_parsedUrdf = outcome.m_urdfHandle;
                     report += "# " + tr("XACRO execution succeeded") + "\n";
+                    m_assetPage->ClearAssetsList();
                 }
                 else
                 {
                     report += "# " + tr("XACRO parsing failed") + "\n";
-                    report += "\n\n## " + tr("Command called") +  "\n\n`" + QString::fromUtf8(outcome.m_called.data()) + "`";
+                    report += "\n\n## " + tr("Command called") + "\n\n`" + QString::fromUtf8(outcome.m_called.data()) + "`";
                     report += "\n\n" + tr("Process failed");
                     report += "\n\n## " + tr("Error output") + "\n\n";
                     report += "```\n";
                     if (outcome.m_logErrorOutput.size())
                     {
-                        report += QString::fromLocal8Bit(outcome.m_logErrorOutput.data(), static_cast<int>(outcome.m_logErrorOutput.size()));
+                        report +=
+                            QString::fromLocal8Bit(outcome.m_logErrorOutput.data(), static_cast<int>(outcome.m_logErrorOutput.size()));
                     }
                     else
                     {
@@ -111,7 +112,8 @@ namespace ROS2
                     report += "```\n";
                     if (outcome.m_logStandardOutput.size())
                     {
-                        report += QString::fromLocal8Bit(outcome.m_logStandardOutput.data(), static_cast<int>(outcome.m_logStandardOutput.size()));
+                        report += QString::fromLocal8Bit(
+                            outcome.m_logStandardOutput.data(), static_cast<int>(outcome.m_logStandardOutput.size()));
                     }
                     else
                     {
@@ -140,6 +142,7 @@ namespace ROS2
                 // Report the status of skipping this page
                 AZ_Printf("Wizard", "Wizard skips m_checkUrdfPage since there is no errors in URDF\n");
                 m_meshNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), true, true);
+                m_assetPage->ClearAssetsList();
             }
             else
             {
@@ -172,21 +175,43 @@ namespace ROS2
 
     void RobotImporterWidget::FillAssetPage()
     {
-        m_assetPage->ClearAssetsList();
-        if (m_parsedUrdf)
+        if (m_parsedUrdf && m_assetPage->IsEmpty())
         {
-            m_urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(Utils::FindAssetsForUrdf(m_meshNames, m_urdfPath.String()));
             auto collidersNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), false, true);
             auto visualNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), true, false);
+
+            if (m_importAssetWithUrdf)
+            {
+                m_urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(
+                    Utils::CopyAssetForURDFAndCreateAssetMap(m_meshNames, m_urdfPath.String(), collidersNames, visualNames));
+            }
+            else
+            {
+                m_urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(Utils::FindAssetsForUrdf(m_meshNames, m_urdfPath.String()));
+            };
+
             for (const AZStd::string& meshPath : m_meshNames)
             {
-                const QString meshPathqs = QString::fromUtf8(meshPath.data(), meshPath.size());
-                const QString kNotFound = tr("not found");
+                if (m_urdfAssetsMapping->contains(meshPath))
+                {
+                    const auto& asset = m_urdfAssetsMapping->at(meshPath);
+                    bool visual = visualNames.contains(meshPath);
+                    bool collider = collidersNames.contains(meshPath);
+                    Utils::createSceneManifest(asset.m_availableAssetInfo.m_sourceAssetGlobalPath, collider, visual);
+                }
+            }
 
+            for (const AZStd::string& meshPath : m_meshNames)
+            {
+                const QString kNotFound = tr("not found");
+                const AZStd::string kNotFoundAz(kNotFound.toUtf8());
+                AZ::Uuid sourceAssetUuid;
                 if (m_urdfAssetsMapping->contains(meshPath))
                 {
                     QString type = kNotFound;
-                    QString sourcePath = kNotFound;
+                    AZStd::string sourcePath(kNotFoundAz);
+                    AZStd::string resolvedPath(kNotFoundAz);
+                    QString productAssetText;
                     auto crc = AZ::Crc32();
                     QString tooltip = kNotFound;
                     bool visual = visualNames.contains(meshPath);
@@ -207,20 +232,20 @@ namespace ROS2
                     if (m_urdfAssetsMapping->contains(meshPath))
                     {
                         const auto& asset = m_urdfAssetsMapping->at(meshPath);
-                        const AZStd::string& productPath = asset.m_availableAssetInfo.m_productAssetRelativePath;
-                        const AZStd::string& resolvedPath = asset.m_resolvedUrdfPath.data();
-
-                        sourcePath = QString::fromUtf8(productPath.data(), productPath.size());
+                        sourceAssetUuid = asset.m_availableAssetInfo.m_sourceGuid;
+                        sourcePath = asset.m_availableAssetInfo.m_sourceAssetRelativePath;
+                        resolvedPath = asset.m_resolvedUrdfPath.data();
                         crc = asset.m_urdfFileCRC;
                         tooltip = QString::fromUtf8(resolvedPath.data(), resolvedPath.size());
                     }
-                    m_assetPage->ReportAsset(meshPathqs, type, sourcePath, crc, tooltip);
+                    m_assetPage->ReportAsset(sourceAssetUuid, meshPath, type, sourcePath, crc, resolvedPath);
                 }
                 else
                 {
-                    m_assetPage->ReportAsset(meshPathqs, kNotFound, kNotFound, AZ::Crc32(), kNotFound);
+                    m_assetPage->ReportAsset(sourceAssetUuid, meshPath, kNotFound, kNotFoundAz, AZ::Crc32(), kNotFoundAz);
                 };
             }
+            m_assetPage->StartWatchAsset();
         }
     }
 
@@ -252,6 +277,7 @@ namespace ROS2
             {
                 OpenUrdf();
             }
+            m_importAssetWithUrdf = m_fileSelectPage->getIfCopyAssetsDuringUrdfImport();
         }
         if (currentPage() == m_xacroParamsPage)
         {
@@ -329,14 +355,6 @@ namespace ROS2
         m_prefabMaker = AZStd::make_unique<URDFPrefabMaker>(
             m_urdfPath.String(), m_parsedUrdf, prefabPath.String(), m_urdfAssetsMapping, useArticulation);
 
-        auto callback = [&]()
-        {
-            emit SignalFinalizeURDFCreation();
-        };
-        m_prefabMaker->LoadURDF(callback);
-    }
-    void RobotImporterWidget::FinalizeURDFCreation()
-    {
         auto prefabOutcome = m_prefabMaker->CreatePrefabFromURDF();
         if (prefabOutcome.IsSuccess())
         {
@@ -353,6 +371,7 @@ namespace ROS2
             m_prefabMakerPage->setSuccess(false);
         }
     }
+
     void RobotImporterWidget::onCreateButtonPressed()
     {
         CreatePrefab(m_prefabMakerPage->getPrefabName());

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -16,7 +16,6 @@
 #include "Pages/PrefabMakerPage.h"
 #include "Pages/XacroParamsPage.h"
 
-
 #include "URDF/URDFPrefabMaker.h"
 #include "URDF/UrdfParser.h"
 #include <AzCore/Asset/AssetCommon.h>
@@ -72,6 +71,9 @@ namespace ROS2
         AZ::IO::Path m_urdfPath;
         urdf::ModelInterfaceSharedPtr m_parsedUrdf;
 
+        //! User's choice to copy meshes during urdf import
+        bool m_importAssetWithUrdf{ false };
+
         /// mapping from urdf path to asset source
         AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;
         AZStd::unique_ptr<URDFPrefabMaker> m_prefabMaker;
@@ -108,10 +110,5 @@ namespace ROS2
 
         static constexpr QWizard::WizardButton PrefabCreationButtonId{ QWizard::CustomButton1 };
         static constexpr QWizard::WizardOption HavePrefabCreationButton{ QWizard::HaveCustomButton1 };
-
-    signals:
-        void SignalFinalizeURDFCreation();
-    private slots:
-        void FinalizeURDFCreation();
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.h
@@ -37,8 +37,6 @@ namespace ROS2
         //! Prevent copying of existing CollidersMaker
         CollidersMaker(const CollidersMaker& other) = delete;
 
-        ~CollidersMaker();
-
         //! Builds .pxmeshes for every collider in link collider mesh.
         //! @param link A parsed URDF tree link node which could hold information about colliders.
         void BuildColliders(urdf::LinkSharedPtr link);
@@ -61,10 +59,6 @@ namespace ROS2
         void AddColliderToEntity(
             urdf::CollisionSharedPtr collision, AZ::EntityId entityId, const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset) const;
 
-        AZStd::thread m_buildThread;
-        AZStd::mutex m_buildMutex;
-        AZStd::vector<AZ::IO::Path> m_meshesToBuild;
-        AZStd::atomic_bool m_stopBuildFlag;
         AZ::Data::Asset<Physics::MaterialAsset> m_wheelMaterial;
         AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;
     };

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -41,17 +41,6 @@ namespace ROS2
         AZ_Assert(m_model, "Model is nullptr");
     }
 
-    void URDFPrefabMaker::LoadURDF(BuildReadyCallback buildReadyCb)
-    {
-        m_notifyBuildReadyCb = buildReadyCb;
-
-        // Request the build of collider meshes by constructing .assetinfo files.
-        BuildAssetsForLink(m_model->root_link_);
-
-        // Spins thread that waits for all collider meshes to be ready.
-        m_collidersMaker.ProcessMeshes(buildReadyCb);
-    }
-
     void URDFPrefabMaker::BuildAssetsForLink(urdf::LinkSharedPtr link)
     {
         m_collidersMaker.BuildColliders(link);
@@ -197,7 +186,8 @@ namespace ROS2
                 {
                     AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
                     auto result = m_jointsMaker.AddJointComponent(jointPtr, childEntity.GetValue(), leadEntity.GetValue());
-                    m_status.emplace(name, AZStd::string::format(" %s %llu", result.IsSuccess()?"created as":"Failed", result.GetValue()));
+                    m_status.emplace(
+                        name, AZStd::string::format(" %s %llu", result.IsSuccess() ? "created as" : "Failed", result.GetValue()));
                 }
                 else
                 {

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -43,10 +43,6 @@ namespace ROS2
 
         ~URDFPrefabMaker() = default;
 
-        //! Loads URDF file and builds all required meshes and colliders.
-        //! @param buildReadyCb Function to call when the build finishes.
-        void LoadURDF(BuildReadyCallback buildReadyCb);
-
         //! Create and return a prefab corresponding to the URDF model as set through the constructor.
         //! @return result which is either a prefab containing the imported model based on URDF or an error.
         AzToolsFramework::Prefab::CreatePrefabResult CreatePrefabFromURDF();
@@ -72,7 +68,7 @@ namespace ROS2
         InertialsMaker m_inertialsMaker;
         JointsMaker m_jointsMaker;
         ArticulationsMaker m_articulationsMaker;
-        BuildReadyCallback m_notifyBuildReadyCb;
+
         AZStd::mutex m_statusLock;
         AZStd::multimap<AZStd::string, AZStd::string> m_status;
 

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -155,11 +155,16 @@ namespace ROS2
                     }
 
                     entity->Activate();
+
+                    const auto productAssetPath = Utils::GetModelProductAsset(asset->m_sourceGuid);
+                    AZ_Warning(
+                        "AddVisual",
+                        productAssetPath.size(),
+                        "There is no product asset for %s.",
+                        asset->m_sourceAssetRelativePath.c_str());
                     // Set asset path
                     AZ::Render::MeshComponentRequestBus::Event(
-                        entityId,
-                        &AZ::Render::MeshComponentRequestBus::Events::SetModelAssetPath,
-                        asset->m_sourceAssetRelativePath.c_str());
+                        entityId, &AZ::Render::MeshComponentRequestBus::Events::SetModelAssetPath, productAssetPath);
 
                     // Set scale, uniform or non-uniform
                     if (isUniformScale)

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -6,12 +6,67 @@
  *
  */
 
-#include <AzCore/IO/Path/Path.h>
 #include "SourceAssetsStorage.h"
 #include "RobotImporterUtils.h"
+#include <AzCore/IO/FileIO.h>
+#include <AzCore/Serialization/Json/JsonUtils.h>
+#include <AzCore/Utils/Utils.h>
+#include <AzToolsFramework/Asset/AssetUtils.h>
+#include <SceneAPI/SceneCore/Containers/Scene.h>
+#include <SceneAPI/SceneCore/Containers/Utilities/Filters.h>
+#include <SceneAPI/SceneCore/DataTypes/Groups/ISceneNodeGroup.h>
+#include <SceneAPI/SceneCore/Events/AssetImportRequest.h>
+#include <SceneAPI/SceneCore/Events/SceneSerializationBus.h>
+#include <SceneAPI/SceneCore/Utilities/SceneGraphSelector.h>
+#include <SceneAPI/SceneData/Groups/MeshGroup.h>
+#include <SceneAPI/SceneData/Rules/UVsRule.h>
+#include <Source/Pipeline/MeshGroup.h> // PhysX/Code/Source/Pipeline/MeshGroup.h
 
 namespace ROS2::Utils
 {
+
+    //! A helper class that do no extend PhysX::Pipeline::MeshGroup functionality, but gives neccessary setters.
+    class UrdfPhysxMeshGroupHelper : public PhysX::Pipeline::MeshGroup
+    {
+    public:
+        void SetIsDecomposeMeshes(bool decompose)
+        {
+            m_decomposeMeshes = decompose;
+        }
+        void SetMeshExportMethod(PhysX::Pipeline::MeshExportMethod method)
+        {
+            m_exportMethod = method;
+        }
+    };
+
+    //! Returns supported filenames by Asset Processor
+    AZStd::vector<AZStd::string> GetSupportedExtensions()
+    {
+        struct Visitor : AZ::SettingsRegistryInterface::Visitor
+        {
+            void Visit(const AZ::SettingsRegistryInterface::VisitArgs&, AZStd::string_view value) override
+            {
+                m_supportedFileExtensions.emplace_back(value);
+            }
+
+            AZStd::vector<AZStd::string> m_supportedFileExtensions;
+        };
+        auto settingsRegistry = AZ::SettingsRegistry::Get();
+
+        if (settingsRegistry == nullptr)
+        {
+            AZ_Warning("GetInterestingSourceAssetsCRC", false, "Global Settings Registry is not set.");
+            return AZStd::vector<AZStd::string>();
+        }
+
+        using namespace AzToolsFramework::AssetUtils;
+        Visitor assetImporterVisitor;
+        settingsRegistry->Visit(
+            assetImporterVisitor,
+            AZ::SettingsRegistryInterface::FixedValueString("/O3DE/SceneAPI/AssetImporter/SupportedFileTypeExtensions"));
+        return assetImporterVisitor.m_supportedFileExtensions;
+    }
+
     /// Function computes CRC32 on first kilobyte of file.
     AZ::Crc32 GetFileCRC(const AZStd::string& filename)
     {
@@ -33,93 +88,277 @@ namespace ROS2::Utils
         return r;
     }
 
-    AZStd::unordered_map<AZ::Crc32, AvailableAsset> GetInterestingSourceAssetsCRC()
+    AZStd::string GetProductAsset(const AZ::Uuid& sourceAssetUUID, const AZ::TypeId typeId)
     {
-        const AZStd::unordered_set<AZStd::string> kInterestingExtensions{ ".dae", ".stl", ".obj", ".fbx" };
-        constexpr char AzModelExtension[] {".azmodel"} ;
-        AZStd::unordered_map<AZ::Crc32, AvailableAsset> availableAssets;
-
-        // take all meshes in catalog
-        AZ::Data::AssetCatalogRequests::AssetEnumerationCB collectAssetsCb =
-            [&](const AZ::Data::AssetId id, const AZ::Data::AssetInfo& info)
+        AZStd::vector<AZ::Data::AssetInfo> productsAssetInfo;
+        using AssetSysReqBus = AzToolsFramework::AssetSystemRequestBus;
+        bool ok{ false };
+        AssetSysReqBus::BroadcastResult(ok, &AssetSysReqBus::Events::GetAssetsProducedBySourceUUID, sourceAssetUUID, productsAssetInfo);
+        if (ok)
         {
-            if (AZ::Data::AssetManager::Instance().GetHandler(info.m_assetType))
+            for (auto& product : productsAssetInfo)
             {
-                if (!info.m_relativePath.ends_with(AzModelExtension))
+                if (product.m_assetType == typeId)
                 {
-                    return;
-                }
-                using AssetSysReqBus = AzToolsFramework::AssetSystemRequestBus;
-                bool pathFound{ false };
-                AZStd::string fullSourcePathStr;
-
-                AssetSysReqBus::BroadcastResult(
-                    pathFound, &AssetSysReqBus::Events::GetFullSourcePathFromRelativeProductPath, info.m_relativePath, fullSourcePathStr);
-                if (!pathFound)
-                {
-                    return;
-                }
-                const AZ::IO::Path fullSourcePath(fullSourcePathStr);
-                const AZStd::string extension = fullSourcePath.Extension().Native();
-
-                if (!kInterestingExtensions.contains(extension))
-                {
-                    return;
-                }
-
-                AZ::Crc32 crc = Utils::GetFileCRC(fullSourcePathStr);
-                AZ_Printf(
-                    "RobotImporterWidget",
-                    "m_relativePath %s %s : %s %llu \n",
-                    info.m_relativePath.c_str(),
-                    info.m_assetId.ToString<AZStd::string>().c_str(),
-                    fullSourcePath.c_str(),
-                    crc);
-
-                AvailableAsset foundAsset;
-                foundAsset.m_sourceAssetRelativePath = info.m_relativePath;
-                foundAsset.m_assetId = info.m_assetId;
-                foundAsset.m_sourceAssetGlobalPath = fullSourcePathStr;
-                foundAsset.m_productAssetRelativePath = info.m_relativePath;
-                auto availableAssetIt = availableAssets.find(crc);
-                if (availableAssetIt != availableAssets.end())
-                {
-                    const AZStd::string stem(fullSourcePath.Stem().Native());
-                    // probably there is already submesh added. Replace only if there is exact name
-                    if (info.m_relativePath.contains(stem + AzModelExtension))
-                    {
-                        availableAssetIt->second = foundAsset;
-                    }
-                }
-                else
-                {
-                    availableAssets.insert({crc, foundAsset});
+                    AZStd::string assetPath;
+                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                        assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, product.m_assetId);
+                    return assetPath;
                 }
             }
-        };
-        AZ::Data::AssetCatalogRequestBus::Broadcast(
-            &AZ::Data::AssetCatalogRequestBus::Events::EnumerateAssets, nullptr, collectAssetsCb, nullptr);
+        }
+        return "";
+    }
 
+    AZStd::string GetModelProductAsset(const AZ::Uuid& sourceAssetUUID)
+    {
+        return GetProductAsset(sourceAssetUUID, AZ::TypeId("{2C7477B6-69C5-45BE-8163-BCD6A275B6D8}")); // AZ::RPI::ModelAsset;
+    }
+
+    AZStd::string GetPhysXMeshProductAsset(const AZ::Uuid& sourceAssetUUID)
+    {
+        return GetProductAsset(sourceAssetUUID, AZ::TypeId("{7A2871B9-5EAB-4DE0-A901-B0D2C6920DDB}")); // PhysX::Pipeline::MeshAsset
+    }
+
+    AvailableAsset GetAvailableAssetInfo(const AZStd::string& globalSourceAssetPath)
+    {
+        using AssetSysReqBus = AzToolsFramework::AssetSystemRequestBus;
+        AvailableAsset foundAsset;
+
+        // get relativePath
+        bool relativePathFound{ false };
+        AZStd::string relativeSourcePath;
+        AZStd::string rootFilePath;
+        AssetSysReqBus::BroadcastResult(
+            relativePathFound,
+            &AssetSysReqBus::Events::GenerateRelativeSourcePath,
+            globalSourceAssetPath,
+            relativeSourcePath,
+            rootFilePath);
+        if (!relativePathFound)
+        {
+            return foundAsset;
+        }
+
+        // get source asset info
+        bool sourceAssetFound{ false };
+        AZ::Data::AssetInfo assetInfo;
+        AZStd::string watchFolder;
+        AssetSysReqBus::BroadcastResult(
+            sourceAssetFound, &AssetSysReqBus::Events::GetSourceInfoBySourcePath, relativeSourcePath.c_str(), assetInfo, watchFolder);
+        if (!sourceAssetFound)
+        {
+            return foundAsset;
+        }
+
+        foundAsset.m_sourceGuid = assetInfo.m_assetId.m_guid;
+
+        foundAsset.m_sourceAssetRelativePath = assetInfo.m_relativePath;
+        foundAsset.m_sourceAssetGlobalPath = globalSourceAssetPath;
+
+        AZ::Crc32 crc = Utils::GetFileCRC(foundAsset.m_sourceAssetGlobalPath);
+        if (crc == AZ::Crc32(0))
+        {
+            AZ_Warning("GetInterestingSourceAssetsCRC", false, "Zero CRC for source asset %s", foundAsset.m_sourceAssetGlobalPath.c_str());
+            return foundAsset;
+        }
+        // Todo Remove in review
+        AZ_Printf("GetAvailableAssetInfo", "Found asset:");
+        AZ_Printf("GetAvailableAssetInfo", "\tm_sourceAssetRelativePath  : %s", foundAsset.m_sourceAssetRelativePath.c_str());
+        AZ_Printf("GetAvailableAssetInfo", "\tm_sourceAssetGlobalPath    : %s", foundAsset.m_sourceAssetGlobalPath.c_str());
+        AZ_Printf("GetAvailableAssetInfo", "\tm_productAssetRelativePath : %s", foundAsset.m_productAssetRelativePath.c_str());
+        AZ_Printf("GetAvailableAssetInfo", "\tm_sourceGuid               : %s", foundAsset.m_sourceGuid.ToString<AZStd::string>().c_str());
+
+        return foundAsset;
+    }
+
+    AZStd::unordered_map<AZ::Crc32, AvailableAsset> GetInterestingSourceAssetsCRC()
+    {
+        // connect to database API
+        const AZStd::vector<AZStd::string> InterestingExtensions = GetSupportedExtensions();
+        AZStd::unordered_map<AZ::Crc32, AvailableAsset> availableAssets;
+
+        AzToolsFramework::AssetDatabase::AssetDatabaseConnection assetDatabaseConnection;
+        if (!assetDatabaseConnection.OpenDatabase())
+        {
+            AZ_Warning("GetInterestingSourceAssetsCRC", false, "Cannot open database");
+        }
+        auto callback = [&availableAssets](AzToolsFramework::AssetDatabase::SourceDatabaseEntry& entry)
+        {
+            using AssetSysReqBus = AzToolsFramework::AssetSystemRequestBus;
+            AvailableAsset foundAsset;
+            foundAsset.m_sourceGuid = entry.m_sourceGuid;
+
+            using AssetSysReqBus = AzToolsFramework::AssetSystemRequestBus;
+
+            // get source asset info
+            bool sourceAssetFound{ false };
+            AZ::Data::AssetInfo assetInfo;
+            AZStd::string watchFolder;
+            AssetSysReqBus::BroadcastResult(
+                sourceAssetFound, &AssetSysReqBus::Events::GetSourceInfoBySourceUUID, entry.m_sourceGuid, assetInfo, watchFolder);
+            if (!sourceAssetFound)
+            {
+                AZ_Warning("GetInterestingSourceAssetsCRC", false, "Cannot find source asset info for %s", entry.ToString().c_str());
+                return true;
+            }
+
+            const auto fullSourcePath = AZ::IO::Path(watchFolder) / AZ::IO::Path(assetInfo.m_relativePath);
+
+            foundAsset.m_sourceAssetRelativePath = assetInfo.m_relativePath;
+            foundAsset.m_sourceAssetGlobalPath = fullSourcePath.String();
+
+            AZ::Crc32 crc = Utils::GetFileCRC(foundAsset.m_sourceAssetGlobalPath);
+            if (crc == AZ::Crc32(0))
+            {
+                AZ_Warning(
+                    "GetInterestingSourceAssetsCRC", false, "Zero CRC for source asset %s", foundAsset.m_sourceAssetGlobalPath.c_str());
+                return true;
+            }
+            AZ_Printf("GetInterestingSourceAssetsCRC", "Found asset:");
+            AZ_Printf("GetInterestingSourceAssetsCRC", "\tm_sourceAssetRelativePath  : %s", foundAsset.m_sourceAssetRelativePath.c_str());
+            AZ_Printf("GetInterestingSourceAssetsCRC", "\tm_sourceAssetGlobalPath    : %s", foundAsset.m_sourceAssetGlobalPath.c_str());
+            AZ_Printf("GetInterestingSourceAssetsCRC", "\tm_productAssetRelativePath : %s", foundAsset.m_productAssetRelativePath.c_str());
+            AZ_Printf(
+                "GetInterestingSourceAssetsCRC",
+                "\tm_sourceGuid               : %s",
+                foundAsset.m_sourceGuid.ToString<AZStd::string>().c_str());
+            AZ_Printf("GetInterestingSourceAssetsCRC", "\tcrc                        : %d", crc);
+
+            auto availableAssetIt = availableAssets.find(crc);
+            if (availableAssetIt != availableAssets.end())
+            {
+                AZ_Warning(
+                    "GetInterestingSourceAssetsCRC", false, "Asset already in database : %s ", foundAsset.m_sourceAssetGlobalPath.c_str());
+                AZ_Warning(
+                    "GetInterestingSourceAssetsCRC", false, "Found asset : %s ", availableAssetIt->second.m_sourceAssetGlobalPath.c_str());
+            }
+            else
+            {
+                availableAssets.insert({ crc, foundAsset });
+            }
+            return true;
+        };
+
+        for (auto& extension : InterestingExtensions)
+        {
+            assetDatabaseConnection.QuerySourceLikeSourceName(
+                extension.c_str(), AzToolsFramework::AssetDatabase::AssetDatabaseConnection::LikeType::EndsWith, callback);
+        }
         return availableAssets;
     }
 
-    UrdfAssetMap FindAssetsForUrdf(const AZStd::unordered_set<AZStd::string>& meshesFilenames, const AZStd::string& urdFilename)
+    UrdfAssetMap CopyAssetForURDFAndCreateAssetMap(
+        const AZStd::unordered_set<AZStd::string>& meshesFilenames,
+        const AZStd::string& urdfFilename,
+        const AZStd::unordered_set<AZStd::string>& colliders,
+        const AZStd::unordered_set<AZStd::string>& visuals,
+        AZ::IO::FileIOBase* fileIO)
     {
         auto enviromentalVariable = std::getenv("AMENT_PREFIX_PATH");
         AZ_Error("UrdfAssetMap", enviromentalVariable, "AMENT_PREFIX_PATH is not found.");
-        AZStd::string amentPrefixPath {enviromentalVariable};
+
+        UrdfAssetMap urdfAssetMap;
+        if (meshesFilenames.empty())
+        {
+            return urdfAssetMap;
+        }
+
+        //! Maps the unresolved urdf path to global path
+        AZStd::unordered_map<AZStd::string, AZ::IO::Path> copiedFiles;
+
+        AZ_Assert(fileIO, "No FileIO instance") AZ::Crc32 urdfFileCrc;
+        urdfFileCrc.Add(urdfFilename);
+        const AZ::IO::Path urdfPath(urdfFilename);
+        const AZStd::string directoryNameTmp = AZStd::string::format("$tmp_%u.tmp", AZ::u32(urdfFileCrc));
+        const AZStd::string directoryNameDst = AZStd::string::format("%u_%s", AZ::u32(urdfFileCrc), urdfPath.Stem().String().c_str());
+
+        const AZ::IO::Path importDirectoryTmp = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "UrdfImporter" / directoryNameTmp;
+        const AZ::IO::Path importDirectoryDst = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "UrdfImporter" / directoryNameDst;
+
+        // remove, if old import exists
+        fileIO->DestroyPath(importDirectoryTmp.c_str());
+        fileIO->DestroyPath(importDirectoryDst.c_str());
+
+        AZStd::string amentPrefixPath{ enviromentalVariable };
+        AZStd::set<AZStd::string> files;
+
+        for (const auto& unresolvedUrfFileName : meshesFilenames)
+        {
+            auto resolved = Utils::ResolveURDFPath(unresolvedUrfFileName, urdfFilename, amentPrefixPath);
+            if (!resolved.empty())
+            {
+                AZ::IO::Path resolvedPath(resolved);
+                AZ::IO::Path targetPathTmp(importDirectoryTmp / resolvedPath.Filename());
+                AZ::IO::Path targetPathDst(importDirectoryDst / resolvedPath.Filename());
+
+                const auto outcome = fileIO->Copy(resolvedPath.c_str(), targetPathTmp.c_str());
+                AZ_Printf(
+                    "CopyAssetForURDF", "Copy %s to %s, result: %d", resolvedPath.c_str(), targetPathTmp.c_str(), outcome.GetResultCode());
+                if (outcome)
+                {
+                    copiedFiles[unresolvedUrfFileName] = targetPathDst.String();
+                    bool needsVisual = visuals.contains(unresolvedUrfFileName);
+                    bool needsCollider = colliders.contains(unresolvedUrfFileName);
+                    if (needsCollider || needsVisual)
+                    {
+                        createSceneManifest(targetPathTmp.String(), needsCollider, needsVisual);
+                    }
+                }
+            }
+            Utils::UrdfAsset asset;
+            asset.m_urdfPath = urdfFilename;
+            asset.m_resolvedUrdfPath = Utils::ResolveURDFPath(unresolvedUrfFileName, urdfFilename, amentPrefixPath);
+            asset.m_urdfFileCRC = AZ::Crc32();
+            urdfAssetMap.emplace(unresolvedUrfFileName, AZStd::move(asset));
+        }
+
+        // rename
+        const auto outcome = fileIO->Rename(importDirectoryTmp.c_str(), importDirectoryDst.c_str());
+        AZ_Printf(
+            "CopyAssetForURDF",
+            "Rename %s to %s, result: %d",
+            importDirectoryTmp.c_str(),
+            importDirectoryDst.c_str(),
+            outcome.GetResultCode());
+        if (!outcome)
+        {
+            copiedFiles.clear();
+        }
+
+        for (const auto& copied : copiedFiles)
+        {
+            AZ_Printf("CopyAssetForURDF", " %s is copied to %s", copied.first.c_str(), copied.second.c_str());
+        }
+
+        // add assetInfo
+        for (const auto& [unresolvedUrfFileName, sourceAssetGlobalPath] : copiedFiles)
+        {
+            AZ_Assert(
+                urdfAssetMap.contains(unresolvedUrfFileName), "urdfAssetMap should contain urdf path %s", unresolvedUrfFileName.c_str());
+            urdfAssetMap[unresolvedUrfFileName].m_availableAssetInfo = Utils::GetAvailableAssetInfo(sourceAssetGlobalPath.String());
+        }
+
+        return urdfAssetMap;
+    }
+
+    UrdfAssetMap FindAssetsForUrdf(const AZStd::unordered_set<AZStd::string>& meshesFilenames, const AZStd::string& urdfFilename)
+    {
+        auto enviromentalVariable = std::getenv("AMENT_PREFIX_PATH");
+        AZ_Error("UrdfAssetMap", enviromentalVariable, "AMENT_PREFIX_PATH is not found.");
+        AZStd::string amentPrefixPath{ enviromentalVariable };
 
         UrdfAssetMap urdfToAsset;
         for (const auto& t : meshesFilenames)
         {
             Utils::UrdfAsset asset;
             asset.m_urdfPath = t;
-            asset.m_resolvedUrdfPath = Utils::ResolveURDFPath(asset.m_urdfPath, urdFilename, amentPrefixPath);
+            asset.m_resolvedUrdfPath = Utils::ResolveURDFPath(asset.m_urdfPath, urdfFilename, amentPrefixPath);
             asset.m_urdfFileCRC = Utils::GetFileCRC(asset.m_resolvedUrdfPath);
             urdfToAsset.emplace(t, AZStd::move(asset));
         }
 
-        const AZStd::unordered_map<AZ::Crc32, AvailableAsset> availableAssets = Utils::GetInterestingSourceAssetsCRC();
+        AZStd::unordered_map<AZ::Crc32, AvailableAsset> availableAssets = Utils::GetInterestingSourceAssetsCRC();
 
         // Search for suitable mappings by comparing checksum
         for (auto it = urdfToAsset.begin(); it != urdfToAsset.end(); it++)
@@ -131,7 +370,91 @@ namespace ROS2::Utils
                 asset.m_availableAssetInfo = found_source_asset->second;
             }
         }
+
         return urdfToAsset;
     }
 
+    bool createSceneManifest(const AZStd::string sourceAssetPath, bool collider, bool visual)
+    {
+        const AZStd::string azMeshPath = sourceAssetPath;
+
+        AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> scene;
+        AZ::SceneAPI::Events::SceneSerializationBus::BroadcastResult(
+            scene, &AZ::SceneAPI::Events::SceneSerialization::LoadScene, azMeshPath.c_str(), AZ::Uuid::CreateNull(), "");
+        if (!scene)
+        {
+            AZ_Error("createSceneManifest", false, "Error loading collider. Invalid scene: %s", azMeshPath.c_str());
+            return false;
+        }
+
+        AZ::SceneAPI::Containers::SceneManifest& manifest = scene->GetManifest();
+        auto valueStorage = manifest.GetValueStorage();
+        if (valueStorage.empty())
+        {
+            AZ_Error("createSceneManifest", false, "Error loading collider. Invalid value storage: %s", azMeshPath.c_str());
+            return false;
+        }
+
+        // remove default configuration to avoid procedural prefab creation
+        AZStd::vector<AZStd::shared_ptr<AZ::SceneAPI::DataTypes::IManifestObject>> toDelete;
+        for (size_t i = 0; i < manifest.GetEntryCount(); i++)
+        {
+            AZStd::shared_ptr<AZ::SceneAPI::DataTypes::IManifestObject> obj = manifest.GetValue(i);
+            toDelete.push_back(obj);
+        }
+
+        for (auto obj : toDelete)
+        {
+            AZ_Printf("createSceneManifest", "Deleting %s", obj->RTTI_GetType().ToString<AZStd::string>().c_str());
+            manifest.RemoveEntry(obj);
+        }
+
+        if (visual)
+        {
+            AZStd::shared_ptr<AZ::SceneAPI::SceneData::MeshGroup> sceneDataMeshGroup =
+                AZStd::make_shared<AZ::SceneAPI::SceneData::MeshGroup>();
+
+            // select all nodes to this mesh group
+            AZ::SceneAPI::Utilities::SceneGraphSelector::SelectAll(scene->GetGraph(), sceneDataMeshGroup->GetSceneNodeSelectionList());
+
+            // enable auto-generation of UVs
+            sceneDataMeshGroup->GetRuleContainer().AddRule(AZStd::make_shared<AZ::SceneAPI::SceneData::UVsRule>());
+
+            manifest.AddEntry(sceneDataMeshGroup);
+        }
+
+        if (collider)
+        {
+            AZStd::shared_ptr<UrdfPhysxMeshGroupHelper> physxDataMeshGroup = AZStd::make_shared<UrdfPhysxMeshGroupHelper>();
+            physxDataMeshGroup->SetIsDecomposeMeshes(true);
+            physxDataMeshGroup->SetMeshExportMethod(PhysX::Pipeline::MeshExportMethod::Convex);
+
+            // select all nodes to this mesh group
+            AZ::SceneAPI::Utilities::SceneGraphSelector::SelectAll(scene->GetGraph(), physxDataMeshGroup->GetSceneNodeSelectionList());
+
+            manifest.AddEntry(physxDataMeshGroup);
+        }
+
+        // Update assetinfo
+        AZ::SceneAPI::Events::ProcessingResultCombiner result;
+        AZ::SceneAPI::Events::AssetImportRequestBus::BroadcastResult(
+            result,
+            &AZ::SceneAPI::Events::AssetImportRequest::UpdateManifest,
+            *scene,
+            AZ::SceneAPI::Events::AssetImportRequest::ManifestAction::Update,
+            AZ::SceneAPI::Events::AssetImportRequest::RequestingApplication::Editor);
+
+        if (result.GetResult() != AZ::SceneAPI::Events::ProcessingResult::Success)
+        {
+            AZ_TracePrintf("createSceneManifest", "Scene updated\n");
+            return false;
+        }
+        auto assetInfoFilePath = AZ::IO::Path{ azMeshPath };
+        assetInfoFilePath.Native() += ".assetinfo";
+        scene->GetManifest().SaveToFile(assetInfoFilePath.c_str());
+
+        AZ_Printf("createSceneManifest", "Saving scene manifest to %s\n", assetInfoFilePath.c_str());
+
+        return true;
+    }
 } // namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -7,6 +7,8 @@
  */
 #pragma once
 
+#include <AssetDatabase/AssetDatabaseConnection.h>
+#include <AssetDatabase/PathOrUuid.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetManagerBus.h>
@@ -31,8 +33,8 @@ namespace ROS2::Utils
         //! Relative path to source asset eg `foo_robot/meshes/bar_link.azmodel`.
         AZStd::string m_productAssetRelativePath;
 
-        //! Product asset ID @see AZ::Data::AssetInfo.
-        AZ::Data::AssetId m_assetId;
+        //! Source GUID of source asset
+        AZ::Uuid m_sourceGuid = AZ::Uuid::CreateNull();
     };
 
     //! The structure contains a mapping between URDF's path to O3DE asset information.
@@ -69,8 +71,44 @@ namespace ROS2::Utils
     //! - Function scans all available O3DE assets by calling `GetInterestingSourceAssetsCRC`.
     //! - Suitable mapping to the O3DE asset is found by comparing the checksum of the file pointed by the URDF path and source asset.
     //! @param meshesFilenames - list of the unresolved path from the URDF file
-    //! @param urdFilename - filename of URDF file, used for resolvement
+    //! @param urdfFilename - filename of URDF file, used for resolvement
     //! @returns a URDF Asset map where the key is unresolved URDF path to AvailableAsset
-    UrdfAssetMap FindAssetsForUrdf(const AZStd::unordered_set<AZStd::string>& meshesFilenames, const AZStd::string& urdFilename);
+    UrdfAssetMap FindAssetsForUrdf(const AZStd::unordered_set<AZStd::string>& meshesFilenames, const AZStd::string& urdfFilename);
+
+    //! Helper function that gives product's path from source asset GUID
+    //! @param sourceAssetUUID is source asset GUID
+    //! @param typeId type of product asset
+    //! @returns relative path to product, empty string if product is not found
+    AZStd::string GetProductAsset(const AZ::Uuid& sourceAssetUUID, const AZ::TypeId typeId);
+
+    //! Helper function that gives AZ::RPI::ModelAsset product asset from source asset GUID
+    //! @param sourceAssetUUID is source asset GUID
+    //! @returns relative path to product, empty string if product is not found
+    AZStd::string GetModelProductAsset(const AZ::Uuid& sourceAssetUUID);
+
+    //! Helper function that gives PhysX::Pipeline::MeshAsset product asset from source asset GUID
+    //! @param sourceAssetUUID is source asset GUID
+    //! @returns relative path to product, empty string if product is not found
+    AZStd::string GetPhysXMeshProductAsset(const AZ::Uuid& sourceAssetUUID);
+
+    //! Creates side-car file (.assetinfo) that configures scene to generate physx Mesh.
+    //! @param sourceAssetPath - global path to source asset
+    bool createSceneManifest(const AZStd::string sourceAssetPath, bool collider, bool visual);
+
+    //! A function that copies and prepares meshes that are referenced in URDF.
+    //! It resolves every mesh, creates a directory in Project's Asset directory, copies files, and prepares assets info.
+    //! Finally, it assembles its results into mapping that allows mapping Urdf's mesh name to the source asset.
+    //! @param meshesFilenames - files to copy (as unresolved urdf paths)
+    //! @param urdFilename - path to URDF file (as a global path)
+    //! @param colliders - files to create collider assetinfo (as unresolved urdf paths)
+    //! @param visuals - files to create visual assetinfo (as unresolved urdf paths)
+    //! @param fileIO - instance to fileIO class
+    //! @returns mapping from unresolved urdf paths to source asset info
+    UrdfAssetMap CopyAssetForURDFAndCreateAssetMap(
+        const AZStd::unordered_set<AZStd::string>& meshesFilenames,
+        const AZStd::string& urdfFilename,
+        const AZStd::unordered_set<AZStd::string>& colliders,
+        const AZStd::unordered_set<AZStd::string>& visual,
+        AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 
 } // namespace ROS2::Utils


### PR DESCRIPTION
Work in progress URDF Wizard page that is affected:
![image](https://user-images.githubusercontent.com/3209244/227975646-f73bd1c6-296d-4f13-bb03-c94c795f8888.png)
To do:
- [x] Deal with failed product asset (e.g. icon + button to bring AssetProcessor)
- [x] Copy packages to dedicated folder during import