### PR TITLE
Fix compile error caused by missing includes

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -14,6 +14,8 @@
 #include "UrdfParser.h"
 #include "VisualsMaker.h"
 #include <AzCore/Component/EntityId.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/containers/map.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>


### PR DESCRIPTION
Fixes the following compile error:
```
3e706/Code/CMakeFiles/ROS2.Editor.Static.dir/Unity/unity_1_cxx.cxx
In file included from /home/github/RobotVacuumSample/build/linux/External/ROS2-9043e706/Code/CMakeFiles/ROS2.Editor.Static.dir/Unity/unity_1_cxx.cxx:3:
In file included from /home/github/o3de-extras/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp:13:
In file included from /home/github/o3de-extras/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h:20:
/home/github/o3de-extras/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h:71:16: error: too few template arguments for class template 'multimap'
        AZStd::multimap<AZStd::string, AZStd::string> m_status;
               ^
/home/github/o3de/Code/Framework/AzCore/./AzCore/std/typetraits/internal/is_template_copy_constructible.h:25:11: note: template is declared here
    class multimap;
          ^
In file included from /home/github/RobotVacuumSample/build/linux/External/ROS2-9043e706/Code/CMakeFiles/ROS2.Editor.Static.dir/Unity/unity_1_cxx.cxx:3:
In file included from /home/github/o3de-extras/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp:13:
In file included from /home/github/o3de-extras/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h:20:
/home/github/o3de-extras/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h:71:55: error: private field 'm_status' is not used [-Werror,-Wunused-private-field]
        AZStd::multimap<AZStd::string, AZStd::string> m_status;
```
note: This change was included in a [back port](https://github.com/o3de/o3de-extras/pull/237) from stabilization to development, but was never in stabilization