### PR TITLE
Camera sensor post processing abstraction

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Camera/CameraPostProcessingRequestBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Camera/CameraPostProcessingRequestBus.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/std/parallel/mutex.h>
+#include <AzCore/std/string/string.h>
+
+#include <sensor_msgs/msg/image.hpp>
+
+namespace ROS2
+{
+    //! Interface class that allows to add post-processing to the pipeline
+    class CameraPostProcessingRequests : public AZ::EBusTraits
+    {
+    public:
+        using BusIdType = AZ::EntityId;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        using MutexType = AZStd::recursive_mutex;
+
+        //! Apply post-processing function, if any implementations to the bus are in the entity.
+        //! @param image standard image message passed as a reference. It will be changed through post-processing.
+        //! @note you should check whether the encoding format is supported first with SupportsFormat.
+        virtual void ApplyPostProcessing(sensor_msgs::msg::Image& image) = 0;
+
+        //! Query whether a particular image encoding is supported by registered postprocessing.
+        //! @param encodingFormat name of the format.
+        virtual bool SupportsFormat(const AZStd::string& encodingFormat) = 0;
+
+    protected:
+        ~CameraPostProcessingRequests() = default;
+    };
+
+    using CameraPostProcessingRequestBus = AZ::EBus<CameraPostProcessingRequests>;
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Camera/CameraSensor.h
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensor.h
@@ -89,9 +89,8 @@ namespace ROS2
         virtual AZStd::string GetPipelineTemplateName() const = 0; //! Returns name of pass template to use in pipeline
         virtual AZStd::string GetPipelineTypeName() const = 0; //! Type of returned data eg Color, Depth, Optical flow
 
-        AZ::EntityId m_entityId;
-
     protected:
+        AZ::EntityId m_entityId;
         AZ::RPI::RenderPipelinePtr m_pipeline;
         AZStd::string m_pipelineName;
 

--- a/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "CameraSensorConfiguration.h"
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+
+namespace ROS2
+{
+    void CameraSensorConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<CameraSensorConfiguration>()
+                ->Version(1)
+                ->Field("VerticalFieldOfViewDeg", &CameraSensorConfiguration::m_verticalFieldOfViewDeg)
+                ->Field("Width", &CameraSensorConfiguration::m_width)
+                ->Field("Height", &CameraSensorConfiguration::m_height)
+                ->Field("Depth", &CameraSensorConfiguration::m_depthCamera)
+                ->Field("Color", &CameraSensorConfiguration::m_colorCamera);
+
+            if (AZ::EditContext* ec = serializeContext->GetEditContext())
+            {
+                ec->Class<CameraSensorConfiguration>("Camera Sensor Configuration", "Configuration for image size, FOV and type of images")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &CameraSensorConfiguration::m_verticalFieldOfViewDeg,
+                        "Vertical field of view",
+                        "Camera's vertical (y axis) field of view in degrees.")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_width, "Image width", "Image width")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_height, "Image height", "Image height")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_colorCamera, "Color Camera", "Color Camera")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_depthCamera, "Depth Camera", "Depth Camera");
+            }
+        }
+    }
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.h
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/string/string.h>
+
+namespace ROS2
+{
+    //! A structure capturing configuration of a single camera sensor with up to two image sources (color and depth).
+    struct CameraSensorConfiguration
+    {
+        AZ_TYPE_INFO(CameraSensorConfiguration, "{386A2640-442B-473D-BC2A-665D049D7EF5}");
+        static void Reflect(AZ::ReflectContext* context);
+
+        float m_verticalFieldOfViewDeg = 90.0f; //!< Vertical field of view of camera sensor.
+        int m_width = 640; //!< Camera image width in pixels.
+        int m_height = 480; //!< Camera image height in pixels.
+        bool m_colorCamera = true; //!< Use color camera?
+        bool m_depthCamera = true; //!< Use depth camera?
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
@@ -9,8 +9,6 @@
 #include "ROS2CameraSensorComponent.h"
 #include <ROS2/Communication/TopicConfiguration.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
-#include <ROS2/ROS2Bus.h>
-#include <ROS2/Utilities/ROS2Names.h>
 
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/TransformBus.h>
@@ -22,17 +20,8 @@
 namespace ROS2
 {
     ROS2CameraSensorComponent::ROS2CameraSensorComponent(
-        const SensorConfiguration& sensorConfiguration,
-        float verticalFieldOfViewDeg,
-        int width,
-        int height,
-        bool colorCamera,
-        bool depthCamera)
-        : m_verticalFieldOfViewDeg(verticalFieldOfViewDeg)
-        , m_width(width)
-        , m_height(height)
-        , m_colorCamera(colorCamera)
-        , m_depthCamera(depthCamera)
+        const SensorConfiguration& sensorConfiguration, const CameraSensorConfiguration& cameraConfiguration)
+        : m_cameraConfiguration(cameraConfiguration)
     {
         m_sensorConfiguration = sensorConfiguration;
     }
@@ -42,13 +31,8 @@ namespace ROS2
         auto* serialize = azrtti_cast<AZ::SerializeContext*>(context);
         if (serialize)
         {
-            serialize->Class<ROS2CameraSensorComponent, ROS2SensorComponent>()
-                ->Version(3)
-                ->Field("VerticalFieldOfViewDeg", &ROS2CameraSensorComponent::m_verticalFieldOfViewDeg)
-                ->Field("Width", &ROS2CameraSensorComponent::m_width)
-                ->Field("Height", &ROS2CameraSensorComponent::m_height)
-                ->Field("Depth", &ROS2CameraSensorComponent::m_depthCamera)
-                ->Field("Color", &ROS2CameraSensorComponent::m_colorCamera);
+            serialize->Class<ROS2CameraSensorComponent, ROS2SensorComponent>()->Version(4)->Field(
+                "CameraSensorConfig", &ROS2CameraSensorComponent::m_cameraConfiguration);
         }
     }
 
@@ -56,46 +40,25 @@ namespace ROS2
     {
         ROS2SensorComponent::Activate();
 
-        auto ros2Node = ROS2Interface::Get()->GetNode();
-
         const auto cameraInfoPublisherConfig = m_sensorConfiguration.m_publishersConfigurations[CameraConstants::InfoConfig];
         AZStd::string cameraInfoFullTopic = ROS2Names::GetNamespacedName(GetNamespace(), cameraInfoPublisherConfig.m_topic);
         AZ_TracePrintf("ROS2", "Creating publisher for camera info on topic %s\n", cameraInfoFullTopic.data());
 
+        auto ros2Node = ROS2Interface::Get()->GetNode();
         m_cameraInfoPublisher =
             ros2Node->create_publisher<sensor_msgs::msg::CameraInfo>(cameraInfoFullTopic.data(), cameraInfoPublisherConfig.GetQoS());
 
-        const CameraSensorDescription description{
-            GetCameraNameFromFrame(GetEntity()), m_verticalFieldOfViewDeg, m_width, m_height, GetEntityId()
-        };
-        if (m_colorCamera)
+        if (m_cameraConfiguration.m_colorCamera && m_cameraConfiguration.m_depthCamera)
         {
-            const auto cameraImagePublisherConfig = m_sensorConfiguration.m_publishersConfigurations[CameraConstants::ColorImageConfig];
-            AZStd::string cameraImageFullTopic = ROS2Names::GetNamespacedName(GetNamespace(), cameraImagePublisherConfig.m_topic);
-            auto publisher =
-                ros2Node->create_publisher<sensor_msgs::msg::Image>(cameraImageFullTopic.data(), cameraImagePublisherConfig.GetQoS());
-            m_imagePublishers.emplace_back(publisher);
+            AddImageSource<CameraRGBDSensor>();
         }
-        if (m_depthCamera)
+        else if (m_cameraConfiguration.m_colorCamera)
         {
-            const auto cameraImagePublisherConfig = m_sensorConfiguration.m_publishersConfigurations[CameraConstants::DepthImageConfig];
-            AZStd::string cameraImageFullTopic = ROS2Names::GetNamespacedName(GetNamespace(), cameraImagePublisherConfig.m_topic);
-            auto publisher =
-                ros2Node->create_publisher<sensor_msgs::msg::Image>(cameraImageFullTopic.data(), cameraImagePublisherConfig.GetQoS());
-            m_imagePublishers.emplace_back(publisher);
+            AddImageSource<CameraColorSensor>();
         }
-
-        if (m_colorCamera && m_depthCamera)
+        else if (m_cameraConfiguration.m_depthCamera)
         {
-            m_cameraSensor = AZStd::make_shared<CameraRGBDSensor>(description);
-        }
-        else if (m_colorCamera)
-        {
-            m_cameraSensor = AZStd::make_shared<CameraColorSensor>(description);
-        }
-        else if (m_depthCamera)
-        {
-            m_cameraSensor = AZStd::make_shared<CameraDepthSensor>(description);
+            AddImageSource<CameraDepthSensor>();
         }
 
         const auto* component = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
@@ -123,8 +86,8 @@ namespace ROS2
             ros_header.stamp = timestamp;
             ros_header.frame_id = m_frameName.c_str();
             cameraInfo.header = ros_header;
-            cameraInfo.width = m_width;
-            cameraInfo.height = m_height;
+            cameraInfo.width = m_cameraConfiguration.m_width;
+            cameraInfo.height = m_cameraConfiguration.m_height;
             cameraInfo.distortion_model = sensor_msgs::distortion_models::PLUMB_BOB;
             AZ_Assert(cameraIntrinsics.size() == 9, "camera matrix should have 9 elements");
             AZ_Assert(cameraInfo.k.size() == 9, "camera matrix should have 9 elements");

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.h
@@ -11,14 +11,15 @@
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
-#include <ROS2/Sensor/ROS2SensorComponent.h>
-
 #include <AzCore/Component/Component.h>
 
+#include "CameraSensor.h"
+#include "CameraSensorConfiguration.h"
 #include <ROS2/Frame/NamespaceConfiguration.h>
 #include <ROS2/Frame/ROS2Transform.h>
-
-#include "CameraSensor.h"
+#include <ROS2/ROS2Bus.h>
+#include <ROS2/Sensor/ROS2SensorComponent.h>
+#include <ROS2/Utilities/ROS2Names.h>
 
 namespace ROS2
 {
@@ -42,14 +43,7 @@ namespace ROS2
     {
     public:
         ROS2CameraSensorComponent() = default;
-
-        ROS2CameraSensorComponent(
-            const SensorConfiguration& sensorConfiguration,
-            float verticalFieldOfViewDeg,
-            int width,
-            int height,
-            bool colorCamera,
-            bool depthCamera);
+        ROS2CameraSensorComponent(const SensorConfiguration& sensorConfiguration, const CameraSensorConfiguration& cameraConfiguration);
 
         ~ROS2CameraSensorComponent() override = default;
         AZ_COMPONENT(ROS2CameraSensorComponent, "{3C6B8AE6-9721-4639-B8F9-D8D28FD7A071}", ROS2SensorComponent);
@@ -65,18 +59,51 @@ namespace ROS2
         //! Pointer to ROS2 camera sensor publisher type
         using CameraInfoPublisherPtrType = std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::CameraInfo>>;
 
-        //! Type that combines pointer to ROS2 publisher and CameraSensor
-        using PublisherSensorPtrPair = AZStd::pair<ImagePublisherPtrType, AZStd::shared_ptr<CameraSensor>>;
-
-        //! Helper to construct a PublisherSensorPtrPair with a pointer to ROS2 publisher and intrinsic calibration.
-        //! @tparam CameraType type of camera sensor (eg 'CameraColorSensor')
-        //! @param publisher pointer to ROS2 image publisher
-        //! @param description CameraSensorDescription with intrinsic calibration
-        //! @return PublisherSensorPtrPair with all provided parameters
         template<typename CameraType>
-        PublisherSensorPtrPair CreatePair(ImagePublisherPtrType publisher, const CameraSensorDescription& description) const
+        AZStd::vector<TopicConfiguration> GetCameraTopicConfiguration()
         {
-            return { publisher, AZStd::make_shared<CameraType>(description) };
+            TopicConfiguration defaultConfig;
+            return { defaultConfig };
+        }
+
+        template<>
+        AZStd::vector<TopicConfiguration> GetCameraTopicConfiguration<CameraColorSensor>()
+        {
+            return { m_sensorConfiguration.m_publishersConfigurations[CameraConstants::ColorImageConfig] };
+        }
+
+        template<>
+        AZStd::vector<TopicConfiguration> GetCameraTopicConfiguration<CameraDepthSensor>()
+        {
+            return { m_sensorConfiguration.m_publishersConfigurations[CameraConstants::DepthImageConfig] };
+        }
+
+        template<>
+        AZStd::vector<TopicConfiguration> GetCameraTopicConfiguration<CameraRGBDSensor>()
+        {
+            // Note: the order matters.
+            return { m_sensorConfiguration.m_publishersConfigurations[CameraConstants::ColorImageConfig],
+                     m_sensorConfiguration.m_publishersConfigurations[CameraConstants::DepthImageConfig] };
+        }
+
+        //! Helper that adds an image source.
+        //! @tparam CameraType type of camera sensor (eg 'CameraColorSensor')
+        template<typename CameraType>
+        void AddImageSource()
+        {
+            CameraConfiguration cameraConfiguration = { m_cameraConfiguration.m_verticalFieldOfViewDeg,
+                                                        m_cameraConfiguration.m_width,
+                                                        m_cameraConfiguration.m_height };
+            const CameraSensorDescription description{ GetCameraNameFromFrame(GetEntity()), cameraConfiguration };
+            const auto cameraImagePublisherConfigs = GetCameraTopicConfiguration<CameraType>();
+            for (const auto& cameraImagePublisherConfig : cameraImagePublisherConfigs)
+            {
+                AZStd::string fullTopic = ROS2Names::GetNamespacedName(GetNamespace(), cameraImagePublisherConfig.m_topic);
+                auto ros2Node = ROS2Interface::Get()->GetNode();
+                auto publisher = ros2Node->create_publisher<sensor_msgs::msg::Image>(fullTopic.data(), cameraImagePublisherConfig.GetQoS());
+                m_imagePublishers.emplace_back(publisher);
+            }
+            m_cameraSensor = AZStd::make_shared<CameraType>(description, GetEntityId());
         }
 
         //! Retrieve camera name from ROS2FrameComponent's FrameID.
@@ -84,14 +111,10 @@ namespace ROS2
         //! @returns FrameID from ROS2FrameComponent
         AZStd::string GetCameraNameFromFrame(const AZ::Entity* entity) const;
 
-        float m_verticalFieldOfViewDeg = 90.0f;
-        int m_width = 640;
-        int m_height = 480;
-        bool m_colorCamera = true;
-        bool m_depthCamera = true;
-        AZStd::string m_frameName;
-
         void FrequencyTick() override;
+
+        CameraSensorConfiguration m_cameraConfiguration;
+        AZStd::string m_frameName;
 
         AZStd::vector<ImagePublisherPtrType> m_imagePublishers;
         AZStd::shared_ptr<CameraSensor> m_cameraSensor;

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.h
@@ -8,14 +8,14 @@
 #pragma once
 
 #include <AzCore/Component/Component.h>
-#include <ROS2/Frame/NamespaceConfiguration.h>
-#include <ROS2/Frame/ROS2Transform.h>
-#include <ROS2/Sensor/SensorConfiguration.h>
-
+#include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzToolsFramework/API/ComponentEntitySelectionBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 
-#include "CameraSensor.h"
+#include "CameraSensorConfiguration.h"
+#include <ROS2/Frame/NamespaceConfiguration.h>
+#include <ROS2/Frame/ROS2Transform.h>
+#include <ROS2/Sensor/SensorConfiguration.h>
 
 namespace ROS2
 {
@@ -35,11 +35,10 @@ namespace ROS2
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& required);
 
-        static void GetPr(AZ::ComponentDescriptor::DependencyArrayType& required);
         void Activate() override;
         void Deactivate() override;
 
-        // AzToolsFramework::Components::EditorComponentBase override
+        // AzToolsFramework::Components::EditorComponentBase overrides
         void BuildGameEntity(AZ::Entity* gameEntity) override;
 
     private:
@@ -49,10 +48,6 @@ namespace ROS2
         AZStd::pair<AZStd::string, TopicConfiguration> MakeTopicConfigurationPair(
             const AZStd::string& topic, const AZStd::string& messageType, const AZStd::string& configName) const;
         SensorConfiguration m_sensorConfiguration;
-        float m_VerticalFieldOfViewDeg = 90.0f;
-        int m_width = 640;
-        int m_height = 480;
-        bool m_colorCamera = true;
-        bool m_depthCamera = true;
+        CameraSensorConfiguration m_cameraSensorConfiguration;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/ros2_files.cmake
+++ b/Gems/ROS2/Code/ros2_files.cmake
@@ -11,6 +11,8 @@ set(FILES
         ../Assets/Passes/ROSPassTemplates.azasset
         Source/Camera/CameraSensor.cpp
         Source/Camera/CameraSensor.h
+        Source/Camera/CameraSensorConfiguration.cpp
+        Source/Camera/CameraSensorConfiguration.h
         Source/Camera/ROS2CameraSensorComponent.cpp
         Source/Camera/ROS2CameraSensorComponent.h
         Source/Clock/SimulationClock.cpp

--- a/Gems/ROS2/Code/ros2_header_files.cmake
+++ b/Gems/ROS2/Code/ros2_header_files.cmake
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 set(FILES
+        Include/ROS2/Camera/CameraPostProcessingRequestBus.h
         Include/ROS2/Clock/SimulationClock.h
         Include/ROS2/Frame/NamespaceConfiguration.h
         Include/ROS2/Frame/ROS2FrameComponent.h


### PR DESCRIPTION
Small refactoring of camera sensor code needed to add post processing, which is very useful for simulation.
Includes exposing the interface to add custom post processing function to the pipeline before publishing data, both for depth and color.