### PR TITLE
ROS2 Lidar Sensor - fix for incorrect calculation of ray's rotation

### DIFF
--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
@@ -83,7 +83,7 @@ namespace ROS2
         }
 
         const AZStd::vector<AZ::Vector3> rayDirections =
-            LidarTemplateUtils::RotationsToDirections(m_rayRotations, lidarTransform.GetEulerRadians());
+            LidarTemplateUtils::RotationsToDirections(m_rayRotations, lidarTransform);
 
         const AZ::Vector3 lidarPosition = lidarTransform.GetTranslation();
 

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.cpp
@@ -8,6 +8,7 @@
 
 #include <Lidar/LidarTemplateUtils.h>
 #include <AzCore/Math/Quaternion.h>
+#include <AzCore/Math/Transform.h>
 
 namespace ROS2
 {

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.cpp
@@ -176,15 +176,13 @@ namespace ROS2
     }
 
     AZStd::vector<AZ::Vector3> LidarTemplateUtils::RotationsToDirections(
-        const AZStd::vector<AZ::Vector3>& rotations, const AZ::Vector3& rootRotation)
+        const AZStd::vector<AZ::Vector3>& rotations, const AZ::Transform& rootTransform)
     {
         AZStd::vector<AZ::Vector3> directions;
         directions.reserve(rotations.size());
         for (const auto& angle : rotations)
         {
-            const auto rotation = AZ::Quaternion::CreateFromEulerRadiansZYX(
-                { 0.0f, -(angle.GetY() + rootRotation.GetY()), angle.GetZ() + rootRotation.GetZ() });
-
+            const AZ::Quaternion rotation = rootTransform.GetRotation() * AZ::Quaternion::CreateFromEulerRadiansZYX({ 0.0f, -angle.GetY(), angle.GetZ() });
             directions.emplace_back(rotation.TransformVector(AZ::Vector3::CreateAxisX()));
         }
 

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.h
@@ -35,6 +35,6 @@ namespace ROS2
         //! @param rotations Rotations as Euler angles in radians to compute directions from.
         //! @param rootRotation Root rotation as Euler angles in radians.
         //! @return Ray directions constructed by transforming an X axis unit vector by the provided rotations.
-        AZStd::vector<AZ::Vector3> RotationsToDirections(const AZStd::vector<AZ::Vector3>& rotations, const AZ::Vector3& rootRotation);
+        AZStd::vector<AZ::Vector3> RotationsToDirections(const AZStd::vector<AZ::Vector3>& rotations, const AZ::Transform& rootTransform);
     }; // namespace LidarTemplateUtils
 } // namespace ROS2


### PR DESCRIPTION
Fix for #268