### PR TITLE
Seperate camera infos

### DIFF
--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
@@ -21,7 +21,9 @@ namespace ROS2
         m_sensorConfiguration.m_publishersConfigurations.insert(
             MakeTopicConfigurationPair("camera_image_depth", CameraConstants::ImageMessageType, CameraConstants::DepthImageConfig));
         m_sensorConfiguration.m_publishersConfigurations.insert(
-            MakeTopicConfigurationPair("camera_info", CameraConstants::CameraInfoMessageType, CameraConstants::InfoConfig));
+            MakeTopicConfigurationPair("color_camera_info", CameraConstants::CameraInfoMessageType, CameraConstants::ColorInfoConfig));
+        m_sensorConfiguration.m_publishersConfigurations.insert(
+            MakeTopicConfigurationPair("depth_camera_info", CameraConstants::CameraInfoMessageType, CameraConstants::DepthInfoConfig));
     }
 
     void ROS2CameraSensorEditorComponent::Reflect(AZ::ReflectContext* context)


### PR DESCRIPTION
Added toggle in ROS2 CameraSensorConfiguration to change publishing rules for camera_info
Previously always published on
<Namespace>/<camera_info>

This PR allows for
<Namespace>/<depth_camera>/<camera_info>
<Namespace>/<color_camera>/<camera_info>

Camera info is duplicated because both color and depth cameras have the same specification 