### PR TITLE
Add check for open level

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/IntroPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/IntroPage.cpp
@@ -24,7 +24,8 @@ namespace ROS2
                                          " The tool (Asset Processor) allows processing source assets (e.g, meshes, textures)"
                                          " to its supported internal format. To learn more about asset processors click"
                                          " <a href=\"https://www.o3de.org/docs/user-guide/assets/asset-processor/\">here</a>."
-                                         " URDF Importer will find correct meshes in product assets during import."));
+                                         " URDF Importer will find correct meshes in product assets during import."
+                                         " A level must be opened before using URDF Importer."));
         m_label->setTextFormat(Qt::RichText);
         m_label->setOpenExternalLinks(true);
         m_label->setWordWrap(true);

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -258,6 +258,24 @@ namespace ROS2
             m_params = m_xacroParamsPage->GetXacroParameters();
             OpenUrdf();
         }
+        if (currentPage() == m_introPage)
+        {
+            AZ::EntityId levelEntityId;
+            AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+                levelEntityId, &AzToolsFramework::ToolsApplicationRequests::GetCurrentLevelEntityId);
+
+            AZ::Entity* levelEntity{ nullptr };
+            AZ::ComponentApplicationBus::BroadcastResult(levelEntity, &AZ::ComponentApplicationRequests::FindEntity, levelEntityId);
+
+            if (!levelEntityId.IsValid() || levelEntity == nullptr)
+            {
+                QMessageBox noLevelLoadedMessage;
+                noLevelLoadedMessage.critical(0, "No level opened", "A level must be opened before using URDF Importer");
+                noLevelLoadedMessage.setFixedSize(500, 200);
+
+                return false;
+            }
+        }
         return currentPage()->validatePage();
     }
 


### PR DESCRIPTION
I've added a check for an open level while importing a URDF file. If a level is not open this check will prevent further pages in Robot Importer Widget, displaying a message box describing the error. This fixes #265.