### PR TITLE
Ros2FleetRobotTemplate: updated the rendering passes

### DIFF
--- a/Templates/Ros2FleetRobotTemplate/Template/Passes/PostProcessParent.pass
+++ b/Templates/Ros2FleetRobotTemplate/Template/Passes/PostProcessParent.pass
@@ -86,7 +86,7 @@
                 },
                 {
                     "Name": "TaaPass",
-                    "TemplateName": "TaaTemplate",
+                    "TemplateName": "TaaParentTemplate",
                     "Enabled": true,
                     "Connections": [
                         {

--- a/Templates/Ros2FleetRobotTemplate/Template/Passes/Taa.pass
+++ b/Templates/Ros2FleetRobotTemplate/Template/Passes/Taa.pass
@@ -17,7 +17,12 @@
                     "Name": "InputDepth",
                     "SlotType": "Input",
                     "ShaderInputName": "m_inputDepth",
-                    "ScopeAttachmentUsage": "Shader"
+                    "ScopeAttachmentUsage": "Shader",
+                    "ImageViewDesc": {
+                        "AspectFlags": [
+                            "Depth"
+                        ]
+                    }
                 },
                 {
                     "Name": "MotionVectors",
@@ -54,8 +59,8 @@
                     },
                     "ImageDescriptor": {
                         "Format": "R16G16B16A16_FLOAT",
-                        "BindFlags": "3",
-                        "SharedQueueMask": "1"
+                        "BindFlags": "ShaderReadWrite",
+                        "SharedQueueMask": "Graphics"
                     }
                 },
                 {
@@ -73,8 +78,8 @@
                     },
                     "ImageDescriptor": {
                         "Format": "R16G16B16A16_FLOAT",
-                        "BindFlags": "3",
-                        "SharedQueueMask": "1"
+                        "BindFlags": "ShaderReadWrite",
+                        "SharedQueueMask": "Graphics"
                     }
                 }
             ],


### PR DESCRIPTION
Updated pass filters to match current ones in o3de:stabilization/2305 ([link](https://github.com/o3de/o3de/tree/stabilization/2305/Gems/Atom/Feature/Common/Assets/Passes)). Results:

Before:
![Screenshot from 2023-04-20 10-37-36](https://user-images.githubusercontent.com/31925544/233315189-b6ca784c-ac7f-4419-bce5-c5996e967479.png)

After:
![Screenshot from 2023-04-20 10-42-11](https://user-images.githubusercontent.com/31925544/233315226-a988b4f3-091c-48e0-8bb1-5d305876563b.png)

This PR addresses #282

