### PR TITLE
Add ROS2CameraSensor service and horizontal field of view param

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Camera/CameraSensor.h
+++ b/Gems/ROS2/Code/Include/ROS2/Camera/CameraSensor.h
@@ -10,7 +10,7 @@
 #include <Atom/Feature/Utils/FrameCaptureBus.h>
 #include <AzCore/std/containers/span.h>
 
-#include "CameraPublishers.h"
+#include "../Source/Camera/CameraPublishers.h"
 #include <ROS2/ROS2GemUtilities.h>
 
 #include <chrono>
@@ -74,6 +74,7 @@ namespace ROS2
     class CameraDepthSensor : public CameraSensor
     {
     public:
+        AZ_TYPE_INFO(CameraDepthSensor, "{ADD4F0E4-F0ED-4770-9FF3-12AA4050953B}");
         CameraDepthSensor(const CameraSensorDescription& cameraSensorDescription, const AZ::EntityId& entityId);
 
     private:
@@ -85,6 +86,7 @@ namespace ROS2
     class CameraColorSensor : public CameraSensor
     {
     public:
+        AZ_TYPE_INFO(CameraColorSensor, "{8AA28B00-635D-4801-B1D8-37B66B535BA2}");
         CameraColorSensor(const CameraSensorDescription& cameraSensorDescription, const AZ::EntityId& entityId);
 
     private:
@@ -96,6 +98,7 @@ namespace ROS2
     class CameraRGBDSensor : public CameraColorSensor
     {
     public:
+        AZ_TYPE_INFO(CameraRGBDSensor, "{724D6C9F-EC61-4644-9EC9-C162AE5F26AF}");
         CameraRGBDSensor(const CameraSensorDescription& cameraSensorDescription, const AZ::EntityId& entityId);
 
         // CameraSensor overrides

--- a/Gems/ROS2/Code/Source/Camera/CameraPublishers.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraPublishers.cpp
@@ -8,7 +8,7 @@
 
 #include "CameraPublishers.h"
 #include "CameraConstants.h"
-#include "CameraSensor.h"
+#include "ROS2/Camera/CameraSensor.h"
 #include <ROS2/Communication/TopicConfiguration.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/Sensor/SensorConfiguration.h>

--- a/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include "CameraSensor.h"
+#include "ROS2/Camera/CameraSensor.h"
 #include <ROS2/Camera/CameraPostProcessingRequestBus.h>
 
 #include <Atom/RPI.Public/Base.h>

--- a/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.cpp
@@ -32,6 +32,8 @@ namespace ROS2
                         &CameraSensorConfiguration::m_verticalFieldOfViewDeg,
                         "Vertical field of view",
                         "Camera's vertical (y axis) field of view in degrees.")
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                    ->Attribute(AZ::Edit::Attributes::Max, 179.99f) // asserted to be less than 180 ([see the link](https://github.com/o3de/o3de-extras/blob/stabilization/2305/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp#L72))
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_width, "Image width", "Image width")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_height, "Image height", "Image height")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_colorCamera, "Color Camera", "Color Camera")

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
@@ -64,6 +64,21 @@ namespace ROS2
         ROS2SensorComponent::Deactivate();
     }
 
+    void ROS2CameraSensorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC("ROS2Frame"));
+    }
+
+    void ROS2CameraSensorComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("ROS2CameraSensor"));
+    }
+
+    void ROS2CameraSensorComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("ROS2CameraSensor"));
+    }
+
     void ROS2CameraSensorComponent::FrequencyTick()
     {
         const AZ::Transform transform = GetEntity()->GetTransform()->GetWorldTM();

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.h
@@ -14,7 +14,7 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/std/containers/vector.h>
 
-#include "CameraSensor.h"
+#include "ROS2/Camera/CameraSensor.h"
 #include "CameraSensorConfiguration.h"
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/Sensor/ROS2SensorComponent.h>
@@ -37,6 +37,9 @@ namespace ROS2
         ~ROS2CameraSensorComponent() override = default;
         AZ_COMPONENT(ROS2CameraSensorComponent, "{3C6B8AE6-9721-4639-B8F9-D8D28FD7A071}", ROS2SensorComponent);
         static void Reflect(AZ::ReflectContext* context);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
 
         void Activate() override;
         void Deactivate() override;

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
@@ -80,9 +80,9 @@ namespace ROS2
         incompatible.push_back(AZ_CRC_CE("ROS2CameraSensor"));
     }
 
-    void ROS2CameraSensorEditorComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    void ROS2CameraSensorEditorComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
     {
-        required.push_back(AZ_CRC_CE("ROS2CameraSensor"));
+        provided.push_back(AZ_CRC_CE("ROS2CameraSensor"));
     }
 
     void ROS2CameraSensorEditorComponent::BuildGameEntity(AZ::Entity* gameEntity)

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.h
@@ -33,7 +33,7 @@ namespace ROS2
         static void Reflect(AZ::ReflectContext* context);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
-        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
 
         void Activate() override;
         void Deactivate() override;

--- a/Gems/ROS2/Code/ros2_files.cmake
+++ b/Gems/ROS2/Code/ros2_files.cmake
@@ -13,7 +13,6 @@ set(FILES
         Source/Camera/CameraPublishers.cpp
         Source/Camera/CameraPublishers.h
         Source/Camera/CameraSensor.cpp
-        Source/Camera/CameraSensor.h
         Source/Camera/CameraSensorDescription.cpp
         Source/Camera/CameraSensorDescription.h
         Source/Camera/CameraSensorConfiguration.cpp

--- a/Gems/ROS2/Code/ros2_header_files.cmake
+++ b/Gems/ROS2/Code/ros2_header_files.cmake
@@ -5,6 +5,7 @@
 
 set(FILES
         Include/ROS2/Camera/CameraPostProcessingRequestBus.h
+        Include/ROS2/Camera/CameraSensor.h
         Include/ROS2/Clock/PhysicallyStableClock.h
         Include/ROS2/Clock/SimulationClock.h
         Include/ROS2/Frame/NamespaceConfiguration.h


### PR DESCRIPTION
Added:
- macro `AZ_TYPE_INFO` to the CameraDepthSensor and CameraRGBDSensor
- services to `ROS2CameraSensorComponent`
- move `CameraSensor` header to shared directory 

Solves https://github.com/o3de/o3de-extras/issues/278
Based on https://github.com/RobotecAI/o3de-extras/pull/11