### PR TITLE
Updated gem.json to reflect versioning RFC

### DIFF
--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -18,8 +18,8 @@
         "ROS2"
     ],
     "compatible_engines": [
-        “o3de-sdk==1.2.0”,
-        “o3de>=2.0.0”
+        "o3de-sdk==1.2.0",
+        "o3de>=2.0.0"
     ],
     "icon_path": "preview.png",
     "requirements": "Requires ros2 installation (supported distributions: humble). Source your workspace before building the Gem",

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -1,5 +1,9 @@
 {
     "gem_name": "ROS2",
+    "version": "1.0.0",
+    "platform": [
+        "Linux"
+    ],
     "display_name": "ROS2",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -13,8 +17,12 @@
     "user_tags": [
         "ROS2"
     ],
+    "compatible_engines": [
+        “o3de-sdk==1.2.0”,
+        “o3de>=2.0.0”
+    ],
     "icon_path": "preview.png",
-    "requirements": "Requires ros2 installation (supported distributions: foxy, galactic, humble). Source your workspace before building the Gem",
+    "requirements": "Requires ros2 installation (supported distributions: humble). Source your workspace before building the Gem",
     "documentation_url": "https://o3de.org/docs/user-guide/gems/reference/design/ros2/",
     "dependencies": [],
     "restricted": "ROS2"

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -24,6 +24,13 @@
     "icon_path": "preview.png",
     "requirements": "Requires ros2 installation (supported distributions: humble). Source your workspace before building the Gem",
     "documentation_url": "https://o3de.org/docs/user-guide/gems/reference/design/ros2/",
-    "dependencies": [],
+    "dependencies": [
+        "Atom_RPI",
+        "Atom_Feature_Common",
+        "Atom_Component_DebugCamera",
+        "CommonFeaturesAtom",
+        "PhysX",
+        "StartingPointInput"
+    ],
     "restricted": "ROS2"
 }

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -1,7 +1,7 @@
 {
     "gem_name": "ROS2",
     "version": "1.0.0",
-    "platform": [
+    "platforms": [
         "Linux"
     ],
     "display_name": "ROS2",

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -19,7 +19,7 @@
     ],
     "compatible_engines": [
         "o3de-sdk==1.2.0",
-        "o3de>=2.0.0"
+        "o3de>=1.2.0"
     ],
     "icon_path": "preview.png",
     "requirements": "Requires ros2 installation (supported distributions: humble). Source your workspace before building the Gem",


### PR DESCRIPTION
This change updates the Gem metadata to support versioning: https://github.com/o3de/sig-core/issues/44

Additionaly, it updates the json to include supported platform (Linux). 