### PR TITLE
Add requirement for PhysicsRigidBodyService in ROS2WheelOdometry

### DIFF
--- a/Gems/ROS2/Code/Source/Odometry/ROS2WheelOdometry.cpp
+++ b/Gems/ROS2/Code/Source/Odometry/ROS2WheelOdometry.cpp
@@ -51,6 +51,7 @@ namespace ROS2
 
     void ROS2WheelOdometryComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
+        required.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
         required.push_back(AZ_CRC_CE("ROS2Frame"));
         required.push_back(AZ_CRC_CE("SkidSteeringModelService"));
     }


### PR DESCRIPTION
I've added a requirement in ROS2WheelOdometry for PhysicsRigidBodyService. This addresses #309.