### PR TITLE
Added sanity checks to xacro preventing crash to URDF importer

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -321,6 +321,10 @@ namespace ROS2
                     return m_checkUrdfPage->nextId();
                 }
             }
+            if (m_params.empty())
+            {
+                return m_xacroParamsPage->nextId();
+            }
         }
         return currentPage()->nextId();
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
@@ -94,7 +94,15 @@ namespace ROS2::Utils::xacro
         AZStd::unordered_map<AZStd::string, AZStd::string> params;
         AZ::rapidxml::xml_document<char> doc;
         doc.parse<AZ::rapidxml::parse_full>(dataArray.data());
+        if (doc.first_node() == nullptr)
+        {
+            return params;
+        }
         AZ::rapidxml::xml_node<char>* xmlRootNode = doc.first_node("robot");
+        if (xmlRootNode == nullptr)
+        {
+            return params;
+        }
         for (AZ::rapidxml::xml_node<>* child_node = xmlRootNode->first_node(); child_node; child_node = child_node->next_sibling())
         {
             if (strcmp(argNameTag, child_node->name()) == 0)

--- a/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
@@ -462,6 +462,13 @@ namespace UnitTest
         EXPECT_EQ(result, resolvedDae);
     }
 
+    TEST_F(UrdfParserTest, XacroParseArgsInvalid)
+    {
+        AZStd::string xacroParams = GetXacroParams();
+        ROS2::Utils::xacro::Params params = ROS2::Utils::xacro::GetParameterFromXacroData("");
+        EXPECT_EQ(params.size(), 0);
+    }
+
     TEST_F(UrdfParserTest, XacroParseArgs)
     {
         AZStd::string xacroParams = GetXacroParams();


### PR DESCRIPTION
The PR fix case explained in #307, caused by lack of safety in parsing XACRO file for parameters.
Fixed and tested against manual test cases in :
https://github.com/RobotecAI/o3de-ros2-gem-testing/tree/main/URDFTest