### PR TITLE
ROS2WheelOdometrySensor covariance settings in Editor  

### DIFF
--- a/Gems/ROS2/Code/Source/Odometry/ROS2OdometryCovariance.cpp
+++ b/Gems/ROS2/Code/Source/Odometry/ROS2OdometryCovariance.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ROS2OdometryCovariance.h"
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+#include <AzCore/base.h>
+#include <array>
+
+namespace ROS2
+{
+    void ROS2OdometryCovariance::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<ROS2OdometryCovariance>()
+                ->Version(1)
+                ->Field("Linear covariance", &ROS2OdometryCovariance::m_linearCovariance)
+                ->Field("Angular covariance", &ROS2OdometryCovariance::m_angularCovariance);
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<ROS2OdometryCovariance>("ROS2 Odometry Covariance", "Define Odometry covariance")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2OdometryCovariance::m_linearCovariance,
+                        "Linear covariance",
+                        "Set the ROS linear covariance")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2OdometryCovariance::m_angularCovariance,
+                        "Angular covariance",
+                        "Set the ROS angular covariance");
+            }
+        }
+    }
+
+    std::array<double, 36> ROS2OdometryCovariance::GetRosCovariance() const
+    {
+        const AZ::Vector3& lin = m_linearCovariance;
+        const AZ::Vector3& ang = m_angularCovariance;
+
+        // clang-format off
+        return {
+            lin.GetX(), 0.0L,       0.0L,       0.0L,       0.0L,       0.0L, 
+            0.0L,       lin.GetY(), 0.0L,       0.0L,       0.0L,       0.0L,
+            0.0L,       0.0L,       lin.GetZ(), 0.0L,       0.0L,       0.0L,
+            0.0L,       0.0L,       0.0L,       ang.GetX(), 0.0L,       0.0L,
+            0.0L,       0.0L,       0.0L,       0.0L,       ang.GetY(), 0.0L, 
+            0.0L,       0.0L,       0.0L,       0.0L,       0.0L,       ang.GetZ() 
+        };
+        // clang-format on
+    }
+
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Odometry/ROS2OdometryCovariance.h
+++ b/Gems/ROS2/Code/Source/Odometry/ROS2OdometryCovariance.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/RTTI/TypeInfoSimple.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <array>
+
+namespace ROS2
+{
+    struct ROS2OdometryCovariance
+    {
+        AZ_TYPE_INFO(ROS2OdometryCovariance, "{db015832-f621-11ed-b67e-0242ac120002}");
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        std::array<double, 36> GetRosCovariance() const;
+
+        AZ::Vector3 m_linearCovariance = AZ::Vector3::CreateZero();
+        AZ::Vector3 m_angularCovariance = AZ::Vector3::CreateZero();
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Odometry/ROS2WheelOdometry.h
+++ b/Gems/ROS2/Code/Source/Odometry/ROS2WheelOdometry.h
@@ -7,15 +7,16 @@
  */
 #pragma once
 
+#include "ROS2OdometryCovariance.h"
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/Physics/Common/PhysicsEvents.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
 #include <ROS2/Sensor/ROS2SensorComponent.h>
+#include <Utilities/PhysicsCallbackHandler.h>
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/publisher.hpp>
-#include <Utilities/PhysicsCallbackHandler.h>
 
 namespace ROS2
 {
@@ -44,6 +45,8 @@ namespace ROS2
         nav_msgs::msg::Odometry m_odometryMsg;
         AZ::Vector3 m_robotPose{ 0 };
         AZ::Quaternion m_robotRotation{ 0, 0, 0, 1 };
+        ROS2OdometryCovariance m_poseCovariance;
+        ROS2OdometryCovariance m_twistCovariance;
 
         // ROS2SensorComponent overrides ...
         void SetupRefreshLoop() override;

--- a/Gems/ROS2/Code/ros2_files.cmake
+++ b/Gems/ROS2/Code/ros2_files.cmake
@@ -59,6 +59,8 @@ set(FILES
         Source/Odometry/ROS2OdometrySensorComponent.h
         Source/Odometry/ROS2WheelOdometry.cpp
         Source/Odometry/ROS2WheelOdometry.h
+        Source/Odometry/ROS2OdometryCovariance.cpp
+        Source/Odometry/ROS2OdometryCovariance.h
         Source/RobotControl/Ackermann/AckermannSubscriptionHandler.cpp
         Source/RobotControl/Ackermann/AckermannSubscriptionHandler.h
         Source/RobotControl/ControlConfiguration.cpp
@@ -117,4 +119,4 @@ set(FILES
         Source/VehicleDynamics/WheelControllerComponent.cpp
         Source/VehicleDynamics/WheelControllerComponent.h
         Source/VehicleDynamics/WheelDynamicsData.h
-        )
+)


### PR DESCRIPTION
Allows for changing covariance values in ros2 message.
Limits choice to diagonal for simplicity. 