### PR TITLE
Validate configuration fields for sensors

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Sensor/SensorConfiguration.h
+++ b/Gems/ROS2/Code/Include/ROS2/Sensor/SensorConfiguration.h
@@ -37,6 +37,6 @@ namespace ROS2
         bool m_visualise = true; //!< Determines whether the sensor is visualised in O3DE (for example, point cloud is drawn for LIDAR).
     private:
         // Frequency limit is once per day.
-        static constexpr float m_minFrequency = 1. / (24. * 3600.);
+        static constexpr float m_minFrequency = AZStd::numeric_limits<float>::epsilon();
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Sensor/SensorConfiguration.h
+++ b/Gems/ROS2/Code/Include/ROS2/Sensor/SensorConfiguration.h
@@ -35,5 +35,8 @@ namespace ROS2
 
         bool m_publishingEnabled = true; //!< Determines whether the sensor is publishing (sending data to ROS 2 ecosystem).
         bool m_visualise = true; //!< Determines whether the sensor is visualised in O3DE (for example, point cloud is drawn for LIDAR).
+    private:
+        // Frequency limit is once per day.
+        static constexpr float m_minFrequency = 1. / (24. * 3600.);
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.cpp
@@ -32,8 +32,12 @@ namespace ROS2
                         &CameraSensorConfiguration::m_verticalFieldOfViewDeg,
                         "Vertical field of view",
                         "Camera's vertical (y axis) field of view in degrees.")
+                    ->Attribute(AZ::Edit::Attributes::Min, &CameraSensorConfiguration::m_minVerticalFieldOfViewDeg)
+                    ->Attribute(AZ::Edit::Attributes::Max, &CameraSensorConfiguration::m_maxVerticalFieldOfViewDeg)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_width, "Image width", "Image width")
+                    ->Attribute(AZ::Edit::Attributes::Min, &CameraSensorConfiguration::m_minWidth)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_height, "Image height", "Image height")
+                    ->Attribute(AZ::Edit::Attributes::Min, &CameraSensorConfiguration::m_minHeight)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_colorCamera, "Color Camera", "Color Camera")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_depthCamera, "Depth Camera", "Depth Camera");
             }

--- a/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.cpp
@@ -35,9 +35,9 @@ namespace ROS2
                     ->Attribute(AZ::Edit::Attributes::Min, &CameraSensorConfiguration::m_minVerticalFieldOfViewDeg)
                     ->Attribute(AZ::Edit::Attributes::Max, &CameraSensorConfiguration::m_maxVerticalFieldOfViewDeg)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_width, "Image width", "Image width")
-                    ->Attribute(AZ::Edit::Attributes::Min, &CameraSensorConfiguration::m_minWidth)
+                    ->Attribute(AZ::Edit::Attributes::Min, CameraSensorConfiguration::m_minWidth)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_height, "Image height", "Image height")
-                    ->Attribute(AZ::Edit::Attributes::Min, &CameraSensorConfiguration::m_minHeight)
+                    ->Attribute(AZ::Edit::Attributes::Min, CameraSensorConfiguration::m_minHeight)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_colorCamera, "Color Camera", "Color Camera")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraSensorConfiguration::m_depthCamera, "Depth Camera", "Depth Camera");
             }

--- a/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.h
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.h
@@ -19,13 +19,14 @@ namespace ROS2
         AZ_TYPE_INFO(CameraSensorConfiguration, "{386A2640-442B-473D-BC2A-665D049D7EF5}");
         static void Reflect(AZ::ReflectContext* context);
 
+        static constexpr int m_minWidth = 1;
+        static constexpr int m_minHeight = 1;
+
         float m_verticalFieldOfViewDeg = 90.0f; //!< Vertical field of view of camera sensor.
         float m_minVerticalFieldOfViewDeg = 0.0f;
         float m_maxVerticalFieldOfViewDeg = 360.0f;
         int m_width = 640; //!< Camera image width in pixels.
-        int m_minWidth = 1;
         int m_height = 480; //!< Camera image height in pixels.
-        int m_minHeight = 1;
         bool m_colorCamera = true; //!< Use color camera?
         bool m_depthCamera = true; //!< Use depth camera?
     };

--- a/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.h
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensorConfiguration.h
@@ -20,8 +20,12 @@ namespace ROS2
         static void Reflect(AZ::ReflectContext* context);
 
         float m_verticalFieldOfViewDeg = 90.0f; //!< Vertical field of view of camera sensor.
+        float m_minVerticalFieldOfViewDeg = 0.0f;
+        float m_maxVerticalFieldOfViewDeg = 360.0f;
         int m_width = 640; //!< Camera image width in pixels.
+        int m_minWidth = 1;
         int m_height = 480; //!< Camera image height in pixels.
+        int m_minHeight = 1;
         bool m_colorCamera = true; //!< Use color camera?
         bool m_depthCamera = true; //!< Use depth camera?
     };

--- a/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.cpp
@@ -52,14 +52,9 @@ namespace ROS2
                         AZ::Edit::UIHandlers::Slider,
                         &ROS2ImuSensorComponent::m_filterSize,
                         "Filter Length",
-<<<<<<< HEAD
                         "Filter Length, Large value reduce numeric noise but increase lag")
                     ->Attribute(AZ::Edit::Attributes::Max, &ROS2ImuSensorComponent::m_maxFilterSize)
                     ->Attribute(AZ::Edit::Attributes::Min, &ROS2ImuSensorComponent::m_minFilterSize)
-=======
-                        "Filter Length, large value allows to reduce numeric noise")
-                    ->Attribute(AZ::Edit::Attributes::Min, ROS2ImuSensorComponent::m_minFilterSize)
->>>>>>> 9a7eb84 (Apply suggestions from review)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ROS2ImuSensorComponent::m_includeGravity,

--- a/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.cpp
@@ -53,8 +53,8 @@ namespace ROS2
                         &ROS2ImuSensorComponent::m_filterSize,
                         "Filter Length",
                         "Filter Length, Large value reduce numeric noise but increase lag")
-                    ->Attribute(AZ::Edit::Attributes::Min, 1)
-                    ->Attribute(AZ::Edit::Attributes::Max, 200)
+                    ->Attribute(AZ::Edit::Attributes::Max, &ROS2ImuSensorComponent::m_maxFilterSize)
+                    ->Attribute(AZ::Edit::Attributes::Min, &ROS2ImuSensorComponent::m_minFilterSize)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ROS2ImuSensorComponent::m_includeGravity,

--- a/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.cpp
@@ -52,9 +52,14 @@ namespace ROS2
                         AZ::Edit::UIHandlers::Slider,
                         &ROS2ImuSensorComponent::m_filterSize,
                         "Filter Length",
+<<<<<<< HEAD
                         "Filter Length, Large value reduce numeric noise but increase lag")
                     ->Attribute(AZ::Edit::Attributes::Max, &ROS2ImuSensorComponent::m_maxFilterSize)
                     ->Attribute(AZ::Edit::Attributes::Min, &ROS2ImuSensorComponent::m_minFilterSize)
+=======
+                        "Filter Length, large value allows to reduce numeric noise")
+                    ->Attribute(AZ::Edit::Attributes::Min, ROS2ImuSensorComponent::m_minFilterSize)
+>>>>>>> 9a7eb84 (Apply suggestions from review)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ROS2ImuSensorComponent::m_includeGravity,

--- a/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.h
@@ -39,10 +39,15 @@ namespace ROS2
         //////////////////////////////////////////////////////////////////////////
 
     private:
+        static constexpr int m_minFilterSize = 1;
+
         //! Length of filter that removes numerical noise
         int m_filterSize{ 10 };
+<<<<<<< HEAD
         int m_minFilterSize{ 0 };
         int m_maxFilterSize{ 200 };
+=======
+>>>>>>> 4559cef (Add private limits struct)
 
         //! Include gravity acceleration
         bool m_includeGravity{ true };

--- a/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.h
@@ -39,15 +39,10 @@ namespace ROS2
         //////////////////////////////////////////////////////////////////////////
 
     private:
-        static constexpr int m_minFilterSize = 1;
-
         //! Length of filter that removes numerical noise
         int m_filterSize{ 10 };
-<<<<<<< HEAD
-        int m_minFilterSize{ 0 };
+        int m_minFilterSize{ 1 };
         int m_maxFilterSize{ 200 };
-=======
->>>>>>> 4559cef (Add private limits struct)
 
         //! Include gravity acceleration
         bool m_includeGravity{ true };

--- a/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.h
@@ -41,6 +41,8 @@ namespace ROS2
     private:
         //! Length of filter that removes numerical noise
         int m_filterSize{ 10 };
+        int m_minFilterSize{ 0 };
+        int m_maxFilterSize{ 200 };
 
         //! Include gravity acceleration
         bool m_includeGravity{ true };

--- a/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
@@ -9,7 +9,6 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <ROS2/Sensor/SensorConfiguration.h>
-#include <limits>
 
 namespace ROS2
 {

--- a/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
@@ -38,7 +38,7 @@ namespace ROS2
                         "Toggle publishing for topic")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_frequency, "Frequency", "Frequency of publishing [Hz]")
-                    ->Attribute(AZ::Edit::Attributes::Min, AZStd::numeric_limits<float>::epsilon())
+                    ->Attribute(AZ::Edit::Attributes::Min, SensorConfiguration::m_minFrequency)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_publishersConfigurations, "Publishers", "Publishers")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)

--- a/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <ROS2/Sensor/SensorConfiguration.h>
+#include <limits>
 
 namespace ROS2
 {
@@ -37,6 +38,7 @@ namespace ROS2
                         "Toggle publishing for topic")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_frequency, "Frequency", "Frequency of publishing [Hz]")
+                    ->Attribute(AZ::Edit::Attributes::Min, AZStd::numeric_limits<float>::epsilon())
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &SensorConfiguration::m_publishersConfigurations, "Publishers", "Publishers")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)


### PR DESCRIPTION
I've added limits for suitable configuration fields inside sensors. Most of them are minimum limits to eliminate values such as negative frequency. This addresses issue #129.