### PR TITLE
Add check for ROS2 distribution in CMakeLists.txt

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -25,12 +25,18 @@ get_property(ROS_DISTRO_TYPE CACHE ROS_DISTRO PROPERTY TYPE)
 # Perform checks with cached ROS 2 distribution and sourced distribution. Save the distribution into cache if it was not cached before or if they do not match end with error.
 if (NOT ROS_DISTRO_TYPE)
     set(ROS_DISTRO $ENV{ROS_DISTRO} CACHE STRING "ROS 2 distribution of current configuration" FORCE)
-elseif(NOT "${ROS_DISTRO}" STREQUAL "$ENV{ROS_DISTRO}")
-    message(FATAL_ERROR "ROS 2 distribution does not match. Configuration created for: ${ROS_DISTRO}, sourced distribution: $ENV{ROS_DISTRO}. Remove CMakeCache.txt and reconfigure project.")
+elseif(NOT "$ENV{ROS_DISTRO}" STREQUAL "${ROS_DISTRO}")
+    get_cmake_property(CACHED_VARIABLES CACHE_VARIABLES)
+    set(ROS_DISTRO_COPY ${ROS_DISTRO})
+    # Iterate over cached variables and unset them
+    foreach(CACHED_VARIABLE ${CACHED_VARIABLES})
+        unset(${CACHED_VARIABLE} CACHE)
+    endforeach()
+    message(FATAL_ERROR "ROS 2 distribution does not match. Configuration created for: ${ROS_DISTRO_COPY}, sourced distribution: $ENV{ROS_DISTRO}.  Removed invalid configuration, please reconfigure project.")
 endif()
 
 # Add a custom target to always check during build if sourced and cached distributions match.
-ADD_CUSTOM_TARGET(
+add_custom_target(
     ROS2DistributionCheck ALL 
     COMMENT "Checking if sourced ROS 2 distribution matches with the configuration"
     COMMAND ${CMAKE_COMMAND} -DROS_DISTRO=${ROS_DISTRO} -P ${CMAKE_CURRENT_SOURCE_DIR}/checkROS2Distribution.cmake

--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -19,6 +19,23 @@ if (NOT ROS2_FOUND)
 endif()
 message(DEBUG "Building ${gem_name} Gem with ros2 $ENV{ROS_DISTRO}")
 
+# Check if ROS 2 distribution is cached
+get_property(ROS_DISTRO_TYPE CACHE ROS_DISTRO PROPERTY TYPE)
+
+# Perform checks with cached ROS 2 distribution and sourced distribution. Save the distribution into cache if it was not cached before or if they do not match end with error.
+if (NOT ROS_DISTRO_TYPE)
+    set(ROS_DISTRO $ENV{ROS_DISTRO} CACHE STRING "ROS 2 distribution of current configuration" FORCE)
+elseif(NOT "${ROS_DISTRO}" STREQUAL "$ENV{ROS_DISTRO}")
+    message(FATAL_ERROR "ROS 2 distribution does not match. Configuration created for: ${ROS_DISTRO}, sourced distribution: $ENV{ROS_DISTRO}. Remove CMakeCache.txt and reconfigure project.")
+endif()
+
+# Add a custom target to always check during build if sourced and cached distributions match.
+ADD_CUSTOM_TARGET(
+    ROS2DistributionCheck ALL 
+    COMMENT "Checking if sourced ROS 2 distribution matches with the configuration"
+    COMMAND ${CMAKE_COMMAND} -DROS_DISTRO=${ROS_DISTRO} -P ${CMAKE_CURRENT_SOURCE_DIR}/checkROS2Distribution.cmake
+)
+
 # Add the ROS2.Static target
 # Note: We include the common files and the platform specific files which are set in ros2_common_files.cmake
 # and in ${pal_dir}/ros2_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake

--- a/Gems/ROS2/Code/checkROS2Distribution.cmake
+++ b/Gems/ROS2/Code/checkROS2Distribution.cmake
@@ -1,3 +1,8 @@
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
 if (NOT "$ENV{ROS_DISTRO}" STREQUAL "${ROS_DISTRO}")
-    message(FATAL_ERROR "ROS 2 distribution does not match. Configuration created for: ${ROS_DISTRO}, sourced distribution: $ENV{ROS_DISTRO}. Remove CMakeCache.txt and reconfigure project.")
+    message(FATAL_ERROR "ROS 2 distribution does not match. Configuration created for: ${ROS_DISTRO}, sourced distribution: $ENV{ROS_DISTRO}. Please reconfigure project")
 endif()

--- a/Gems/ROS2/Code/checkROS2Distribution.cmake
+++ b/Gems/ROS2/Code/checkROS2Distribution.cmake
@@ -1,0 +1,3 @@
+if (NOT "$ENV{ROS_DISTRO}" STREQUAL "${ROS_DISTRO}")
+    message(FATAL_ERROR "ROS 2 distribution does not match. Configuration created for: ${ROS_DISTRO}, sourced distribution: $ENV{ROS_DISTRO}. Remove CMakeCache.txt and reconfigure project.")
+endif()


### PR DESCRIPTION
I've modified CMakeLists.txt to check if the initial configuration was run under the same ROS 2 distribution as the one sourced during project setup and build. I've changed CMakeLists.txt such that the ROS 2 distribution will be cached into CMakeCache.txt during the project's configuration. A check during the configuration process prevents users from building when their sourced distribution is different. I've also added the same check during the build process.

Removing the CMakeCache.txt, as proposed by me (```Remove CMakeCache.txt and reconfigure project.```), does not cause rebuilding of the O3DE Engine.

This addresses #135.