### PR TITLE
Added support for Physx::ArticulationComponent in ROS2FrameComponent

### DIFF
--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -92,7 +92,9 @@ namespace ROS2
                     m_entity, AZ::Uuid("{B01FD1D2-1D91-438D-874A-BF5EB7E919A8}")); // Physx::JointComponent;
                 const bool hasFixedJoints = Internal::CheckIfEntityHasComponentOfType(
                     m_entity, AZ::Uuid("{02E6C633-8F44-4CEE-AE94-DCB06DE36422}")); // Physx::FixedJointComponent
-                m_isDynamic = hasJoints && !hasFixedJoints;
+                const bool hasArticulations = Internal::CheckIfEntityHasComponentOfType(
+                    m_entity, AZ::Uuid("{48751E98-B35F-4A2F-A908-D9CDD5230264}")); // Physx::ArticulationComponent
+                m_isDynamic = (hasJoints && !hasFixedJoints) || hasArticulations;
             }
 
             AZ_TracePrintf(


### PR DESCRIPTION
The articulation support was missing in ROS2FrameComponent, so ROS2FrameComponent treated the frame as static.
https://github.com/o3de/o3de-extras/assets/3209244/7469b1c4-c287-4293-9ba9-b0c8f86c4bc2

