### PR TITLE
constrain IMU filter length

### DIFF
--- a/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.cpp
@@ -50,6 +50,7 @@ namespace ROS2
                         &ROS2ImuSensorComponent::m_filterSize,
                         "Filter Length",
                         "Filter Length, large value allows to reduce numeric noise")
+                    ->Attribute(AZ::Edit::Attributes::Min, 1)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ROS2ImuSensorComponent::m_includeGravity,

--- a/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Imu/ROS2ImuSensorComponent.cpp
@@ -46,11 +46,12 @@ namespace ROS2
                     ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
+                        AZ::Edit::UIHandlers::Slider,
                         &ROS2ImuSensorComponent::m_filterSize,
                         "Filter Length",
-                        "Filter Length, large value allows to reduce numeric noise")
+                        "Filter Length, Large value reduce numeric noise but increase lag")
                     ->Attribute(AZ::Edit::Attributes::Min, 1)
+                    ->Attribute(AZ::Edit::Attributes::Max, 200)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ROS2ImuSensorComponent::m_includeGravity,


### PR DESCRIPTION
When the IMU's filter length is set to 0 sensor fails to publish data. This PR is adding a constraint on the IMU component's `Filter Length` property as only positive values make sense