### PR TITLE
Fix `PhysicallyStableClock` crash in MaterialEditor.

### DIFF
--- a/Gems/ROS2/Code/Source/Clock/PhysicallyStableClock.cpp
+++ b/Gems/ROS2/Code/Source/Clock/PhysicallyStableClock.cpp
@@ -18,6 +18,11 @@ namespace ROS2
     void PhysicallyStableClock::Activate()
     {
         auto* systemInterface = AZ::Interface<AzPhysics::SystemInterface>::Get();
+        if (!systemInterface)
+        {
+            AZ_Warning("SimulationPhysicalClock", false, "Failed to get AzPhysics::SystemInterface");
+            return;
+        }
         m_onSceneSimulationEvent = AzPhysics::SceneEvents::OnSceneSimulationFinishHandler(
             [this](AzPhysics::SceneHandle sceneHandle, float deltaTime)
             {


### PR DESCRIPTION
There was null-pointer dereference when  PhysicallyStableClock is used in the project.

Fixes #352.