### PR TITLE
docker environment for Ros2ProjectTemplate

### DIFF
--- a/Templates/Ros2ProjectTemplate/Docker/Dockerfile
+++ b/Templates/Ros2ProjectTemplate/Docker/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-get install -y --no-install-recommends \
 
 
 # Copy script used to remove build artifacts
-#TODO COPY cleanup.bash /data/workspace/cleanup.bash
+COPY cleanup.bash /data/workspace/cleanup.bash
 
 # Clone and register O3DE repos 
 RUN if [ "${IMAGE_TYPE}" = "simulation" ]; then \
@@ -111,7 +111,8 @@ RUN if [ "${IMAGE_TYPE}" = "simulation" ]; then \
         . /opt/ros/${ROS_DISTRO}/setup.sh && \
         $WORKSPACE/o3de/scripts/o3de.sh create-project --project-path $PROJECT_PATH --template-path $WORKSPACE/o3de-extras/Templates/Ros2ProjectTemplate && \
         cmake -B $PROJECT_PATH/build/linux -S $PROJECT_PATH -G "Ninja Multi-Config" -DLY_STRIP_DEBUG_SYMBOLS=TRUE -DLY_DISABLE_TEST_MODULES=ON && \
-        cmake --build $PROJECT_PATH/build/linux --config profile --target Ros2Project Editor Ros2Project.Assets -j $CMAKE_JOBS; \
+        cmake --build $PROJECT_PATH/build/linux --config profile --target Ros2Project Editor Ros2Project.Assets Ros2Project.GameLauncher -j $CMAKE_JOBS && \
+        $WORKSPACE/cleanup.bash; \
     fi
 
 COPY LaunchSimulation.bash /data/workspace/LaunchSimulation.bash
@@ -122,4 +123,4 @@ ENV LAUNCH_FULLSCREEN_OPT=0
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES all
 
-ENTRYPOINT ["/bin/bash", "-c"]
+ENTRYPOINT ["/bin/bash"]

--- a/Templates/Ros2ProjectTemplate/Docker/Dockerfile
+++ b/Templates/Ros2ProjectTemplate/Docker/Dockerfile
@@ -9,9 +9,6 @@ ARG UBUNTU_VERSION=jammy
 
 FROM ros:${ROS_VERSION}-ros-base-${UBUNTU_VERSION}
 
-ARG ROS_VERSION
-ARG UBUNTU_VERSION
-
 # Argument to determining the image type ('simulation' or 'navstack')
 ARG IMAGE_TYPE=simulation  # Default to 'simulation'
 
@@ -33,45 +30,55 @@ WORKDIR $WORKSPACE
 
 RUN apt-get update && apt-get upgrade -y
 
-# Add additional package repositories needed for packages
-# RUN apt-get install -y --no-install-recommends gpg wget curl
+# For ubuntu 20.04 (focal) the default version of cmake is not supported. Update and get version 3.24.1 from kitware
+RUN if [ "${UBUNTU_VERSION}" = "focal" ]; then \
+        apt-get install -y --no-install-recommends gpg wget curl && \
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
+            gpg --dearmor - | \
+            tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+        echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | \
+            tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
+        apt-get update; \
+    fi
 
 # Install packages needed for cloning and building from the source repos
-RUN apt-get install -y --no-install-recommends git \
-                       git-lfs \
-                       clang-12 \
-                       ninja-build \
-                       cmake \
-                       libglu1-mesa-dev \
-                       libxcb-xinerama0 \
-                       libxcb-xinput0 \
-                       libxcb-xinput-dev \
-                       libxcb-xfixes0-dev \
-                       libxcb-xkb-dev \
-                       libxkbcommon-dev \
-                       libxkbcommon-x11-dev \
-                       libfontconfig1-dev \
-                       libcurl4-openssl-dev \
-                       libsdl2-dev \
-                       zlib1g-dev \
-                       mesa-common-dev \
-                       libssl-dev libxcb-icccm4 \
-                       libxcb-image0 \
-                       libxcb-keysyms1 \
-                       libxcb-render-util0 \
-                       libxcb-randr0 \
-                       libnvidia-gl-470 \
-                       ufw \
-                       ros-${ROS_DISTRO}-slam-toolbox \
-                       ros-${ROS_DISTRO}-navigation2 \
-                       ros-${ROS_DISTRO}-nav2-bringup \
-                       ros-${ROS_DISTRO}-pointcloud-to-laserscan \
-                       ros-${ROS_DISTRO}-gazebo-msgs \
-                       ros-${ROS_DISTRO}-ackermann-msgs \
-                       ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
-                       ros-${ROS_DISTRO}-control-toolbox \
-                       ros-${ROS_DISTRO}-nav-msgs \
-                       ros-${ROS_DISTRO}-desktop
+RUN apt-get install -y --no-install-recommends \
+    git \
+    git-lfs \
+    clang-12 \
+    ninja-build \
+    cmake \
+    libglu1-mesa-dev \
+    libxcb-xinerama0 \
+    libxcb-xinput0 \
+    libxcb-xinput-dev \
+    libxcb-xfixes0-dev \
+    libxcb-xkb-dev \
+    libxkbcommon-dev \
+    libxkbcommon-x11-dev \
+    libfontconfig1-dev \
+    libcurl4-openssl-dev \
+    libsdl2-dev \
+    zlib1g-dev \
+    mesa-common-dev \
+    libssl-dev libxcb-icccm4 \
+    libxcb-image0 \
+    libxcb-keysyms1 \
+    libxcb-render-util0 \
+    libxcb-randr0 \
+    libnvidia-gl-470 \
+    ufw \
+    ros-${ROS_DISTRO}-slam-toolbox \
+    ros-${ROS_DISTRO}-navigation2 \
+    ros-${ROS_DISTRO}-nav2-bringup \
+    ros-${ROS_DISTRO}-pointcloud-to-laserscan \
+    ros-${ROS_DISTRO}-gazebo-msgs \
+    ros-${ROS_DISTRO}-ackermann-msgs \
+    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+    ros-${ROS_DISTRO}-control-toolbox \
+    ros-${ROS_DISTRO}-nav-msgs \
+    ros-${ROS_DISTRO}-desktop
+
 
 # Copy script used to remove build artifacts
 #TODO COPY cleanup.bash /data/workspace/cleanup.bash
@@ -98,7 +105,7 @@ RUN if [ "${IMAGE_TYPE}" = "simulation" ]; then \
     else \
         echo "Unsupported IMAGE_TYPE: ${IMAGE_TYPE}" && exit 1; \
     fi
-    
+
 # Build and cleanup in the same layer to reduce the size
 RUN if [ "${IMAGE_TYPE}" = "simulation" ]; then \
         . /opt/ros/${ROS_DISTRO}/setup.sh && \
@@ -107,13 +114,12 @@ RUN if [ "${IMAGE_TYPE}" = "simulation" ]; then \
         cmake --build $PROJECT_PATH/build/linux --config profile --target Ros2Project Editor Ros2Project.Assets -j $CMAKE_JOBS; \
     fi
 
-#TODO prepare and add cleanup script
-
-#TODO prepare and copy launcher scripts
+COPY LaunchSimulation.bash /data/workspace/LaunchSimulation.bash
+COPY LaunchNavStack.bash /data/workspace/LaunchNavStack.bash
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp 
 ENV LAUNCH_FULLSCREEN_OPT=0
 ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES all
- 
+
 ENTRYPOINT ["/bin/bash", "-c"]

--- a/Templates/Ros2ProjectTemplate/Docker/Dockerfile
+++ b/Templates/Ros2ProjectTemplate/Docker/Dockerfile
@@ -12,7 +12,7 @@ FROM ros:${ROS_VERSION}-ros-base-${UBUNTU_VERSION}
 # Argument to determining the image type ('simulation' or 'navstack')
 ARG IMAGE_TYPE=simulation  # Default to 'simulation'
 
-# Arguments for the source repos needed for the robot vacuum sample docker
+# Arguments for the source repos needed for the Ros2Template sample docker
 ARG O3DE_REPO=https://github.com/o3de/o3de.git
 ARG O3DE_BRANCH=2305.0
 
@@ -111,8 +111,7 @@ RUN if [ "${IMAGE_TYPE}" = "simulation" ]; then \
         . /opt/ros/${ROS_DISTRO}/setup.sh && \
         $WORKSPACE/o3de/scripts/o3de.sh create-project --project-path $PROJECT_PATH --template-path $WORKSPACE/o3de-extras/Templates/Ros2ProjectTemplate && \
         cmake -B $PROJECT_PATH/build/linux -S $PROJECT_PATH -G "Ninja Multi-Config" -DLY_STRIP_DEBUG_SYMBOLS=TRUE -DLY_DISABLE_TEST_MODULES=ON && \
-        cmake --build $PROJECT_PATH/build/linux --config profile --target Ros2Project Editor Ros2Project.Assets Ros2Project.GameLauncher -j $CMAKE_JOBS && \
-        $WORKSPACE/cleanup.bash; \
+        cmake --build $PROJECT_PATH/build/linux --config profile --target Ros2Project Editor Ros2Project.Assets Ros2Project.GameLauncher -j $CMAKE_JOBS ; \
     fi
 
 COPY LaunchSimulation.bash /data/workspace/LaunchSimulation.bash

--- a/Templates/Ros2ProjectTemplate/Docker/Dockerfile
+++ b/Templates/Ros2ProjectTemplate/Docker/Dockerfile
@@ -1,0 +1,119 @@
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+ARG ROS_VERSION=iron
+ARG UBUNTU_VERSION=jammy
+
+FROM ros:${ROS_VERSION}-ros-base-${UBUNTU_VERSION}
+
+ARG ROS_VERSION
+ARG UBUNTU_VERSION
+
+# Argument to determining the image type ('simulation' or 'navstack')
+ARG IMAGE_TYPE=simulation  # Default to 'simulation'
+
+# Arguments for the source repos needed for the robot vacuum sample docker
+ARG O3DE_REPO=https://github.com/o3de/o3de.git
+ARG O3DE_BRANCH=2305.0
+
+ARG O3DE_EXTRAS_REPO=https://github.com/o3de/o3de-extras.git
+ARG O3DE_EXTRAS_BRANCH=2305.0
+
+# Additional argument to control build concurrency
+ARG CMAKE_JOBS=8
+
+ENV WORKSPACE=/data/workspace
+
+ENV PROJECT_PATH=/data/workspace/Ros2Project
+
+WORKDIR $WORKSPACE
+
+RUN apt-get update && apt-get upgrade -y
+
+# Add additional package repositories needed for packages
+# RUN apt-get install -y --no-install-recommends gpg wget curl
+
+# Install packages needed for cloning and building from the source repos
+RUN apt-get install -y --no-install-recommends git \
+                       git-lfs \
+                       clang-12 \
+                       ninja-build \
+                       cmake \
+                       libglu1-mesa-dev \
+                       libxcb-xinerama0 \
+                       libxcb-xinput0 \
+                       libxcb-xinput-dev \
+                       libxcb-xfixes0-dev \
+                       libxcb-xkb-dev \
+                       libxkbcommon-dev \
+                       libxkbcommon-x11-dev \
+                       libfontconfig1-dev \
+                       libcurl4-openssl-dev \
+                       libsdl2-dev \
+                       zlib1g-dev \
+                       mesa-common-dev \
+                       libssl-dev libxcb-icccm4 \
+                       libxcb-image0 \
+                       libxcb-keysyms1 \
+                       libxcb-render-util0 \
+                       libxcb-randr0 \
+                       libnvidia-gl-470 \
+                       ufw \
+                       ros-${ROS_DISTRO}-slam-toolbox \
+                       ros-${ROS_DISTRO}-navigation2 \
+                       ros-${ROS_DISTRO}-nav2-bringup \
+                       ros-${ROS_DISTRO}-pointcloud-to-laserscan \
+                       ros-${ROS_DISTRO}-gazebo-msgs \
+                       ros-${ROS_DISTRO}-ackermann-msgs \
+                       ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+                       ros-${ROS_DISTRO}-control-toolbox \
+                       ros-${ROS_DISTRO}-nav-msgs \
+                       ros-${ROS_DISTRO}-desktop
+
+# Copy script used to remove build artifacts
+#TODO COPY cleanup.bash /data/workspace/cleanup.bash
+
+# Clone and register O3DE repos 
+RUN if [ "${IMAGE_TYPE}" = "simulation" ]; then \
+        cd $WORKSPACE && \
+        git clone --recursive $O3DE_REPO && \
+        git -C $WORKSPACE/o3de checkout $O3DE_BRANCH &&\
+        git -C $WORKSPACE/o3de lfs install && \
+        git -C $WORKSPACE/o3de lfs pull && \
+        $WORKSPACE/o3de/python/get_python.sh && \
+        $WORKSPACE/o3de/scripts/o3de.sh register -ep $WORKSPACE/o3de && \
+        git clone $O3DE_EXTRAS_REPO && \
+        git -C $WORKSPACE/o3de-extras checkout $O3DE_EXTRAS_BRANCH && \
+        $WORKSPACE/o3de/scripts/o3de.sh register -gp $WORKSPACE/o3de-extras/Gems/ROS2 && \
+        $WORKSPACE/o3de/scripts/o3de.sh register -gp $WORKSPACE/o3de-extras/Gems/RosRobotSample && \
+        $WORKSPACE/o3de/scripts/o3de.sh register -gp $WORKSPACE/o3de-extras/Gems/WarehouseAssets && \
+        $WORKSPACE/o3de/scripts/o3de.sh register -gp $WORKSPACE/o3de-extras/Gems/WarehouseSample; \
+    elif [  "${IMAGE_TYPE}" = "navstack" ]; then \
+        cd $WORKSPACE && \
+        git clone $O3DE_EXTRAS_REPO && \
+        git -C $WORKSPACE/o3de-extras checkout $O3DE_EXTRAS_BRANCH; \
+    else \
+        echo "Unsupported IMAGE_TYPE: ${IMAGE_TYPE}" && exit 1; \
+    fi
+    
+# Build and cleanup in the same layer to reduce the size
+RUN if [ "${IMAGE_TYPE}" = "simulation" ]; then \
+        . /opt/ros/${ROS_DISTRO}/setup.sh && \
+        $WORKSPACE/o3de/scripts/o3de.sh create-project --project-path $PROJECT_PATH --template-path $WORKSPACE/o3de-extras/Templates/Ros2ProjectTemplate && \
+        cmake -B $PROJECT_PATH/build/linux -S $PROJECT_PATH -G "Ninja Multi-Config" -DLY_STRIP_DEBUG_SYMBOLS=TRUE -DLY_DISABLE_TEST_MODULES=ON && \
+        cmake --build $PROJECT_PATH/build/linux --config profile --target Ros2Project Editor Ros2Project.Assets -j $CMAKE_JOBS; \
+    fi
+
+#TODO prepare and add cleanup script
+
+#TODO prepare and copy launcher scripts
+
+ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp 
+ENV LAUNCH_FULLSCREEN_OPT=0
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES all
+ 
+ENTRYPOINT ["/bin/bash", "-c"]

--- a/Templates/Ros2ProjectTemplate/Docker/Dockerfile
+++ b/Templates/Ros2ProjectTemplate/Docker/Dockerfile
@@ -111,7 +111,8 @@ RUN if [ "${IMAGE_TYPE}" = "simulation" ]; then \
         . /opt/ros/${ROS_DISTRO}/setup.sh && \
         $WORKSPACE/o3de/scripts/o3de.sh create-project --project-path $PROJECT_PATH --template-path $WORKSPACE/o3de-extras/Templates/Ros2ProjectTemplate && \
         cmake -B $PROJECT_PATH/build/linux -S $PROJECT_PATH -G "Ninja Multi-Config" -DLY_STRIP_DEBUG_SYMBOLS=TRUE -DLY_DISABLE_TEST_MODULES=ON && \
-        cmake --build $PROJECT_PATH/build/linux --config profile --target Ros2Project Editor Ros2Project.Assets Ros2Project.GameLauncher -j $CMAKE_JOBS ; \
+        cmake --build $PROJECT_PATH/build/linux --config profile --target Ros2Project Editor Ros2Project.Assets Ros2Project.GameLauncher -j $CMAKE_JOBS && \
+        $WORKSPACE/cleanup.bash ; \
     fi
 
 COPY LaunchSimulation.bash /data/workspace/LaunchSimulation.bash

--- a/Templates/Ros2ProjectTemplate/Docker/LaunchNavStack.bash
+++ b/Templates/Ros2ProjectTemplate/Docker/LaunchNavStack.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+unset LD_LIBRARY_PATH
+
+source /opt/ros/$ROS_DISTRO/setup.bash
+
+cd /data/workspace/o3de-extras/Templates/Ros2ProjectTemplate/Template/Examples/slam_navigation/launch
+
+ros2 launch navigation.launch.py

--- a/Templates/Ros2ProjectTemplate/Docker/LaunchSimulation.bash
+++ b/Templates/Ros2ProjectTemplate/Docker/LaunchSimulation.bash
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+unset LD_LIBRARY_PATH
+
+source /opt/ros/$ROS_DISTRO/setup.bash
+
+export LD_LIBRARY_PATH=/data/workspace/Ros2Project/build/linux/bin/profile:$LD_LIBRARY_PATH
+
+if [ -d /data/workspace/Ros2Project/build/linux/bin/profile ]
+then
+    cd /data/workspace/Ros2Project/build/linux/bin/profile
+    ./Ros2Project.GameLauncher -r_fullscreen=$LAUNCH_FULLSCREEN_OPT -bg_ConnectToAssetProcessor=0 > /data/workspace/simulation_launch.log 2>&1
+else
+    echo "Simulation not installed on this image"
+fi
+

--- a/Templates/Ros2ProjectTemplate/Docker/README.md
+++ b/Templates/Ros2ProjectTemplate/Docker/README.md
@@ -8,24 +8,25 @@ The following Dockerfiles defined in this path will prepare the appropriate ROS2
 * Ubuntu 20.04 (Focal) or 22.04 (Jammy)
 * At least 60 GB of free disk space
 * Docker installed and configured
-  * **Note** It is recommended to have Docker installed correctly and in a secure manner so that the docker commands in this guide do not require elevated priviledges (sudo) in order to run them. See [Docker Engine post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) for more details.
+  * **Note** It is recommended to have Docker installed correctly and in a secure manner so that the docker commands in this guide do not require elevated privileges (sudo) to run them. See [Docker Engine post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) for more details.
 * [NVidia container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
 
 ## Building the Docker Image
 
-By default, the docker script provided in this template will build a docker image to run the Ros2Project sample using Ubuntu 22.04 (jammy) with the ROS2 Iron distribution. Run the following command to build the docker image with a default configuration:
+By default, the docker script provided in this template will build a docker image to run the Ros2Project sample using Ubuntu 22.04 (jammy) with the ROS2 Iron distribution. All obsolete source code, git artifacts, and build artifacts will be removed by the 'cleanup.bash' script when completed. 
+
+Run the following command to build the docker image with a default configuration:
 
 ```
 docker build -t o3de_ros2project:latest -f Dockerfile .
 ```
 
 **Note** 
-The above command example tags specific commits for O3DE, and the ROS2 gem repos and based on known working commits. See the Advanced Options section below for more information.
+The above command example tags specific commits for O3DE, and the ROS2 gem repos based on known working commits. See the Advanced Options section below for more information.
 
 This will create a docker image named 'o3de_ros2project' with the tag 'latest' that contains both the simulation launcher and the navigation stack. 
 
-It will also contain helper scripts that will launch either the simulation (LaunchSimulation.bash) or 
-the RViz2 (LaunchNavStack.bash).
+It will also contain helper scripts that will launch either the simulation (LaunchSimulation.bash) or the RViz2 (LaunchNavStack.bash).
 
 You can also create a separate docker image that only contains the navigation stack and RViz2 by supplying the argument `IMAGE_TYPE` and setting it to 'navstack':
 
@@ -40,7 +41,7 @@ ROS2 allows for communication across multiple docker images running on the same 
 Launching O3DE applications in a Docker container requires GPU acceleration support. (Make sure that the [nvidia-docker 2](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker) is installed.)
 
 ### Direct Access to the X Server
-The simulation docker image should be launched before bringing up the robot application. To run the robot application, first allow the container root user to access the running X server for display
+The simulation docker image should be launched before bringing up the robot application. To run the robot application, first, allow the container root user to access the running X server for display
 
 ```
 xhost +local:root
@@ -99,14 +100,14 @@ The Docker script defaults to building an image based on Ubuntu 22.04 (jammy) an
 
 ### Custom source repos and branches
 
-The Dockerscripts use the following arguments to determine the repository to pull the source from. 
+The Dockerscripts use the following arguments to determine the repository to pull the source: 
 
 | Argument              | Repository                 | Default                                      |
 |-----------------------|----------------------------|----------------------------------------------|
 | O3DE_REPO             | O3DE                       | https://github.com/o3de/o3de.git             |
 | O3DE_EXTRAS_REPO      | O3DE Extras                | https://github.com/o3de/o3de-extras.git      |
 
-In addition the repositories, the following arguments target the branch, commit, or tag to pull from their corresponding repository
+In addition to repositories, the following arguments target the branch, commit, or tag to pull from their corresponding repository:
 
 | Argument                | Repository                       | Default     |
 |-------------------------|----------------------------------|-------------|

--- a/Templates/Ros2ProjectTemplate/Docker/README.md
+++ b/Templates/Ros2ProjectTemplate/Docker/README.md
@@ -27,8 +27,7 @@ This will create a docker image named 'o3de_ros2project' with the tag 'latest' t
 It will also contain helper scripts that will launch either the simulation (LaunchSimulation.bash) or 
 the RViz2 (LaunchNavStack.bash).
 
-You can also create a separate docker image that only contains the navigation stack and RViz2 by supplying the argument 
-```IMAGE_TYPE``` and setting it to 'navstack':
+You can also create a separate docker image that only contains the navigation stack and RViz2 by supplying the argument `IMAGE_TYPE` and setting it to 'navstack':
 
 ```
 docker build --build-arg IMAGE_TYPE=navstack -t o3de_ros2project_nav:latest .
@@ -90,7 +89,7 @@ rocker --x11 --nvidia o3de_ros2project:latest /data/workspace/LaunchNavStack.bas
 ## Advanced Options
 
 ### Target ROS2 Distribution
-The Docker script defaults to building an image based on Ubuntu 22.04 (jammy) and the ROS2 Iron distribution. This can be overridden with a combination if the ```ROS_VERSION``` and ```UBUNTU_VERSION``` arguments.
+The Docker script defaults to building an image based on Ubuntu 22.04 (jammy) and the ROS2 Iron distribution. This can be overridden with a combination if the `ROS_VERSION` and `UBUNTU_VERSION` arguments.
 
 | ROS2 Distro   | Repository                                |
 |---------------|-------------------------------------------|

--- a/Templates/Ros2ProjectTemplate/Docker/README.md
+++ b/Templates/Ros2ProjectTemplate/Docker/README.md
@@ -1,0 +1,119 @@
+# Docker scripts for running the O3DE Ros2Project based on O3DE Ros2ProjectTemplate
+
+The following Dockerfiles defined in this path will prepare the appropriate ROS2 package (Ubuntu 20.04/Focal + Galactic or Ubuntu 22.04/Jammy + Iron) based environment and build the components necessary to run the O3DE demo project simulator through the O3DE engine using the Ros2Project template.
+
+## Prerequisites
+
+* [Hardware requirements of o3de](https://www.o3de.org/docs/welcome-guide/requirements/)
+* Ubuntu 20.04 (Focal) or 22.04 (Jammy)
+* At least 60 GB of free disk space
+* Docker installed and configured
+  * **Note** It is recommended to have Docker installed correctly and in a secure manner so that the docker commands in this guide do not require elevated priviledges (sudo) in order to run them. See [Docker Engine post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) for more details.
+* [NVidia container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker)
+
+## Building the Docker Image
+
+By default, the docker script provided in this template will build a docker image to run the Ros2Project sample using Ubuntu 22.04 (jammy) with the ROS2 Iron distribution. Run the following command to build the docker image with a default configuration:
+
+```
+docker build -t o3de_ros2project:latest -f Dockerfile .
+```
+
+**Note** 
+The above command example tags specific commits for O3DE, and the ROS2 gem repos and based on known working commits. See the Advanced Options section below for more information.
+
+This will create a docker image named 'o3de_ros2project' with the tag 'latest' that contains both the simulation launcher and the navigation stack. 
+
+It will also contain helper scripts that will launch either the simulation (LaunchSimulation.bash) or 
+the RViz2 (LaunchNavStack.bash).
+
+You can also create a separate docker image that only contains the navigation stack and RViz2 by supplying the argument 
+```IMAGE_TYPE``` and setting it to 'navstack':
+
+```
+docker build --build-arg IMAGE_TYPE=navstack -t o3de_ros2project_nav:latest .
+```
+
+ROS2 allows for communication across multiple docker images running on the same host, provided that they specify the 'bridge' network type when launching.
+
+## Running the Docker Image
+
+Launching O3DE applications in a Docker container requires GPU acceleration support. (Make sure that the [nvidia-docker 2](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker) is installed.)
+
+### Direct Access to the X Server
+The simulation docker image should be launched before bringing up the robot application. To run the robot application, first allow the container root user to access the running X server for display
+
+```
+xhost +local:root
+```
+
+Then launch the built simulation docker image with the following command
+
+```
+docker run --rm --network="bridge" --gpus all -e DISPLAY=:1 -v /tmp/.X11-unix:/tmp/.X11-unix -it o3de_ros2project:latest /data/workspace/LaunchSimulation.bash
+```
+
+Once the simulation is up and running, launch the navigation stack inside the simulation docker image, which will bring up RViz to control the robot.
+
+```
+docker run --rm --network="bridge" --gpus all -e DISPLAY=:1 -v /tmp/.X11-unix:/tmp/.X11-unix -it o3de_ros2project:latest /data/workspace/LaunchNavStack.bash
+
+```
+
+If you created a separate docker image 'o3de_ros2project_nav:latest', which only contains the navigation stack and RViz2, you can launch it using that image, provided that the simulation docker image 'o3de_ros2project' is running.
+
+```
+docker run --rm --network="bridge" --gpus all -e DISPLAY=:1 -v /tmp/.X11-unix:/tmp/.X11-unix -it o3de_ros2project_nav:latest /data/workspace/LaunchNavStack.bash
+```
+Make sure to revoke access to the X server when the simulation ends.
+
+```
+xhost -local:root
+```
+
+### Running using Rocker
+
+Alternatively, you can use [Rocker](https://github.com/osrf/rocker) to run a GPU-accelerated docker image. 
+
+Launch the built simulation docker image with the following rocker command
+
+```
+rocker --x11 --nvidia o3de_ros2project:latest /data/workspace/LaunchSimulation.bash
+```
+
+Once the simulation is up and running, launch the robot application docker image, which will bring up RViz to control the robot.
+
+```
+rocker --x11 --nvidia o3de_ros2project:latest /data/workspace/LaunchNavStack.bash
+```
+
+## Advanced Options
+
+### Target ROS2 Distribution
+The Docker script defaults to building an image based on Ubuntu 22.04 (jammy) and the ROS2 Iron distribution. This can be overridden with a combination if the ```ROS_VERSION``` and ```UBUNTU_VERSION``` arguments.
+
+| ROS2 Distro   | Repository                                |
+|---------------|-------------------------------------------|
+| galactic      | ROS_VERSION=galactic UBUNTU_VERSION=focal |
+| humble        | ROS_VERSION=humble   UBUNTU_VERSION=jammy |
+| iron          | ROS_VERSION=iron     UBUNTU_VERSION=jammy |
+
+### Custom source repos and branches
+
+The Dockerscripts use the following arguments to determine the repository to pull the source from. 
+
+| Argument              | Repository                 | Default                                      |
+|-----------------------|----------------------------|----------------------------------------------|
+| O3DE_REPO             | O3DE                       | https://github.com/o3de/o3de.git             |
+| O3DE_EXTRAS_REPO      | O3DE Extras                | https://github.com/o3de/o3de-extras.git      |
+
+In addition the repositories, the following arguments target the branch, commit, or tag to pull from their corresponding repository
+
+| Argument                | Repository                       | Default     |
+|-------------------------|----------------------------------|-------------|
+| O3DE_BRANCH             | O3DE                             | 2305.0      |
+| O3DE_EXTRAS_BRANCH      | O3DE Extras                      | 2305.0      |
+
+### Optimizing the build process ###
+The docker script provides a cmake-specific argument override to control the number of parallel jobs that can be used during the build of the docker image. `CMAKE_JOBS` sets the maximum number of concurrent jobs cmake will run during its build process and defaults to 8 jobs. This number can be adjusted to better suit the hardware which is running the docker image build.
+

--- a/Templates/Ros2ProjectTemplate/Docker/cleanup.bash
+++ b/Templates/Ros2ProjectTemplate/Docker/cleanup.bash
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+
+# Delete obsolete files after the build of the code and assets are complete
+
+DELETE_LIST=(~/.o3de/3rdParty/ \
+             o3de/.git \
+             o3de/AutomatedTesting \
+             o3de/python/downloaded_packages \
+             o3de/Code \
+             o3de/Gems \
+             Ros2Project/build/linux/Azcg/ \
+             Ros2Project/build/linux/CMake \
+             Ros2Project/build/linux/CMakeFiles/ \
+             Ros2Project/build/linux/External/ \
+             Ros2Project/build/linux/Testing/ \
+             Ros2Project/build/linux/_deps/ \
+             Ros2Project/build/linux/cmake \
+             Ros2Project/build/linux/lib/ \
+             Ros2Project/build/linux/o3de/ \
+             Ros2Project/build/linux/packages/ \
+             Ros2Project/build/linux/runtime_dependencies/ 
+             Ros2Project/build/linux/bin/profile/EditorPlugins \
+             Ros2Project/build/linux/bin/profile/Editor \
+             Ros2Project/build/linux/bin/profile/AssetProcessor \
+             Ros2Project/build/linux/bin/profile/AssetProcessorBatch \
+             Ros2Project/build/linux/bin/profile/MaterialEditor \
+             Ros2Project/build/linux/bin/profile/AssetBuilder \
+             Ros2Project/build/linux/bin/profile/MaterialCanvas )
+
+for i in ${DELETE_LIST[@]}
+do
+   echo "Deleting /data/workspace/$i"
+   rm -rf $i
+done
+
+exit 0
+


### PR DESCRIPTION
This PR implements the last point in the #246 issue. Please double check if #246 can be closed.

The _Dockerfile_ and the remaining files are based on the https://github.com/o3de/RobotVacuumSample docker configuration.

Open questions:
- Docker folder location: on top of the repo or inside of the template folder?
    -> if the option to keep this folder top of the repo is selected, an argument to switch between _Ros2FleetRobotTemplate_ and _Ros2ProjectTemplate_ should be added
- is Ubuntu 22.04 with _iron_ a valid choice as default?
    -> the target for this PR is `development` branch; I believe _iron_ should be the target for the next stable release
- which o3de and o3de-extras branches should be used? I did use the last stable release, i.e., 2305.0