### PR TITLE
Added dependency for XR to OpenXRVK.

### DIFF
--- a/Gems/OpenXRVk/gem.json
+++ b/Gems/OpenXRVk/gem.json
@@ -13,7 +13,9 @@
     "user_tags": [],
     "requirements": "",
     "documentation_url": "",
-    "dependencies": [],
+    "dependencies": [
+        "XR"
+    ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/openxrvk-1.0.0-gem.zip",
     "version": "1.0.0"


### PR DESCRIPTION
The OpenXRVK gem requires the XR gem to be enabled along side itself to fully configure and compile. This PR simply adds the XR gem as a dependency for the OpenXRVK gem.