### PR TITLE
Fix crash after moveit action stop

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Manipulation/JointsTrajectoryRequests.h
+++ b/Gems/ROS2/Code/Include/ROS2/Manipulation/JointsTrajectoryRequests.h
@@ -44,7 +44,7 @@ namespace ROS2
         //! Cancel current trajectory goal.
         //! @param result Result of trajectory goal with explanation on why it was cancelled.
         //! @return nothing on success, error if the goal could not be cancelled.
-        virtual AZ::Outcome<void, AZStd::string> CancelTrajectoryGoal(TrajectoryResultPtr result) = 0;
+        virtual AZ::Outcome<void, AZStd::string> CancelTrajectoryGoal() = 0;
 
         //! Retrieve current trajectory goal status.
         //! @return Status of trajectory goal.

--- a/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.h
+++ b/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.h
@@ -40,6 +40,9 @@ namespace ROS2
         //! @param result Result to be passed to through action server to the client.
         void CancelGoal(std::shared_ptr<FollowJointTrajectory::Result> result);
 
+        //! Sets the goal status to success
+        void SetGoalSuccess();
+
         //! Report goal success to the action server.
         //! @param result Result which contains success code.
         void GoalSuccess(std::shared_ptr<FollowJointTrajectory::Result> result);
@@ -67,5 +70,7 @@ namespace ROS2
         rclcpp_action::CancelResponse GoalCancelledCallback(const std::shared_ptr<GoalHandle> goalHandle);
 
         void GoalAcceptedCallback(const std::shared_ptr<GoalHandle> goalHandle);
+
+        static constexpr int cancelGoalTimeout = 5;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.h
+++ b/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.h
@@ -70,7 +70,5 @@ namespace ROS2
         rclcpp_action::CancelResponse GoalCancelledCallback(const std::shared_ptr<GoalHandle> goalHandle);
 
         void GoalAcceptedCallback(const std::shared_ptr<GoalHandle> goalHandle);
-
-        static constexpr int cancelGoalTimeout = 5;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
@@ -12,6 +12,7 @@
 #include "JointStatePublisher.h"
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/TransformBus.h>
+#include <AzCore/Debug/Trace.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/Manipulation/Controllers/JointsPositionControllerRequests.h>
@@ -316,7 +317,15 @@ namespace ROS2
     {
         for (auto& [jointName, jointInfo] : m_manipulationJoints)
         { // Set all target joint positions to their current positions.
-            jointInfo.m_restPosition = GetJointPosition(jointName).GetValue();
+            auto joint = GetJointPosition(jointName);
+            if (joint.IsSuccess())
+            {
+                jointInfo.m_restPosition = joint.GetValue();
+            }
+            else
+            {
+                AZ_Warning("JointsManipulationComponent", false, "Unable to get joint position for %s", jointName.c_str());
+            }
         }
     }
 

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
@@ -317,10 +317,10 @@ namespace ROS2
     {
         for (auto& [jointName, jointInfo] : m_manipulationJoints)
         { // Set all target joint positions to their current positions.
-            auto joint = GetJointPosition(jointName);
-            if (joint.IsSuccess())
+            auto jointPosition = GetJointPosition(jointName);
+            if (jointPosition.IsSuccess())
             {
-                jointInfo.m_restPosition = joint.GetValue();
+                jointInfo.m_restPosition = jointPosition.GetValue();
             }
             else
             {

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
@@ -316,16 +316,9 @@ namespace ROS2
     void JointsManipulationComponent::Stop()
     {
         for (auto& [jointName, jointInfo] : m_manipulationJoints)
-        { // Set all target joint positions to their current positions.
-            auto jointPosition = GetJointPosition(jointName);
-            if (jointPosition.IsSuccess())
-            {
-                jointInfo.m_restPosition = jointPosition.GetValue();
-            }
-            else
-            {
-                AZ_Warning("JointsManipulationComponent", false, "Unable to get joint position for %s", jointName.c_str());
-            }
+        { // Set all target joint positions to their current positions. There is no need to check if the outcome is successful, because
+          // jointName is always valid.
+            jointInfo.m_restPosition = GetJointPosition(jointName).GetValue();
         }
     }
 

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
@@ -38,7 +38,7 @@ namespace ROS2
         //! @see ROS2::JointsTrajectoryRequestBus::StartTrajectoryGoal
         AZ::Outcome<void, AZStd::string> StartTrajectoryGoal(TrajectoryGoalPtr trajectoryGoal) override;
         //! @see ROS2::JointsTrajectoryRequestBus::CancelTrajectoryGoal
-        AZ::Outcome<void, AZStd::string> CancelTrajectoryGoal(TrajectoryResultPtr trajectoryResult) override;
+        AZ::Outcome<void, AZStd::string> CancelTrajectoryGoal() override;
         //! @see ROS2::JointsTrajectoryRequestBus::GetGoalStatus
         TrajectoryActionStatus GetGoalStatus() override;
 


### PR DESCRIPTION
I've implemented a fix for the crash when the moveit action stop was called. The fix requires a separate thread that sets the state of the action server after the cancel request was accepted. This is needed because the state of the action server can be changed to ```canceled``` only after the state is ```canceling```.

There was also another error that would stop moving the joints after a cancelation. This resulted in the joints not keeping their positions and the robot arm to slowly falling with gravity. This was also fixed.

This PR addresses #366 