### PR TITLE
Update to gem.json files to denote compatible engines

### DIFF
--- a/Gems/ProteusRobot/gem.json
+++ b/Gems/ProteusRobot/gem.json
@@ -22,7 +22,10 @@
     "documentation_url": "https://www.o3de.org/docs/user-guide/interactivity/robotics/project-configuration/#ros-2-project-templates",
     "dependencies": [],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "compatible_engines": [],
+     "compatible_engines": [
+        "o3de-sdk>=1.2.0",
+        "o3de>=1.2.0"
+    ],
     "engine_api_dependencies": [],
     "restricted": "ProteusRobot",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/proteusrobot-1.0.0-gem.zip"

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -18,7 +18,7 @@
         "ROS2"
     ],
     "compatible_engines": [
-        "o3de-sdk==1.2.0",
+        "o3de-sdk>=1.2.0",
         "o3de>=1.2.0"
     ],
     "icon_path": "preview.png",

--- a/Gems/RosRobotSample/gem.json
+++ b/Gems/RosRobotSample/gem.json
@@ -22,6 +22,10 @@
     "dependencies": [
         "ROS2"
     ],
+    "compatible_engines": [
+        "o3de-sdk>=1.2.0",
+        "o3de>=1.2.0"
+    ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "restricted": "",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/rosrobotsample-1.0.0-gem.zip",

--- a/Gems/WarehouseAssets/gem.json
+++ b/Gems/WarehouseAssets/gem.json
@@ -21,7 +21,10 @@
     "documentation_url": "",
     "dependencies": [],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "compatible_engines": [],
+    "compatible_engines": [
+        "o3de-sdk>=1.2.0",
+        "o3de>=1.2.0"
+    ],
     "engine_api_dependencies": [],
     "restricted": "",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehouseassets-1.0.0-gem.zip",

--- a/Gems/WarehouseSample/gem.json
+++ b/Gems/WarehouseSample/gem.json
@@ -21,6 +21,10 @@
     "documentation_url": "",
     "dependencies": [],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
+    "compatible_engines": [
+        "o3de-sdk>=1.2.0",
+        "o3de>=1.2.0"
+    ],
     "restricted": "",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehousesample-1.0.0-gem.zip",
     "version": "1.0.0"

--- a/Templates/Ros2FleetRobotTemplate/Template/Gem/gem.json
+++ b/Templates/Ros2FleetRobotTemplate/Template/Gem/gem.json
@@ -23,6 +23,8 @@
     "dependencies": [
     ],
     "compatible_engines": [
+        "o3de-sdk>=1.2.0",
+        "o3de>=1.2.0"
     ],
     "engine_api_dependencies":[
     ]

--- a/Templates/Ros2ProjectTemplate/Template/Gem/gem.json
+++ b/Templates/Ros2ProjectTemplate/Template/Gem/gem.json
@@ -18,6 +18,10 @@
     ],
     "icon_path": "preview.png",
     "requirements": "",
+    "compatible_engines": [
+        "o3de-sdk>=1.2.0",
+        "o3de>=1.2.0"
+    ],
     "documentation_url": "",
     "dependencies": [
     ]


### PR DESCRIPTION
Update compatible_engines fields:
- we will continue to support working with development branch of o3de (so it is >= BASE_VERSION)
- we will not support earlier versions of engine / sdk (there are version tags for that).