### PR TITLE
Error messages in Joint Trajectory

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Manipulation/JointsTrajectoryRequests.h
+++ b/Gems/ROS2/Code/Include/ROS2/Manipulation/JointsTrajectoryRequests.h
@@ -24,6 +24,7 @@ namespace ROS2
 
         using TrajectoryGoal = control_msgs::action::FollowJointTrajectory::Goal;
         using TrajectoryGoalPtr = std::shared_ptr<const TrajectoryGoal>;
+        using TrajectoryResult = control_msgs::action::FollowJointTrajectory::Result;
         using TrajectoryResultPtr = std::shared_ptr<control_msgs::action::FollowJointTrajectory::Result>;
 
         //! Status of trajectory action.
@@ -39,7 +40,7 @@ namespace ROS2
         //! @param trajectoryGoal Specified trajectory including points with timing and tolerances.
         //! @return Nothing on success, error message if failed.
         //! @note The call will return an error if the goal trajectory mismatches joints system.
-        virtual AZ::Outcome<void, AZStd::string> StartTrajectoryGoal(TrajectoryGoalPtr trajectoryGoal) = 0;
+        virtual AZ::Outcome<void, TrajectoryResult> StartTrajectoryGoal(TrajectoryGoalPtr trajectoryGoal) = 0;
 
         //! Cancel current trajectory goal.
         //! @param result Result of trajectory goal with explanation on why it was cancelled.

--- a/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.cpp
@@ -137,7 +137,7 @@ namespace ROS2
         {
             AZ_Trace(
                 "FollowJointTrajectoryActionServer",
-                "Execution not be accepted: %s",
+                "Execution was not accepted: %s",
                 executionOrderOutcome.GetError().error_string.c_str());
 
             auto result = std::make_shared<FollowJointTrajectory::Result>(executionOrderOutcome.GetError());

--- a/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.cpp
@@ -80,7 +80,7 @@ namespace ROS2
     }
 
     rclcpp_action::GoalResponse FollowJointTrajectoryActionServer::GoalReceivedCallback(
-        [[maybe_unused]] const rclcpp_action::GoalUUID& uuid, std::shared_ptr<const FollowJointTrajectory::Goal> goal)
+        [[maybe_unused]] const rclcpp_action::GoalUUID& uuid, [[maybe_unused]] std::shared_ptr<const FollowJointTrajectory::Goal> goal)
     { // Accept each received goal. It will be aborted if other goal is active (no deferring/queuing).
         return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
     }

--- a/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.cpp
@@ -129,17 +129,19 @@ namespace ROS2
             return;
         }
 
-        AZ::Outcome<void, AZStd::string> executionOrderOutcome;
+        AZ::Outcome<void, FollowJointTrajectory::Result> executionOrderOutcome;
         JointsTrajectoryRequestBus::EventResult(
             executionOrderOutcome, m_entityId, &JointsTrajectoryRequests::StartTrajectoryGoal, goalHandle->get_goal());
 
         if (!executionOrderOutcome)
         {
-            AZ_Trace("FollowJointTrajectoryActionServer", "Execution not be accepted: %s", executionOrderOutcome.GetError().c_str());
+            AZ_Trace(
+                "FollowJointTrajectoryActionServer",
+                "Execution not be accepted: %s",
+                executionOrderOutcome.GetError().error_string.c_str());
 
-            auto result = std::make_shared<FollowJointTrajectory::Result>();
-            result->error_string = "Execution not accepted: " + std::string(executionOrderOutcome.GetError().c_str());
-            result->error_code = FollowJointTrajectory::Result::INVALID_GOAL;
+            auto result = std::make_shared<FollowJointTrajectory::Result>(executionOrderOutcome.GetError());
+
             goalHandle->abort(result);
             return;
         }

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
@@ -36,7 +36,7 @@ namespace ROS2
 
         // JointsTrajectoryRequestBus::Handler overrides ...
         //! @see ROS2::JointsTrajectoryRequestBus::StartTrajectoryGoal
-        AZ::Outcome<void, AZStd::string> StartTrajectoryGoal(TrajectoryGoalPtr trajectoryGoal) override;
+        AZ::Outcome<void, TrajectoryResult> StartTrajectoryGoal(TrajectoryGoalPtr trajectoryGoal) override;
         //! @see ROS2::JointsTrajectoryRequestBus::CancelTrajectoryGoal
         AZ::Outcome<void, AZStd::string> CancelTrajectoryGoal(TrajectoryResultPtr trajectoryResult) override;
         //! @see ROS2::JointsTrajectoryRequestBus::GetGoalStatus
@@ -53,7 +53,7 @@ namespace ROS2
         //! Follow set trajectory.
         //! @param deltaTimeNs frame time step, to advance trajectory by.
         void FollowTrajectory(const uint64_t deltaTimeNs);
-        AZ::Outcome<void, AZStd::string> ValidateGoal(TrajectoryGoalPtr trajectoryGoal);
+        AZ::Outcome<void, TrajectoryResult> ValidateGoal(TrajectoryGoalPtr trajectoryGoal);
         void MoveToNextPoint(const trajectory_msgs::msg::JointTrajectoryPoint currentTrajectoryPoint);
         void UpdateFeedback();
 


### PR DESCRIPTION

Invalid goals are now accepted, and later aborted with error message explaining the reason.  Addresses #375.