### PR TITLE
Filled the published JointState message

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Manipulation/JointInfo.h
+++ b/Gems/ROS2/Code/Include/ROS2/Manipulation/JointInfo.h
@@ -18,6 +18,7 @@ namespace ROS2
 {
     using JointPosition = float;
     using JointVelocity = float;
+    using JointEffort = float;
     struct JointInfo
     {
         AZ_TYPE_INFO(JointInfo, "{2E33E4D0-78DD-436D-B3AB-F752E744F421}");

--- a/Gems/ROS2/Code/Include/ROS2/Manipulation/JointInfo.h
+++ b/Gems/ROS2/Code/Include/ROS2/Manipulation/JointInfo.h
@@ -17,6 +17,7 @@
 namespace ROS2
 {
     using JointPosition = float;
+    using JointVelocity = float;
     struct JointInfo
     {
         AZ_TYPE_INFO(JointInfo, "{2E33E4D0-78DD-436D-B3AB-F752E744F421}");

--- a/Gems/ROS2/Code/Include/ROS2/Manipulation/JointsManipulationRequests.h
+++ b/Gems/ROS2/Code/Include/ROS2/Manipulation/JointsManipulationRequests.h
@@ -24,6 +24,7 @@ namespace ROS2
         static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
 
         using JointsPositionsMap = AZStd::unordered_map<AZStd::string, JointPosition>;
+        using JointsVelocitiesMap = AZStd::unordered_map<AZStd::string, JointVelocity>;
 
         //! Get all entity tree joints, including joint or articulation component hierarchy.
         //! @return An unordered map of joint names to joint info structure.
@@ -38,7 +39,7 @@ namespace ROS2
         virtual AZ::Outcome<JointPosition, AZStd::string> GetJointPosition(const AZStd::string& jointName) = 0;
 
         //! Get velocity of a joint by name.
-        //! Works with hinge joints and articulation links (I hope, lol, maybe it doesn't).
+        //! Works with hinge joints and articulation links.
         //! @param jointName name of the joint. Use names acquired from GetJoints() query.
         //! @return outcome with velocity if joint exists.
         //! If it does not exist or some other error happened, error message is returned.
@@ -47,6 +48,17 @@ namespace ROS2
         //! Return positions of all single DOF joints.
         //! @return a vector of all joints relative positions in degree of motion range or error message.
         virtual JointsPositionsMap GetAllJointsPositions() = 0;
+
+        //! Return velocity of all single DOF joints.
+        //! @return a vector of all joints velocities or error message.
+        virtual JointsVelocitiesMap GetAllJointsVelocities() = 0;
+
+        //! Get effort of a force-driven articulation link by name.
+        //! If the joint is not an articulation link, returns 0.
+        //! @param jointName name of the joint. Use names acquired from GetJoints() query.
+        //! @return outcome with effort if joint exists.
+        //! If it does not exist or some other error happened, error message is returned.
+        virtual AZ::Outcome<JointEffort, AZStd::string> GetJointEffort(const AZStd::string& jointName) = 0;
 
         //! Move specified joints into positions.
         //! @param new positions for each named joint. Use names queried through GetJoints().

--- a/Gems/ROS2/Code/Include/ROS2/Manipulation/JointsManipulationRequests.h
+++ b/Gems/ROS2/Code/Include/ROS2/Manipulation/JointsManipulationRequests.h
@@ -25,6 +25,7 @@ namespace ROS2
 
         using JointsPositionsMap = AZStd::unordered_map<AZStd::string, JointPosition>;
         using JointsVelocitiesMap = AZStd::unordered_map<AZStd::string, JointVelocity>;
+        using JointsEffortsMap = AZStd::unordered_map<AZStd::string, JointEffort>;
 
         //! Get all entity tree joints, including joint or articulation component hierarchy.
         //! @return An unordered map of joint names to joint info structure.
@@ -49,16 +50,20 @@ namespace ROS2
         //! @return a vector of all joints relative positions in degree of motion range or error message.
         virtual JointsPositionsMap GetAllJointsPositions() = 0;
 
-        //! Return velocity of all single DOF joints.
+        //! Return velocities of all single DOF joints.
         //! @return a vector of all joints velocities or error message.
         virtual JointsVelocitiesMap GetAllJointsVelocities() = 0;
 
         //! Get effort of a force-driven articulation link by name.
-        //! If the joint is not an articulation link, returns 0.
+        //! If the joint is not an articulation link, or it's acceleration-driven, returns 0.
         //! @param jointName name of the joint. Use names acquired from GetJoints() query.
         //! @return outcome with effort if joint exists.
         //! If it does not exist or some other error happened, error message is returned.
         virtual AZ::Outcome<JointEffort, AZStd::string> GetJointEffort(const AZStd::string& jointName) = 0;
+
+        //! Return efforts of all single DOF joints.
+        //! @return a vector of all joints efforts or error message.
+        virtual JointsEffortsMap GetAllJointsEfforts() = 0;
 
         //! Move specified joints into positions.
         //! @param new positions for each named joint. Use names queried through GetJoints().

--- a/Gems/ROS2/Code/Include/ROS2/Manipulation/JointsManipulationRequests.h
+++ b/Gems/ROS2/Code/Include/ROS2/Manipulation/JointsManipulationRequests.h
@@ -37,6 +37,13 @@ namespace ROS2
         //! If it does not exist or some other error happened, error message is returned.
         virtual AZ::Outcome<JointPosition, AZStd::string> GetJointPosition(const AZStd::string& jointName) = 0;
 
+        //! Get velocity of a joint by name.
+        //! Works with hinge joints and articulation links (I hope, lol, maybe it doesn't).
+        //! @param jointName name of the joint. Use names acquired from GetJoints() query.
+        //! @return outcome with velocity if joint exists.
+        //! If it does not exist or some other error happened, error message is returned.
+        virtual AZ::Outcome<JointVelocity, AZStd::string> GetJointVelocity(const AZStd::string& jointName) = 0;
+
         //! Return positions of all single DOF joints.
         //! @return a vector of all joints relative positions in degree of motion range or error message.
         virtual JointsPositionsMap GetAllJointsPositions() = 0;

--- a/Gems/ROS2/Code/Source/Manipulation/JointStatePublisher.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointStatePublisher.cpp
@@ -45,11 +45,13 @@ namespace ROS2
             auto currentJointPosition = result.GetValue();
             JointsManipulationRequestBus::EventResult(result, m_context.m_entityId, &JointsManipulationRequests::GetJointVelocity, jointName);
             auto currentJointVelocity = result.GetValue();
+            JointsManipulationRequestBus::EventResult(result, m_context.m_entityId, &JointsManipulationRequests::GetJointEffort, jointName);
+            auto currentJointEffort = result.GetValue();
 
             m_jointStateMsg.name[i] = jointName.c_str();
             m_jointStateMsg.position[i] = currentJointPosition;
             m_jointStateMsg.velocity[i] = currentJointVelocity;
-            m_jointStateMsg.effort[i] = 0.0;
+            m_jointStateMsg.effort[i] = currentJointEffort;
             i++;
         }
         m_jointStatePublisher->publish(m_jointStateMsg);

--- a/Gems/ROS2/Code/Source/Manipulation/JointStatePublisher.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointStatePublisher.cpp
@@ -43,10 +43,12 @@ namespace ROS2
             AZ::Outcome<float, AZStd::string> result;
             JointsManipulationRequestBus::EventResult(result, m_context.m_entityId, &JointsManipulationRequests::GetJointPosition, jointName);
             auto currentJointPosition = result.GetValue();
+            JointsManipulationRequestBus::EventResult(result, m_context.m_entityId, &JointsManipulationRequests::GetJointVelocity, jointName);
+            auto currentJointVelocity = result.GetValue();
 
             m_jointStateMsg.name[i] = jointName.c_str();
             m_jointStateMsg.position[i] = currentJointPosition;
-            m_jointStateMsg.velocity[i] = 0.0;
+            m_jointStateMsg.velocity[i] = currentJointVelocity;
             m_jointStateMsg.effort[i] = 0.0;
             i++;
         }

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
@@ -222,6 +222,30 @@ namespace ROS2
         return AZ::Success(position);
     }
 
+    AZ::Outcome<JointVelocity, AZStd::string> JointsManipulationComponent::GetJointVelocity(const AZStd::string& jointName)
+    {
+        if (!m_manipulationJoints.contains(jointName))
+        {
+            return AZ::Failure(AZStd::string::format("Joint %s does not exist", jointName.c_str()));
+        }
+
+        auto jointInfo = m_manipulationJoints.at(jointName);
+        float velocity{ 0 };
+        if (jointInfo.m_isArticulation)
+        {
+            PhysX::ArticulationJointRequestBus::EventResult(
+                    velocity,
+                    jointInfo.m_entityComponentIdPair.GetEntityId(),
+                    &PhysX::ArticulationJointRequests::GetJointVelocity,
+                    jointInfo.m_axis);
+        }
+        else
+        {
+            PhysX::JointRequestBus::EventResult(velocity, jointInfo.m_entityComponentIdPair, &PhysX::JointRequests::GetVelocity);
+        }
+        return AZ::Success(velocity);
+    }
+
     JointsManipulationRequests::JointsPositionsMap JointsManipulationComponent::GetAllJointsPositions()
     {
         JointsManipulationRequests::JointsPositionsMap positions;

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
@@ -46,6 +46,10 @@ namespace ROS2
         AZ::Outcome<JointVelocity, AZStd::string> GetJointVelocity(const AZStd::string& jointName) override;
         //! @see ROS2::JointsManipulationRequestBus::GetAllJointsPositions
         JointsPositionsMap GetAllJointsPositions() override;
+        //! @see ROS2::JointsManipulationRequestBus::GetAllJointsVelocities
+        JointsVelocitiesMap GetAllJointsVelocities() override;
+        //! @see ROS2::JointsManipulationRequestBus::GetJointEffort
+        AZ::Outcome<JointEffort, AZStd::string> GetJointEffort(const AZStd::string& jointName) override;
         //! @see ROS2::JointsManipulationRequestBus::MoveJointsToPositions
         AZ::Outcome<void, AZStd::string> MoveJointsToPositions(const JointsPositionsMap& positions) override;
         //! @see ROS2::JointsManipulationRequestBus::MoveJointToPosition

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
@@ -42,6 +42,8 @@ namespace ROS2
         ManipulationJoints GetJoints() override;
         //! @see ROS2::JointsManipulationRequestBus::GetJointPosition
         AZ::Outcome<JointPosition, AZStd::string> GetJointPosition(const AZStd::string& jointName) override;
+        //! @see ROS2::JointsManipulationRequestBus::GetJointVelocity
+        AZ::Outcome<JointVelocity, AZStd::string> GetJointVelocity(const AZStd::string& jointName) override;
         //! @see ROS2::JointsManipulationRequestBus::GetAllJointsPositions
         JointsPositionsMap GetAllJointsPositions() override;
         //! @see ROS2::JointsManipulationRequestBus::MoveJointsToPositions

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
@@ -50,6 +50,8 @@ namespace ROS2
         JointsVelocitiesMap GetAllJointsVelocities() override;
         //! @see ROS2::JointsManipulationRequestBus::GetJointEffort
         AZ::Outcome<JointEffort, AZStd::string> GetJointEffort(const AZStd::string& jointName) override;
+        //! @see ROS2::JointsManipulationRequestBus::GetAllJointsEfforts
+        JointsEffortsMap GetAllJointsEfforts() override;
         //! @see ROS2::JointsManipulationRequestBus::MoveJointsToPositions
         AZ::Outcome<void, AZStd::string> MoveJointsToPositions(const JointsPositionsMap& positions) override;
         //! @see ROS2::JointsManipulationRequestBus::MoveJointToPosition


### PR DESCRIPTION
Filled the JointState message. Velocity is always filled in, effort is filled for force-driven articulation joints (for other joint types it's still 0).