### PR TITLE
Support for PID and Proximity sensor buses

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/ProximitySensor/ProximitySensorNotificationBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/ProximitySensor/ProximitySensorNotificationBus.h
@@ -20,11 +20,11 @@ namespace ROS2
         static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
         static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
 
-        //! Notify that a particular sensor detected an object.
-        virtual void OnObjectDetected() = 0;
+        //! Notify that a particular sensor is detecting an object (notification published for each frequency tick).
+        virtual void OnObjectInRange() = 0;
 
-        //! Notify that a particular sensor did not detect an object.
-        virtual void OnObjectUnseen() = 0;
+        //! Notify that a particular sensor is not detecting an object (notification published for each frequency tick).
+        virtual void OnObjectOutOfRange() = 0;
 
     protected:
         ~ProximitySensorNotifications() = default;

--- a/Gems/ROS2/Code/Include/ROS2/ProximitySensor/ProximitySensorNotificationBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/ProximitySensor/ProximitySensorNotificationBus.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/EBus/EBus.h>
+
+namespace ROS2
+{
+    //! Interface class that allows to add post-processing to the pipeline
+    class ProximitySensorNotifications : public AZ::EBusTraits
+    {
+    public:
+        using BusIdType = AZ::EntityId;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+
+        //! Notify that a particular sensor detected an object.
+        virtual void OnObjectDetected() = 0;
+
+        //! Notify that a particular sensor did not detect an object.
+        virtual void OnObjectUnseen() = 0;
+
+    protected:
+        ~ProximitySensorNotifications() = default;
+    };
+
+    using ProximitySensorNotificationBus = AZ::EBus<ProximitySensorNotifications>;
+} // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/ProximitySensor/ProximitySensorNotificationBusHandler.h
+++ b/Gems/ROS2/Code/Include/ROS2/ProximitySensor/ProximitySensorNotificationBusHandler.h
@@ -23,19 +23,19 @@ namespace ROS2
             ProximitySensorNotificationBusHandler,
             "{cc9c2e5a-318d-4212-abeb-95bd0575452d}",
             AZ::SystemAllocator,
-            OnObjectDetected,
-            OnObjectUnseen);
+            OnObjectInRange,
+            OnObjectOutOfRange);
 
         // Sent when the object is detected.
-        void OnObjectDetected() override
+        void OnObjectInRange() override
         {
-            Call(FN_OnObjectDetected);
+            Call(FN_OnObjectInRange);
         }
 
         // Sent when there are no objects detected.
-        void OnObjectUnseen() override
+        void OnObjectOutOfRange() override
         {
-            Call(FN_OnObjectUnseen);
+            Call(FN_OnObjectOutOfRange);
         }
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/ProximitySensor/ProximitySensorNotificationBusHandler.h
+++ b/Gems/ROS2/Code/Include/ROS2/ProximitySensor/ProximitySensorNotificationBusHandler.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/RTTI/BehaviorInterfaceProxy.h>
+
+#include <ROS2/ProximitySensor/ProximitySensorNotificationBus.h>
+
+namespace ROS2
+{
+    class ProximitySensorNotificationBusHandler
+        : public ProximitySensorNotificationBus::Handler
+        , public AZ::BehaviorEBusHandler
+    {
+    public:
+        AZ_EBUS_BEHAVIOR_BINDER(
+            ProximitySensorNotificationBusHandler,
+            "{cc9c2e5a-318d-4212-abeb-95bd0575452d}",
+            AZ::SystemAllocator,
+            OnObjectDetected,
+            OnObjectUnseen);
+
+        // Sent when the object is detected.
+        void OnObjectDetected() override
+        {
+            Call(FN_OnObjectDetected);
+        }
+
+        // Sent when there are no objects detected.
+        void OnObjectUnseen() override
+        {
+            Call(FN_OnObjectUnseen);
+        }
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Manipulation/MotorizedJoints/PidMotorControllerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/MotorizedJoints/PidMotorControllerComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/Component/ComponentBus.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <PhysX/Joint/PhysXJointRequestsBus.h>
 #include <ROS2/Manipulation/MotorizedJoints/PidMotorControllerComponent.h>
@@ -36,6 +37,16 @@ namespace ROS2
                         "Allows to change offset of zero to set point")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &PidMotorControllerComponent::m_pidPos, "Pid Position", "Pid Position");
             }
+        }
+
+        if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<PidMotorControllerRequestBus>("PidMotorControllerComponent", "PidMotorControllerRequestBus")
+                ->Attribute(AZ::Edit::Attributes::Category, "ROS2/PidMotorController")
+                ->Event("SetSetpoint", &PidMotorControllerRequestBus::Events::SetSetpoint)
+                ->Event("GetSetpoint", &PidMotorControllerRequestBus::Events::GetSetpoint)
+                ->Event("GetCurrentMeasurement", &PidMotorControllerRequestBus::Events::GetCurrentMeasurement)
+                ->Event("GetError", &PidMotorControllerRequestBus::Events::GetError);
         }
     }
 

--- a/Gems/ROS2/Code/Source/ProximitySensor/ROS2ProximitySensor.cpp
+++ b/Gems/ROS2/Code/Source/ProximitySensor/ROS2ProximitySensor.cpp
@@ -15,6 +15,8 @@
 #include <AzCore/std/string/string.h>
 
 #include <ROS2/Communication/TopicConfiguration.h>
+#include <ROS2/ProximitySensor/ProximitySensorNotificationBus.h>
+#include <ROS2/ProximitySensor/ProximitySensorNotificationBusHandler.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/Sensor/ROS2SensorComponent.h>
 #include <ROS2/Utilities/ROS2Names.h>
@@ -48,6 +50,12 @@ namespace ROS2
                         "The maximum distance from where object is detected")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.);
             }
+        }
+        if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<ProximitySensorNotificationBus>("ROS2ProximitySensor", "ProximitySensorNotificationBus")
+                ->Attribute(AZ::Edit::Attributes::Category, "ROS2/ProximitySensor")
+                ->Handler<ProximitySensorNotificationBusHandler>();
         }
     }
 
@@ -143,8 +151,17 @@ namespace ROS2
 
             std_msgs::msg::Bool msg;
             m_position = !result.m_hits.empty() ? std::make_optional(result.m_hits.front().m_position) : std::nullopt;
-            msg.data = m_position ? true : false;;
+            msg.data = m_position ? true : false;
             m_detectionPublisher->publish(msg);
+
+            if (m_position)
+            {
+                ProximitySensorNotificationBus::Event(GetEntityId(), &ProximitySensorNotifications::OnObjectDetected);
+            }
+            else
+            {
+                ProximitySensorNotificationBus::Event(GetEntityId(), &ProximitySensorNotifications::OnObjectUnseen);
+            }
         }
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/ProximitySensor/ROS2ProximitySensor.cpp
+++ b/Gems/ROS2/Code/Source/ProximitySensor/ROS2ProximitySensor.cpp
@@ -156,11 +156,11 @@ namespace ROS2
 
             if (m_position)
             {
-                ProximitySensorNotificationBus::Event(GetEntityId(), &ProximitySensorNotifications::OnObjectDetected);
+                ProximitySensorNotificationBus::Event(GetEntityId(), &ProximitySensorNotifications::OnObjectInRange);
             }
             else
             {
-                ProximitySensorNotificationBus::Event(GetEntityId(), &ProximitySensorNotifications::OnObjectUnseen);
+                ProximitySensorNotificationBus::Event(GetEntityId(), &ProximitySensorNotifications::OnObjectOutOfRange);
             }
         }
     }

--- a/Gems/ROS2/Code/ros2_header_files.cmake
+++ b/Gems/ROS2/Code/ros2_header_files.cmake
@@ -23,6 +23,8 @@ set(FILES
         Include/ROS2/Manipulation/MotorizedJoints/ManualMotorControllerComponent.h
         Include/ROS2/Manipulation/MotorizedJoints/PidMotorControllerBus.h
         Include/ROS2/Manipulation/MotorizedJoints/PidMotorControllerComponent.h
+        Include/ROS2/ProximitySensor/ProximitySensorNotificationBus.h
+        Include/ROS2/ProximitySensor/ProximitySensorNotificationBusHandler.h
         Include/ROS2/RobotControl/ControlConfiguration.h
         Include/ROS2/RobotControl/ControlSubscriptionHandler.h
         Include/ROS2/Lidar/LidarRaycasterBus.h


### PR DESCRIPTION
This PR adds _notification bus_ to `ROS2ProximitySensor` (alongside with _ScriptCanvas_ support) and adds _ScriptCanvas_ support to `PidMotorControllerComponent`.

Thanks to that it is possible to use a simple script:
![image](https://github.com/o3de/o3de-extras/assets/134940295/ca470581-2fab-40ed-9682-1c11d44797d7)

in order to create a more advanced conveyor bus handling (note: the conveyor bus PR is an ongoing work):
[20230707_conveyor_scripts_short.webm](https://github.com/o3de/o3de-extras/assets/134940295/0f6d0655-e160-46f8-8b4f-865b63fc30bb)
