### PR TITLE
JointsArticulationController requires ArticulationLink

### DIFF
--- a/Gems/ROS2/Code/Source/Manipulation/Controllers/JointsArticulationControllerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/Controllers/JointsArticulationControllerComponent.cpp
@@ -40,6 +40,11 @@ namespace ROS2
         return AZ::Success();
     }
 
+    void JointsArticulationControllerComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC_CE("ArticulationLinkService"));
+    }
+
     void JointsArticulationControllerComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
     {
         provided.push_back(AZ_CRC_CE("JointsControllerService"));

--- a/Gems/ROS2/Code/Source/Manipulation/Controllers/JointsArticulationControllerComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/Controllers/JointsArticulationControllerComponent.h
@@ -23,6 +23,7 @@ namespace ROS2
         ~JointsArticulationControllerComponent() = default;
         AZ_COMPONENT(JointsArticulationControllerComponent, "{243E9F07-5F84-4F83-9E6D-D1DA04D7CEF9}", AZ::Component);
 
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
         static void Reflect(AZ::ReflectContext* context);


### PR DESCRIPTION
Added ArticulationLinkService to list of services required by JointsArticulationController.

Relies on https://github.com/o3de/o3de/pull/16321 which introduces ArticulationLinkService to list of services provided by ArticulationLinkComponent and EditorArticulationLinkComponent.
Addresses #389.