### PR TITLE
Make output directories of RobotImporter unique

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -108,7 +108,7 @@ namespace ROS2
         if (importAssetWithUrdf)
         {
             urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(
-                Utils::CopyAssetForURDFAndCreateAssetMap(meshNames, filePath, AZ::Crc32(), collidersNames, visualNames));
+                Utils::CopyAssetForURDFAndCreateAssetMap(meshNames, filePath, collidersNames, visualNames));
         }
         bool allAssetProcessed = false;
         bool assetProcessorFailed = false;

--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "ROS2RobotImporterEditorSystemComponent.h"
+#include "AzCore/Math/Crc.h"
 #include "RobotImporter/URDF/UrdfParser.h"
 #include "RobotImporter/Utils/FilePath.h"
 #include "RobotImporterWidget.h"
@@ -107,7 +108,7 @@ namespace ROS2
         if (importAssetWithUrdf)
         {
             urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(
-                Utils::CopyAssetForURDFAndCreateAssetMap(meshNames, filePath, collidersNames, visualNames));
+                Utils::CopyAssetForURDFAndCreateAssetMap(meshNames, filePath, AZ::Crc32(), collidersNames, visualNames));
         }
         bool allAssetProcessed = false;
         bool assetProcessorFailed = false;

--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "ROS2RobotImporterEditorSystemComponent.h"
-#include "AzCore/Math/Crc.h"
 #include "RobotImporter/URDF/UrdfParser.h"
 #include "RobotImporter/Utils/FilePath.h"
 #include "RobotImporterWidget.h"

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -9,7 +9,7 @@
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/Utils/Utils.h>
-#include <AzCore/Math/Crc.h>
+#include <AzCore/Math/Uuid.h>
 
 #include "RobotImporterWidget.h"
 #include "URDF/URDFPrefabMaker.h"
@@ -182,19 +182,19 @@ namespace ROS2
             auto collidersNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), false, true);
             auto visualNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), true, false);
 
-            AZ::Crc32 params_crc;
+            auto paramsUuid = AZ::Uuid::CreateNull();
             for (auto& [key, value] : m_params)
             {
-                params_crc.Add(key);
-                params_crc.Add(value);
+                paramsUuid += AZ::Uuid::CreateName(key);
+                paramsUuid += AZ::Uuid::CreateName(value);
             }
 
-            auto dir_suffix = AZStd::string::format("%d", AZ::u32(params_crc));
+            auto dirSuffix = paramsUuid.ToString<AZStd::string_view>();
 
             if (m_importAssetWithUrdf)
             {
                 m_urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(
-                    Utils::CopyAssetForURDFAndCreateAssetMap(m_meshNames, m_urdfPath.String(), collidersNames, visualNames, dir_suffix));
+                    Utils::CopyAssetForURDFAndCreateAssetMap(m_meshNames, m_urdfPath.String(), collidersNames, visualNames, dirSuffix));
             }
             else
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -188,10 +188,12 @@ namespace ROS2
                 params_crc.Add(key + "_" + value);
             }
 
+            auto dir_suffix = AZStd::string::format("%d", AZ::u32(params_crc));
+
             if (m_importAssetWithUrdf)
             {
                 m_urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(
-                    Utils::CopyAssetForURDFAndCreateAssetMap(m_meshNames, m_urdfPath.String(), params_crc, collidersNames, visualNames));
+                    Utils::CopyAssetForURDFAndCreateAssetMap(m_meshNames, m_urdfPath.String(), collidersNames, visualNames, dir_suffix));
             }
             else
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -8,8 +8,8 @@
 
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/Path/Path.h>
-#include <AzCore/Utils/Utils.h>
 #include <AzCore/Math/Uuid.h>
+#include <AzCore/Utils/Utils.h>
 
 #include "RobotImporterWidget.h"
 #include "URDF/URDFPrefabMaker.h"
@@ -182,14 +182,18 @@ namespace ROS2
             auto collidersNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), false, true);
             auto visualNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), true, false);
 
-            auto paramsUuid = AZ::Uuid::CreateNull();
-            for (auto& [key, value] : m_params)
+            AZStd::string_view dirSuffix = "";
+            if (!m_params.empty())
             {
-                paramsUuid += AZ::Uuid::CreateName(key);
-                paramsUuid += AZ::Uuid::CreateName(value);
-            }
+                auto paramsUuid = AZ::Uuid::CreateNull();
+                for (auto& [key, value] : m_params)
+                {
+                    paramsUuid += AZ::Uuid::CreateName(key);
+                    paramsUuid += AZ::Uuid::CreateName(value);
+                }
 
-            auto dirSuffix = paramsUuid.ToString<AZStd::string_view>();
+                dirSuffix = paramsUuid.ToString<AZStd::string_view>();
+            }
 
             if (m_importAssetWithUrdf)
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -185,7 +185,8 @@ namespace ROS2
             AZ::Crc32 params_crc;
             for (auto& [key, value] : m_params)
             {
-                params_crc.Add(key + "_" + value);
+                params_crc.Add(key);
+                params_crc.Add(value);
             }
 
             auto dir_suffix = AZStd::string::format("%d", AZ::u32(params_crc));

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/Utils/Utils.h>
 
+#include "AzCore/Math/Crc.h"
 #include "RobotImporterWidget.h"
 #include "URDF/URDFPrefabMaker.h"
 #include "URDF/UrdfParser.h"
@@ -181,10 +182,16 @@ namespace ROS2
             auto collidersNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), false, true);
             auto visualNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), true, false);
 
+            AZ::Crc32 params_crc;
+            for (auto& [key, value] : m_params)
+            {
+                params_crc.Add(key + "_" + value);
+            }
+
             if (m_importAssetWithUrdf)
             {
                 m_urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(
-                    Utils::CopyAssetForURDFAndCreateAssetMap(m_meshNames, m_urdfPath.String(), collidersNames, visualNames));
+                    Utils::CopyAssetForURDFAndCreateAssetMap(m_meshNames, m_urdfPath.String(), params_crc, collidersNames, visualNames));
             }
             else
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -9,8 +9,8 @@
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/Utils/Utils.h>
+#include <AzCore/Math/Crc.h>
 
-#include "AzCore/Math/Crc.h"
 #include "RobotImporterWidget.h"
 #include "URDF/URDFPrefabMaker.h"
 #include "URDF/UrdfParser.h"

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "SourceAssetsStorage.h"
+#include "AzCore/Math/Crc.h"
 #include "RobotImporterUtils.h"
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
@@ -253,6 +254,7 @@ namespace ROS2::Utils
     UrdfAssetMap CopyAssetForURDFAndCreateAssetMap(
         const AZStd::unordered_set<AZStd::string>& meshesFilenames,
         const AZStd::string& urdfFilename,
+        AZ::Crc32 params_crc,
         const AZStd::unordered_set<AZStd::string>& colliders,
         const AZStd::unordered_set<AZStd::string>& visuals,
         AZ::IO::FileIOBase* fileIO)
@@ -270,7 +272,7 @@ namespace ROS2::Utils
         AZStd::unordered_map<AZStd::string, AZ::IO::Path> copiedFiles;
 
         AZ_Assert(fileIO, "No FileIO instance");
-        AZ::Crc32 urdfFileCrc;
+        AZ::Crc32 urdfFileCrc = params_crc;
         urdfFileCrc.Add(urdfFilename);
         const AZ::IO::Path urdfPath(urdfFilename);
         const AZStd::string directoryNameTmp = AZStd::string::format("$tmp_%u.tmp", AZ::u32(urdfFileCrc));

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "SourceAssetsStorage.h"
-#include "AzCore/Math/Crc.h"
 #include "RobotImporterUtils.h"
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -255,7 +255,7 @@ namespace ROS2::Utils
         const AZStd::string& urdfFilename,
         const AZStd::unordered_set<AZStd::string>& colliders,
         const AZStd::unordered_set<AZStd::string>& visuals,
-        const AZStd::string& outputDirSuffix,
+        AZStd::string_view outputDirSuffix,
         AZ::IO::FileIOBase* fileIO)
     {
         auto enviromentalVariable = std::getenv("AMENT_PREFIX_PATH");
@@ -275,8 +275,8 @@ namespace ROS2::Utils
         urdfFileCrc.Add(urdfFilename);
         const AZ::IO::Path urdfPath(urdfFilename);
         const AZStd::string directoryNameTmp = AZStd::string::format("$tmp_%u.tmp", AZ::u32(urdfFileCrc));
-        const auto directoryNameDst =
-            AZ::IO::FixedMaxPathString::format("%u_%.*s%.*s", AZ::u32(urdfFileCrc), AZ_PATH_ARG(urdfPath.Stem()), AZ_STRING_ARG(outputDirSuffix));
+        const auto directoryNameDst = AZ::IO::FixedMaxPathString::format(
+            "%u_%.*s%.*s", AZ::u32(urdfFileCrc), AZ_PATH_ARG(urdfPath.Stem()), AZ_STRING_ARG(outputDirSuffix));
 
         const AZ::IO::Path importDirectoryTmp = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "UrdfImporter" / directoryNameTmp;
         const AZ::IO::Path importDirectoryDst = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "UrdfImporter" / directoryNameDst;

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -254,9 +254,9 @@ namespace ROS2::Utils
     UrdfAssetMap CopyAssetForURDFAndCreateAssetMap(
         const AZStd::unordered_set<AZStd::string>& meshesFilenames,
         const AZStd::string& urdfFilename,
-        AZ::Crc32 params_crc,
         const AZStd::unordered_set<AZStd::string>& colliders,
         const AZStd::unordered_set<AZStd::string>& visuals,
+        const AZStd::string& outputDirSuffix,
         AZ::IO::FileIOBase* fileIO)
     {
         auto enviromentalVariable = std::getenv("AMENT_PREFIX_PATH");
@@ -272,11 +272,12 @@ namespace ROS2::Utils
         AZStd::unordered_map<AZStd::string, AZ::IO::Path> copiedFiles;
 
         AZ_Assert(fileIO, "No FileIO instance");
-        AZ::Crc32 urdfFileCrc = params_crc;
+        AZ::Crc32 urdfFileCrc;
         urdfFileCrc.Add(urdfFilename);
         const AZ::IO::Path urdfPath(urdfFilename);
         const AZStd::string directoryNameTmp = AZStd::string::format("$tmp_%u.tmp", AZ::u32(urdfFileCrc));
-        const AZStd::string directoryNameDst = AZStd::string::format("%u_%s", AZ::u32(urdfFileCrc), urdfPath.Stem().String().c_str());
+        const AZStd::string directoryNameDst =
+            AZStd::string::format("%u_%s%s", AZ::u32(urdfFileCrc), urdfPath.Stem().String().c_str(), outputDirSuffix.c_str());
 
         const AZ::IO::Path importDirectoryTmp = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "UrdfImporter" / directoryNameTmp;
         const AZ::IO::Path importDirectoryDst = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "UrdfImporter" / directoryNameDst;

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -275,8 +275,8 @@ namespace ROS2::Utils
         urdfFileCrc.Add(urdfFilename);
         const AZ::IO::Path urdfPath(urdfFilename);
         const AZStd::string directoryNameTmp = AZStd::string::format("$tmp_%u.tmp", AZ::u32(urdfFileCrc));
-        const AZStd::string directoryNameDst =
-            AZStd::string::format("%u_%s%s", AZ::u32(urdfFileCrc), urdfPath.Stem().String().c_str(), outputDirSuffix.c_str());
+        const auto directoryNameDst =
+            AZ::IO::FixedMaxPathString::format("%u_%.*s%.*s", AZ::u32(urdfFileCrc), AZ_PATH_ARG(urdfPath.Stem()), AZ_STRING_ARG(outputDirSuffix));
 
         const AZ::IO::Path importDirectoryTmp = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "UrdfImporter" / directoryNameTmp;
         const AZ::IO::Path importDirectoryDst = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "UrdfImporter" / directoryNameDst;

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -114,14 +114,15 @@ namespace ROS2::Utils
     //! @param urdFilename - path to URDF file (as a global path)
     //! @param colliders - files to create collider assetinfo (as unresolved urdf paths)
     //! @param visuals - files to create visual assetinfo (as unresolved urdf paths)
+    //! @param outputDirSuffix - suffix to make output directory unique, if xacro file was used
     //! @param fileIO - instance to fileIO class
     //! @returns mapping from unresolved urdf paths to source asset info
     UrdfAssetMap CopyAssetForURDFAndCreateAssetMap(
         const AZStd::unordered_set<AZStd::string>& meshesFilenames,
         const AZStd::string& urdfFilename,
-        AZ::Crc32 params_crc,
         const AZStd::unordered_set<AZStd::string>& colliders,
         const AZStd::unordered_set<AZStd::string>& visual,
+        const AZStd::string& outputDirSuffix = "",
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 
 } // namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -119,6 +119,7 @@ namespace ROS2::Utils
     UrdfAssetMap CopyAssetForURDFAndCreateAssetMap(
         const AZStd::unordered_set<AZStd::string>& meshesFilenames,
         const AZStd::string& urdfFilename,
+        AZ::Crc32 params_crc,
         const AZStd::unordered_set<AZStd::string>& colliders,
         const AZStd::unordered_set<AZStd::string>& visual,
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -122,7 +122,7 @@ namespace ROS2::Utils
         const AZStd::string& urdfFilename,
         const AZStd::unordered_set<AZStd::string>& colliders,
         const AZStd::unordered_set<AZStd::string>& visual,
-        const AZStd::string& outputDirSuffix = "",
+        AZStd::string_view outputDirSuffix = "",
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 
 } // namespace ROS2::Utils


### PR DESCRIPTION
Added Uuid of parameters passed to XACRO to the name name of RobotImporter's output directory.
This makes the directory unique for each robot imported from the same xacro file. 
Addresses  https://github.com/o3de/o3de-extras/issues/392.