### PR TITLE
Added parameter to toggle manual control of entities with VehicleModelComponent in Editor

### DIFF
--- a/Gems/ROS2/Code/Source/VehicleDynamics/VehicleModelComponent.cpp
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/VehicleModelComponent.cpp
@@ -22,7 +22,9 @@ namespace ROS2::VehicleDynamics
     void VehicleModelComponent::Activate()
     {
         VehicleInputControlRequestBus::Handler::BusConnect(GetEntityId());
-        m_manualControlEventHandler.Activate(GetEntityId());
+
+        if (m_manuallyControled)
+            m_manualControlEventHandler.Activate(GetEntityId());
         AZ::TickBus::Handler::BusConnect();
     }
 
@@ -41,8 +43,10 @@ namespace ROS2::VehicleDynamics
 
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<VehicleModelComponent, AZ::Component>()->Version(4)->Field(
-                "VehicleConfiguration", &VehicleModelComponent::m_vehicleConfiguration);
+            serialize->Class<VehicleModelComponent, AZ::Component>()
+                ->Version(4)
+                ->Field("VehicleConfiguration", &VehicleModelComponent::m_vehicleConfiguration)
+                ->Field("ManualControl", &VehicleModelComponent::m_manuallyControled);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
@@ -51,7 +55,12 @@ namespace ROS2::VehicleDynamics
                         AZ::Edit::UIHandlers::Default,
                         &VehicleModelComponent::m_vehicleConfiguration,
                         "Vehicle settings",
-                        "Vehicle settings including axles and common wheel parameters");
+                        "Vehicle settings including axles and common wheel parameters")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &VehicleModelComponent::m_manuallyControled,
+                        "ManualControl",
+                        "Enable manual control of the vehicle");
             }
         }
     }

--- a/Gems/ROS2/Code/Source/VehicleDynamics/VehicleModelComponent.h
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/VehicleModelComponent.h
@@ -54,6 +54,7 @@ namespace ROS2::VehicleDynamics
 
     protected:
         ManualControlEventHandler m_manualControlEventHandler;
+        bool m_manuallyControled = true;
         VehicleInputDeadline m_inputsState;
         VehicleDynamics::VehicleConfiguration m_vehicleConfiguration;
         virtual DriveModel* GetDriveModel() = 0;


### PR DESCRIPTION
Added boolean parameter that can be changed via Editor to enable/disable activation of ManualControlEventHandler.
Addresses https://github.com/o3de/o3de-extras/issues/384.