### PR TITLE
added missing fields to move constructor of LidarRaycaster

### DIFF
--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
@@ -43,6 +43,7 @@ namespace ROS2
         : m_busId{ lidarRaycaster.m_busId }
         , m_sceneEntityId{ lidarRaycaster.m_sceneEntityId }
         , m_sceneHandle{ lidarRaycaster.m_sceneHandle }
+        , m_resultFlags{ lidarRaycaster.m_resultFlags }
         , m_range{ lidarRaycaster.m_range }
         , m_addMaxRangePoints{ lidarRaycaster.m_addMaxRangePoints }
         , m_rayRotations{ AZStd::move(lidarRaycaster.m_rayRotations) }

--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
@@ -44,6 +44,7 @@ namespace ROS2
         , m_sceneEntityId{ lidarRaycaster.m_sceneEntityId }
         , m_sceneHandle{ lidarRaycaster.m_sceneHandle }
         , m_resultFlags{ lidarRaycaster.m_resultFlags }
+        , m_minRange{ lidarRaycaster.m_minRange }
         , m_range{ lidarRaycaster.m_range }
         , m_addMaxRangePoints{ lidarRaycaster.m_addMaxRangePoints }
         , m_rayRotations{ AZStd::move(lidarRaycaster.m_rayRotations) }


### PR DESCRIPTION
Added copying of m_resultFlags and m_minRange to move constructor of LidarRaycaster.

This addresses https://github.com/o3de/o3de-extras/issues/401, as previously configuration was lost by this constructor.
This caused RaycastResultFlags::Ranges to be disabled (default value). As a result m_ranges field of RaycastResult was not populated by LidarRaycaster that was moved.

m_minRange was lost in similar manner (this is not connected to issue linked above).
