### PR TITLE
Fleet navigation - TF namespaces rework

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2Transform.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2Transform.h
@@ -27,7 +27,7 @@ namespace ROS2
         //! Construct and delegate publishing of a transform according to members' values.
         //! @param transform AZ::Transform with current transformation between m_parentFrame and m_childFrame.
         //! @note The actual publishing is done by singleton tf broadcasters.
-        void Publish(const AZ::Transform& transform);
+        void Publish(const AZ::Transform& transform, std::string ns = "");
 
     private:
         geometry_msgs::msg::TransformStamped CreateTransformMessage(const AZ::Transform& transform);

--- a/Gems/ROS2/Code/Include/ROS2/ROS2Bus.h
+++ b/Gems/ROS2/Code/Include/ROS2/ROS2Bus.h
@@ -31,7 +31,7 @@ namespace ROS2
         //! You can use this node to create publishers and subscribers.
         //! @return The central ROS2 node which holds default publishers for core topics such as /clock and /tf.
         //! @note Alternatively, you can use your own node along with an executor.
-        virtual std::shared_ptr<rclcpp::Node> GetNode() const = 0;
+        virtual std::shared_ptr<rclcpp::Node> GetNode(std::string ns = "") const = 0;
 
         //! Acquire current time as ROS2 timestamp.
         //! Timestamps provide temporal context for messages such as sensor data.
@@ -50,7 +50,7 @@ namespace ROS2
         //! only once and are to be used when the spatial relationship between two frames does not change.
         //! @note Transforms are already published by each ROS2FrameComponent.
         //! Use this function directly only when default behavior of ROS2FrameComponent is not sufficient.
-        virtual void BroadcastTransform(const geometry_msgs::msg::TransformStamped& t, bool isDynamic) const = 0;
+        virtual void BroadcastTransform(const geometry_msgs::msg::TransformStamped& t, bool isDynamic, std::string ns = "") const = 0;
 
         //! Obtains a simulation clock that is used across simulation.
         //! @returns constant reference to currently running clock.

--- a/Gems/ROS2/Code/Include/ROS2/RobotControl/ControlSubscriptionHandler.h
+++ b/Gems/ROS2/Code/Include/ROS2/RobotControl/ControlSubscriptionHandler.h
@@ -42,9 +42,9 @@ namespace ROS2
             if (!m_controlSubscription)
             {
                 auto ros2Frame = entity->FindComponent<ROS2FrameComponent>();
-                AZStd::string namespacedTopic = ROS2Names::GetNamespacedName(ros2Frame->GetNamespace(), subscriberConfiguration.m_topic);
+                AZStd::string namespacedTopic = ROS2Names::GetNamespacedName("", subscriberConfiguration.m_topic);
 
-                auto ros2Node = ROS2Interface::Get()->GetNode();
+                auto ros2Node = ROS2Interface::Get()->GetNode(ros2Frame->GetNamespace().data());
                 m_controlSubscription = ros2Node->create_subscription<T>(
                     namespacedTopic.data(),
                     subscriberConfiguration.GetQoS(),

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -112,7 +112,7 @@ namespace ROS2
             }
             else
             {
-                m_ros2Transform->Publish(GetFrameTransform());
+                m_ros2Transform->Publish(GetFrameTransform(), GetNamespace().data());
             }
         }
     }
@@ -131,12 +131,12 @@ namespace ROS2
 
     void ROS2FrameComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
-        m_ros2Transform->Publish(GetFrameTransform());
+        m_ros2Transform->Publish(GetFrameTransform(), GetNamespace().data());
     }
 
     AZStd::string ROS2FrameComponent::GetGlobalFrameName() const
     {
-        return ROS2Names::GetNamespacedName(GetNamespace(), AZStd::string("odom"));
+        return ROS2Names::GetNamespacedName("", AZStd::string("odom"));
     }
 
     bool ROS2FrameComponent::IsTopLevel() const
@@ -182,7 +182,7 @@ namespace ROS2
 
     AZStd::string ROS2FrameComponent::GetFrameID() const
     {
-        return ROS2Names::GetNamespacedName(GetNamespace(), m_frameName);
+        return ROS2Names::GetNamespacedName("", m_frameName);
     }
 
     void ROS2FrameComponent::SetFrameID(const AZStd::string& frameId)

--- a/Gems/ROS2/Code/Source/Frame/ROS2Transform.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2Transform.cpp
@@ -32,13 +32,13 @@ namespace ROS2
         return t;
     }
 
-    void ROS2Transform::Publish(const AZ::Transform& transform)
+    void ROS2Transform::Publish(const AZ::Transform& transform, std::string ns)
     {
         if (m_isPublished && !m_isDynamic)
         { // Only publish static transforms once
             return;
         }
-        ROS2Interface::Get()->BroadcastTransform(CreateTransformMessage(transform), m_isDynamic);
+        ROS2Interface::Get()->BroadcastTransform(CreateTransformMessage(transform), m_isDynamic, ns);
         m_isPublished = true;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.cpp
@@ -224,11 +224,11 @@ namespace ROS2
 
     void ROS2Lidar2DSensorComponent::Activate()
     {
-        auto ros2Node = ROS2Interface::Get()->GetNode();
+        auto ros2Node = ROS2Interface::Get()->GetNode(GetNamespace().data());
         AZ_Assert(m_sensorConfiguration.m_publishersConfigurations.size() == 1, "Invalid configuration of publishers for lidar sensor");
 
         const TopicConfiguration& publisherConfig = m_sensorConfiguration.m_publishersConfigurations[Internal::kLaserScanType];
-        AZStd::string fullTopic = ROS2Names::GetNamespacedName(GetNamespace(), publisherConfig.m_topic);
+        AZStd::string fullTopic = ROS2Names::GetNamespacedName("", publisherConfig.m_topic);
         m_laserScanPublisher = ros2Node->create_publisher<sensor_msgs::msg::LaserScan>(fullTopic.data(), publisherConfig.GetQoS());
 
         if (m_sensorConfiguration.m_visualise)

--- a/Gems/ROS2/Code/Source/Odometry/ROS2OdometrySensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Odometry/ROS2OdometrySensorComponent.cpp
@@ -96,9 +96,9 @@ namespace ROS2
     void ROS2OdometrySensorComponent::Activate()
     {
         // "odom" is globally fixed frame for all robots, no matter the namespace
-        m_odometryMsg.header.frame_id = ROS2Names::GetNamespacedName(GetNamespace(), "odom").c_str();
+        m_odometryMsg.header.frame_id = ROS2Names::GetNamespacedName("", "odom").c_str();
         m_odometryMsg.child_frame_id = GetFrameID().c_str();
-        auto ros2Node = ROS2Interface::Get()->GetNode();
+        auto ros2Node = ROS2Interface::Get()->GetNode(GetNamespace().data());
         AZ_Assert(m_sensorConfiguration.m_publishersConfigurations.size() == 1, "Invalid configuration of publishers for Odometry sensor");
 
         const auto publisherConfig = m_sensorConfiguration.m_publishersConfigurations[Internal::kOdometryMsgType];

--- a/Gems/ROS2/Code/Source/ROS2SystemComponent.h
+++ b/Gems/ROS2/Code/Source/ROS2SystemComponent.h
@@ -60,9 +60,9 @@ namespace ROS2
 
         //////////////////////////////////////////////////////////////////////////
         // ROS2RequestBus::Handler overrides
-        std::shared_ptr<rclcpp::Node> GetNode() const override;
+        std::shared_ptr<rclcpp::Node> GetNode(std::string ns) const override;
         builtin_interfaces::msg::Time GetROSTimestamp() const override;
-        void BroadcastTransform(const geometry_msgs::msg::TransformStamped& t, bool isDynamic) const override;
+        void BroadcastTransform(const geometry_msgs::msg::TransformStamped& t, bool isDynamic, std::string ns) const override;
         const SimulationClock& GetSimulationClock() const override;
         //////////////////////////////////////////////////////////////////////////
 
@@ -79,10 +79,12 @@ namespace ROS2
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
         ////////////////////////////////////////////////////////////////////////
     private:
-        std::shared_ptr<rclcpp::Node> m_ros2Node;
+        std::map<std::string, std::shared_ptr<rclcpp::Node>> m_ros2Nodes;
         AZStd::shared_ptr<rclcpp::executors::SingleThreadedExecutor> m_executor;
-        AZStd::unique_ptr<tf2_ros::TransformBroadcaster> m_dynamicTFBroadcaster;
-        AZStd::unique_ptr<tf2_ros::StaticTransformBroadcaster> m_staticTFBroadcaster;
+
+        std::map<std::string, AZStd::unique_ptr<tf2_ros::TransformBroadcaster>> m_dynamicTFBroadcasters;
+        std::map<std::string, AZStd::unique_ptr<tf2_ros::StaticTransformBroadcaster>> m_staticTFBroadcasters;
+
         AZStd::unique_ptr<SimulationClock> m_simulationClock;
         //! Load the pass templates of the ROS2 gem.
         void LoadPassTemplateMappings();

--- a/Gems/RosRobotSample/Assets/ROSbot.prefab
+++ b/Gems/RosRobotSample/Assets/ROSbot.prefab
@@ -287,7 +287,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{D5BE771A-53A9-534E-8DCC-A91D6127540D}"
-                                            }
+                                            },
+                                            "assetHint": "robot/rosbot_xl_description/meshes/materials/antenna_plastic_-_matte_black_.azmaterial"
                                         }
                                     }
                                 }
@@ -335,7 +336,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{D5BE771A-53A9-534E-8DCC-A91D6127540D}"
-                                            }
+                                            },
+                                            "assetHint": "robot/rosbot_xl_description/meshes/materials/antenna_plastic_-_matte_black_.azmaterial"
                                         }
                                     }
                                 }
@@ -1360,7 +1362,8 @@
                     "m_template": {
                         "$type": "ROS2FrameComponent",
                         "Namespace Configuration": {
-                            "Namespace Strategy": 1
+                            "Namespace Strategy": 3,
+                            "Namespace": "robot1"
                         },
                         "Frame Name": "body_link"
                     }
@@ -2042,8 +2045,7 @@
                     "Id": 16056351394850261418,
                     "Controller": {
                         "Configuration": {
-                            "Field of View": 60.0,
-                            "EditorEntityId": 15598184734561212878
+                            "Field of View": 60.0
                         }
                     }
                 },


### PR DESCRIPTION
This PR is PoC for changing the way namespaces are handled in TF frames. It is expected by Nav2 package that tf namespace is handled via the topic name, rather than inside the `frame_id` value. 

It contains lot of hard-coded developer code which needs to be resolved. Implementation details:

- each robot has its own ROS 2 node with a namespace (hard-coded two extra nodes with namespaces for testing: `robot1` and `robot2`), there is a default node for o3de
- node references are kept in a map container
- global tf frames are remapped to relative (removed the prepending `/`) to utilize the rosnode namespaces,
- similarly to ros nodes, each robot has its own static and dynamic tf broadcaster
- sensors tf frames updated (control and lidar)