### PR TITLE
Add pass template mapping handler initialization

### DIFF
--- a/Gems/ROS2/Code/Source/ROS2EditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/ROS2EditorSystemComponent.cpp
@@ -49,6 +49,7 @@ namespace ROS2
     void ROS2EditorSystemComponent::Activate()
     {
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
+        ROS2SystemComponent::InitPassTemplateMappingsHandler();
     }
 
     void ROS2EditorSystemComponent::Deactivate()

--- a/Gems/ROS2/Code/Source/ROS2SystemComponent.h
+++ b/Gems/ROS2/Code/Source/ROS2SystemComponent.h
@@ -66,6 +66,8 @@ namespace ROS2
         const SimulationClock& GetSimulationClock() const override;
         //////////////////////////////////////////////////////////////////////////
 
+        void InitPassTemplateMappingsHandler();
+
     protected:
         ////////////////////////////////////////////////////////////////////////
         // AZ::Component override


### PR DESCRIPTION
I've added a separate function that initializes the ```LoadPassTemplateMappings```. This fixes #415. There is also a check added for the application type to differently run the initialization function depending if the Game Launcher is used or the Editor.