### PR TITLE
Adding the sdformat13 3rdParty library as a dependency the `ROS2.Editor.Static` TARGET

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 
 # Add a custom target to always check during build if sourced and cached distributions match.
 add_custom_target(
-    ROS2DistributionCheck ALL 
+    ROS2DistributionCheck ALL
     COMMENT "Checking if sourced ROS 2 distribution matches with the configuration"
     COMMAND ${CMAKE_COMMAND} -DROS_DISTRO=${ROS_DISTRO} -P ${CMAKE_CURRENT_SOURCE_DIR}/checkROS2Distribution.cmake
 )
@@ -136,7 +136,8 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::${gem_name}.Static
             PRIVATE
                 AZ::AssetBuilderSDK
-        )
+                3rdParty::sdformat
+    )
 
     find_package(urdfdom)
     target_link_libraries(${gem_name}.Editor.Static PUBLIC urdfdom::urdfdom_model)

--- a/Gems/ROS2/Code/Platform/Linux/PAL_linux.cmake
+++ b/Gems/ROS2/Code/Platform/Linux/PAL_linux.cmake
@@ -7,3 +7,13 @@
 #
 
 set(PAL_TRAIT_BUILD_ROS2_GEM_SUPPORTED TRUE)
+
+if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+    ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev0-linux
+        TARGETS sdformat
+        PACKAGE_HASH 407a335c1fefc134e89b2dc2d1ffd6a47ea33546e77df4aaabf3edf8b3402ecb)
+elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+    ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev0-linux-aarch64
+        TARGETS sdformat
+        PACKAGE_HASH a23977b262d6d80a5e1b22c24db27d25fe827c982296766c0f04ebf77ad0a217)
+endif()

--- a/Gems/ROS2/Code/Platform/Linux/PAL_linux.cmake
+++ b/Gems/ROS2/Code/Platform/Linux/PAL_linux.cmake
@@ -11,9 +11,9 @@ set(PAL_TRAIT_BUILD_ROS2_GEM_SUPPORTED TRUE)
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev0-linux
         TARGETS sdformat
-        PACKAGE_HASH 4a2ae3ababc253e080440696b42930bf18cb350e3e0d1733e00204894602bc7f)
+        PACKAGE_HASH 6bd52db178a5bfed12555db2a9710bb4f20baab73f0d7374c6c70b6568a3ba3f)
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
     ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev0-linux-aarch64
         TARGETS sdformat
-        PACKAGE_HASH 5411d678bd5143fc4972d53fc0a8858aa8d05b5a83459c88827637dbe7afc230)
+        PACKAGE_HASH f422699e67a92a787536c2f037f5f0e0904d82f88e66f2a1b856409aec67b0fe)
 endif()

--- a/Gems/ROS2/Code/Platform/Linux/PAL_linux.cmake
+++ b/Gems/ROS2/Code/Platform/Linux/PAL_linux.cmake
@@ -11,9 +11,9 @@ set(PAL_TRAIT_BUILD_ROS2_GEM_SUPPORTED TRUE)
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev0-linux
         TARGETS sdformat
-        PACKAGE_HASH 407a335c1fefc134e89b2dc2d1ffd6a47ea33546e77df4aaabf3edf8b3402ecb)
+        PACKAGE_HASH fd7f34bf9e9d20320ff29ae74ea0fce8b9f7688dd3c1dbd4b4b8a68d31b7d2ee)
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
     ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev0-linux-aarch64
         TARGETS sdformat
-        PACKAGE_HASH a23977b262d6d80a5e1b22c24db27d25fe827c982296766c0f04ebf77ad0a217)
+        PACKAGE_HASH ca0fedaa00d82f6b211a2ed94101f2dafb11fa2732c3955443db78325abda2a6)
 endif()

--- a/Gems/ROS2/Code/Platform/Linux/PAL_linux.cmake
+++ b/Gems/ROS2/Code/Platform/Linux/PAL_linux.cmake
@@ -11,9 +11,9 @@ set(PAL_TRAIT_BUILD_ROS2_GEM_SUPPORTED TRUE)
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev0-linux
         TARGETS sdformat
-        PACKAGE_HASH fd7f34bf9e9d20320ff29ae74ea0fce8b9f7688dd3c1dbd4b4b8a68d31b7d2ee)
+        PACKAGE_HASH 4a2ae3ababc253e080440696b42930bf18cb350e3e0d1733e00204894602bc7f)
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
     ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev0-linux-aarch64
         TARGETS sdformat
-        PACKAGE_HASH ca0fedaa00d82f6b211a2ed94101f2dafb11fa2732c3955443db78325abda2a6)
+        PACKAGE_HASH 5411d678bd5143fc4972d53fc0a8858aa8d05b5a83459c88827637dbe7afc230)
 endif()


### PR DESCRIPTION

An `ly_associate_package` call has been added to allow the sdformat13 3rdParty library to be downloaded during CMake configure when building on Linux.

Both a x86_64 and Aarch64 package has been built.

NOTE: These packages have not been uploaded to the O3DE 3rdParty package repo and therefore this change cannot go in until then.

It is posted for review to streamline the process when the package is approved to be uploaded.