### PR TITLE
Fixed directory name creation in URDF Importer

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -182,7 +182,7 @@ namespace ROS2
             auto collidersNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), false, true);
             auto visualNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), true, false);
 
-            AZStd::string dirSuffix = "";
+            AZ::Uuid::FixedString dirSuffix;
             if (!m_params.empty())
             {
                 auto paramsUuid = AZ::Uuid::CreateNull();
@@ -192,7 +192,7 @@ namespace ROS2
                     paramsUuid += AZ::Uuid::CreateName(value);
                 }
 
-                dirSuffix = paramsUuid.ToString<AZStd::string_view>();
+                dirSuffix = paramsUuid.ToFixedString();
             }
 
             if (m_importAssetWithUrdf)

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -182,7 +182,7 @@ namespace ROS2
             auto collidersNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), false, true);
             auto visualNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), true, false);
 
-            AZStd::string_view dirSuffix = "";
+            AZStd::string dirSuffix = "";
             if (!m_params.empty())
             {
                 auto paramsUuid = AZ::Uuid::CreateNull();


### PR DESCRIPTION
https://github.com/o3de/o3de-extras/pull/394 resolved https://github.com/o3de/o3de-extras/issues/392 by introducing `dirSuffix` - additional directory path part, that was added in order to make it unique. 

In https://github.com/o3de/o3de-extras/pull/394 `dirSuffix` is an  `AZStd::string_view` created from `paramsUuid.ToString<AZStd::string_view>()`, which is an error, as the string is a temporary value. 
This PR changes it to be a `AZStd::string` instead, so that it's value lives for the duration of call to `CopyAssetForURDFAndCreateAssetMap`.
