### PR TITLE
[URDF] Functioning asset builder

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -160,6 +160,8 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PUBLIC
                 Gem::${gem_name}.Editor.Static
                 Gem::Atom_Feature_Common.Static
+            PRIVATE
+                AZ::AzToolsFramework
     )
 
     # By default, we will specify that the above target ROS2 would be used by

--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -161,8 +161,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PUBLIC
                 Gem::${gem_name}.Editor.Static
                 Gem::Atom_Feature_Common.Static
-            PRIVATE
-                AZ::AzToolsFramework
     )
 
     # By default, we will specify that the above target ROS2 would be used by

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
@@ -168,7 +168,7 @@ namespace ROS2
         return m_assetsUuids.empty();
     }
 
-    void CheckAssetPage::DoubleClickRow(int row, int col)
+    void CheckAssetPage::DoubleClickRow(int row, [[maybe_unused]] int col)
     {
         AZ_Printf("CheckAssetPage", "Clicked on row", row);
         if (row < m_assetsPaths.size())

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
@@ -57,12 +57,10 @@ namespace ROS2
         {
             m_wheelMaterial =
                 AZ::Data::Asset<Physics::MaterialAsset>(assetId, Physics::MaterialAsset::TYPEINFO_Uuid(), physicsMaterialAssetRelPath);
-            AZ_TracePrintf(Internal::CollidersMakerLoggingTag, "Waiting for asset load\n");
-            m_wheelMaterial.BlockUntilLoadComplete();
         }
         else
         {
-            AZ_Warning(Internal::CollidersMakerLoggingTag, false, "Cannot load wheel material");
+            AZ_Warning(Internal::CollidersMakerLoggingTag, false, "Cannot locate wheel material asset");
         }
     }
 
@@ -287,7 +285,6 @@ namespace ROS2
             {
                 AZ_Error(
                     Internal::CollidersMakerLoggingTag, false, "Could not find pxmodel for %s", asset->m_sourceAssetGlobalPath.c_str());
-                entity->Deactivate();
                 return;
             }
             AZ_Printf(Internal::CollidersMakerLoggingTag, "pxmodelPath  %s\n", pxmodelPath.c_str());
@@ -361,7 +358,7 @@ namespace ROS2
                 }
                 else
                 {
-                    AZ_Warning(Internal::CollidersMakerLoggingTag, false, "The entity was no activated %s", entity->GetName().c_str());
+                    AZ_Warning(Internal::CollidersMakerLoggingTag, false, "The entity was not activated %s", entity->GetName().c_str());
                 }
             }
             break;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
@@ -37,7 +37,6 @@ namespace ROS2
     CollidersMaker::CollidersMaker(const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping)
         : m_urdfAssetsMapping(urdfAssetsMapping)
     {
-        FindWheelMaterial();
     }
 
     void CollidersMaker::FindWheelMaterial()
@@ -215,6 +214,10 @@ namespace ROS2
         if (isWheelEntity)
         {
             AZ_Printf(Internal::CollidersMakerLoggingTag, "Due to its name, %s is considered a wheel entity\n", link->name.c_str());
+            if (!m_wheelMaterial.GetId().IsValid())
+            {
+                FindWheelMaterial();
+            }
         }
         const AZ::Data::Asset<Physics::MaterialAsset> materialAsset =
             isWheelEntity ? m_wheelMaterial : AZ::Data::Asset<Physics::MaterialAsset>();

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/PrefabMakerUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/PrefabMakerUtils.cpp
@@ -76,6 +76,8 @@ namespace ROS2::PrefabMakerUtils
             return AZ::Failure(AZStd::string("Invalid id for created entity"));
         }
 
+        AZ_Info("CreateEntity", "Processing entity id: %s with name: %s\n", entityId.ToString().c_str(), name.c_str());
+        
         // If the parent is invalid, parent to the container of the currently focused prefab if one exists.
         if (!parentEntityId.IsValid())
         {

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/PrefabMakerUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/PrefabMakerUtils.h
@@ -34,12 +34,17 @@ namespace ROS2::PrefabMakerUtils
     //! @param entityId entity which will be modified.
     void SetEntityTransformLocal(const urdf::Pose& origin, AZ::EntityId entityId);
 
-    //! Create a prefab entity in hierarchy.
+    //! Create a prefab entity in a hierarchy. The new entity will not yet be active.
     //! @param parentEntityId id of parent entity for this new entity.
     //! Passing an invalid id would get the entity in the current context (for example, an entity which is currently open in the Editor).
     //! @param name name for the new entity.
     //! @return a result which is either a created prefab entity or an error.
     AzToolsFramework::Prefab::PrefabEntityResult CreateEntity(AZ::EntityId parentEntityId, const AZStd::string& name);
+
+    //! Set the parent entity for an entity. The entity getting parent is expected to be inactive.
+    //! @param entityId the id for entity that needs a parent.
+    //! @param parentEntityId the id for the parent entity.
+    void SetEntityParent(AZ::EntityId entityId, AZ::EntityId parentEntityId);
 
     //! Create an entity name from arguments.
     //! @param rootName root of entity's name.

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -58,7 +58,7 @@ namespace ROS2
         }
     }
 
-    AZ::Outcome<AzToolsFramework::Prefab::TemplateId, AZStd::string> URDFPrefabMaker::CreatePrefabTemplateFromURDF()
+    URDFPrefabMaker::CreatePrefabResult URDFPrefabMaker::CreatePrefabTemplateFromURDF()
     {
         {
             AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
@@ -257,7 +257,7 @@ namespace ROS2
         return AZ::Success(prefabTemplateId);
     }
 
-    AZ::Outcome<AzToolsFramework::Prefab::TemplateId, AZStd::string> URDFPrefabMaker::CreatePrefabFromURDF()
+    URDFPrefabMaker::CreatePrefabResult URDFPrefabMaker::CreatePrefabFromURDF()
     {
         // Begin an undo batch for prefab creation process
         AzToolsFramework::UndoSystem::URSequencePoint* currentUndoBatch = nullptr;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -58,7 +58,7 @@ namespace ROS2
         }
     }
 
-    URDFPrefabMaker::CreatePrefabResult URDFPrefabMaker::CreatePrefabTemplateFromURDF()
+    URDFPrefabMaker::CreatePrefabTemplateResult URDFPrefabMaker::CreatePrefabTemplateFromURDF()
     {
         {
             AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
@@ -257,7 +257,7 @@ namespace ROS2
         return AZ::Success(prefabTemplateId);
     }
 
-    URDFPrefabMaker::CreatePrefabResult URDFPrefabMaker::CreatePrefabFromURDF()
+    URDFPrefabMaker::CreatePrefabTemplateResult URDFPrefabMaker::CreatePrefabFromURDF()
     {
         // Begin an undo batch for prefab creation process
         AzToolsFramework::UndoSystem::URSequencePoint* currentUndoBatch = nullptr;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -19,6 +19,7 @@
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzCore/std/string/string.h>
+#include <AzToolsFramework/Prefab/PrefabIdTypes.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <RobotImporter/Utils/SourceAssetsStorage.h>
 
@@ -45,12 +46,11 @@ namespace ROS2
 
         //! Create and return a prefab corresponding to the URDF model as set through the constructor.
         //! @return result which is either the root prefab entity containing the imported model based on URDF or an error.
-        AzToolsFramework::Prefab::CreatePrefabResult CreatePrefabFromURDF();
+        AZ::Outcome<AzToolsFramework::Prefab::TemplateId, AZStd::string> CreatePrefabFromURDF();
 
-        //! Create and return a prefab JSON string corresponding to the URDF model set in the constructor.
-        //! @param outputPrefab The string to put the output prefab into.
-        //! @return result which is either the root prefab entity containing the imported model based on URDF or an error.
-        AzToolsFramework::Prefab::CreatePrefabResult CreatePrefabStringFromURDF(AZStd::string& outputPrefab);
+        //! Create and return a prefab template ID corresponding to the URDF model set in the constructor.
+        //! @return result which is either the prefab template id or an error message.
+        AZ::Outcome<AzToolsFramework::Prefab::TemplateId, AZStd::string> CreatePrefabTemplateFromURDF();
 
         //! Get path to the prefab resulting from the import.
         //! @return path to the prefab.

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -47,13 +47,17 @@ namespace ROS2
 
         ~URDFPrefabMaker() = default;
 
+        //! On prefab creation this will contain a prefab template id when successful,
+        //! and an error string on failure.
+        using CreatePrefabResult = AZ::Outcome<AzToolsFramework::Prefab::TemplateId, AZStd::string>;
+
         //! Create and return a prefab corresponding to the URDF model as set through the constructor.
         //! @return result which is either the root prefab entity containing the imported model based on URDF or an error.
-        AZ::Outcome<AzToolsFramework::Prefab::TemplateId, AZStd::string> CreatePrefabFromURDF();
+        CreatePrefabResult CreatePrefabFromURDF();
 
         //! Create and return a prefab template ID corresponding to the URDF model set in the constructor.
         //! @return result which is either the prefab template id or an error message.
-        AZ::Outcome<AzToolsFramework::Prefab::TemplateId, AZStd::string> CreatePrefabTemplateFromURDF();
+        CreatePrefabResult CreatePrefabTemplateFromURDF();
 
         //! Get path to the prefab resulting from the import.
         //! @return path to the prefab.

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -44,8 +44,13 @@ namespace ROS2
         ~URDFPrefabMaker() = default;
 
         //! Create and return a prefab corresponding to the URDF model as set through the constructor.
-        //! @return result which is either a prefab containing the imported model based on URDF or an error.
+        //! @return result which is either the root prefab entity containing the imported model based on URDF or an error.
         AzToolsFramework::Prefab::CreatePrefabResult CreatePrefabFromURDF();
+
+        //! Create and return a prefab JSON string corresponding to the URDF model set in the constructor.
+        //! @param outputPrefab The string to put the output prefab into.
+        //! @return result which is either the root prefab entity containing the imported model based on URDF or an error.
+        AzToolsFramework::Prefab::CreatePrefabResult CreatePrefabStringFromURDF(AZStd::string& outputPrefab);
 
         //! Get path to the prefab resulting from the import.
         //! @return path to the prefab.
@@ -56,7 +61,7 @@ namespace ROS2
         AZStd::string GetStatus();
 
     private:
-        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(urdf::LinkSharedPtr link, AZ::EntityId parentEntityId);
+        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(urdf::LinkSharedPtr link, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities);
         void BuildAssetsForLink(urdf::LinkSharedPtr link);
         void AddRobotControl(AZ::EntityId rootEntityId);
         static void MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId);

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -49,15 +49,16 @@ namespace ROS2
 
         //! On prefab creation this will contain a prefab template id when successful,
         //! and an error string on failure.
-        using CreatePrefabResult = AZ::Outcome<AzToolsFramework::Prefab::TemplateId, AZStd::string>;
+        using CreatePrefabTemplateResult = AZ::Outcome<AzToolsFramework::Prefab::TemplateId, AZStd::string>;
 
-        //! Create and return a prefab corresponding to the URDF model as set through the constructor.
-        //! @return result which is either the root prefab entity containing the imported model based on URDF or an error.
-        CreatePrefabResult CreatePrefabFromURDF();
+        //! Create and return a prefab template corresponding to the URDF model as set through the constructor.
+        //! This will also instantiate the prefab template into the level.
+        //! @return result which is either the prefab template id containing the imported model or an error message.
+        CreatePrefabTemplateResult CreatePrefabFromURDF();
 
-        //! Create and return a prefab template ID corresponding to the URDF model set in the constructor.
+        //! Create and return a prefab template id corresponding to the URDF model set in the constructor.
         //! @return result which is either the prefab template id or an error message.
-        CreatePrefabResult CreatePrefabTemplateFromURDF();
+        CreatePrefabTemplateResult CreatePrefabTemplateFromURDF();
 
         //! Get path to the prefab resulting from the import.
         //! @return path to the prefab.

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.h
@@ -29,10 +29,11 @@ namespace ROS2
         //! Note that a sub-entity will be added to hold each visual (since they can have different transforms).
         //! @param link A parsed URDF tree link node which could hold information about visuals.
         //! @param entityId A non-active entity which will be affected.
-        void AddVisuals(urdf::LinkSharedPtr link, AZ::EntityId entityId) const;
+        //! @return List containing any entities created.
+        AZStd::vector<AZ::EntityId> AddVisuals(urdf::LinkSharedPtr link, AZ::EntityId entityId) const;
 
     private:
-        void AddVisual(urdf::VisualSharedPtr visual, AZ::EntityId entityId, const AZStd::string& generatedName) const;
+        AZ::EntityId AddVisual(urdf::VisualSharedPtr visual, AZ::EntityId entityId, const AZStd::string& generatedName) const;
         void AddVisualToEntity(urdf::VisualSharedPtr visual, AZ::EntityId entityId) const;
         void AddMaterialForVisual(urdf::VisualSharedPtr visual, AZ::EntityId entityId) const;
 

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -170,6 +170,7 @@ namespace ROS2::Utils
         if (!assetDatabaseConnection.OpenDatabase())
         {
             AZ_Warning("GetInterestingSourceAssetsCRC", false, "Cannot open database");
+            return {};
         }
         auto callback = [&availableAssets](AzToolsFramework::AssetDatabase::SourceDatabaseEntry& entry)
         {

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -363,16 +363,19 @@ namespace ROS2::Utils
             urdfToAsset.emplace(t, AZStd::move(asset));
         }
 
-        AZStd::unordered_map<AZ::Crc32, AvailableAsset> availableAssets = Utils::GetInterestingSourceAssetsCRC();
-
-        // Search for suitable mappings by comparing checksum
-        for (auto it = urdfToAsset.begin(); it != urdfToAsset.end(); it++)
+        if (!urdfToAsset.empty())
         {
-            Utils::UrdfAsset& asset = it->second;
-            auto found_source_asset = availableAssets.find(asset.m_urdfFileCRC);
-            if (found_source_asset != availableAssets.end())
+            AZStd::unordered_map<AZ::Crc32, AvailableAsset> availableAssets = Utils::GetInterestingSourceAssetsCRC();
+
+            // Search for suitable mappings by comparing checksum
+            for (auto it = urdfToAsset.begin(); it != urdfToAsset.end(); it++)
             {
-                asset.m_availableAssetInfo = found_source_asset->second;
+                Utils::UrdfAsset& asset = it->second;
+                auto found_source_asset = availableAssets.find(asset.m_urdfFileCRC);
+                if (found_source_asset != availableAssets.end())
+                {
+                    asset.m_availableAssetInfo = found_source_asset->second;
+                }
             }
         }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -131,7 +131,7 @@ namespace ROS2::Utils
         AssetSysReqBus::BroadcastResult(ok, &AssetSysReqBus::Events::GetAssetsProducedBySourceUUID, sourceAssetUUID, productsAssetInfo);
         if (ok)
         {
-            for (auto& product : productsAssetInfo)
+            for (const auto& product : productsAssetInfo)
             {
                 if (product.m_assetType == typeId)
                 {

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -46,6 +46,7 @@ namespace ROS2::Utils
     {
         struct Visitor : AZ::SettingsRegistryInterface::Visitor
         {
+            using AZ::SettingsRegistryInterface::Visitor::Visit;
             void Visit(const AZ::SettingsRegistryInterface::VisitArgs&, AZStd::string_view value) override
             {
                 m_supportedFileExtensions.emplace_back(value);

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -123,6 +123,35 @@ namespace ROS2::Utils
         return GetProductAsset(sourceAssetUUID, AZ::TypeId("{7A2871B9-5EAB-4DE0-A901-B0D2C6920DDB}")); // PhysX::Pipeline::MeshAsset
     }
 
+    AZ::Data::AssetId GetProductAssetId(const AZ::Uuid& sourceAssetUUID, const AZ::TypeId typeId)
+    {
+        AZStd::vector<AZ::Data::AssetInfo> productsAssetInfo;
+        using AssetSysReqBus = AzToolsFramework::AssetSystemRequestBus;
+        bool ok{ false };
+        AssetSysReqBus::BroadcastResult(ok, &AssetSysReqBus::Events::GetAssetsProducedBySourceUUID, sourceAssetUUID, productsAssetInfo);
+        if (ok)
+        {
+            for (auto& product : productsAssetInfo)
+            {
+                if (product.m_assetType == typeId)
+                {
+                    return product.m_assetId;
+                }
+            }
+        }
+        return {};
+    }
+
+    AZ::Data::AssetId GetModelProductAssetId(const AZ::Uuid& sourceAssetUUID)
+    {
+        return GetProductAssetId(sourceAssetUUID, AZ::TypeId("{2C7477B6-69C5-45BE-8163-BCD6A275B6D8}")); // AZ::RPI::ModelAsset;
+    }
+
+    AZ::Data::AssetId GetPhysXMeshProductAssetId(const AZ::Uuid& sourceAssetUUID)
+    {
+        return GetProductAssetId(sourceAssetUUID, AZ::TypeId("{7A2871B9-5EAB-4DE0-A901-B0D2C6920DDB}")); // PhysX::Pipeline::MeshAsset
+    }
+
     AvailableAsset GetAvailableAssetInfo(const AZStd::string& globalSourceAssetPath)
     {
         using AssetSysReqBus = AzToolsFramework::AssetSystemRequestBus;

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -91,6 +91,22 @@ namespace ROS2::Utils
     //! @returns relative path to product, empty string if product is not found
     AZStd::string GetPhysXMeshProductAsset(const AZ::Uuid& sourceAssetUUID);
 
+    //! Helper function that gives the desired product asset ID from source asset GUID
+    //! @param sourceAssetUUID is source asset GUID
+    //! @param typeId type of product asset
+    //! @returns product asset id (invalid id if not found)
+    AZ::Data::AssetId GetProductAssetId(const AZ::Uuid& sourceAssetUUID, const AZ::TypeId typeId);
+
+    //! Helper function that gives AZ::RPI::ModelAsset product asset from source asset GUID
+    //! @param sourceAssetUUID is source asset GUID
+    //! @returns product asset id (invalid id if not found)
+    AZ::Data::AssetId GetModelProductAssetId(const AZ::Uuid& sourceAssetUUID);
+
+    //! Helper function that gives PhysX::Pipeline::MeshAsset product asset from source asset GUID
+    //! @param sourceAssetUUID is source asset GUID
+    //! @returns product asset id (invalid id if not found)
+    AZ::Data::AssetId GetPhysXMeshProductAssetId(const AZ::Uuid& sourceAssetUUID);
+
     //! Creates side-car file (.assetinfo) that configures the imported scene (eg DAE file).
     //! The .assetinfo will be create next to scene's file.
     //! @param sourceAssetPath - global path to source asset

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
@@ -261,7 +261,7 @@ namespace ROS2
         AZ_Info(SdfAssetBuilderName, "Finding asset IDs for all mesh and collider assets.");
         auto assetMap = AZStd::make_shared<Utils::UrdfAssetMap>(FindAssets(parsedSourceFile->getRoot(), request.m_fullPath));
 
-        // Given the prased SDF
+        // Given the parsed source file and asset mappings, generate an in-memory prefab.
         AZ_Info(SdfAssetBuilderName, "Creating prefab from source file.");
         auto prefabMaker = AZStd::make_unique<URDFPrefabMaker>(
             request.m_fullPath, parsedSourceFile, tempAssetOutputPath.String(), assetMap, useArticulation);

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
@@ -38,9 +38,5 @@ namespace ROS2
     private:
         AZStd::vector<AssetBuilderSDK::AssetBuilderPattern> GetSupportedBuilderPatterns();
         Utils::UrdfAssetMap FindAssets(const urdf::LinkConstSharedPtr& rootLink, const AZStd::string& sourceFilename) const;
-
-        AZStd::string CreateDefaultProcPrefab(
-            const AssetBuilderSDK::ProcessJobRequest& request,
-            AssetBuilderSDK::ProcessJobResponse& response) const;
     };
 } // ROS2

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
@@ -11,6 +11,7 @@
 #include <AssetBuilderSDK/AssetBuilderBusses.h>
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 
+#include <URDF/UrdfParser.h>
 #include <Utils/SourceAssetsStorage.h>
 
 namespace ROS2
@@ -36,7 +37,7 @@ namespace ROS2
         void ShutDown() override { }
     private:
         AZStd::vector<AssetBuilderSDK::AssetBuilderPattern> GetSupportedBuilderPatterns();
-        Utils::UrdfAssetMap FindAssets([[maybe_unused]] const AZStd::unordered_set<AZStd::string>& meshesFilenames, [[maybe_unused]] const AZStd::string& urdfFilename) const;
+        Utils::UrdfAssetMap FindAssets(const urdf::LinkConstSharedPtr& rootLink, const AZStd::string& sourceFilename) const;
 
         AZStd::string CreateDefaultProcPrefab(
             const AssetBuilderSDK::ProcessJobRequest& request,

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
@@ -11,6 +11,8 @@
 #include <AssetBuilderSDK/AssetBuilderBusses.h>
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 
+#include <Utils/SourceAssetsStorage.h>
+
 namespace ROS2
 {
     //! Builder to convert the following file types into procedural prefab assets:
@@ -34,6 +36,7 @@ namespace ROS2
         void ShutDown() override { }
     private:
         AZStd::vector<AssetBuilderSDK::AssetBuilderPattern> GetSupportedBuilderPatterns();
+        Utils::UrdfAssetMap FindAssets([[maybe_unused]] const AZStd::unordered_set<AZStd::string>& meshesFilenames, [[maybe_unused]] const AZStd::string& urdfFilename) const;
 
         AZStd::string CreateDefaultProcPrefab(
             const AssetBuilderSDK::ProcessJobRequest& request,


### PR DESCRIPTION
This PR modifies the SDFAssetBuilder to produce functional procedural prefabs for URDF model files. It works by calling into the RobotImporter code and saving the result as a procedural prefab in the Cache directory instead of a regular prefab in a source asset directory. 

Features:
* Parses the URDF and generates the procprefab using the same logic as the RobotImporter.
* Creates AP job dependencies on every referenced asset to guarantee the procprefab can be generated and used without race conditions.

To make the code shareable between the Editor RobotImporter and the Asset Builder, some pieces of functionality needed to be refactored slightly, since the Asset Builder has less services available to it. In particular, the code now generates the hierarchy of entities _before_ creating the prefab template out of it, instead of using the prefab system to build up the entity hierarchy inside a prefab incrementally. Also, the importer code currently uses a pattern of entity activate / change component config / entity deactivate for setting up the components. Pieces of this are starting to migrate towards setting up component configurations without requiring entity activation. This will be more efficient overall, and reduce the reliance even further on runtime services (like Atom Feature Processors), but will likely require some changes to core o3de gems and components to expose component configurations a littler further first.

Some notes about the changes:
* The wheel physicsmaterial asset is no longer loaded during import, just referenced. The import didn't _require_ it to be loaded, it just required the asset reference to get hooked up correctly in the component. This needed to be changed since the asset builder can't support blocking asset loads.
* All of the entities getting created by the importer are now getting explicitly tracked in a flat list. The importer used to _implicitly_ track them by setting them to selected on creation and letting the prefab code build a prefab of all selected entities. Since the asset builder doesn't have a concept of selected entities, we needed to move to a more explicit tracking model.
* The method for finding and resolving external asset references is starting to branch somewhat between the RobotImporter and the SDFAssetBuilder. The asset builder will evolve towards a simplified model that tries to resolve relative paths and either succeeds or fails. The RobotImporter code uses environment variables and more heuristics. Eventually, if the simplified model is proven effective, the more complex lookups in the RobotImporter code could be removed.

Example video demonstrating use:

https://github.com/o3de/o3de-extras/assets/82224783/5c3dafbd-5c66-479c-b1c3-c8ea3de196d8

