### PR TITLE
add SDFormat sensor importer hooks

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -111,20 +111,6 @@ ly_create_alias(NAME ${gem_name}.Unified NAMESPACE Gem TARGETS Gem::${gem_name})
 # will also depend on ${gem_name}.Static
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
-        NAME ${gem_name}.Editor.API INTERFACE
-        NAMESPACE Gem
-        FILES_CMAKE
-            ros2_editor_api_files.cmake
-        INCLUDE_DIRECTORIES
-            INTERFACE
-                Include
-        BUILD_DEPENDENCIES
-            INTERFACE
-                AZ::AzToolsFramework
-                3rdParty::sdformat
-    )
-
-    ly_add_target(
         NAME ${gem_name}.Editor.Static STATIC
         NAMESPACE Gem
         AUTOMOC

--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -68,7 +68,6 @@ ly_add_target(
             Gem::StartingPointInput
             Gem::PhysX.Static
             Gem::LmbrCentral.API
-            3rdParty::sdformat
 )
 
 target_depends_on_ros2_packages(${gem_name}.Static rclcpp builtin_interfaces std_msgs sensor_msgs nav_msgs tf2_ros ackermann_msgs gazebo_msgs)
@@ -111,6 +110,20 @@ ly_create_alias(NAME ${gem_name}.Unified NAMESPACE Gem TARGETS Gem::${gem_name})
 # If we are on a host platform, we want to add the host tools targets like the ${gem_name}.Editor target which
 # will also depend on ${gem_name}.Static
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
+    ly_add_target(
+        NAME ${gem_name}.Editor.API INTERFACE
+        NAMESPACE Gem
+        FILES_CMAKE
+            ros2_editor_api_files.cmake
+        INCLUDE_DIRECTORIES
+            INTERFACE
+                Include
+        BUILD_DEPENDENCIES
+            INTERFACE
+                AZ::AzToolsFramework
+                3rdParty::sdformat
+    )
+
     ly_add_target(
         NAME ${gem_name}.Editor.Static STATIC
         NAMESPACE Gem
@@ -219,6 +232,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                     PRIVATE
                         AZ::AzTest
                         Gem::${gem_name}.Editor
+                        3rdParty::sdformat
             )
 
             # Add ROS2.Editor.Tests to googletest

--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -68,6 +68,7 @@ ly_add_target(
             Gem::StartingPointInput
             Gem::PhysX.Static
             Gem::LmbrCentral.API
+            3rdParty::sdformat
 )
 
 target_depends_on_ros2_packages(${gem_name}.Static rclcpp builtin_interfaces std_msgs sensor_msgs nav_msgs tf2_ros ackermann_msgs gazebo_msgs)
@@ -165,8 +166,8 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     )
 
     # By default, we will specify that the above target ROS2 would be used by
-    # Tool and Builder type targets when this gem is enabled.  If you don't want it
-    # active in Tools or Builders by default, delete one of both of the following lines:
+    # Tool and Builder type targets when this gem is enabled. If you don't want it
+    # active in Tools or Builders by default, delete one or both of the following lines:
     ly_create_alias(NAME ${gem_name}.Tools    NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
     ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
 endif()

--- a/Gems/ROS2/Code/Include/ROS2/RobotImporter/SDFormatSensorImporterHook.h
+++ b/Gems/ROS2/Code/Include/ROS2/RobotImporter/SDFormatSensorImporterHook.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Entity.h>
+#include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/function/function_template.h>
+#include <AzCore/std/string/string.h>
+
+#include <sdf/Sensor.hh>
+
+namespace ROS2::SDFormat
+{
+    //! Hook used in ROS2 Gem Robot Importer to create ROS2 sensor components based on SDF model description file.
+    //! See the <sensor> element at http://sdformat.org/spec?ver=1.10&elem=sensor for more details.
+    struct SensorImporterHook
+    {
+        AZ_TYPE_INFO(SensorImporterHook, "{23f189e3-8da4-4498-9b89-1ef6c900940a}");
+
+        //! Types of the sensor in the SDF file that can be reused in O3DE.
+        //! Multiple SDF sensors can map to one O3DE component.
+        AZStd::unordered_set<sdf::SensorType> m_sensorTypes;
+
+        //! Names of the options of the sensor in the SDF file that can be reused in O3DE.
+        AZStd::unordered_set<AZStd::string> m_sensorOptions;
+
+        //! Names of the plugins associated with the sensor in the SDF file that can be reused in O3DE.
+        //! Multiple SDF plugins can map to one O3DE component.
+        AZStd::unordered_set<AZStd::string> m_pluginNames;
+
+        //! Names of the options of the plugin associated with the sensor in the SDF file that can be reused in O3DE.
+        AZStd::unordered_set<AZStd::string> m_pluginOptions;
+
+        //! Registered function, that is invoked when an plugin with the specified name
+        //! is processed by the SDF Importer.
+        //! A reference to an Entity is supplied which can be populated with one or more O3DE Components
+        //! that were converted using the SDF Plugin data.
+        using ConvertSDFSensorCallback = AZStd::function<void(AZ::Entity&, const sdf::Sensor&)>;
+        ConvertSDFSensorCallback m_sdfSensorToComponentCallback;
+    };
+} // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Include/ROS2/RobotImporter/SDFormatSensorImporterHook.h
+++ b/Gems/ROS2/Code/Include/ROS2/RobotImporter/SDFormatSensorImporterHook.h
@@ -24,30 +24,32 @@ namespace sdf
 
 namespace ROS2::SDFormat
 {
-    //! Hook used in ROS2 Gem Robot Importer to create ROS2 sensor components based on SDF model description file.
-    //! See the <sensor> element at http://sdformat.org/spec?ver=1.10&elem=sensor for more details.
+    //! Hook used in ROS2 Gem Robot Importer to create ROS2 sensor components based on SDFormat model description.
+    //! It implements the parameters mapping between the SDFormat sensor and the particular O3DE component.
+    //! It should be registered as a serialization attribute in the component's reflection to make the it visible in the SDFormat model
+    //! parser. See the sensor element at http://sdformat.org/spec?ver=1.10&elem=sensor for more details on SDFormat.
     struct SensorImporterHook
     {
         AZ_TYPE_INFO(SensorImporterHook, "{23f189e3-8da4-4498-9b89-1ef6c900940a}");
 
-        //! Types of the sensor in the SDF file that can be reused in O3DE.
-        //! Multiple SDF sensors can map to one O3DE component.
+        //! Types of sensors in SDFormat description that can be mapped to the particular O3DE component.
+        //! Multiple SDFormat sensors can map to one O3DE component.
         AZStd::unordered_set<sdf::SensorType> m_sensorTypes;
 
-        //! Names of the options of the sensor in the SDF file that can be reused in O3DE.
-        AZStd::unordered_set<AZStd::string> m_sensorOptions;
+        //! Names of the sensor's parameters in SDFormat description that are supported by the particular O3DE component.
+        AZStd::unordered_set<AZStd::string> m_supportedSensorParams;
 
-        //! Names of the plugins associated with the sensor in the SDF file that can be reused in O3DE.
-        //! Multiple SDF plugins can map to one O3DE component.
+        //! Names of plugins associated with the sensor in SDFormat description that are supported by the particular O3DE component.
+        //! Multiple SDFormat plugins can map to one O3DE component.
         AZStd::unordered_set<AZStd::string> m_pluginNames;
 
-        //! Names of the options of the plugin associated with the sensor in the SDF file that can be reused in O3DE.
-        AZStd::unordered_set<AZStd::string> m_pluginOptions;
+        //! Names of the plugin's parameters associated with the sensor in SDFormat description that are supported
+        //! by the particular O3DE component.
+        AZStd::unordered_set<AZStd::string> m_supportedPluginParams;
 
-        //! Registered function, that is invoked when an plugin with the specified name
-        //! is processed by the SDF Importer.
-        //! A reference to an Entity is supplied which can be populated with one or more O3DE Components
-        //! that were converted using the SDF Plugin data.
+        //! Registered function that is invoked when a sensor of the specified type is processed by the SDFormat Importer.
+        //! @param AZ::Entity& a reference to the Entity in which one or more O3DE component is created by the importer
+        //! @param sdf::Sensor& a reference to the sensor data in SDFormat, which is used to configure O3DE component
         using ConvertSDFSensorCallback = AZStd::function<void(AZ::Entity&, const sdf::Sensor&)>;
         ConvertSDFSensorCallback m_sdfSensorToComponentCallback;
     };

--- a/Gems/ROS2/Code/Include/ROS2/RobotImporter/SDFormatSensorImporterHook.h
+++ b/Gems/ROS2/Code/Include/ROS2/RobotImporter/SDFormatSensorImporterHook.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Component/Entity.h>
+#include <AzCore/Outcome/Outcome.h>
 #include <AzCore/std/containers/unordered_set.h>
 #include <AzCore/std/function/function_template.h>
 #include <AzCore/std/string/string.h>
@@ -50,7 +51,9 @@ namespace ROS2::SDFormat
         //! Registered function that is invoked when a sensor of the specified type is processed by the SDFormat Importer.
         //! @param AZ::Entity& a reference to the Entity in which one or more O3DE component is created by the importer
         //! @param sdf::Sensor& a reference to the sensor data in SDFormat, which is used to configure O3DE component
-        using ConvertSDFSensorCallback = AZStd::function<void(AZ::Entity&, const sdf::Sensor&)>;
+        using ErrorString = AZStd::string;
+        using ConvertSensorOutcome = AZ::Outcome<void, AZStd::string>;
+        using ConvertSDFSensorCallback = AZStd::function<ConvertSensorOutcome(AZ::Entity&, const sdf::Sensor&)>;
         ConvertSDFSensorCallback m_sdfSensorToComponentCallback;
     };
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Include/ROS2/RobotImporter/SDFormatSensorImporterHook.h
+++ b/Gems/ROS2/Code/Include/ROS2/RobotImporter/SDFormatSensorImporterHook.h
@@ -13,7 +13,14 @@
 #include <AzCore/std/function/function_template.h>
 #include <AzCore/std/string/string.h>
 
-#include <sdf/Sensor.hh>
+namespace sdf
+{
+    inline namespace v13
+    {
+        enum class SensorType;
+        class Sensor;
+    } // namespace v13
+} // namespace sdf
 
 namespace ROS2::SDFormat
 {

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
@@ -28,6 +28,13 @@ namespace ROS2
             MakeTopicConfigurationPair("depth_camera_info", CameraConstants::CameraInfoMessageType, CameraConstants::DepthInfoConfig));
     }
 
+    ROS2CameraSensorEditorComponent::ROS2CameraSensorEditorComponent(
+        const SensorConfiguration& sensorConfiguration, const CameraSensorConfiguration& cameraConfiguration)
+        : m_sensorConfiguration(sensorConfiguration)
+        , m_cameraSensorConfiguration(cameraConfiguration)
+    {
+    }
+
     void ROS2CameraSensorEditorComponent::Reflect(AZ::ReflectContext* context)
     {
         CameraSensorConfiguration::Reflect(context);

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.h
@@ -22,7 +22,7 @@ namespace ROS2
 {
     //! ROS2 Camera Editor sensor component class
     //! Allows turning an entity into a camera sensor in Editor
-    //! Component draws camera frustrum in the Editor
+    //! Component draws camera frustum in the Editor
     class ROS2CameraSensorEditorComponent
         : public AzToolsFramework::Components::EditorComponentBase
         , public CameraCalibrationRequestBus::Handler
@@ -30,6 +30,8 @@ namespace ROS2
     {
     public:
         ROS2CameraSensorEditorComponent();
+        ROS2CameraSensorEditorComponent(
+            const SensorConfiguration& sensorConfiguration, const CameraSensorConfiguration& cameraConfiguration);
         ~ROS2CameraSensorEditorComponent() override = default;
         AZ_EDITOR_COMPONENT(ROS2CameraSensorEditorComponent, "{3C2A86B2-AD58-4BF1-A5EF-71E0F94A2B42}");
         static void Reflect(AZ::ReflectContext* context);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SensorHooks.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SensorHooks.cpp
@@ -45,7 +45,8 @@ namespace ROS2::SDFormat
                                                                           "libgazebo_ros_depth_camera.so",
                                                                           "libgazebo_ros_openni_kinect.so" };
         importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{};
-        importerHook.m_sdfSensorToComponentCallback = [](AZ::Entity& entity, const sdf::Sensor& sdfSensor)
+        importerHook.m_sdfSensorToComponentCallback = [](AZ::Entity& entity,
+                                                         const sdf::Sensor& sdfSensor) -> SensorImporterHook::ConvertSensorOutcome
         {
             auto* cameraSensor = sdfSensor.CameraSensor();
 
@@ -84,7 +85,14 @@ namespace ROS2::SDFormat
                     sensorConfiguration, "depth_camera_info", CameraConstants::CameraInfoMessageType, CameraConstants::DepthInfoConfig);
             }
 
-            entity.CreateComponent<ROS2CameraSensorEditorComponent>(sensorConfiguration, cameraConfiguration);
+            if (entity.CreateComponent<ROS2CameraSensorEditorComponent>(sensorConfiguration, cameraConfiguration))
+            {
+                return AZ::Success();
+            }
+            else
+            {
+                return AZ::Failure(AZStd::string("Failed to create ROS2 Camera Sensor component"));
+            }
         };
 
         return importerHook;

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SensorHooks.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SensorHooks.cpp
@@ -38,13 +38,13 @@ namespace ROS2::SDFormat
         SensorImporterHook importerHook;
         importerHook.m_sensorTypes =
             AZStd::unordered_set<sdf::SensorType>{ sdf::SensorType::CAMERA, sdf::SensorType::DEPTH_CAMERA, sdf::SensorType::RGBD_CAMERA };
-        importerHook.m_sensorOptions =
+        importerHook.m_supportedSensorParams =
             AZStd::unordered_set<AZStd::string>{ ">update_rate",         ">camera>horizontal_fov", ">camera>image>width",
                                                  ">camera>image>height", ">camera>clip>near",      ">camera>clip>far" };
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_camera.so",
                                                                           "libgazebo_ros_depth_camera.so",
                                                                           "libgazebo_ros_openni_kinect.so" };
-        importerHook.m_pluginOptions = AZStd::unordered_set<AZStd::string>{};
+        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{};
         importerHook.m_sdfSensorToComponentCallback = [](AZ::Entity& entity, const sdf::Sensor& sdfSensor)
         {
             auto* cameraSensor = sdfSensor.CameraSensor();

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SensorHooks.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SensorHooks.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ROS2SensorHooks.h"
+
+#include <Camera/CameraConstants.h>
+#include <Camera/ROS2CameraSensorEditorComponent.h>
+#include <GNSS/ROS2GNSSSensorComponent.h>
+#include <RobotImporter/Utils/RobotImporterUtils.h>
+
+#include <sdf/Camera.hh>
+#include <sdf/NavSat.hh>
+
+namespace ROS2::SDFormat
+{
+    namespace Internal
+    {
+        void AddTopicConfiguration(
+            SensorConfiguration& sensorConfig,
+            const AZStd::string& topic,
+            const AZStd::string& messageType,
+            const AZStd::string& configName)
+        {
+            TopicConfiguration config;
+            config.m_topic = topic;
+            config.m_type = messageType;
+            sensorConfig.m_publishersConfigurations.insert(AZStd::make_pair(configName, config));
+        }
+    } // namespace Internal
+
+    SensorImporterHook ROS2SensorHooks::ROS2CameraSensor()
+    {
+        SensorImporterHook importerHook;
+        importerHook.m_sensorTypes =
+            AZStd::unordered_set<sdf::SensorType>{ sdf::SensorType::CAMERA, sdf::SensorType::DEPTH_CAMERA, sdf::SensorType::RGBD_CAMERA };
+        importerHook.m_sensorOptions =
+            AZStd::unordered_set<AZStd::string>{ ">update_rate",         ">camera>horizontal_fov", ">camera>image>width",
+                                                 ">camera>image>height", ">camera>clip>near",      ">camera>clip>far" };
+        importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_camera.so",
+                                                                          "libgazebo_ros_depth_camera.so",
+                                                                          "libgazebo_ros_openni_kinect.so" };
+        importerHook.m_pluginOptions = AZStd::unordered_set<AZStd::string>{};
+        importerHook.m_sdfSensorToComponentCallback = [](AZ::Entity& entity, const sdf::Sensor& sdfSensor)
+        {
+            auto* cameraSensor = sdfSensor.CameraSensor();
+
+            CameraSensorConfiguration cameraConfiguration;
+            cameraConfiguration.m_depthCamera = cameraSensor->HasDepthCamera();
+            cameraConfiguration.m_colorCamera = (sdfSensor.Type() != sdf::SensorType::DEPTH_CAMERA) ? true : false;
+            cameraConfiguration.m_width = cameraSensor->ImageWidth();
+            cameraConfiguration.m_height = cameraSensor->ImageHeight();
+            cameraConfiguration.m_verticalFieldOfViewDeg =
+                cameraSensor->HorizontalFov().Degree() * (cameraConfiguration.m_height / cameraConfiguration.m_width);
+            if (sdfSensor.Type() != sdf::SensorType::DEPTH_CAMERA)
+            {
+                cameraConfiguration.m_nearClipDistance = static_cast<float>(cameraSensor->NearClip());
+                cameraConfiguration.m_farClipDistance = static_cast<float>(cameraSensor->FarClip());
+            }
+            else
+            {
+                cameraConfiguration.m_nearClipDistance = static_cast<float>(cameraSensor->DepthNearClip());
+                cameraConfiguration.m_farClipDistance = static_cast<float>(cameraSensor->DepthFarClip());
+            }
+
+            SensorConfiguration sensorConfiguration;
+            sensorConfiguration.m_frequency = sdfSensor.UpdateRate();
+            if (sdfSensor.Type() != sdf::SensorType::DEPTH_CAMERA)
+            {
+                Internal::AddTopicConfiguration(
+                    sensorConfiguration, "camera_image_color", CameraConstants::ImageMessageType, CameraConstants::ColorImageConfig);
+                Internal::AddTopicConfiguration(
+                    sensorConfiguration, "color_camera_info", CameraConstants::CameraInfoMessageType, CameraConstants::ColorInfoConfig);
+            }
+            if (sdfSensor.Type() != sdf::SensorType::CAMERA)
+            {
+                Internal::AddTopicConfiguration(
+                    sensorConfiguration, "camera_image_depth", CameraConstants::ImageMessageType, CameraConstants::DepthImageConfig);
+                Internal::AddTopicConfiguration(
+                    sensorConfiguration, "depth_camera_info", CameraConstants::CameraInfoMessageType, CameraConstants::DepthInfoConfig);
+            }
+
+            entity.CreateComponent<ROS2CameraSensorEditorComponent>(sensorConfiguration, cameraConfiguration);
+        };
+
+        return importerHook;
+    }
+
+} // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SensorHooks.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SensorHooks.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <ROS2/RobotImporter/SDFormatSensorImporterHook.h>
+
+namespace ROS2::SDFormat
+{
+    namespace ROS2SensorHooks
+    {
+        SensorImporterHook ROS2CameraSensor();
+    } // namespace ROS2SensorHooks
+} // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -332,10 +332,10 @@ namespace ROS2
             return path.Filename().String();
         }
 
-        AZStd::vector<AZStd::string> GetUnsupportedOptions(
-            const sdf::ElementPtr& rootElement, const AZStd::unordered_set<AZStd::string>& supportedOptions)
+        AZStd::vector<AZStd::string> GetUnsupportedParams(
+            const sdf::ElementPtr& rootElement, const AZStd::unordered_set<AZStd::string>& supportedParams)
         {
-            AZStd::vector<AZStd::string> unsupportedOptions;
+            AZStd::vector<AZStd::string> unsupportedParams;
 
             AZStd::function<void(const sdf::ElementPtr& elementPtr, const std::string& prefix)> elementVisitor =
                 [&](const sdf::ElementPtr& elementPtr, const std::string& prefix) -> void
@@ -343,9 +343,9 @@ namespace ROS2
                 auto childPtr = elementPtr->GetFirstElement();
 
                 AZStd::string prefixAz(prefix.c_str(), prefix.size());
-                if (!childPtr && !prefixAz.empty() && !supportedOptions.contains(prefixAz))
+                if (!childPtr && !prefixAz.empty() && !supportedParams.contains(prefixAz))
                 {
-                    unsupportedOptions.push_back(prefixAz);
+                    unsupportedParams.push_back(prefixAz);
                 }
 
                 while (childPtr)
@@ -366,7 +366,7 @@ namespace ROS2
 
             elementVisitor(rootElement, "");
 
-            return unsupportedOptions;
+            return unsupportedParams;
         }
 
         bool IsPluginSupported(const sdf::Plugin& plugin, const AZStd::unordered_set<AZStd::string>& supportedPlugins)

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -15,7 +15,6 @@
 #include <AzCore/StringFunc/StringFunc.h>
 #include <AzCore/std/string/regex.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
-#include <filesystem>
 #include <string.h>
 
 namespace ROS2
@@ -329,8 +328,8 @@ namespace ROS2
     {
         AZStd::string GetPluginFilename(const sdf::Plugin& plugin)
         {
-            const std::filesystem::path path = plugin.Filename();
-            return AZStd::string(path.filename().u8string().c_str(), path.filename().u8string().size());
+            const AZ::IO::Path path{ plugin.Filename().c_str() };
+            return path.Filename().String();
         }
 
         AZStd::vector<AZStd::string> GetUnsupportedOptions(

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -88,13 +88,13 @@ namespace ROS2
             //! @returns filename (including extension) without path
             AZStd::string GetPluginFilename(const sdf::Plugin& plugin);
 
-            //! Retrieve all options that were defined for an element in XML data that are not supported in O3DE.
-            //! Allows to store the list of unsupported options in metadata and logs. It is typically used with sensors and plugins.
+            //! Retrieve all parameters that were defined for an element in XML data that are not supported in O3DE.
+            //! Allows to store the list of unsupported parameters in metadata and logs. It is typically used with sensors and plugins.
             //! @param rootElement pointer to a root Element in parsed XML data that will be a subject to heuristics
-            //! @param supportedOptions set of predefined sensor's options that are supported
-            //! @returns list of unsupported options defined for given element
-            AZStd::vector<AZStd::string> GetUnsupportedOptions(
-                const sdf::ElementPtr& rootElement, const AZStd::unordered_set<AZStd::string>& supportedOptions);
+            //! @param supportedParams set of predefined parameters that are supported
+            //! @returns list of unsupported parameters defined for given element
+            AZStd::vector<AZStd::string> GetUnsupportedParams(
+                const sdf::ElementPtr& rootElement, const AZStd::unordered_set<AZStd::string>& supportedParams);
 
             //! Check if plugin is supported by using it's filename. The filepath is converted into the filename if necessary.
             //! @param plugin plugin in the parsed SDFormat data

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -11,9 +11,13 @@
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/containers/vector.h>
 #include <AzCore/std/function/function_template.h>
 #include <AzCore/std/string/string.h>
 #include <RobotImporter/URDF/UrdfParser.h>
+
+#include <sdf/sdf.hh>
 
 namespace ROS2
 {
@@ -76,6 +80,28 @@ namespace ROS2
         //! @param sourceAssetsPaths - set of all non relative paths to assets for which we want to wait for processing
         //! @returns false if a timeout or error occurs, otherwise true
         bool WaitForAssetsToProcess(const AZStd::unordered_map<AZStd::string, AZ::IO::Path>& sourceAssetsPaths);
+
+        namespace SDFormat
+        {
+            //! Retrieve plugin's filename. The filepath is converted into the filename if necessary.
+            //! @param plugin plugin in the parsed SDFormat data
+            //! @returns filename (including extension) without path
+            AZStd::string GetPluginFilename(const sdf::Plugin& plugin);
+
+            //! Retrieve all options that were defined for an element in XML data that are not supported in O3DE.
+            //! Allows to store the list of unsupported options in metadata and logs. It is typically used with sensors and plugins.
+            //! @param rootElement pointer to a root Element in parsed XML data that will be a subject to heuristics
+            //! @param supportedOptions set of predefined sensor's options that are supported
+            //! @returns list of unsupported options defined for given element
+            AZStd::vector<AZStd::string> GetUnsupportedOptions(
+                const sdf::ElementPtr& rootElement, const AZStd::unordered_set<AZStd::string>& supportedOptions);
+
+            //! Check if plugin is supported by using it's filename. The filepath is converted into the filename if necessary.
+            //! @param plugin plugin in the parsed SDFormat data
+            //! @param supportedPlugins set of predefined plugins that are supported
+            //! @returns true if plugin is supported
+            bool IsPluginSupported(const sdf::Plugin& plugin, const AZStd::unordered_set<AZStd::string>& supportedPlugins);
+        } // namespace SDFormat
 
     } // namespace Utils
 } // namespace ROS2

--- a/Gems/ROS2/Code/Tests/SdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/SdfParserTest.cpp
@@ -9,7 +9,6 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzTest/AzTest.h>
-#include <ROS2/RobotImporter/SDFormatSensorImporterHook.h>
 #include <RobotImporter/SDFormat/ROS2SensorHooks.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
 
@@ -39,55 +38,55 @@ namespace UnitTest
 
         std::string GetSdfWithTwoSensors()
         {
-            return "<?xml version=\"1.0\" ?>\n"
-                   "<sdf version=\"1.6\">\n"
-                   "  <model name=\"test_two_sensors\">\n"
-                   "    <link name=\"link1\">\n"
-                   "      <sensor name=\"camera\" type=\"camera\">\n"
-                   "        <pose>0 0 0 0 0 0</pose>\n"
-                   "        <camera>\n"
-                   "          <horizontal_fov>2.0</horizontal_fov>\n"
-                   "          <image>\n"
-                   "            <width>640</width>\n"
-                   "            <height>480</height>\n"
-                   "          </image>\n"
-                   "          <clip>\n"
-                   "            <near>0.01</near>\n"
-                   "            <far>1000</far>\n"
-                   "          </clip>\n"
-                   "        </camera>\n"
-                   "        <update_rate>10</update_rate>\n"
-                   "        <plugin name=\"camera_plug\" filename=\"libgazebo_ros_camera.so\">\n"
-                   "          <camera_name>custom_camera</camera_name>\n"
-                   "        </plugin>\n"
-                   "      </sensor>\n"
-                   "    </link>\n"
-                   "    <link name=\"link2\">\n"
-                   "      <sensor name=\"laser\" type=\"ray\">\n"
-                   "        <always_on>1</always_on>\n"
-                   "        <visualize>1</visualize>\n"
-                   "        <update_rate>20.0</update_rate>\n"
-                   "        <pose>0 0 0 0 0 0</pose>\n"
-                   "        <ray>\n"
-                   "          <scan>\n"
-                   "            <horizontal>\n"
-                   "              <samples>640</samples>\n"
-                   "              <resolution>1.0</resolution>\n"
-                   "              <min_angle>-2.0</min_angle>\n"
-                   "              <max_angle>2.5</max_angle>\n"
-                   "            </horizontal>\n"
-                   "          </scan>\n"
-                   "          <range>\n"
-                   "            <min>0.02</min>\n"
-                   "            <max>10</max>\n"
-                   "            <resolution>0.01</resolution>\n"
-                   "          </range>\n"
-                   "        </ray>\n"
-                   "        <plugin name=\"laser_plug\" filename=\"librayplugin.so\"/>\n"
-                   "      </sensor>\n"
-                   "    </link>\n"
-                   "  </model>\n"
-                   "</sdf>\n";
+            return R"(<?xml version="1.0"?>
+                      <sdf version="1.6">
+                        <model name="test_two_sensors">
+                          <link name="link1">
+                            <sensor name="camera" type="camera">
+                              <pose>0 0 0 0 0 0</pose>
+                              <camera>
+                                <horizontal_fov>2.0</horizontal_fov>
+                                <image>
+                                  <width>640</width>
+                                  <height>480</height>
+                                </image>
+                                <clip>
+                                  <near>0.01</near>
+                                  <far>1000</far>
+                                </clip>
+                              </camera>
+                              <update_rate>10</update_rate>
+                              <plugin name="camera_plug" filename="libgazebo_ros_camera.so">
+                                <camera_name>custom_camera</camera_name>
+                              </plugin>
+                            </sensor>
+                          </link>
+                          <link name="link2">
+                            <sensor name="laser" type="ray">
+                              <always_on>1</always_on>
+                              <visualize>1</visualize>
+                              <update_rate>20.0</update_rate>
+                              <pose>0 0 0 0 0 0</pose>
+                              <ray>
+                                <scan>
+                                  <horizontal>
+                                    <samples>640</samples>
+                                    <resolution>1.0</resolution>
+                                    <min_angle>-2.0</min_angle>
+                                    <max_angle>2.5</max_angle>
+                                  </horizontal>
+                                </scan>
+                                <range>
+                                  <min>0.02</min>
+                                  <max>10</max>
+                                  <resolution>0.01</resolution>
+                                </range>
+                              </ray>
+                              <plugin name="laser_plug" filename="librayplugin.so"/>
+                            </sensor>
+                          </link>
+                        </model>
+                      </sdf>)";
         }
     };
 

--- a/Gems/ROS2/Code/Tests/SdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/SdfParserTest.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzTest/AzTest.h>
+#include <ROS2/RobotImporter/SDFormatSensorImporterHook.h>
+#include <RobotImporter/SDFormat/ROS2SensorHooks.h>
+#include <RobotImporter/Utils/RobotImporterUtils.h>
+
+#include <sdf/sdf.hh>
+
+namespace UnitTest
+{
+
+    class SdfParserTest : public LeakDetectionFixture
+    {
+    public:
+        AZStd::shared_ptr<sdf::Root> Parse(const std::string& xmlString)
+        {
+            sdf::SDFPtr sdfElement(new sdf::SDF());
+            sdf::init(sdfElement);
+            sdf::Errors readErrors;
+            const bool success = sdf::readString(xmlString, sdfElement, readErrors);
+            if (!success)
+            {
+                return nullptr;
+            }
+
+            auto sdfDom = AZStd::make_shared<sdf::Root>();
+            sdf::Errors parseErrors = sdfDom->Load(sdfElement);
+            return sdfDom;
+        }
+
+        std::string GetSdfWithTwoSensors()
+        {
+            return "<?xml version=\"1.0\" ?>\n"
+                   "<sdf version=\"1.6\">\n"
+                   "  <model name=\"test_two_sensors\">\n"
+                   "    <link name=\"link1\">\n"
+                   "      <sensor name=\"camera\" type=\"camera\">\n"
+                   "        <pose>0 0 0 0 0 0</pose>\n"
+                   "        <camera>\n"
+                   "          <horizontal_fov>2.0</horizontal_fov>\n"
+                   "          <image>\n"
+                   "            <width>640</width>\n"
+                   "            <height>480</height>\n"
+                   "          </image>\n"
+                   "          <clip>\n"
+                   "            <near>0.01</near>\n"
+                   "            <far>1000</far>\n"
+                   "          </clip>\n"
+                   "        </camera>\n"
+                   "        <update_rate>10</update_rate>\n"
+                   "        <plugin name=\"camera_plug\" filename=\"libgazebo_ros_camera.so\">\n"
+                   "          <camera_name>custom_camera</camera_name>\n"
+                   "        </plugin>\n"
+                   "      </sensor>\n"
+                   "    </link>\n"
+                   "    <link name=\"link2\">\n"
+                   "      <sensor name=\"laser\" type=\"ray\">\n"
+                   "        <always_on>1</always_on>\n"
+                   "        <visualize>1</visualize>\n"
+                   "        <update_rate>20.0</update_rate>\n"
+                   "        <pose>0 0 0 0 0 0</pose>\n"
+                   "        <ray>\n"
+                   "          <scan>\n"
+                   "            <horizontal>\n"
+                   "              <samples>640</samples>\n"
+                   "              <resolution>1.0</resolution>\n"
+                   "              <min_angle>-2.0</min_angle>\n"
+                   "              <max_angle>2.5</max_angle>\n"
+                   "            </horizontal>\n"
+                   "          </scan>\n"
+                   "          <range>\n"
+                   "            <min>0.02</min>\n"
+                   "            <max>10</max>\n"
+                   "            <resolution>0.01</resolution>\n"
+                   "          </range>\n"
+                   "        </ray>\n"
+                   "        <plugin name=\"laser_plug\" filename=\"librayplugin.so\"/>\n"
+                   "      </sensor>\n"
+                   "    </link>\n"
+                   "  </model>\n"
+                   "</sdf>\n";
+        }
+    };
+
+    TEST_F(SdfParserTest, CheckModelCorrectness)
+    {
+        const auto xmlStr = GetSdfWithTwoSensors();
+        const auto sdfRoot = Parse(xmlStr);
+        ASSERT_TRUE(sdfRoot);
+        const auto* sdfModel = sdfRoot->Model();
+        ASSERT_TRUE(sdfModel);
+
+        EXPECT_EQ(sdfModel->Name(), "test_two_sensors");
+        EXPECT_EQ(sdfModel->LinkCount(), 2U);
+
+        const auto* link1 = sdfModel->LinkByName("link1");
+        ASSERT_TRUE(link1);
+        EXPECT_EQ(link1->SensorCount(), 1U);
+        const auto* sensor1 = link1->SensorByIndex(0U);
+        ASSERT_TRUE(sensor1);
+        EXPECT_EQ(sensor1->Type(), sdf::SensorType::CAMERA);
+        EXPECT_EQ(sensor1->UpdateRate(), 10);
+        auto* cameraSensor = sensor1->CameraSensor();
+        ASSERT_TRUE(cameraSensor);
+        EXPECT_EQ(cameraSensor->ImageWidth(), 640);
+        EXPECT_EQ(cameraSensor->ImageHeight(), 480);
+        EXPECT_NEAR(cameraSensor->HorizontalFov().Radian(), 2.0, 1e-5);
+        EXPECT_NEAR(cameraSensor->NearClip(), 0.01, 1e-5);
+        EXPECT_NEAR(cameraSensor->FarClip(), 1000, 1e-5);
+        EXPECT_EQ(sensor1->Plugins().size(), 1U);
+        EXPECT_EQ(sensor1->Plugins().at(0).Name(), "camera_plug");
+        EXPECT_EQ(sensor1->Plugins().at(0).Filename(), "libgazebo_ros_camera.so");
+
+        const auto* link2 = sdfModel->LinkByName("link2");
+        ASSERT_TRUE(link2);
+        EXPECT_EQ(link2->SensorCount(), 1U);
+        const auto* sensor2 = link2->SensorByIndex(0U);
+        ASSERT_TRUE(sensor2);
+        EXPECT_EQ(sensor2->Type(), sdf::SensorType::LIDAR);
+        EXPECT_EQ(sensor2->UpdateRate(), 20);
+        auto* lidarSensor = sensor2->LidarSensor();
+        ASSERT_TRUE(lidarSensor);
+        EXPECT_EQ(lidarSensor->HorizontalScanSamples(), 640);
+        EXPECT_NEAR(lidarSensor->HorizontalScanResolution(), 1.0, 1e-5);
+        EXPECT_NEAR(lidarSensor->HorizontalScanMinAngle().Radian(), -2.0, 1e-5);
+        EXPECT_NEAR(lidarSensor->HorizontalScanMaxAngle().Radian(), 2.5, 1e-5);
+        EXPECT_NEAR(lidarSensor->RangeResolution(), 0.01, 1e-5);
+        EXPECT_NEAR(lidarSensor->RangeMin(), 0.02, 1e-5);
+        EXPECT_NEAR(lidarSensor->RangeMax(), 10.0, 1e-5);
+        EXPECT_EQ(sensor2->Plugins().size(), 1U);
+        EXPECT_EQ(sensor2->Plugins().at(0).Name(), "laser_plug");
+        EXPECT_EQ(sensor2->Plugins().at(0).Filename(), "librayplugin.so");
+    }
+
+    TEST_F(SdfParserTest, RobotImporterUtils)
+    {
+        AZStd::unordered_set<AZStd::string> supportedPlugins{ "libgazebo_ros_camera.so", "libgazebo_ros_openni_kinect.so" };
+        sdf::Plugin plug;
+
+        plug.SetName("test_camera");
+        plug.SetFilename("libgazebo_ros_camera.so");
+        EXPECT_EQ("libgazebo_ros_camera.so", ROS2::Utils::SDFormat::GetPluginFilename(plug));
+        EXPECT_TRUE(ROS2::Utils::SDFormat::IsPluginSupported(plug, supportedPlugins));
+        plug.SetFilename("/usr/lib/libgazebo_ros_camera.so");
+        EXPECT_EQ("libgazebo_ros_camera.so", ROS2::Utils::SDFormat::GetPluginFilename(plug));
+        EXPECT_TRUE(ROS2::Utils::SDFormat::IsPluginSupported(plug, supportedPlugins));
+        plug.SetFilename("~/dev/libgazebo_ros_camera.so");
+        EXPECT_EQ("libgazebo_ros_camera.so", ROS2::Utils::SDFormat::GetPluginFilename(plug));
+        EXPECT_TRUE(ROS2::Utils::SDFormat::IsPluginSupported(plug, supportedPlugins));
+        plug.SetFilename("fun.so");
+        EXPECT_EQ("fun.so", ROS2::Utils::SDFormat::GetPluginFilename(plug));
+        EXPECT_FALSE(ROS2::Utils::SDFormat::IsPluginSupported(plug, supportedPlugins));
+        plug.SetFilename("fun");
+        EXPECT_EQ("fun", ROS2::Utils::SDFormat::GetPluginFilename(plug));
+        EXPECT_FALSE(ROS2::Utils::SDFormat::IsPluginSupported(plug, supportedPlugins));
+
+        AZStd::unordered_set<AZStd::string> cameraSupportedOptions{
+            ">update_rate", ">camera>horizontal_fov", ">camera>image>width", ">camera>image>height"
+        };
+
+        const auto xmlStr = GetSdfWithTwoSensors();
+        const auto sdfRoot = Parse(xmlStr);
+        const auto* sdfModel = sdfRoot->Model();
+        const sdf::ElementPtr cameraElement = sdfModel->LinkByName("link1")->SensorByIndex(0U)->Element();
+        const sdf::ElementPtr laserElement = sdfModel->LinkByName("link2")->SensorByIndex(0U)->Element();
+
+        {
+            const auto& unsupportedCameraOptions = ROS2::Utils::SDFormat::GetUnsupportedOptions(cameraElement, cameraSupportedOptions);
+            EXPECT_EQ(unsupportedCameraOptions.size(), 3U);
+            EXPECT_EQ(unsupportedCameraOptions[0U], ">pose");
+            EXPECT_EQ(unsupportedCameraOptions[1U], ">camera>clip>near");
+            EXPECT_EQ(unsupportedCameraOptions[2U], ">camera>clip>far");
+        }
+
+        cameraSupportedOptions.emplace(">pose");
+        {
+            const auto& unsupportedCameraOptions = ROS2::Utils::SDFormat::GetUnsupportedOptions(cameraElement, cameraSupportedOptions);
+            EXPECT_EQ(unsupportedCameraOptions.size(), 2U);
+            EXPECT_EQ(unsupportedCameraOptions[0U], ">camera>clip>near");
+            EXPECT_EQ(unsupportedCameraOptions[1U], ">camera>clip>far");
+        }
+
+        cameraSupportedOptions.emplace(">camera>clip>near");
+        cameraSupportedOptions.emplace(">camera>clip>far");
+        {
+            const auto& unsupportedCameraOptions = ROS2::Utils::SDFormat::GetUnsupportedOptions(cameraElement, cameraSupportedOptions);
+            EXPECT_EQ(unsupportedCameraOptions.size(), 0U);
+        }
+
+        const AZStd::unordered_set<AZStd::string> laserSupportedOptions{ ">pose",
+                                                                         ">update_rate",
+                                                                         ">ray>scan>horizontal>samples",
+                                                                         ">ray>scan>horizontal>resolution",
+                                                                         ">ray>scan>horizontal>min_angle",
+                                                                         ">ray>scan>horizontal>max_angle",
+                                                                         ">ray>range>min",
+                                                                         ">ray>range>max",
+                                                                         ">ray>range>resolution",
+                                                                         ">always_on",
+                                                                         ">visualize" };
+        const auto& unsupportedLaserOptions = ROS2::Utils::SDFormat::GetUnsupportedOptions(laserElement, laserSupportedOptions);
+        EXPECT_EQ(unsupportedLaserOptions.size(), 0U);
+    }
+
+    TEST_F(SdfParserTest, SensorPluginImporterHookCheck)
+    {
+        const auto xmlStr = GetSdfWithTwoSensors();
+        const auto sdfRoot = Parse(xmlStr);
+        const auto* sdfModel = sdfRoot->Model();
+        const sdf::ElementPtr cameraElement = sdfModel->LinkByName("link1")->SensorByIndex(0U)->Element();
+        const auto& importerHook = ROS2::SDFormat::ROS2SensorHooks::ROS2CameraSensor();
+
+        const auto& unsupportedCameraOptions = ROS2::Utils::SDFormat::GetUnsupportedOptions(cameraElement, importerHook.m_sensorOptions);
+        EXPECT_EQ(unsupportedCameraOptions.size(), 1U);
+        EXPECT_EQ(unsupportedCameraOptions[0U], ">pose");
+
+        sdf::Plugin plug;
+        plug.SetName("test_camera");
+        plug.SetFilename("libgazebo_ros_camera.so");
+        EXPECT_TRUE(ROS2::Utils::SDFormat::IsPluginSupported(plug, importerHook.m_pluginNames));
+        plug.SetFilename("/usr/lib/libgazebo_ros_openni_kinect.so");
+        EXPECT_TRUE(ROS2::Utils::SDFormat::IsPluginSupported(plug, importerHook.m_pluginNames));
+        plug.SetFilename("~/dev/libgazebo_ros_imu.so");
+        EXPECT_FALSE(ROS2::Utils::SDFormat::IsPluginSupported(plug, importerHook.m_pluginNames));
+        plug.SetFilename("libgazebo_ros_camera");
+        EXPECT_FALSE(ROS2::Utils::SDFormat::IsPluginSupported(plug, importerHook.m_pluginNames));
+
+        EXPECT_TRUE(importerHook.m_sensorTypes.contains(sdf::SensorType::CAMERA));
+        EXPECT_TRUE(importerHook.m_sensorTypes.contains(sdf::SensorType::DEPTH_CAMERA));
+        EXPECT_FALSE(importerHook.m_sensorTypes.contains(sdf::SensorType::GPS));
+    }
+} // namespace UnitTest

--- a/Gems/ROS2/Code/Tests/SdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/SdfParserTest.cpp
@@ -162,7 +162,7 @@ namespace UnitTest
         EXPECT_EQ("fun", ROS2::Utils::SDFormat::GetPluginFilename(plug));
         EXPECT_FALSE(ROS2::Utils::SDFormat::IsPluginSupported(plug, supportedPlugins));
 
-        AZStd::unordered_set<AZStd::string> cameraSupportedOptions{
+        AZStd::unordered_set<AZStd::string> cameraSupportedParams{
             ">update_rate", ">camera>horizontal_fov", ">camera>image>width", ">camera>image>height"
         };
 
@@ -173,41 +173,41 @@ namespace UnitTest
         const sdf::ElementPtr laserElement = sdfModel->LinkByName("link2")->SensorByIndex(0U)->Element();
 
         {
-            const auto& unsupportedCameraOptions = ROS2::Utils::SDFormat::GetUnsupportedOptions(cameraElement, cameraSupportedOptions);
-            EXPECT_EQ(unsupportedCameraOptions.size(), 3U);
-            EXPECT_EQ(unsupportedCameraOptions[0U], ">pose");
-            EXPECT_EQ(unsupportedCameraOptions[1U], ">camera>clip>near");
-            EXPECT_EQ(unsupportedCameraOptions[2U], ">camera>clip>far");
+            const auto& unsupportedCameraParams = ROS2::Utils::SDFormat::GetUnsupportedParams(cameraElement, cameraSupportedParams);
+            EXPECT_EQ(unsupportedCameraParams.size(), 3U);
+            EXPECT_EQ(unsupportedCameraParams[0U], ">pose");
+            EXPECT_EQ(unsupportedCameraParams[1U], ">camera>clip>near");
+            EXPECT_EQ(unsupportedCameraParams[2U], ">camera>clip>far");
         }
 
-        cameraSupportedOptions.emplace(">pose");
+        cameraSupportedParams.emplace(">pose");
         {
-            const auto& unsupportedCameraOptions = ROS2::Utils::SDFormat::GetUnsupportedOptions(cameraElement, cameraSupportedOptions);
-            EXPECT_EQ(unsupportedCameraOptions.size(), 2U);
-            EXPECT_EQ(unsupportedCameraOptions[0U], ">camera>clip>near");
-            EXPECT_EQ(unsupportedCameraOptions[1U], ">camera>clip>far");
+            const auto& unsupportedCameraParams = ROS2::Utils::SDFormat::GetUnsupportedParams(cameraElement, cameraSupportedParams);
+            EXPECT_EQ(unsupportedCameraParams.size(), 2U);
+            EXPECT_EQ(unsupportedCameraParams[0U], ">camera>clip>near");
+            EXPECT_EQ(unsupportedCameraParams[1U], ">camera>clip>far");
         }
 
-        cameraSupportedOptions.emplace(">camera>clip>near");
-        cameraSupportedOptions.emplace(">camera>clip>far");
+        cameraSupportedParams.emplace(">camera>clip>near");
+        cameraSupportedParams.emplace(">camera>clip>far");
         {
-            const auto& unsupportedCameraOptions = ROS2::Utils::SDFormat::GetUnsupportedOptions(cameraElement, cameraSupportedOptions);
-            EXPECT_EQ(unsupportedCameraOptions.size(), 0U);
+            const auto& unsupportedCameraParams = ROS2::Utils::SDFormat::GetUnsupportedParams(cameraElement, cameraSupportedParams);
+            EXPECT_EQ(unsupportedCameraParams.size(), 0U);
         }
 
-        const AZStd::unordered_set<AZStd::string> laserSupportedOptions{ ">pose",
-                                                                         ">update_rate",
-                                                                         ">ray>scan>horizontal>samples",
-                                                                         ">ray>scan>horizontal>resolution",
-                                                                         ">ray>scan>horizontal>min_angle",
-                                                                         ">ray>scan>horizontal>max_angle",
-                                                                         ">ray>range>min",
-                                                                         ">ray>range>max",
-                                                                         ">ray>range>resolution",
-                                                                         ">always_on",
-                                                                         ">visualize" };
-        const auto& unsupportedLaserOptions = ROS2::Utils::SDFormat::GetUnsupportedOptions(laserElement, laserSupportedOptions);
-        EXPECT_EQ(unsupportedLaserOptions.size(), 0U);
+        const AZStd::unordered_set<AZStd::string> laserSupportedParams{ ">pose",
+                                                                        ">update_rate",
+                                                                        ">ray>scan>horizontal>samples",
+                                                                        ">ray>scan>horizontal>resolution",
+                                                                        ">ray>scan>horizontal>min_angle",
+                                                                        ">ray>scan>horizontal>max_angle",
+                                                                        ">ray>range>min",
+                                                                        ">ray>range>max",
+                                                                        ">ray>range>resolution",
+                                                                        ">always_on",
+                                                                        ">visualize" };
+        const auto& unsupportedLaserParams = ROS2::Utils::SDFormat::GetUnsupportedParams(laserElement, laserSupportedParams);
+        EXPECT_EQ(unsupportedLaserParams.size(), 0U);
     }
 
     TEST_F(SdfParserTest, SensorPluginImporterHookCheck)
@@ -218,9 +218,10 @@ namespace UnitTest
         const sdf::ElementPtr cameraElement = sdfModel->LinkByName("link1")->SensorByIndex(0U)->Element();
         const auto& importerHook = ROS2::SDFormat::ROS2SensorHooks::ROS2CameraSensor();
 
-        const auto& unsupportedCameraOptions = ROS2::Utils::SDFormat::GetUnsupportedOptions(cameraElement, importerHook.m_sensorOptions);
-        EXPECT_EQ(unsupportedCameraOptions.size(), 1U);
-        EXPECT_EQ(unsupportedCameraOptions[0U], ">pose");
+        const auto& unsupportedCameraParams =
+            ROS2::Utils::SDFormat::GetUnsupportedParams(cameraElement, importerHook.m_supportedSensorParams);
+        EXPECT_EQ(unsupportedCameraParams.size(), 1U);
+        EXPECT_EQ(unsupportedCameraParams[0U], ">pose");
 
         sdf::Plugin plug;
         plug.SetName("test_camera");

--- a/Gems/ROS2/Code/ros2_editor_api_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_api_files.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+set(FILES
+    Include/ROS2/RobotImporter/SDFormatSensorImporterHook.h
+)

--- a/Gems/ROS2/Code/ros2_editor_api_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_api_files.cmake
@@ -1,8 +1,0 @@
-# Copyright (c) Contributors to the Open 3D Engine Project.
-# For complete copyright and license terms please see the LICENSE at the root of this distribution.
-#
-# SPDX-License-Identifier: Apache-2.0 OR MIT
-
-set(FILES
-    Include/ROS2/RobotImporter/SDFormatSensorImporterHook.h
-)

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -28,6 +28,8 @@ set(FILES
     Source/RobotImporter/RobotImporterWidget.h
     Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
     Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.h
+    Source/RobotImporter/SDFormat/ROS2SensorHooks.cpp
+    Source/RobotImporter/SDFormat/ROS2SensorHooks.h
     Source/RobotImporter/URDF/ArticulationsMaker.cpp
     Source/RobotImporter/URDF/ArticulationsMaker.h
     Source/RobotImporter/URDF/CollidersMaker.cpp

--- a/Gems/ROS2/Code/ros2_editor_tests_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_tests_files.cmake
@@ -5,5 +5,6 @@
 
 set(FILES
     Tests/ROS2EditorTest.cpp
+    Tests/SdfParserTest.cpp
     Tests/UrdfParserTest.cpp
 )

--- a/Gems/ROS2/Code/ros2_header_files.cmake
+++ b/Gems/ROS2/Code/ros2_header_files.cmake
@@ -28,7 +28,6 @@ set(FILES
         Include/ROS2/ProximitySensor/ProximitySensorNotificationBusHandler.h
         Include/ROS2/RobotControl/ControlConfiguration.h
         Include/ROS2/RobotControl/ControlSubscriptionHandler.h
-        Include/ROS2/RobotImporter/SDFormatSensorImporterHook.h
         Include/ROS2/Lidar/LidarRaycasterBus.h
         Include/ROS2/Lidar/LidarSystemBus.h
         Include/ROS2/Lidar/LidarRegistrarBus.h

--- a/Gems/ROS2/Code/ros2_header_files.cmake
+++ b/Gems/ROS2/Code/ros2_header_files.cmake
@@ -28,6 +28,7 @@ set(FILES
         Include/ROS2/ProximitySensor/ProximitySensorNotificationBusHandler.h
         Include/ROS2/RobotControl/ControlConfiguration.h
         Include/ROS2/RobotControl/ControlSubscriptionHandler.h
+        Include/ROS2/RobotImporter/SDFormatSensorImporterHook.h
         Include/ROS2/Lidar/LidarRaycasterBus.h
         Include/ROS2/Lidar/LidarSystemBus.h
         Include/ROS2/Lidar/LidarRegistrarBus.h


### PR DESCRIPTION
This PR is based on #437

The context: the reflection hook for user-defined mappings will allow developers to add new plugins and support them with gems and components. This will work similarly to AssetBuilder registration system, using SerializeContext reflection system. 

This PR adds the following:
* Add _SDFormat_ sensor importer hook template
* Add sample implementation of the hook for `ROS2CameraSensorEditorComponent`
* Add _SDFormat_ sensor importer hook utilities
* Add tests
