### PR TITLE
Updating the SDFormat revision that the ROS2 Gems uses to 13.5.0-rev1

### DIFF
--- a/Gems/ROS2/Code/Platform/Linux/PAL_linux.cmake
+++ b/Gems/ROS2/Code/Platform/Linux/PAL_linux.cmake
@@ -9,11 +9,11 @@
 set(PAL_TRAIT_BUILD_ROS2_GEM_SUPPORTED TRUE)
 
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
-    ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev0-linux
+    ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev1-linux
         TARGETS sdformat
-        PACKAGE_HASH 6bd52db178a5bfed12555db2a9710bb4f20baab73f0d7374c6c70b6568a3ba3f)
+        PACKAGE_HASH 71a86e255cfc7a176f6087e069fb26c9837c98e277becf87f3a4b0e25fe90bd3)
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
-    ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev0-linux-aarch64
+    ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev1-linux-aarch64
         TARGETS sdformat
-        PACKAGE_HASH f422699e67a92a787536c2f037f5f0e0904d82f88e66f2a1b856409aec67b0fe)
+        PACKAGE_HASH c8ca2ffad604162cbc8ed852c8ea8695851c4c69c5f39f2a9d8e423511ce78f9)
 endif()


### PR DESCRIPTION
The rev1 revision fixes an issue where the libsdformat.so file did not have the RPATH set to `$ORIGIN` and therefore it would attempt to find the dependencies of `libgz-utils2.so` and `libgz-math7.so` using the distro default library load path which is `/usr/lib`.