### PR TITLE
fix ConveyorBeltComponent serialization

### DIFF
--- a/Gems/ROS2/Code/Source/FactorySimulation/ConveyorBeltComponent.cpp
+++ b/Gems/ROS2/Code/Source/FactorySimulation/ConveyorBeltComponent.cpp
@@ -27,7 +27,8 @@ namespace ROS2
         ConveyorBeltComponentConfiguration::Reflect(context);
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<ConveyorBeltComponent>()->Version(1)->Field("Configuration", &ConveyorBeltComponent::m_configuration);
+            serialize->Class<ConveyorBeltComponent, AZ::Component>()->Version(1)->Field(
+                "Configuration", &ConveyorBeltComponent::m_configuration);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {


### PR DESCRIPTION
`ConveyorBeltComponent` serialization did not take into consideration the base class, which should also be serialized. There was the information about it in O3DE console:

![Screenshot from 2023-08-02 10-28-41](https://github.com/o3de/o3de-extras/assets/134940295/4b63460e-09af-46d7-a8a9-d6126cd9ae96)

Now it is gone.