### PR TITLE
Add the concept of global settings to the SdfAssetBuilder

### DIFF
--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
@@ -37,8 +37,7 @@ namespace ROS2
     SdfAssetBuilder::SdfAssetBuilder()
     {
         // Read in all of the global settings from the settings registry.
-        auto settingsRegistry = AZ::SettingsRegistry::Get();
-        m_globalSettings.LoadSettings(settingsRegistry);
+        m_globalSettings.LoadSettings();
 
         // Turn our global settings into a cached fingerprint that we'll use on every job
         // so that we can detect when to rebuild assets on global setting changes.

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
@@ -11,6 +11,7 @@
 #include <AssetBuilderSDK/AssetBuilderBusses.h>
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 
+#include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
 #include <URDF/UrdfParser.h>
 #include <Utils/SourceAssetsStorage.h>
 
@@ -21,7 +22,6 @@ namespace ROS2
     //! * urdf (Unified Robotics Description Format: http://wiki.ros.org/urdf )
     //! * world (Gazebo sdf files typically containing a full simulation world description: https://classic.gazebosim.org/tutorials?tut=components )
     //! * xacro (XML macro used for sdf/urdf file generation: http://wiki.ros.org/xacro )
-    //! source folders into procprefab assets in the cache folder.
     class SdfAssetBuilder
         : public AssetBuilderSDK::AssetBuilderCommandBus::Handler
     {
@@ -36,7 +36,15 @@ namespace ROS2
         void ProcessJob(const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response) const;
         void ShutDown() override { }
     private:
-        AZStd::vector<AssetBuilderSDK::AssetBuilderPattern> GetSupportedBuilderPatterns();
+        //! Get a fingerprint string that contains the global builder settings.
+        //! If any global settings get changed, the builder will rebuild all its assets.
+        AZStd::string GetFingerprint() const;
+
+        //! Create a mapping of all the asset references in the source file.
         Utils::UrdfAssetMap FindAssets(const urdf::LinkConstSharedPtr& rootLink, const AZStd::string& sourceFilename) const;
+
+        SdfAssetBuilderSettings m_globalSettings;
+        AZStd::string m_fingerprint;
     };
+
 } // ROS2

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
@@ -59,7 +59,7 @@ namespace ROS2
                     // Ignore any entries that are either completely empty or *only* contain a '.'.
                     // These will produce excessive (and presumably incorrect) wildcard matches.
                     if (value.empty() ||
-                        ((value.size() == 1) && value.starts_with('.')))
+                        value == ".")
                     {
                         return AZ::SettingsRegistryInterface::VisitResponse::Continue;
                     }

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
@@ -36,9 +36,8 @@ namespace ROS2
         }
     }
 
-    void SdfAssetBuilderSettings::LoadGlobalSettings()
+    void SdfAssetBuilderSettings::LoadSettings(AZ::SettingsRegistryInterface* settingsRegistry)
     {
-        auto settingsRegistry = AZ::SettingsRegistry::Get();
         if (settingsRegistry == nullptr)
         {
             AZ_Error(SdfAssetBuilderName, false, "Settings Registry not found, Sdf Asset Builder settings will use defaults.");

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
+
+#include <AzCore/Serialization/Json/JsonUtils.h>
+#include <AzCore/Settings/SettingsRegistryVisitorUtils.h>
+
+namespace ROS2
+{
+        namespace
+        {
+            constexpr const char* SdfAssetBuilderSupportedFileExtensionsRegistryKey = "/O3DE/ROS2/SdfAssetBuilder/SupportedFileTypeExtensions";
+            constexpr const char* SdfAssetBuilderUseArticulationsRegistryKey = "/O3DE/ROS2/SdfAssetBuilder/UseArticulations";
+        }
+
+    void SdfAssetBuilderSettings::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<SdfAssetBuilderSettings>()
+                ->Version(0)
+                ->Field("UseArticulations", &SdfAssetBuilderSettings::m_useArticulations)
+
+                // m_builderPatterns aren't serialized because we only use the serialization
+                // to detect when global settings changes cause us to rebuild our assets.
+                // A change to the builder patterns will cause the Asset Processor to add or
+                // remove the affected product assets, so we don't need to trigger any 
+                // additional rebuilds beyond that.
+             ;
+        }
+    }
+
+    void SdfAssetBuilderSettings::LoadGlobalSettings()
+    {
+        auto settingsRegistry = AZ::SettingsRegistry::Get();
+        if (settingsRegistry == nullptr)
+        {
+            AZ_Error(SdfAssetBuilderName, false, "Settings Registry not found, Sdf Asset Builder settings will use defaults.");
+            return;
+        }
+
+        // Set whether or not the outputs should use PhysX articulation components for joints.
+        // Default to using articulations.
+        settingsRegistry->Get(m_useArticulations, SdfAssetBuilderUseArticulationsRegistryKey);
+
+        // Visit each supported file type extension and create an asset builder wildcard pattern for it.
+        auto VisitFileTypeExtensions = [&settingsRegistry, this]
+            (const AZ::SettingsRegistryInterface::VisitArgs& visitArgs)
+            {
+                if (AZ::SettingsRegistryInterface::FixedValueString value;
+                    settingsRegistry->Get(value, visitArgs.m_jsonKeyPath))
+                {
+                    // Ignore any entries that are either completely empty or *only* contain a '.'.
+                    // These will produce excessive (and presumably incorrect) wildcard matches.
+                    if (value.empty() ||
+                        ((value.size() == 1) && value.starts_with('.')))
+                    {
+                        return AZ::SettingsRegistryInterface::VisitResponse::Continue;
+                    }
+
+                    // Support both 'sdf' and '.sdf' style entries in the setreg file for robustness.
+                    // Either one will get turned into a '*.sdf' pattern.
+                    AZStd::string wildcardPattern = value.starts_with('.')
+                        ? AZStd::string::format("*%s", value.c_str())
+                        : AZStd::string::format("*.%s", value.c_str());
+
+                    m_builderPatterns.push_back(
+                            AssetBuilderSDK::AssetBuilderPattern(
+                                wildcardPattern, AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+                }
+                return AZ::SettingsRegistryInterface::VisitResponse::Continue;
+            };
+        AZ::SettingsRegistryVisitorUtils::VisitArray(*settingsRegistry, VisitFileTypeExtensions, SdfAssetBuilderSupportedFileExtensionsRegistryKey);
+
+        AZ_Warning(SdfAssetBuilderName, !m_builderPatterns.empty(), "SdfAssetBuilder disabled, no supported file type extensions found.");
+    }
+} // ROS2

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
@@ -40,7 +40,7 @@ namespace ROS2
     {
         if (settingsRegistry == nullptr)
         {
-            AZ_Error(SdfAssetBuilderName, false, "Settings Registry not found, Sdf Asset Builder settings will use defaults.");
+            AZ_Assert(settingsRegistry, "No settings registry provided, Sdf Asset Builder settings will use the defaults.");
             return;
         }
 

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
@@ -9,11 +9,7 @@
 #pragma once
 
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
-
-namespace AZ
-{
-    class SettingsRegistryInterface;
-}
+#include <AzCore/Settings/SettingsRegistry.h>
 
 namespace ROS2
 {

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
@@ -32,7 +32,7 @@ namespace ROS2
         //! the ability to create a default set of values by using the default constructor.
         //! If we read these in the constructor, serialization would see all of the current values
         //! as default values and would try to prune them from the output by default.
-        void LoadSettings(AZ::SettingsRegistryInterface* settingsRegistry);
+        void LoadSettings(AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get());
 
         AZStd::vector<AssetBuilderSDK::AssetBuilderPattern> m_builderPatterns;
         bool m_useArticulations = true;

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
@@ -10,6 +10,11 @@
 
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 
+namespace AZ
+{
+    class SettingsRegistryInterface;
+}
+
 namespace ROS2
 {
     struct SdfAssetBuilderSettings
@@ -22,12 +27,12 @@ namespace ROS2
 
         static void Reflect(AZ::ReflectContext* context);
 
-        //! Read in the global settings from the settings registry.
+        //! Read in the builder settings from the settings registry.
         //! This is done as a separate step from the constructor so that serialization has
         //! the ability to create a default set of values by using the default constructor.
         //! If we read these in the constructor, serialization would see all of the current values
         //! as default values and would try to prune them from the output by default.
-        void LoadGlobalSettings();
+        void LoadSettings(AZ::SettingsRegistryInterface* settingsRegistry);
 
         AZStd::vector<AssetBuilderSDK::AssetBuilderPattern> m_builderPatterns;
         bool m_useArticulations = true;

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AssetBuilderSDK/AssetBuilderSDK.h>
+
+namespace ROS2
+{
+    struct SdfAssetBuilderSettings
+    {
+    public:
+        AZ_RTTI(ROS2::SdfAssetBuilderSettings, "{7FE3FA92-E274-4624-8905-61E1587DDD30}");
+
+        SdfAssetBuilderSettings() = default;
+        virtual ~SdfAssetBuilderSettings() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        //! Read in the global settings from the settings registry.
+        //! This is done as a separate step from the constructor so that serialization has
+        //! the ability to create a default set of values by using the default constructor.
+        //! If we read these in the constructor, serialization would see all of the current values
+        //! as default values and would try to prune them from the output by default.
+        void LoadGlobalSettings();
+
+        AZStd::vector<AssetBuilderSDK::AssetBuilderPattern> m_builderPatterns;
+        bool m_useArticulations = true;
+    };
+} // ROS2

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
@@ -15,7 +15,7 @@ namespace ROS2
     struct SdfAssetBuilderSettings
     {
     public:
-        AZ_RTTI(ROS2::SdfAssetBuilderSettings, "{7FE3FA92-E274-4624-8905-61E1587DDD30}");
+        AZ_RTTI(SdfAssetBuilderSettings, "{7FE3FA92-E274-4624-8905-61E1587DDD30}");
 
         SdfAssetBuilderSettings() = default;
         virtual ~SdfAssetBuilderSettings() = default;

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSystemComponent.cpp
@@ -8,6 +8,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <SdfAssetBuilder/SdfAssetBuilderSystemComponent.h>
 #include <SdfAssetBuilder/SdfAssetBuilder.h>
+#include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
 
 namespace ROS2
 {
@@ -20,6 +21,8 @@ namespace ROS2
 
     void SdfAssetBuilderSystemComponent::Reflect(AZ::ReflectContext* context)
     {
+        SdfAssetBuilderSettings::Reflect(context);
+
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<SdfAssetBuilderSystemComponent, AZ::Component>()

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -64,6 +64,8 @@ set(FILES
     Source/Spawner/ROS2SpawnPointEditorComponent.h
     Source/SdfAssetBuilder/SdfAssetBuilder.cpp
     Source/SdfAssetBuilder/SdfAssetBuilder.h
+    Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
+    Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
     Source/SdfAssetBuilder/SdfAssetBuilderSystemComponent.cpp
     Source/SdfAssetBuilder/SdfAssetBuilderSystemComponent.h
 )

--- a/Gems/ROS2/Registry/assetprocessor_settings.setreg
+++ b/Gems/ROS2/Registry/assetprocessor_settings.setreg
@@ -11,19 +11,7 @@
                     "watch": "@GEMROOT:ROS2@/Registry",
                     "recursive": 1,
                     "order": 102
-                },
-                "MetaDataTypes": {
-                    "animsettings": "i_caf",
-                    "Animations/SkeletonList.xml": "i_caf",
-                    "cbc": "abc",
-                    "fbx.assetinfo": "fbx",
-                    "stl.assetinfo": "stl",
-                    "gltf.assetinfo": "gltf",
-                    "glb.assetinfo": "glb",
-                    "dae.assetinfo": "dae",
-                    "obj.assetinfo": "obj"
                 }
-                
             }
         }
     }

--- a/Gems/ROS2/Registry/assetprocessor_settings.setreg
+++ b/Gems/ROS2/Registry/assetprocessor_settings.setreg
@@ -11,7 +11,19 @@
                     "watch": "@GEMROOT:ROS2@/Registry",
                     "recursive": 1,
                     "order": 102
+                },
+                "MetaDataTypes": {
+                    "animsettings": "i_caf",
+                    "Animations/SkeletonList.xml": "i_caf",
+                    "cbc": "abc",
+                    "fbx.assetinfo": "fbx",
+                    "stl.assetinfo": "stl",
+                    "gltf.assetinfo": "gltf",
+                    "glb.assetinfo": "glb",
+                    "dae.assetinfo": "dae",
+                    "obj.assetinfo": "obj"
                 }
+                
             }
         }
     }

--- a/Gems/ROS2/Registry/sceneassetimporter.setreg
+++ b/Gems/ROS2/Registry/sceneassetimporter.setreg
@@ -1,0 +1,21 @@
+{
+	"O3DE":
+	{
+		"SceneAPI":
+		{
+			"AssetImporter":
+			{
+				"SupportedFileTypeExtensions":
+				[
+					".dae",
+					".fbx",
+					".stl",
+					".gltf",
+					".glb",
+					".obj"
+				]
+			}
+		}
+	}
+}
+

--- a/Gems/ROS2/Registry/sceneassetimporter.setreg
+++ b/Gems/ROS2/Registry/sceneassetimporter.setreg
@@ -1,21 +1,21 @@
 {
-	"O3DE":
-	{
-		"SceneAPI":
-		{
-			"AssetImporter":
-			{
-				"SupportedFileTypeExtensions":
-				[
-					".dae",
-					".fbx",
-					".stl",
-					".gltf",
-					".glb",
-					".obj"
-				]
-			}
-		}
-	}
+    "O3DE":
+    {
+        "SceneAPI":
+        {
+            "AssetImporter":
+            {
+                "SupportedFileTypeExtensions":
+                [
+                    ".dae",
+                    ".fbx",
+                    ".stl",
+                    ".gltf",
+                    ".glb",
+                    ".obj"
+                ]
+            }
+        }
+    }
 }
 

--- a/Gems/ROS2/Registry/sceneassetimporter.setreg
+++ b/Gems/ROS2/Registry/sceneassetimporter.setreg
@@ -5,6 +5,10 @@
         {
             "AssetImporter":
             {
+            	// This list controls the set of file types that will get processed
+            	// by the Scene asset builder.
+            	// All supported file types need to be listed here because setreg
+            	// merges will completely replace the contents of the array.
                 "SupportedFileTypeExtensions":
                 [
                     ".dae",
@@ -16,6 +20,22 @@
                 ]
             }
         }
+    },
+    "Amazon": {
+        "AssetProcessor": {
+            "Settings": {
+            	// Only the newly-exposed Scene types need to be listed here, as
+            	// these will get appended to any MetaDataTypes that have been
+            	// previously listed.
+            	// This setting ensures that changes to an .assetinfo file will cause
+            	// the source asset to automatically rebuild itself.
+                "MetaDataTypes": {
+                    "dae.assetinfo": "dae",
+                    "obj.assetinfo": "obj"
+                }
+            }
+        }
     }
+}    
 }
 

--- a/Gems/ROS2/Registry/sdfassetbuilder_settings.setreg
+++ b/Gems/ROS2/Registry/sdfassetbuilder_settings.setreg
@@ -11,7 +11,8 @@
                     "urdf",
                     "world",
                     "xacro"
-                ]
+                ],
+                "UseArticulations": true
             }
         }
     }


### PR DESCRIPTION
This PR changes the SdfAssetBuilder to read in global builder settings from a setreg file to apply as the defaults when building all assets. Changes to the settings in the setreg file will cause all affected assets to rebuild the next time the AP is run. Currently, the only global setting that exists is "UseArticulations", but other settings can be added easily.

The mechanism used for rebuilding the assets is the builder "fingerprint". Any time the fingerprint changes, the builder will rebuild all of its assets. The global settings are read in from the setreg file and then serialized back out into a JSON string that is used as the fingerprint. Changes to the settings changes the fingerprint string, which triggers the rebuild.

This PR also has a separate change to the ROS2 Gem to enable .dae and .obj files in the Scene Builder by default. These are common file types for robotics, so we want the scene builder to attempt to convert them. Note that enabling them also requires a change to the AssetProcessor settings to list the .assetinfo files for those new types - that setting is used to ensure that the asset reprocesses whenever its .assetinfo file changes.