### PR TITLE
Refactor ros2 frame with tests

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -199,7 +199,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         )
 
         
-        # integration test for URDF importer
+        # integration test for ROS2 Frame
         ly_add_target(
             NAME ROS2.Frame.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
                 NAMESPACE Gem
@@ -219,8 +219,6 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                     AZ::AzManipulatorTestFramework.Static
                     Gem::ROS2.Static
                     Gem::ROS2.Editor.Static
-                RUNTIME_DEPENDENCIES
-                    Gem::PhysX.Editor
         )
 
         ly_add_googletest(

--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -197,6 +197,35 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         ly_add_googletest(
             NAME Gem::${gem_name}.Tests
         )
+
+        
+        # integration test for URDF importer
+        ly_add_target(
+            NAME ROS2.Frame.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
+                NAMESPACE Gem
+            FILES_CMAKE
+                frame_test_files.cmake
+            INCLUDE_DIRECTORIES
+                PRIVATE
+                    Source
+                    Tests
+            BUILD_DEPENDENCIES
+                PRIVATE
+                    AZ::AzTestShared
+                    AZ::AzToolsFramework
+                    Legacy::CryCommon
+                    Legacy::EditorCommon
+                    Legacy::Editor.Headers
+                    AZ::AzManipulatorTestFramework.Static
+                    Gem::ROS2.Static
+                RUNTIME_DEPENDENCIES
+                    Gem::PhysX.Editor
+        )
+
+        ly_add_googletest(
+                NAME Gem::ROS2.Frame.Tests
+        )
+
     endif()
 
     # If we are a host platform we want to add tools test like editor tests here
@@ -217,6 +246,8 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 BUILD_DEPENDENCIES
                     PRIVATE
                         AZ::AzTest
+                        AZ::AzTestShared
+                        AZ::AzToolsFramework
                         Gem::${gem_name}.Editor
                         3rdParty::sdformat
             )

--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -218,6 +218,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                     Legacy::Editor.Headers
                     AZ::AzManipulatorTestFramework.Static
                     Gem::ROS2.Static
+                    Gem::ROS2.Editor.Static
                 RUNTIME_DEPENDENCIES
                     Gem::PhysX.Editor
         )

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameBus.h
@@ -29,10 +29,18 @@ namespace ROS2
         //! @return Frame id which includes the namespace, ready to send in a ROS2 message
         virtual AZStd::string GetFrameID() const = 0;
 
+        //! Set a above-mentioned frame id
+        virtual void SetFrameID(const AZStd::string& frameId) = 0;
+
         //! Get the joint name including the namespace
         //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
         //! @return The namespaced joint name, ready to send in a ROS2 message
         virtual AZ::Name GetJointName() const = 0;
+
+        //! Set the joint name
+        //! @note May be populated during URDF import or set by the user in the Editor view
+        //! @param jointNameString does not include the namespace. The namespace prefix is added automatically.
+        virtual void SetJointName(const AZStd::string& jointNameString) = 0;
 
         //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
         //! @return A complete namespace (including parent namespaces)
@@ -48,6 +56,8 @@ namespace ROS2
         //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
         virtual AZStd::string GetGlobalFrameName() const = 0;
 
+        //! Bus function to check if there is a handler connected.
+        //! @return True it handler is connected.
         virtual bool IsFrame() const = 0;
     };
 

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameBus.h
@@ -7,9 +7,9 @@
  */
 #pragma once
 
-#include "AzCore/Component/ComponentBus.h"
-#include "AzCore/Component/EntityId.h"
-#include "AzCore/EBus/EBus.h"
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/EBus/EBus.h>
 #include <AzFramework/Components/TransformComponent.h>
 #include <ROS2/Frame/ROS2Transform.h>
 #include <ROS2/ROS2GemUtilities.h>
@@ -73,12 +73,21 @@ namespace ROS2
 
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
 
+        //! Notification when ROS2EditorFrameComponent activates.
+        //! @param entity - ID of the entity which activated the component.
+        //! @param parentEntity - ID of the closest parent which has a ROS2EditorFrameComponent.
         virtual void OnActivate(AZ::EntityId entity, AZ::EntityId parentEntity) = 0;
 
+        //! Notification when ROS2EditorFrameComponent deactivates.
+        //! @param entity - ID of the entity which activated the component.
+        //! @param parentEntity - ID of the closest parent which has a ROS2EditorFrameComponent.
         virtual void OnDeactivate(AZ::EntityId entity, AZ::EntityId parentEntity) = 0;
 
+        //! Notification when the reflected configuration changes in the editor.
         virtual void OnConfigurationChange() = 0;
 
+        //! Notification when ROS2EditorFrameComponent reconfigures (repopulates namespace, changed frameID etc.).
+        //! @param entity - ID of the ROS2EditorFrameComponent which reconfigured.
         virtual void OnReconfigure(AZ::EntityId entity) = 0;
     };
 

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameBus.h
@@ -13,6 +13,7 @@
 #include <AzFramework/Components/TransformComponent.h>
 #include <ROS2/Frame/ROS2Transform.h>
 #include <ROS2/ROS2GemUtilities.h>
+#include <ROS2/Frame/NamespaceConfiguration.h>
 
 namespace ROS2
 {
@@ -58,6 +59,11 @@ namespace ROS2
         //! Global frame name in ros2 ecosystem.
         //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
         virtual AZStd::string GetGlobalFrameName() const = 0;
+
+        //! Updates the namespace and namespace strategy of the underlying namespace configuration
+        //! @param ns Namespace to set.
+        //! @param strategy Namespace strategy to use.
+        virtual void UpdateNamespaceConfiguration(const AZStd::string& ns, NamespaceConfiguration::NamespaceStrategy strategy) = 0;
 
         //! Bus function to check if there is a handler connected.
         //! @return True it handler is connected.

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameBus.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzFramework/Components/TransformComponent.h>
+#include <ROS2/Frame/ROS2Transform.h>
+#include <ROS2/ROS2GemUtilities.h>
+
+namespace ROS2
+{
+    class ROS2FrameComponentRequests : public AZ::ComponentBus
+    {
+    public:
+        // One handler per address is supported.
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+
+        // The EBus has multiple addresses. Addresses are not ordered.
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+
+        // Messages are addressed by EntityId.
+        using BusIdType = AZ::EntityId;
+
+        //! Get a frame id, which is needed for any ROS2 message with a Header
+        //! @return Frame id which includes the namespace, ready to send in a ROS2 message
+        virtual AZStd::string GetFrameID() const = 0;
+
+        //! Get the joint name including the namespace
+        //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
+        //! @return The namespaced joint name, ready to send in a ROS2 message
+        virtual AZ::Name GetJointName() const = 0;
+
+        //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
+        //! @return A complete namespace (including parent namespaces)
+        virtual AZStd::string GetNamespace() const = 0;
+
+        //! Get a transform between this frame and the next frame up in hierarchy.
+        //! @return If the parent frame is found, return a Transform between this frame and the parent.
+        //! Otherwise, return a global Transform.
+        //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame components.
+        virtual AZ::Transform GetFrameTransform() const = 0;
+
+        //! Global frame name in ros2 ecosystem.
+        //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
+        virtual AZStd::string GetGlobalFrameName() const = 0;
+
+        virtual bool IsFrame() const = 0;
+    };
+
+    using ROS2FrameComponentBus = AZ::EBus<ROS2FrameComponentRequests>;
+} // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameBus.h
@@ -7,6 +7,9 @@
  */
 #pragma once
 
+#include "AzCore/Component/ComponentBus.h"
+#include "AzCore/Component/EntityId.h"
+#include "AzCore/EBus/EBus.h"
 #include <AzFramework/Components/TransformComponent.h>
 #include <ROS2/Frame/ROS2Transform.h>
 #include <ROS2/ROS2GemUtilities.h>
@@ -62,4 +65,22 @@ namespace ROS2
     };
 
     using ROS2FrameComponentBus = AZ::EBus<ROS2FrameComponentRequests>;
+
+    class ROS2FrameNotificationRequests : public AZ::ComponentBus
+    {
+    public:
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+
+        virtual void OnActivate(AZ::EntityId entity, AZ::EntityId parentEntity) = 0;
+
+        virtual void OnDeactivate(AZ::EntityId entity, AZ::EntityId parentEntity) = 0;
+
+        virtual void OnConfigurationChange() = 0;
+
+        virtual void OnReconfigure(AZ::EntityId entity) = 0;
+    };
+
+    using ROS2FrameNotificationBus = AZ::EBus<ROS2FrameNotificationRequests>;
 } // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
@@ -27,6 +27,7 @@ namespace ROS2
     //! @note A robot should have this component on every level of entity hierarchy (for each joint, fixed or dynamic)
     class ROS2FrameComponent
         : public ROS2FrameComponentBase
+        , public ROS2FrameComponentBus::Handler
         , public AZ::TickBus::Handler
     {
     public:
@@ -50,7 +51,7 @@ namespace ROS2
 
         //! Get a frame id, which is needed for any ROS2 message with a Header
         //! @return Frame id which includes the namespace, ready to send in a ROS2 message
-        AZStd::string GetFrameID() const;
+        AZStd::string GetFrameID() const override;
 
         //! Set a above-mentioned frame id
         void SetFrameID(const AZStd::string& frameId);
@@ -58,7 +59,7 @@ namespace ROS2
         //! Get the joint name including the namespace
         //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
         //! @return The namespaced joint name, ready to send in a ROS2 message
-        AZ::Name GetJointName() const;
+        AZ::Name GetJointName() const override;
 
         //! Set the joint name
         //! @note May be populated during URDF import or set by the user in the Editor view 
@@ -67,17 +68,19 @@ namespace ROS2
 
         //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
         //! @return A complete namespace (including parent namespaces)
-        AZStd::string GetNamespace() const;
+        AZStd::string GetNamespace() const override;
 
         //! Get a transform between this frame and the next frame up in hierarchy.
         //! @return If the parent frame is found, return a Transform between this frame and the parent.
         //! Otherwise, return a global Transform.
         //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame components.
-        AZ::Transform GetFrameTransform() const;
+        AZ::Transform GetFrameTransform() const override;
 
         //! Global frame name in ros2 ecosystem.
         //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
-        AZStd::string GetGlobalFrameName() const;
+        AZStd::string GetGlobalFrameName() const override;
+
+        bool IsFrame() const override;
 
         //! Updates the namespace and namespace strategy of the underlying namespace configuration
         //! @param ns Namespace to set.
@@ -94,8 +97,6 @@ namespace ROS2
 
         //! Whether transformation to parent frame can change during the simulation, or is fixed.
         bool IsDynamic() const;
-
-        const ROS2FrameComponent* GetParentROS2FrameComponent() const;
 
         //! Return the frame id of this frame's parent. It can be useful to determine ROS 2 transformations.
         //! @return Parent frame ID.

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
@@ -30,7 +30,7 @@ namespace ROS2
         , public AZ::TickBus::Handler
     {
     public:
-        AZ_COMPONENT(ROS2FrameComponent, "{ed8cf823-1813-4423-a874-5de13e9124d2}", AZ::Component);
+        AZ_COMPONENT(ROS2FrameComponent, "{EE743472-3E25-41EA-961B-14096AC1D66F}", AZ::Component);
 
         ROS2FrameComponent();
         //! Initialize to a specific frame id
@@ -55,28 +55,28 @@ namespace ROS2
         //! Set a above-mentioned frame id
         void SetFrameID(const AZStd::string& frameId);
 
-         //! Get the joint name including the namespace
-         //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
-         //! @return The namespaced joint name, ready to send in a ROS2 message
+        //! Get the joint name including the namespace
+        //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
+        //! @return The namespaced joint name, ready to send in a ROS2 message
         AZ::Name GetJointName() const;
 
-         //! Set the joint name
-         //! @note May be populated during URDF import or set by the user in the Editor view
-         //! @param jointNameString does not include th namespace. The namespace prefix is added automatically.
+        //! Set the joint name
+        //! @note May be populated during URDF import or set by the user in the Editor view
+        //! @param jointNameString does not include th namespace. The namespace prefix is added automatically.
         void SetJointName(const AZStd::string& jointNameString);
 
-         //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
-         //! @return A complete namespace (including parent namespaces)
+        //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
+        //! @return A complete namespace (including parent namespaces)
         AZStd::string GetNamespace() const;
 
-         //! Get a transform between this frame and the next frame up in hierarchy.
-         //! @return If the parent frame is found, return a Transform between this frame and the parent.
-         //! Otherwise, return a global Transform.
-         //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame components.
+        //! Get a transform between this frame and the next frame up in hierarchy.
+        //! @return If the parent frame is found, return a Transform between this frame and the parent.
+        //! Otherwise, return a global Transform.
+        //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame components.
         AZ::Transform GetFrameTransform() const;
 
-         //! Global frame name in ros2 ecosystem.
-         //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
+        //! Global frame name in ros2 ecosystem.
+        //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
         AZStd::string GetGlobalFrameName() const;
 
         bool IsFrame() const override;
@@ -86,21 +86,23 @@ namespace ROS2
         //! @param strategy Namespace strategy to use.
         void UpdateNamespaceConfiguration(const AZStd::string& ns, NamespaceConfiguration::NamespaceStrategy strategy);
 
+        ROS2FrameConfiguration GetConfiguration() const;
+
     private:
         //////////////////////////////////////////////////////////////////////////
         // AZ::TickBus::Handler overrides
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
-         //////////////////////////////////////////////////////////////////////////
+        //////////////////////////////////////////////////////////////////////////
 
         bool IsTopLevel() const; //!< True if this entity does not have a parent entity with ROS2.
 
         //! Whether transformation to parent frame can change during the simulation, or is fixed.
         bool IsDynamic() const;
 
-         //! Return the frame id of this frame's parent. It can be useful to determine ROS 2 transformations.
-         //! @return Parent frame ID.
-         //! @note This also works with top-level frames, returning a global frame name.
-         //! @see GetGlobalFrameName().
+        //! Return the frame id of this frame's parent. It can be useful to determine ROS 2 transformations.
+        //! @return Parent frame ID.
+        //! @note This also works with top-level frames, returning a global frame name.
+        //! @see GetGlobalFrameName().
         AZStd::string GetParentFrameID() const;
 
         AZStd::unique_ptr<ROS2Transform> m_ros2Transform;

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
@@ -30,7 +30,7 @@ namespace ROS2
         , public AZ::TickBus::Handler
     {
     public:
-        AZ_COMPONENT(ROS2FrameComponent, "{EE743472-3E25-41EA-961B-14096AC1D66F}", AZ::Component);
+        AZ_COMPONENT(ROS2FrameComponent, "{ed8cf823-1813-4423-a874-5de13e9124d2}", AZ::Component);
 
         ROS2FrameComponent();
         //! Initialize to a specific frame id

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
@@ -48,11 +48,6 @@ namespace ROS2
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
 
-        //! Updates the namespace and namespace strategy of the underlying namespace configuration
-        //! @param ns Namespace to set.
-        //! @param strategy Namespace strategy to use.
-        void UpdateNamespaceConfiguration(const AZStd::string& ns, NamespaceConfiguration::NamespaceStrategy strategy);
-
         ROS2FrameConfiguration GetConfiguration() const;
 
     private:

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
@@ -27,7 +27,6 @@ namespace ROS2
     //! @note A robot should have this component on every level of entity hierarchy (for each joint, fixed or dynamic)
     class ROS2FrameComponent
         : public ROS2FrameComponentBase
-        , public ROS2FrameComponentBus::Handler
         , public AZ::TickBus::Handler
     {
     public:
@@ -51,34 +50,34 @@ namespace ROS2
 
         //! Get a frame id, which is needed for any ROS2 message with a Header
         //! @return Frame id which includes the namespace, ready to send in a ROS2 message
-        AZStd::string GetFrameID() const override;
+        AZStd::string GetFrameID() const;
 
         //! Set a above-mentioned frame id
         void SetFrameID(const AZStd::string& frameId);
 
-        //! Get the joint name including the namespace
-        //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
-        //! @return The namespaced joint name, ready to send in a ROS2 message
-        AZ::Name GetJointName() const override;
+         //! Get the joint name including the namespace
+         //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
+         //! @return The namespaced joint name, ready to send in a ROS2 message
+        AZ::Name GetJointName() const;
 
-        //! Set the joint name
-        //! @note May be populated during URDF import or set by the user in the Editor view 
-        //! @param jointNameString does not include the namespace. The namespace prefix is added automatically.
+         //! Set the joint name
+         //! @note May be populated during URDF import or set by the user in the Editor view
+         //! @param jointNameString does not include th namespace. The namespace prefix is added automatically.
         void SetJointName(const AZStd::string& jointNameString);
 
-        //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
-        //! @return A complete namespace (including parent namespaces)
-        AZStd::string GetNamespace() const override;
+         //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
+         //! @return A complete namespace (including parent namespaces)
+        AZStd::string GetNamespace() const;
 
-        //! Get a transform between this frame and the next frame up in hierarchy.
-        //! @return If the parent frame is found, return a Transform between this frame and the parent.
-        //! Otherwise, return a global Transform.
-        //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame components.
-        AZ::Transform GetFrameTransform() const override;
+         //! Get a transform between this frame and the next frame up in hierarchy.
+         //! @return If the parent frame is found, return a Transform between this frame and the parent.
+         //! Otherwise, return a global Transform.
+         //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame components.
+        AZ::Transform GetFrameTransform() const;
 
-        //! Global frame name in ros2 ecosystem.
-        //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
-        AZStd::string GetGlobalFrameName() const override;
+         //! Global frame name in ros2 ecosystem.
+         //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
+        AZStd::string GetGlobalFrameName() const;
 
         bool IsFrame() const override;
 
@@ -91,17 +90,17 @@ namespace ROS2
         //////////////////////////////////////////////////////////////////////////
         // AZ::TickBus::Handler overrides
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
-        //////////////////////////////////////////////////////////////////////////
+         //////////////////////////////////////////////////////////////////////////
 
         bool IsTopLevel() const; //!< True if this entity does not have a parent entity with ROS2.
 
         //! Whether transformation to parent frame can change during the simulation, or is fixed.
         bool IsDynamic() const;
 
-        //! Return the frame id of this frame's parent. It can be useful to determine ROS 2 transformations.
-        //! @return Parent frame ID.
-        //! @note This also works with top-level frames, returning a global frame name.
-        //! @see GetGlobalFrameName().
+         //! Return the frame id of this frame's parent. It can be useful to determine ROS 2 transformations.
+         //! @return Parent frame ID.
+         //! @note This also works with top-level frames, returning a global frame name.
+         //! @see GetGlobalFrameName().
         AZStd::string GetParentFrameID() const;
 
         AZStd::unique_ptr<ROS2Transform> m_ros2Transform;

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
@@ -48,39 +48,6 @@ namespace ROS2
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
 
-        //! Get a frame id, which is needed for any ROS2 message with a Header
-        //! @return Frame id which includes the namespace, ready to send in a ROS2 message
-        AZStd::string GetFrameID() const;
-
-        //! Set a above-mentioned frame id
-        void SetFrameID(const AZStd::string& frameId);
-
-        //! Get the joint name including the namespace
-        //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
-        //! @return The namespaced joint name, ready to send in a ROS2 message
-        AZ::Name GetJointName() const;
-
-        //! Set the joint name
-        //! @note May be populated during URDF import or set by the user in the Editor view
-        //! @param jointNameString does not include th namespace. The namespace prefix is added automatically.
-        void SetJointName(const AZStd::string& jointNameString);
-
-        //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
-        //! @return A complete namespace (including parent namespaces)
-        AZStd::string GetNamespace() const;
-
-        //! Get a transform between this frame and the next frame up in hierarchy.
-        //! @return If the parent frame is found, return a Transform between this frame and the parent.
-        //! Otherwise, return a global Transform.
-        //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame components.
-        AZ::Transform GetFrameTransform() const;
-
-        //! Global frame name in ros2 ecosystem.
-        //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
-        AZStd::string GetGlobalFrameName() const;
-
-        bool IsFrame() const override;
-
         //! Updates the namespace and namespace strategy of the underlying namespace configuration
         //! @param ns Namespace to set.
         //! @param strategy Namespace strategy to use.
@@ -93,17 +60,6 @@ namespace ROS2
         // AZ::TickBus::Handler overrides
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
         //////////////////////////////////////////////////////////////////////////
-
-        bool IsTopLevel() const; //!< True if this entity does not have a parent entity with ROS2.
-
-        //! Whether transformation to parent frame can change during the simulation, or is fixed.
-        bool IsDynamic() const;
-
-        //! Return the frame id of this frame's parent. It can be useful to determine ROS 2 transformations.
-        //! @return Parent frame ID.
-        //! @note This also works with top-level frames, returning a global frame name.
-        //! @see GetGlobalFrameName().
-        AZStd::string GetParentFrameID() const;
 
         AZStd::unique_ptr<ROS2Transform> m_ros2Transform;
     };

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
@@ -8,12 +8,14 @@
 #pragma once
 
 #include "AzCore/Component/Entity.h"
+#include "ROS2/Frame/ROS2FrameBus.h"
 #include <AzCore/Component/Component.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/string/string.h>
 #include <AzFramework/Components/ComponentAdapter.h>
 #include <ROS2/Frame/NamespaceConfiguration.h>
+#include <ROS2/Utilities/ROS2Names.h>
 
 namespace ROS2
 {
@@ -36,7 +38,7 @@ namespace ROS2
         AZ::EntityId m_editorEntityId;
     };
 
-    class ROS2FrameComponentController
+    class ROS2FrameComponentController : public ROS2FrameComponentBus::Handler
     {
     public:
         AZ_TYPE_INFO(ROS2FrameComponentController, "{f96f3711-56a8-478d-b270-17681e5bb136}");
@@ -57,8 +59,7 @@ namespace ROS2
 
         //! Get a frame id, which is needed for any ROS2 message with a Header
         //! @return Frame id which includes the namespace, ready to send in a ROS2 message
-        template<typename T>
-        AZStd::string GetFrameID() const;
+        AZStd::string GetFrameID() const override;
 
         //! Set a above-mentioned frame id
         void SetFrameID(const AZStd::string& frameId);
@@ -66,8 +67,7 @@ namespace ROS2
         //! Get the joint name including the namespace
         //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
         //! @return The namespaced joint name, ready to send in a ROS2 message
-        template<typename T>
-        AZ::Name GetJointName() const;
+        AZ::Name GetJointName() const override;
 
         //! Set the joint name
         //! @note May be populated during URDF import or set by the user in the Editor view
@@ -76,36 +76,32 @@ namespace ROS2
 
         //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
         //! @return A complete namespace (including parent namespaces)
-        template<typename T>
-        AZStd::string GetNamespace() const;
+        AZStd::string GetNamespace() const override;
 
         //! Get a transform between this frame and the next frame up in hierarchy.
         //! @return If the parent frame is found, return a Transform between this frame and the parent.
         //! Otherwise, return a global Transform.
         //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame
         //! components.
-        template<typename T>
-        AZ::Transform GetFrameTransform() const;
+        AZ::Transform GetFrameTransform() const override;
 
         //! Global frame name in ros2 ecosystem.
         //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
-        template<typename T>
-        AZStd::string GetGlobalFrameName() const;
+        AZStd::string GetGlobalFrameName() const override;
 
-        template<typename T>
+        bool IsFrame() const override;
+
         bool IsTopLevel() const; //!< True if this entity does not have a parent entity with ROS2.
 
         //! Whether transformation to parent frame can change during the simulation, or is fixed.
         bool IsDynamic() const;
 
-        template<typename T>
-        const T* GetParentROS2FrameComponent() const;
+        const AZ::EntityId GetParentROS2FrameComponentId() const;
 
         //! Return the frame id of this frame's parent. It can be useful to determine ROS 2 transformations.
         //! @return Parent frame ID.
         //! @note This also works with top-level frames, returning a global frame name.
         //! @see GetGlobalFrameName().
-        template<typename T>
         AZStd::string GetParentFrameID() const;
 
         void PopulateNamespace(bool isRoot, const AZStd::string& entityName);

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "AzCore/Component/Entity.h"
+#include "AzCore/Component/EntityId.h"
 #include "ROS2/Frame/ROS2FrameBus.h"
 #include <AzCore/Component/Component.h>
 #include <AzCore/RTTI/RTTI.h>
@@ -35,10 +36,10 @@ namespace ROS2
         bool m_publishTransform = true;
         bool m_isDynamic = false;
 
-        AZ::EntityId m_editorEntityId;
+        AZ::EntityId m_activeEntityId;
     };
 
-    class ROS2FrameComponentController : public ROS2FrameComponentBus::Handler
+    class ROS2FrameComponentController
     {
     public:
         AZ_TYPE_INFO(ROS2FrameComponentController, "{f96f3711-56a8-478d-b270-17681e5bb136}");
@@ -59,7 +60,7 @@ namespace ROS2
 
         //! Get a frame id, which is needed for any ROS2 message with a Header
         //! @return Frame id which includes the namespace, ready to send in a ROS2 message
-        AZStd::string GetFrameID() const override;
+        AZStd::string GetFrameID() const;
 
         //! Set a above-mentioned frame id
         void SetFrameID(const AZStd::string& frameId);
@@ -67,7 +68,7 @@ namespace ROS2
         //! Get the joint name including the namespace
         //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
         //! @return The namespaced joint name, ready to send in a ROS2 message
-        AZ::Name GetJointName() const override;
+        AZ::Name GetJointName() const;
 
         //! Set the joint name
         //! @note May be populated during URDF import or set by the user in the Editor view
@@ -76,20 +77,18 @@ namespace ROS2
 
         //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
         //! @return A complete namespace (including parent namespaces)
-        AZStd::string GetNamespace() const override;
+        AZStd::string GetNamespace() const;
 
         //! Get a transform between this frame and the next frame up in hierarchy.
         //! @return If the parent frame is found, return a Transform between this frame and the parent.
         //! Otherwise, return a global Transform.
         //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame
         //! components.
-        AZ::Transform GetFrameTransform() const override;
+        AZ::Transform GetFrameTransform() const;
 
         //! Global frame name in ros2 ecosystem.
         //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
-        AZStd::string GetGlobalFrameName() const override;
-
-        bool IsFrame() const override;
+        AZStd::string GetGlobalFrameName() const;
 
         bool IsTopLevel() const; //!< True if this entity does not have a parent entity with ROS2.
 
@@ -109,6 +108,8 @@ namespace ROS2
         bool GetPublishTransform();
 
         void SetIsDynamic(bool value);
+
+        void SetActiveEntityId(AZ::EntityId entityId);
 
     private:
         ROS2FrameConfiguration m_configuration;

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
@@ -95,7 +95,7 @@ namespace ROS2
         //! Whether transformation to parent frame can change during the simulation, or is fixed.
         bool IsDynamic() const;
 
-        const AZ::EntityId GetParentROS2FrameComponentId() const;
+        const AZ::EntityId GetParentROS2FrameEntityId() const;
 
         //! Return the frame id of this frame's parent. It can be useful to determine ROS 2 transformations.
         //! @return Parent frame ID.
@@ -113,7 +113,8 @@ namespace ROS2
 
         bool IsFrame() const override;
 
-    private:
+        void ConfigurationChange() const;
+
         ROS2FrameConfiguration m_configuration;
     };
 

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "AzCore/Component/Entity.h"
+#include <AzCore/Component/Component.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/string/string.h>
+#include <AzFramework/Components/ComponentAdapter.h>
+#include <ROS2/Frame/NamespaceConfiguration.h>
+
+namespace ROS2
+{
+
+    class ROS2FrameConfiguration final : public AZ::ComponentConfig
+    {
+    public:
+        AZ_TYPE_INFO(ROS2FrameConfiguration, "{04882f01-5451-4efa-b4f8-cd57e4b6cadf}");
+        static void Reflect(AZ::ReflectContext* context);
+
+        AZ::Entity* GetEntity() const;
+
+        NamespaceConfiguration m_namespaceConfiguration;
+        AZStd::string m_frameName = "sensor_frame";
+        AZStd::string m_jointNameString;
+
+        bool m_publishTransform = true;
+        bool m_isDynamic = false;
+
+        AZ::EntityId m_editorEntityId;
+    };
+
+    class ROS2FrameComponentController
+    {
+    public:
+        AZ_TYPE_INFO(ROS2FrameComponentController, "{f96f3711-56a8-478d-b270-17681e5bb136}");
+
+        ROS2FrameComponentController() = default;
+        explicit ROS2FrameComponentController(const ROS2FrameConfiguration& config);
+        ~ROS2FrameComponentController() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        //////////////////////////////////////////////////////////////////////////
+        // Controller component
+        void Activate(AZ::EntityId entityId);
+        void Deactivate();
+        void SetConfiguration(const ROS2FrameConfiguration& config);
+        const ROS2FrameConfiguration& GetConfiguration() const;
+        //////////////////////////////////////////////////////////////////////////
+
+        //! Get a frame id, which is needed for any ROS2 message with a Header
+        //! @return Frame id which includes the namespace, ready to send in a ROS2 message
+        template<typename T>
+        AZStd::string GetFrameID() const;
+
+        //! Set a above-mentioned frame id
+        void SetFrameID(const AZStd::string& frameId);
+
+        //! Get the joint name including the namespace
+        //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
+        //! @return The namespaced joint name, ready to send in a ROS2 message
+        template<typename T>
+        AZ::Name GetJointName() const;
+
+        //! Set the joint name
+        //! @note May be populated during URDF import or set by the user in the Editor view
+        //! @param jointNameString does not include the namespace. The namespace prefix is added automatically.
+        void SetJointName(const AZStd::string& jointNameString);
+
+        //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
+        //! @return A complete namespace (including parent namespaces)
+        template<typename T>
+        AZStd::string GetNamespace() const;
+
+        //! Get a transform between this frame and the next frame up in hierarchy.
+        //! @return If the parent frame is found, return a Transform between this frame and the parent.
+        //! Otherwise, return a global Transform.
+        //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame
+        //! components.
+        template<typename T>
+        AZ::Transform GetFrameTransform() const;
+
+        //! Global frame name in ros2 ecosystem.
+        //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
+        template<typename T>
+        AZStd::string GetGlobalFrameName() const;
+
+        template<typename T>
+        bool IsTopLevel() const; //!< True if this entity does not have a parent entity with ROS2.
+
+        //! Whether transformation to parent frame can change during the simulation, or is fixed.
+        bool IsDynamic() const;
+
+        template<typename T>
+        const T* GetParentROS2FrameComponent() const;
+
+        //! Return the frame id of this frame's parent. It can be useful to determine ROS 2 transformations.
+        //! @return Parent frame ID.
+        //! @note This also works with top-level frames, returning a global frame name.
+        //! @see GetGlobalFrameName().
+        template<typename T>
+        AZStd::string GetParentFrameID() const;
+
+        void PopulateNamespace(bool isRoot, const AZStd::string& entityName);
+
+        bool GetPublishTransform();
+
+        void SetIsDynamic(bool value);
+
+    private:
+        ROS2FrameConfiguration m_configuration;
+    };
+
+} // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
@@ -39,7 +39,7 @@ namespace ROS2
         AZ::EntityId m_activeEntityId;
     };
 
-    class ROS2FrameComponentController
+    class ROS2FrameComponentController : public ROS2FrameComponentBus::Handler
     {
     public:
         AZ_TYPE_INFO(ROS2FrameComponentController, "{f96f3711-56a8-478d-b270-17681e5bb136}");
@@ -60,7 +60,7 @@ namespace ROS2
 
         //! Get a frame id, which is needed for any ROS2 message with a Header
         //! @return Frame id which includes the namespace, ready to send in a ROS2 message
-        AZStd::string GetFrameID() const;
+        AZStd::string GetFrameID() const override;
 
         //! Set a above-mentioned frame id
         void SetFrameID(const AZStd::string& frameId);
@@ -68,7 +68,7 @@ namespace ROS2
         //! Get the joint name including the namespace
         //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
         //! @return The namespaced joint name, ready to send in a ROS2 message
-        AZ::Name GetJointName() const;
+        AZ::Name GetJointName() const override;
 
         //! Set the joint name
         //! @note May be populated during URDF import or set by the user in the Editor view
@@ -77,18 +77,18 @@ namespace ROS2
 
         //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
         //! @return A complete namespace (including parent namespaces)
-        AZStd::string GetNamespace() const;
+        AZStd::string GetNamespace() const override;
 
         //! Get a transform between this frame and the next frame up in hierarchy.
         //! @return If the parent frame is found, return a Transform between this frame and the parent.
         //! Otherwise, return a global Transform.
         //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame
         //! components.
-        AZ::Transform GetFrameTransform() const;
+        AZ::Transform GetFrameTransform() const override;
 
         //! Global frame name in ros2 ecosystem.
         //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
-        AZStd::string GetGlobalFrameName() const;
+        AZStd::string GetGlobalFrameName() const override;
 
         bool IsTopLevel() const; //!< True if this entity does not have a parent entity with ROS2.
 
@@ -110,6 +110,8 @@ namespace ROS2
         void SetIsDynamic(bool value);
 
         void SetActiveEntityId(AZ::EntityId entityId);
+
+        bool IsFrame() const override;
 
     private:
         ROS2FrameConfiguration m_configuration;

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
@@ -58,37 +58,24 @@ namespace ROS2
         const ROS2FrameConfiguration& GetConfiguration() const;
         //////////////////////////////////////////////////////////////////////////
 
-        //! Get a frame id, which is needed for any ROS2 message with a Header
-        //! @return Frame id which includes the namespace, ready to send in a ROS2 message
+        //////////////////////////////////////////////////////////////////////////
+        // ROS2FrameComponentBus::Handler overrides
         AZStd::string GetFrameID() const override;
 
-        //! Set a above-mentioned frame id
         void SetFrameID(const AZStd::string& frameId);
 
-        //! Get the joint name including the namespace
-        //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
-        //! @return The namespaced joint name, ready to send in a ROS2 message
         AZ::Name GetJointName() const override;
 
-        //! Set the joint name
-        //! @note May be populated during URDF import or set by the user in the Editor view
-        //! @param jointNameString does not include the namespace. The namespace prefix is added automatically.
         void SetJointName(const AZStd::string& jointNameString);
 
-        //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
-        //! @return A complete namespace (including parent namespaces)
         AZStd::string GetNamespace() const override;
 
-        //! Get a transform between this frame and the next frame up in hierarchy.
-        //! @return If the parent frame is found, return a Transform between this frame and the parent.
-        //! Otherwise, return a global Transform.
-        //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame
-        //! components.
         AZ::Transform GetFrameTransform() const override;
 
-        //! Global frame name in ros2 ecosystem.
-        //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
         AZStd::string GetGlobalFrameName() const override;
+
+        bool IsFrame() const override;
+        //////////////////////////////////////////////////////////////////////////
 
         bool IsTopLevel() const; //!< True if this entity does not have a parent entity with ROS2.
 
@@ -111,8 +98,8 @@ namespace ROS2
 
         void SetActiveEntityId(AZ::EntityId entityId);
 
-        bool IsFrame() const override;
-
+    private:
+        // Callback for when the reflected configuration changes.
         void ConfigurationChange() const;
 
         ROS2FrameConfiguration m_configuration;

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
@@ -7,15 +7,15 @@
  */
 #pragma once
 
-#include "AzCore/Component/Entity.h"
-#include "AzCore/Component/EntityId.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
 #include <AzCore/Component/Component.h>
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Component/EntityId.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/string/string.h>
 #include <AzFramework/Components/ComponentAdapter.h>
 #include <ROS2/Frame/NamespaceConfiguration.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Utilities/ROS2Names.h>
 
 namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameController.h
@@ -61,19 +61,13 @@ namespace ROS2
         //////////////////////////////////////////////////////////////////////////
         // ROS2FrameComponentBus::Handler overrides
         AZStd::string GetFrameID() const override;
-
         void SetFrameID(const AZStd::string& frameId);
-
         AZ::Name GetJointName() const override;
-
         void SetJointName(const AZStd::string& jointNameString);
-
         AZStd::string GetNamespace() const override;
-
         AZ::Transform GetFrameTransform() const override;
-
         AZStd::string GetGlobalFrameName() const override;
-
+        void UpdateNamespaceConfiguration(const AZStd::string& ns, NamespaceConfiguration::NamespaceStrategy strategy) override;
         bool IsFrame() const override;
         //////////////////////////////////////////////////////////////////////////
 

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
@@ -10,7 +10,10 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzFramework/Components/TransformComponent.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentAdapter.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 #include <ROS2/Frame/NamespaceConfiguration.h>
+#include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/Frame/ROS2FrameController.h>
 #include <ROS2/Frame/ROS2Transform.h>
 #include <ROS2/ROS2GemUtilities.h>
@@ -18,24 +21,23 @@
 namespace ROS2
 {
 
-    using ROS2FrameComponentBase = AzFramework::Components::ComponentAdapter<ROS2FrameComponentController, ROS2FrameConfiguration>;
+    using ROS2FrameEditorComponentBase =
+        AzToolsFramework::Components::EditorComponentAdapter<ROS2FrameComponentController, ROS2FrameComponent, ROS2FrameConfiguration>;
 
     //! This component marks an interesting reference frame for ROS2 ecosystem.
     //! It serves as sensor data frame of reference and is responsible, through ROS2Transform, for publishing
     //! ros2 static and dynamic transforms (/tf_static, /tf). It also facilitates namespace handling.
     //! An entity can only have a single ROS2Frame on each level. Many ROS2 Components require this component.
     //! @note A robot should have this component on every level of entity hierarchy (for each joint, fixed or dynamic)
-    class ROS2FrameComponent
-        : public ROS2FrameComponentBase
-        , public AZ::TickBus::Handler
+    class ROS2FrameEditorComponent : public ROS2FrameEditorComponentBase
     {
     public:
-        AZ_COMPONENT(ROS2FrameComponent, "{EE743472-3E25-41EA-961B-14096AC1D66F}", AZ::Component);
+        AZ_COMPONENT(ROS2FrameEditorComponent, "{ed8cf823-1813-4423-a874-5de13e9124d2}", AzToolsFramework::Components::EditorComponentBase);
 
-        ROS2FrameComponent();
+        ROS2FrameEditorComponent();
         //! Initialize to a specific frame id
-        ROS2FrameComponent(const AZStd::string& frameId);
-        ROS2FrameComponent(const ROS2FrameConfiguration& config);
+        ROS2FrameEditorComponent(const AZStd::string& frameId);
+        ROS2FrameEditorComponent(const ROS2FrameConfiguration& config);
 
         //////////////////////////////////////////////////////////////////////////
         // Component overrides
@@ -61,7 +63,7 @@ namespace ROS2
         AZ::Name GetJointName() const;
 
         //! Set the joint name
-        //! @note May be populated during URDF import or set by the user in the Editor view 
+        //! @note May be populated during URDF import or set by the user in the Editor view
         //! @param jointNameString does not include the namespace. The namespace prefix is added automatically.
         void SetJointName(const AZStd::string& jointNameString);
 
@@ -79,23 +81,13 @@ namespace ROS2
         //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
         AZStd::string GetGlobalFrameName() const;
 
-        //! Updates the namespace and namespace strategy of the underlying namespace configuration
-        //! @param ns Namespace to set.
-        //! @param strategy Namespace strategy to use.
-        void UpdateNamespaceConfiguration(const AZStd::string& ns, NamespaceConfiguration::NamespaceStrategy strategy);
-
     private:
-        //////////////////////////////////////////////////////////////////////////
-        // AZ::TickBus::Handler overrides
-        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
-        //////////////////////////////////////////////////////////////////////////
-
         bool IsTopLevel() const; //!< True if this entity does not have a parent entity with ROS2.
 
         //! Whether transformation to parent frame can change during the simulation, or is fixed.
         bool IsDynamic() const;
 
-        const ROS2FrameComponent* GetParentROS2FrameComponent() const;
+        const ROS2FrameEditorComponent* GetParentROS2FrameComponent() const;
 
         //! Return the frame id of this frame's parent. It can be useful to determine ROS 2 transformations.
         //! @return Parent frame ID.

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
@@ -32,7 +32,7 @@ namespace ROS2
     class ROS2FrameEditorComponent : public ROS2FrameEditorComponentBase
     {
     public:
-        AZ_COMPONENT(ROS2FrameEditorComponent, "{ed8cf823-1813-4423-a874-5de13e9124d2}", AzToolsFramework::Components::EditorComponentBase);
+        AZ_COMPONENT(ROS2FrameEditorComponent, "{EE743472-3E25-41EA-961B-14096AC1D66F}", AzToolsFramework::Components::EditorComponentBase);
 
         ROS2FrameEditorComponent();
         //! Initialize to a specific frame id
@@ -80,6 +80,8 @@ namespace ROS2
         //! Global frame name in ros2 ecosystem.
         //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
         AZStd::string GetGlobalFrameName() const;
+
+        bool ShouldActivateController() const override;
 
     private:
         bool IsTopLevel() const; //!< True if this entity does not have a parent entity with ROS2.

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
@@ -29,7 +29,9 @@ namespace ROS2
     //! ros2 static and dynamic transforms (/tf_static, /tf). It also facilitates namespace handling.
     //! An entity can only have a single ROS2Frame on each level. Many ROS2 Components require this component.
     //! @note A robot should have this component on every level of entity hierarchy (for each joint, fixed or dynamic)
-    class ROS2FrameEditorComponent : public ROS2FrameEditorComponentBase
+    class ROS2FrameEditorComponent
+        : public ROS2FrameEditorComponentBase
+        , public ROS2FrameComponentBus::Handler
     {
     public:
         AZ_COMPONENT(ROS2FrameEditorComponent, "{EE743472-3E25-41EA-961B-14096AC1D66F}", AzToolsFramework::Components::EditorComponentBase);
@@ -52,7 +54,7 @@ namespace ROS2
 
         //! Get a frame id, which is needed for any ROS2 message with a Header
         //! @return Frame id which includes the namespace, ready to send in a ROS2 message
-        AZStd::string GetFrameID() const;
+        AZStd::string GetFrameID() const override;
 
         //! Set a above-mentioned frame id
         void SetFrameID(const AZStd::string& frameId);
@@ -60,7 +62,7 @@ namespace ROS2
         //! Get the joint name including the namespace
         //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
         //! @return The namespaced joint name, ready to send in a ROS2 message
-        AZ::Name GetJointName() const;
+        AZ::Name GetJointName() const override;
 
         //! Set the joint name
         //! @note May be populated during URDF import or set by the user in the Editor view
@@ -69,27 +71,27 @@ namespace ROS2
 
         //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
         //! @return A complete namespace (including parent namespaces)
-        AZStd::string GetNamespace() const;
+        AZStd::string GetNamespace() const override;
 
         //! Get a transform between this frame and the next frame up in hierarchy.
         //! @return If the parent frame is found, return a Transform between this frame and the parent.
         //! Otherwise, return a global Transform.
         //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame components.
-        AZ::Transform GetFrameTransform() const;
+        AZ::Transform GetFrameTransform() const override;
 
         //! Global frame name in ros2 ecosystem.
         //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
-        AZStd::string GetGlobalFrameName() const;
+        AZStd::string GetGlobalFrameName() const override;
 
         bool ShouldActivateController() const override;
+
+        bool IsFrame() const override;
 
     private:
         bool IsTopLevel() const; //!< True if this entity does not have a parent entity with ROS2.
 
         //! Whether transformation to parent frame can change during the simulation, or is fixed.
         bool IsDynamic() const;
-
-        const ROS2FrameEditorComponent* GetParentROS2FrameComponent() const;
 
         //! Return the frame id of this frame's parent. It can be useful to determine ROS 2 transformations.
         //! @return Parent frame ID.

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
@@ -29,9 +29,7 @@ namespace ROS2
     //! ros2 static and dynamic transforms (/tf_static, /tf). It also facilitates namespace handling.
     //! An entity can only have a single ROS2Frame on each level. Many ROS2 Components require this component.
     //! @note A robot should have this component on every level of entity hierarchy (for each joint, fixed or dynamic)
-    class ROS2FrameEditorComponent
-        : public ROS2FrameEditorComponentBase
-        , public ROS2FrameComponentBus::Handler
+    class ROS2FrameEditorComponent : public ROS2FrameEditorComponentBase
     {
     public:
         AZ_COMPONENT(ROS2FrameEditorComponent, "{EE743472-3E25-41EA-961B-14096AC1D66F}", AzToolsFramework::Components::EditorComponentBase);
@@ -46,7 +44,6 @@ namespace ROS2
         void Activate() override;
         void Deactivate() override;
         //////////////////////////////////////////////////////////////////////////
-
         static void Reflect(AZ::ReflectContext* context);
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
@@ -54,7 +51,7 @@ namespace ROS2
 
         //! Get a frame id, which is needed for any ROS2 message with a Header
         //! @return Frame id which includes the namespace, ready to send in a ROS2 message
-        AZStd::string GetFrameID() const override;
+        AZStd::string GetFrameID() const;
 
         //! Set a above-mentioned frame id
         void SetFrameID(const AZStd::string& frameId);
@@ -62,7 +59,7 @@ namespace ROS2
         //! Get the joint name including the namespace
         //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
         //! @return The namespaced joint name, ready to send in a ROS2 message
-        AZ::Name GetJointName() const override;
+        AZ::Name GetJointName() const;
 
         //! Set the joint name
         //! @note May be populated during URDF import or set by the user in the Editor view
@@ -71,21 +68,19 @@ namespace ROS2
 
         //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
         //! @return A complete namespace (including parent namespaces)
-        AZStd::string GetNamespace() const override;
+        AZStd::string GetNamespace() const;
 
         //! Get a transform between this frame and the next frame up in hierarchy.
         //! @return If the parent frame is found, return a Transform between this frame and the parent.
         //! Otherwise, return a global Transform.
         //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame components.
-        AZ::Transform GetFrameTransform() const override;
+        AZ::Transform GetFrameTransform() const;
 
         //! Global frame name in ros2 ecosystem.
         //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
-        AZStd::string GetGlobalFrameName() const override;
+        AZStd::string GetGlobalFrameName() const;
 
         bool ShouldActivateController() const override;
-
-        bool IsFrame() const override;
 
     private:
         bool IsTopLevel() const; //!< True if this entity does not have a parent entity with ROS2.

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
@@ -7,14 +7,14 @@
  */
 #pragma once
 
-#include "API/ToolsApplicationAPI.h"
-#include "AzCore/Component/Entity.h"
-#include "AzCore/Component/EntityBus.h"
-#include "AzCore/Component/EntityId.h"
-#include "AzCore/Component/TransformBus.h"
-#include "AzCore/std/string/string.h"
+#include <API/ToolsApplicationAPI.h>
 #include <AzCore/Component/Component.h>
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Component/EntityBus.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/Component/TransformBus.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/std/string/string.h>
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentAdapter.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
@@ -53,27 +53,33 @@ namespace ROS2
         // Component overrides
         void Activate() override;
         void Deactivate() override;
+        bool ShouldActivateController() const override;
         //////////////////////////////////////////////////////////////////////////
         static void Reflect(AZ::ReflectContext* context);
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
 
-        bool ShouldActivateController() const override;
-
+        //////////////////////////////////////////////////////////////////////////
+        // ROS2FrameNotificationBus::Handler overrides
         void OnActivate(AZ::EntityId entity, AZ::EntityId parentEntity) override;
-
         void OnDeactivate(AZ::EntityId entity, AZ::EntityId parentEntity) override;
-
         void OnReconfigure(AZ::EntityId entity) override;
-
         void OnConfigurationChange() override;
+        //////////////////////////////////////////////////////////////////////////
 
+        //////////////////////////////////////////////////////////////////////////
+        // AzToolsFramework::ToolsApplicationNotificationBus::Handler overrides
         void EntityParentChanged(AZ::EntityId entityId, AZ::EntityId newParentId, AZ::EntityId oldParentId) override;
+        //////////////////////////////////////////////////////////////////////////
 
-        void OnEntityNameChanged(const AZStd::string& name);
+        //////////////////////////////////////////////////////////////////////////
+        //  AZ::EntityBus::Handler overrides
+        void OnEntityNameChanged(const AZStd::string& name) override;
+        //////////////////////////////////////////////////////////////////////////
 
     private:
+        // Refresh the editor reflection for m_effectiveNamespace
         void RefreshEffectiveNamespace();
 
         AZStd::unique_ptr<ROS2Transform> m_ros2Transform;

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
@@ -59,37 +59,6 @@ namespace ROS2
         static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
 
-        //! Get a frame id, which is needed for any ROS2 message with a Header
-        //! @return Frame id which includes the namespace, ready to send in a ROS2 message
-        AZStd::string GetFrameID() const;
-
-        //! Set a above-mentioned frame id
-        void SetFrameID(const AZStd::string& frameId);
-
-        //! Get the joint name including the namespace
-        //! @note Supplementary metadata for Joint components, necessary in some cases for joints addressed by name in ROS 2
-        //! @return The namespaced joint name, ready to send in a ROS2 message
-        AZ::Name GetJointName() const;
-
-        //! Set the joint name
-        //! @note May be populated during URDF import or set by the user in the Editor view
-        //! @param jointNameString does not include the namespace. The namespace prefix is added automatically.
-        void SetJointName(const AZStd::string& jointNameString);
-
-        //! Get a namespace, which should be used for any publisher or subscriber in the same entity.
-        //! @return A complete namespace (including parent namespaces)
-        AZStd::string GetNamespace() const;
-
-        //! Get a transform between this frame and the next frame up in hierarchy.
-        //! @return If the parent frame is found, return a Transform between this frame and the parent.
-        //! Otherwise, return a global Transform.
-        //! @note Parent frame is not the same as parent Transform: there could be many Transforms in between without ROS2Frame components.
-        AZ::Transform GetFrameTransform() const;
-
-        //! Global frame name in ros2 ecosystem.
-        //! @return The name of the global frame with namespace attached. It is typically "odom", "map", "world".
-        AZStd::string GetGlobalFrameName() const;
-
         bool ShouldActivateController() const override;
 
         void OnActivate(AZ::EntityId entity, AZ::EntityId parentEntity) override;
@@ -105,17 +74,6 @@ namespace ROS2
         void OnEntityNameChanged(const AZStd::string& name);
 
     private:
-        bool IsTopLevel() const; //!< True if this entity does not have a parent entity with ROS2.
-
-        //! Whether transformation to parent frame can change during the simulation, or is fixed.
-        bool IsDynamic() const;
-
-        //! Return the frame id of this frame's parent. It can be useful to determine ROS 2 transformations.
-        //! @return Parent frame ID.
-        //! @note This also works with top-level frames, returning a global frame name.
-        //! @see GetGlobalFrameName().
-        AZStd::string GetParentFrameID() const;
-
         void RefreshEffectiveNamespace();
 
         AZStd::unique_ptr<ROS2Transform> m_ros2Transform;

--- a/Gems/ROS2/Code/Include/ROS2/RobotControl/ControlSubscriptionHandler.h
+++ b/Gems/ROS2/Code/Include/ROS2/RobotControl/ControlSubscriptionHandler.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "ROS2/Frame/ROS2FrameBus.h"
 #include <ROS2/Communication/TopicConfiguration.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2Bus.h>
@@ -41,8 +42,9 @@ namespace ROS2
             m_entityId = entity->GetId();
             if (!m_controlSubscription)
             {
-                auto ros2Frame = entity->FindComponent<ROS2FrameComponent>();
-                AZStd::string namespacedTopic = ROS2Names::GetNamespacedName(ros2Frame->GetNamespace(), subscriberConfiguration.m_topic);
+                AZStd::string frameNamespace;
+                ROS2FrameComponentBus::EventResult(frameNamespace, entity->GetId(), &ROS2FrameComponentBus::Events::GetNamespace);
+                AZStd::string namespacedTopic = ROS2Names::GetNamespacedName(frameNamespace, subscriberConfiguration.m_topic);
 
                 auto ros2Node = ROS2Interface::Get()->GetNode();
                 m_controlSubscription = ros2Node->create_subscription<T>(

--- a/Gems/ROS2/Code/Include/ROS2/RobotControl/ControlSubscriptionHandler.h
+++ b/Gems/ROS2/Code/Include/ROS2/RobotControl/ControlSubscriptionHandler.h
@@ -7,8 +7,8 @@
  */
 #pragma once
 
-#include "ROS2/Frame/ROS2FrameBus.h"
 #include <ROS2/Communication/TopicConfiguration.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/Utilities/ROS2Names.h>

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
@@ -8,8 +8,8 @@
 
 #include "ROS2CameraSensorComponent.h"
 #include "CameraUtilities.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
 #include <ROS2/Communication/TopicConfiguration.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 
 #include <AzCore/Component/Entity.h>

--- a/Gems/ROS2/Code/Source/ContactSensor/ROS2ContactSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/ContactSensor/ROS2ContactSensorComponent.cpp
@@ -7,6 +7,8 @@
  */
 
 #include "ROS2ContactSensorComponent.h"
+#include "AzCore/std/string/string.h"
+#include "ROS2/Frame/ROS2FrameBus.h"
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/Serialization/EditContext.h>
@@ -137,9 +139,12 @@ namespace ROS2
 
         // Publishes all contacts
         gazebo_msgs::msg::ContactsState msg;
-        const auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
-        AZ_Assert(ros2Frame, "Invalid component pointer value");
-        msg.header.frame_id = ros2Frame->GetFrameID().data();
+        bool hasFrameComponent = false;
+        ROS2FrameComponentBus::EventResult(hasFrameComponent, GetEntityId(), &ROS2FrameComponentBus::Events::IsFrame);
+        AZ_Assert(hasFrameComponent, "Entity does not have ROS2FrameComponent");
+        AZStd::string frameId;
+        ROS2FrameComponentBus::EventResult(frameId, GetEntityId(), &ROS2FrameComponentBus::Events::GetFrameID);
+        msg.header.frame_id = frameId.data();
         msg.header.stamp = ROS2Interface::Get()->GetROSTimestamp();
 
         {

--- a/Gems/ROS2/Code/Source/ContactSensor/ROS2ContactSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/ContactSensor/ROS2ContactSensorComponent.cpp
@@ -7,20 +7,20 @@
  */
 
 #include "ROS2ContactSensorComponent.h"
-#include "AzCore/std/string/string.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <AzCore/std/parallel/lock.h>
 #include <AzCore/std/parallel/mutex.h>
+#include <AzCore/std/string/string.h>
 #include <AzCore/std/utility/move.h>
 #include <AzFramework/Physics/Collision/CollisionEvents.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBodyEvents.h>
 #include <AzFramework/Physics/Common/PhysicsTypes.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/ROS2GemUtilities.h>

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -6,12 +6,12 @@
  *
  */
 
-#include "ROS2/Frame/ROS2FrameBus.h"
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/EntityUtils.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/Frame/ROS2FrameController.h>
 #include <ROS2/ROS2Bus.h>
@@ -79,7 +79,6 @@ namespace ROS2
                 m_ros2Transform->Publish(m_controller.GetFrameTransform());
             }
         }
-        AZ::TickBus::Handler::BusConnect();
         ROS2FrameComponentBus::Handler::BusConnect(GetEntityId());
     }
 
@@ -163,15 +162,6 @@ namespace ROS2
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<ROS2FrameComponent, ROS2FrameComponentBase>()->Version(1);
-
-            // if (AZ::EditContext* ec = serialize->GetEditContext())
-            // {
-            //     ec->Class<ROS2FrameComponent>("ROS2 Frame", "[ROS2 Frame component]")
-            //         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-            //         ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
-            //         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
-            //         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
-            // }
         }
     }
 

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -161,7 +161,7 @@ namespace ROS2
         ROS2FrameComponentBase::Reflect(context);
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<ROS2FrameComponent, ROS2FrameComponentBase>()->Version(1);
+            serialize->Class<ROS2FrameComponent, ROS2FrameComponentBase>()->Version(2);
         }
     }
 
@@ -190,6 +190,11 @@ namespace ROS2
     ROS2FrameComponent::ROS2FrameComponent(const ROS2FrameConfiguration& config)
         : ROS2FrameComponentBase(config)
     {
+    }
+
+    ROS2FrameConfiguration ROS2FrameComponent::GetConfiguration() const
+    {
+        return m_controller.GetConfiguration();
     }
 
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -101,10 +101,6 @@ namespace ROS2
         m_ros2Transform->Publish(m_controller.GetFrameTransform());
     }
 
-    void ROS2FrameComponent::UpdateNamespaceConfiguration(const AZStd::string& ns, NamespaceConfiguration::NamespaceStrategy strategy)
-    {
-        m_namespaceConfiguration.SetNamespace(ns, strategy);
-    }
     void ROS2FrameComponent::Reflect(AZ::ReflectContext* context)
     {
         ROS2FrameComponentBase::Reflect(context);

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -73,7 +73,7 @@ namespace ROS2
             }
             else
             {
-                m_ros2Transform->Publish(m_controller.GetFrameTransform<ROS2FrameComponent>());
+                m_ros2Transform->Publish(m_controller.GetFrameTransform());
             }
         }
     }
@@ -93,12 +93,12 @@ namespace ROS2
 
     void ROS2FrameComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
-        m_ros2Transform->Publish(m_controller.GetFrameTransform<ROS2FrameComponent>());
+        m_ros2Transform->Publish(m_controller.GetFrameTransform());
     }
 
     AZStd::string ROS2FrameComponent::GetGlobalFrameName() const
     {
-        return m_controller.GetGlobalFrameName<ROS2FrameComponent>();
+        return m_controller.GetGlobalFrameName();
     }
 
     void ROS2FrameComponent::UpdateNamespaceConfiguration(const AZStd::string& ns, NamespaceConfiguration::NamespaceStrategy strategy)
@@ -108,7 +108,7 @@ namespace ROS2
 
     bool ROS2FrameComponent::IsTopLevel() const
     {
-        return m_controller.IsTopLevel<ROS2FrameComponent>();
+        return m_controller.IsTopLevel();
     }
 
     bool ROS2FrameComponent::IsDynamic() const
@@ -116,24 +116,19 @@ namespace ROS2
         return m_controller.IsDynamic();
     }
 
-    const ROS2FrameComponent* ROS2FrameComponent::GetParentROS2FrameComponent() const
-    {
-        return m_controller.GetParentROS2FrameComponent<ROS2FrameComponent>();
-    }
-
     AZ::Transform ROS2FrameComponent::GetFrameTransform() const
     {
-        return m_controller.GetFrameTransform<ROS2FrameComponent>();
+        return m_controller.GetFrameTransform();
     }
 
     AZStd::string ROS2FrameComponent::GetParentFrameID() const
     {
-        return m_controller.GetParentFrameID<ROS2FrameComponent>();
+        return m_controller.GetParentFrameID();
     }
 
     AZStd::string ROS2FrameComponent::GetFrameID() const
     {
-        return m_controller.GetFrameID<ROS2FrameComponent>();
+        return m_controller.GetFrameID();
     }
 
     void ROS2FrameComponent::SetFrameID(const AZStd::string& frameId)
@@ -143,12 +138,12 @@ namespace ROS2
 
     AZStd::string ROS2FrameComponent::GetNamespace() const
     {
-        return m_controller.GetNamespace<ROS2FrameComponent>();
+        return m_controller.GetNamespace();
     }
 
     AZ::Name ROS2FrameComponent::GetJointName() const
     {
-        return m_controller.GetJointName<ROS2FrameComponent>();
+        return m_controller.GetJointName();
     }
 
     void ROS2FrameComponent::SetJointName(const AZStd::string& jointNameString)
@@ -163,14 +158,14 @@ namespace ROS2
         {
             serialize->Class<ROS2FrameComponent, ROS2FrameComponentBase>()->Version(1);
 
-            if (AZ::EditContext* ec = serialize->GetEditContext())
-            {
-                ec->Class<ROS2FrameComponent>("ROS2 Frame", "[ROS2 Frame component]")
-                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
-                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
-            }
+            // if (AZ::EditContext* ec = serialize->GetEditContext())
+            // {
+            //     ec->Class<ROS2FrameComponent>("ROS2 Frame", "[ROS2 Frame component]")
+            //         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+            //         ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
+            //         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+            //         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
+            // }
         }
     }
 

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -101,61 +101,10 @@ namespace ROS2
         m_ros2Transform->Publish(m_controller.GetFrameTransform());
     }
 
-    AZStd::string ROS2FrameComponent::GetGlobalFrameName() const
-    {
-        return m_controller.GetGlobalFrameName();
-    }
-
     void ROS2FrameComponent::UpdateNamespaceConfiguration(const AZStd::string& ns, NamespaceConfiguration::NamespaceStrategy strategy)
     {
         m_namespaceConfiguration.SetNamespace(ns, strategy);
     }
-
-    bool ROS2FrameComponent::IsTopLevel() const
-    {
-        return m_controller.IsTopLevel();
-    }
-
-    bool ROS2FrameComponent::IsDynamic() const
-    {
-        return m_controller.IsDynamic();
-    }
-
-    AZ::Transform ROS2FrameComponent::GetFrameTransform() const
-    {
-        return m_controller.GetFrameTransform();
-    }
-
-    AZStd::string ROS2FrameComponent::GetParentFrameID() const
-    {
-        return m_controller.GetParentFrameID();
-    }
-
-    AZStd::string ROS2FrameComponent::GetFrameID() const
-    {
-        return m_controller.GetFrameID();
-    }
-
-    void ROS2FrameComponent::SetFrameID(const AZStd::string& frameId)
-    {
-        m_controller.SetFrameID(frameId);
-    }
-
-    AZStd::string ROS2FrameComponent::GetNamespace() const
-    {
-        return m_controller.GetNamespace();
-    }
-
-    AZ::Name ROS2FrameComponent::GetJointName() const
-    {
-        return m_controller.GetJointName();
-    }
-
-    void ROS2FrameComponent::SetJointName(const AZStd::string& jointNameString)
-    {
-        m_controller.SetJointName(jointNameString);
-    }
-
     void ROS2FrameComponent::Reflect(AZ::ReflectContext* context)
     {
         ROS2FrameComponentBase::Reflect(context);

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include "ROS2/Frame/ROS2FrameBus.h"
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/EntityUtils.h>
 #include <AzCore/Serialization/EditContext.h>
@@ -35,6 +36,8 @@ namespace ROS2
     void ROS2FrameComponent::Activate()
     {
         ROS2FrameComponentBase::Activate();
+        m_controller.SetActiveEntityId(GetEntityId());
+
         m_controller.PopulateNamespace(IsTopLevel(), GetEntity()->GetName());
 
         if (m_controller.GetPublishTransform())
@@ -76,11 +79,14 @@ namespace ROS2
                 m_ros2Transform->Publish(m_controller.GetFrameTransform());
             }
         }
+        AZ::TickBus::Handler::BusConnect();
+        ROS2FrameComponentBus::Handler::BusConnect(GetEntityId());
     }
 
     void ROS2FrameComponent::Deactivate()
     {
         ROS2FrameComponentBase::Deactivate();
+        ROS2FrameComponentBus::Handler::BusDisconnect();
         if (m_controller.GetPublishTransform())
         {
             if (IsDynamic())
@@ -192,7 +198,12 @@ namespace ROS2
     }
 
     ROS2FrameComponent::ROS2FrameComponent(const ROS2FrameConfiguration& config)
+        : ROS2FrameComponentBase(config)
     {
-        SetConfiguration(config);
+    }
+
+    bool ROS2FrameComponent::IsFrame() const
+    {
+        return true;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameController.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameController.cpp
@@ -145,10 +145,12 @@ namespace ROS2
     void ROS2FrameComponentController::Activate(AZ::EntityId entityId)
     {
         m_configuration.m_activeEntityId = entityId;
+        ROS2FrameComponentBus::Handler::BusConnect(entityId);
     }
 
     void ROS2FrameComponentController::Deactivate()
     {
+        ROS2FrameComponentBus::Handler::BusDisconnect();
     }
 
     AZStd::string ROS2FrameComponentController::GetGlobalFrameName() const
@@ -248,6 +250,11 @@ namespace ROS2
     void ROS2FrameComponentController::SetActiveEntityId(AZ::EntityId entityId)
     {
         m_configuration.m_activeEntityId = entityId;
+    }
+
+    bool ROS2FrameComponentController::IsFrame() const
+    {
+        return true;
     }
 
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameController.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameController.cpp
@@ -257,6 +257,11 @@ namespace ROS2
         m_configuration.m_activeEntityId = entityId;
     }
 
+    void ROS2FrameComponentController::UpdateNamespaceConfiguration(const AZStd::string& ns, NamespaceConfiguration::NamespaceStrategy strategy)
+    {
+        m_configuration.m_namespaceConfiguration.SetNamespace(ns, strategy);
+    }
+
     bool ROS2FrameComponentController::IsFrame() const
     {
         return true;

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameController.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameController.cpp
@@ -99,6 +99,11 @@ namespace ROS2
         }
     }
 
+    void ROS2FrameComponentController::ConfigurationChange() const
+    {
+        ROS2FrameNotificationBus::Event(m_configuration.m_activeEntityId, &ROS2FrameNotificationBus::Events::OnConfigurationChange);
+    }
+
     AZ::Entity* ROS2FrameConfiguration::GetEntity() const
     {
         AZ::Entity* entity = nullptr;
@@ -122,7 +127,8 @@ namespace ROS2
                 editContext->Class<ROS2FrameComponentController>("ROS2FrameConfiguration", "Configuration of the ROS2 frame")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2FrameComponentController::m_configuration);
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2FrameComponentController::m_configuration)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ROS2FrameComponentController::ConfigurationChange);
             }
         }
     }
@@ -168,7 +174,7 @@ namespace ROS2
         return m_configuration.m_isDynamic;
     }
 
-    const AZ::EntityId ROS2FrameComponentController::GetParentROS2FrameComponentId() const
+    const AZ::EntityId ROS2FrameComponentController::GetParentROS2FrameEntityId() const
     {
         return Internal::GetFirstROS2FrameAncestorEntityId(m_configuration.m_activeEntityId);
     }
@@ -177,7 +183,7 @@ namespace ROS2
     {
         AZ::Transform worldFromThis{};
         AZ::TransformBus::EventResult(worldFromThis, m_configuration.m_activeEntityId, &AZ::TransformBus::Events::GetWorldTM);
-        const auto parentFrameId = GetParentROS2FrameComponentId();
+        const auto parentFrameId = GetParentROS2FrameEntityId();
         if (parentFrameId.IsValid())
         {
             AZ::Transform worldFromAncestor{};
@@ -190,7 +196,7 @@ namespace ROS2
 
     AZStd::string ROS2FrameComponentController::GetParentFrameID() const
     {
-        const auto parentFrameEntityId = GetParentROS2FrameComponentId();
+        const auto parentFrameEntityId = GetParentROS2FrameEntityId();
         if (parentFrameEntityId.IsValid())
         {
             AZStd::string parentFrameId;
@@ -213,7 +219,7 @@ namespace ROS2
 
     AZStd::string ROS2FrameComponentController::GetNamespace() const
     {
-        auto parentFrameId = GetParentROS2FrameComponentId();
+        auto parentFrameId = GetParentROS2FrameEntityId();
         AZStd::string parentNamespace;
         if (parentFrameId.IsValid())
         {

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameController.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameController.cpp
@@ -6,23 +6,23 @@
  *
  */
 
-#include "AzCore/Component/ComponentApplicationBus.h"
-#include "AzCore/Component/Entity.h"
-#include "AzCore/Component/EntityId.h"
-#include "AzCore/Component/EntityUtils.h"
-#include "AzCore/Component/TransformBus.h"
-#include "AzCore/Math/Transform.h"
-#include "AzCore/RTTI/RTTIMacros.h"
-#include "AzCore/RTTI/TypeInfo.h"
-#include "AzCore/Serialization/SerializeContext.h"
-#include "AzFramework/Components/TransformComponent.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
-#include "ROS2/ROS2GemUtilities.h"
-#include "ROS2/Sensor/SensorConfiguration.h"
+#include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/Component/EntityUtils.h>
+#include <AzCore/Component/TransformBus.h>
+#include <AzCore/Math/Transform.h>
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <AzCore/RTTI/TypeInfo.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Components/TransformComponent.h>
 #include <ROS2/Frame/NamespaceConfiguration.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameController.h>
+#include <ROS2/ROS2GemUtilities.h>
+#include <ROS2/Sensor/SensorConfiguration.h>
 #include <ROS2/Utilities/ROS2Names.h>
 #include <iostream>
 

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameController.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameController.cpp
@@ -24,7 +24,6 @@
 #include <ROS2/ROS2GemUtilities.h>
 #include <ROS2/Sensor/SensorConfiguration.h>
 #include <ROS2/Utilities/ROS2Names.h>
-#include <iostream>
 
 namespace ROS2
 {

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameController.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameController.cpp
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "AzCore/Component/ComponentApplicationBus.h"
+#include "AzCore/Component/Entity.h"
+#include "AzCore/Component/EntityUtils.h"
+#include "AzCore/Math/Transform.h"
+#include "AzCore/RTTI/RTTIMacros.h"
+#include "AzCore/RTTI/TypeInfo.h"
+#include "AzCore/Serialization/SerializeContext.h"
+#include "AzFramework/Components/TransformComponent.h"
+#include "ROS2/ROS2GemUtilities.h"
+#include "ROS2/Sensor/SensorConfiguration.h"
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+#include <ROS2/Frame/NamespaceConfiguration.h>
+#include <ROS2/Frame/ROS2FrameController.h>
+#include <ROS2/Utilities/ROS2Names.h>
+
+namespace ROS2
+{
+
+    namespace Internal
+    {
+        AZ::TransformInterface* GetEntityTransformInterface(const AZ::Entity* entity)
+        {
+            if (!entity)
+            {
+                AZ_Error("GetEntityTransformInterface", false, "Invalid entity!");
+                return nullptr;
+            }
+
+            auto* interface = Utils::GetGameOrEditorComponent<AzFramework::TransformComponent>(entity);
+
+            return interface;
+        }
+
+        template<typename T>
+        const T* GetFirstROS2FrameAncestor(const AZ::Entity* entity)
+        {
+            auto* entityTransformInterface = GetEntityTransformInterface(entity);
+            if (!entityTransformInterface)
+            {
+                AZ_Error("GetFirstROS2FrameAncestor", false, "Invalid transform interface!");
+                return nullptr;
+            }
+
+            AZ::EntityId parentEntityId = entityTransformInterface->GetParentId();
+            if (!parentEntityId.IsValid())
+            { // We have reached the top level, there is no parent entity so there can be no parent ROS2Frame
+                return nullptr;
+            }
+            AZ::Entity* parentEntity = nullptr;
+            AZ::ComponentApplicationBus::BroadcastResult(parentEntity, &AZ::ComponentApplicationRequests::FindEntity, parentEntityId);
+            AZ_Assert(parentEntity, "No parent entity id : %s", parentEntityId.ToString().c_str());
+
+            auto* component = Utils::GetGameOrEditorComponent<T>(parentEntity);
+            if (component == nullptr)
+            { // Parent entity has no ROS2Frame, but there can still be a ROS2Frame in its ancestors
+                return GetFirstROS2FrameAncestor<T>(parentEntity);
+            }
+
+            // Found the component!
+            return component;
+        }
+
+        // //! Checks whether the entity has a component of the given type
+        // //! @param entity pointer to entity
+        // //! @param typeId type of the component
+        // //! @returns true if entity has component with given type
+        // static bool CheckIfEntityHasComponentOfType(const AZ::Entity* entity, const AZ::Uuid typeId)
+        // {
+        //     auto components = AZ::EntityUtils::FindDerivedComponents(entity, typeId);
+        //     return !components.empty();
+        // }
+    } // namespace Internal
+
+    void ROS2FrameConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        NamespaceConfiguration::Reflect(context);
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<ROS2FrameConfiguration>()
+                ->Version(1)
+                ->Field("Namespace Configuration", &ROS2FrameConfiguration::m_namespaceConfiguration)
+                ->Field("Frame Name", &ROS2FrameConfiguration::m_frameName)
+                ->Field("Joint Name", &ROS2FrameConfiguration::m_jointNameString)
+                ->Field("Publish Transform", &ROS2FrameConfiguration::m_publishTransform);
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<ROS2FrameConfiguration>("ROS2 Frame configuration", "[ROS2 Frame component configuration]")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2FrameConfiguration::m_namespaceConfiguration,
+                        "Namespace Configuration",
+                        "Namespace Configuration")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2FrameConfiguration::m_frameName, "Frame Name", "Frame Name")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2FrameConfiguration::m_jointNameString, "Joint Name", "Joint Name")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2FrameConfiguration::m_publishTransform,
+                        "Publish Transform",
+                        "Publish Transform");
+            }
+        }
+    }
+
+    AZ::Entity* ROS2FrameConfiguration::GetEntity() const
+    {
+        AZ::Entity* entity = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, m_editorEntityId);
+
+        return entity;
+    }
+
+    void ROS2FrameComponentController::Reflect(AZ::ReflectContext* context)
+    {
+        ROS2FrameConfiguration::Reflect(context);
+
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<ROS2FrameComponentController>()->Version(1)->Field(
+                "Configuration", &ROS2FrameComponentController::m_configuration);
+
+            AZ::EditContext* editContext = serialize->GetEditContext();
+            if (editContext)
+            {
+                editContext->Class<ROS2FrameComponentController>("ROS2FrameConfiguration", "Configuration of the ROS2 frame")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2FrameComponentController::m_configuration);
+            }
+        }
+    }
+
+    ROS2FrameComponentController::ROS2FrameComponentController(const ROS2FrameConfiguration& config)
+    {
+        SetConfiguration(config);
+    }
+
+    void ROS2FrameComponentController::SetConfiguration(const ROS2FrameConfiguration& config)
+    {
+        m_configuration = config;
+    }
+
+    const ROS2FrameConfiguration& ROS2FrameComponentController::GetConfiguration() const
+    {
+        return m_configuration;
+    }
+
+    void ROS2FrameComponentController::Activate(AZ::EntityId entityId)
+    {
+        m_configuration.m_editorEntityId = entityId;
+    }
+
+    void ROS2FrameComponentController::Deactivate()
+    {
+    }
+
+    template<typename T>
+    AZStd::string ROS2FrameComponentController::GetGlobalFrameName() const
+    {
+        return ROS2Names::GetNamespacedName(GetNamespace<T>(), AZStd::string("odom"));
+    }
+
+    template<typename T>
+    bool ROS2FrameComponentController::IsTopLevel() const
+    {
+        return GetGlobalFrameName<T>() == GetParentFrameID<T>();
+    }
+
+    bool ROS2FrameComponentController::IsDynamic() const
+    {
+        return m_configuration.m_isDynamic;
+    }
+
+    template<typename T>
+    const T* ROS2FrameComponentController::GetParentROS2FrameComponent() const
+    {
+        return Internal::GetFirstROS2FrameAncestor<T>(m_configuration.GetEntity());
+    }
+
+    template<typename T>
+    AZ::Transform ROS2FrameComponentController::GetFrameTransform() const
+    {
+        auto* transformInterface = Internal::GetEntityTransformInterface(m_configuration.GetEntity());
+        if (const auto* parentFrame = GetParentROS2FrameComponent<T>(); parentFrame != nullptr)
+        {
+            auto* ancestorTransformInterface = Internal::GetEntityTransformInterface(parentFrame->GetEntity());
+            AZ_Assert(ancestorTransformInterface, "No transform interface for an entity with a ROS2Frame component, which requires it!");
+
+            const auto worldFromAncestor = ancestorTransformInterface->GetWorldTM();
+            const auto worldFromThis = transformInterface->GetWorldTM();
+            const auto ancestorFromWorld = worldFromAncestor.GetInverse();
+            return ancestorFromWorld * worldFromThis;
+        }
+        return transformInterface->GetWorldTM();
+    }
+
+    template<typename T>
+    AZStd::string ROS2FrameComponentController::GetParentFrameID() const
+    {
+        if (auto parentFrame = GetParentROS2FrameComponent<T>(); parentFrame != nullptr)
+        {
+            return parentFrame->GetFrameID();
+        }
+        // If parent entity does not exist or does not have a ROS2FrameComponent, return ROS2 default global frame.
+        return GetGlobalFrameName<T>();
+    }
+
+    template<typename T>
+    AZStd::string ROS2FrameComponentController::GetFrameID() const
+    {
+        return ROS2Names::GetNamespacedName(GetNamespace<T>(), m_configuration.m_frameName);
+    }
+
+    void ROS2FrameComponentController::SetFrameID(const AZStd::string& frameId)
+    {
+        m_configuration.m_frameName = frameId;
+    }
+
+    template<typename T>
+    AZStd::string ROS2FrameComponentController::GetNamespace() const
+    {
+        auto parentFrame = GetParentROS2FrameComponent<T>();
+        AZStd::string parentNamespace;
+        if (parentFrame != nullptr)
+        {
+            parentNamespace = parentFrame->GetNamespace();
+        }
+        return m_configuration.m_namespaceConfiguration.GetNamespace(parentNamespace);
+    }
+
+    template<typename T>
+    AZ::Name ROS2FrameComponentController::GetJointName() const
+    {
+        return AZ::Name(ROS2Names::GetNamespacedName(GetNamespace<T>(), m_configuration.m_jointNameString).c_str());
+    }
+
+    void ROS2FrameComponentController::SetJointName(const AZStd::string& jointNameString)
+    {
+        m_configuration.m_jointNameString = jointNameString;
+    }
+
+    void ROS2FrameComponentController::PopulateNamespace(bool isRoot, const AZStd::string& entityName)
+    {
+        m_configuration.m_namespaceConfiguration.PopulateNamespace(isRoot, entityName);
+    }
+
+    void ROS2FrameComponentController::SetIsDynamic(bool value)
+    {
+        m_configuration.m_isDynamic = value;
+    }
+
+    bool ROS2FrameComponentController::GetPublishTransform()
+    {
+        return m_configuration.m_publishTransform;
+    }
+
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -23,13 +23,12 @@ namespace ROS2
 
     void ROS2FrameEditorComponent::Activate()
     {
-        ROS2FrameComponentBus::Handler::BusConnect(GetEntityId());
         ROS2FrameEditorComponentBase::Activate();
+        m_controller.PopulateNamespace(m_controller.IsTopLevel(), GetEntity()->GetName());
     }
 
     void ROS2FrameEditorComponent::Deactivate()
     {
-        ROS2FrameComponentBus::Handler::BusDisconnect();
         ROS2FrameEditorComponentBase::Deactivate();
     }
 
@@ -120,7 +119,7 @@ namespace ROS2
 
     ROS2FrameEditorComponent::ROS2FrameEditorComponent(const AZStd::string& frameId)
     {
-        SetFrameID(frameId);
+        m_controller.SetFrameID(frameId);
     }
 
     ROS2FrameEditorComponent::ROS2FrameEditorComponent(const ROS2FrameConfiguration& config)
@@ -133,8 +132,4 @@ namespace ROS2
         return true;
     }
 
-    bool ROS2FrameEditorComponent::IsFrame() const
-    {
-        return true;
-    }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -76,10 +76,11 @@ namespace ROS2
         m_controller.PopulateNamespace(m_controller.IsTopLevel(), GetEntity()->GetName());
         RefreshEffectiveNamespace();
 
+        ROS2FrameNotificationBus::Handler::BusConnect(GetEntityId());
+
         // Notify other ROS2FrameEditorComponents about new component activation.
         ROS2FrameNotificationBus::Broadcast(&ROS2FrameNotificationBus::Events::OnActivate, GetEntityId(), m_parentFrameEntity);
 
-        ROS2FrameNotificationBus::Handler::BusConnect(GetEntityId());
         AZ::EntityBus::Handler::BusConnect(GetEntityId());
         AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusConnect();
     }

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -33,12 +33,12 @@ namespace ROS2
 
     AZStd::string ROS2FrameEditorComponent::GetGlobalFrameName() const
     {
-        return m_controller.GetGlobalFrameName<ROS2FrameEditorComponent>();
+        return m_controller.GetGlobalFrameName();
     }
 
     bool ROS2FrameEditorComponent::IsTopLevel() const
     {
-        return m_controller.IsTopLevel<ROS2FrameEditorComponent>();
+        return m_controller.IsTopLevel();
     }
 
     bool ROS2FrameEditorComponent::IsDynamic() const
@@ -46,24 +46,19 @@ namespace ROS2
         return m_controller.IsDynamic();
     }
 
-    const ROS2FrameEditorComponent* ROS2FrameEditorComponent::GetParentROS2FrameComponent() const
-    {
-        return m_controller.GetParentROS2FrameComponent<ROS2FrameEditorComponent>();
-    }
-
     AZ::Transform ROS2FrameEditorComponent::GetFrameTransform() const
     {
-        return m_controller.GetFrameTransform<ROS2FrameEditorComponent>();
+        return m_controller.GetFrameTransform();
     }
 
     AZStd::string ROS2FrameEditorComponent::GetParentFrameID() const
     {
-        return m_controller.GetParentFrameID<ROS2FrameEditorComponent>();
+        return m_controller.GetParentFrameID();
     }
 
     AZStd::string ROS2FrameEditorComponent::GetFrameID() const
     {
-        return m_controller.GetFrameID<ROS2FrameEditorComponent>();
+        return m_controller.GetFrameID();
     }
 
     void ROS2FrameEditorComponent::SetFrameID(const AZStd::string& frameId)
@@ -73,12 +68,12 @@ namespace ROS2
 
     AZStd::string ROS2FrameEditorComponent::GetNamespace() const
     {
-        return m_controller.GetNamespace<ROS2FrameEditorComponent>();
+        return m_controller.GetNamespace();
     }
 
     AZ::Name ROS2FrameEditorComponent::GetJointName() const
     {
-        return m_controller.GetJointName<ROS2FrameEditorComponent>();
+        return m_controller.GetJointName();
     }
 
     void ROS2FrameEditorComponent::SetJointName(const AZStd::string& jointNameString)
@@ -97,8 +92,8 @@ namespace ROS2
             {
                 ec->Class<ROS2FrameEditorComponent>("ROS2 Frame", "[ROS2 Frame component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
             }
         }
@@ -129,5 +124,10 @@ namespace ROS2
     ROS2FrameEditorComponent::ROS2FrameEditorComponent(const ROS2FrameConfiguration& config)
     {
         SetConfiguration(config);
+    }
+
+    bool ROS2FrameEditorComponent::ShouldActivateController() const
+    {
+        return true;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -92,56 +92,6 @@ namespace ROS2
         ROS2FrameNotificationBus::Broadcast(&ROS2FrameNotificationBus::Events::OnDeactivate, GetEntityId(), m_parentFrameEntity);
     }
 
-    AZStd::string ROS2FrameEditorComponent::GetGlobalFrameName() const
-    {
-        return m_controller.GetGlobalFrameName();
-    }
-
-    bool ROS2FrameEditorComponent::IsTopLevel() const
-    {
-        return m_controller.IsTopLevel();
-    }
-
-    bool ROS2FrameEditorComponent::IsDynamic() const
-    {
-        return m_controller.IsDynamic();
-    }
-
-    AZ::Transform ROS2FrameEditorComponent::GetFrameTransform() const
-    {
-        return m_controller.GetFrameTransform();
-    }
-
-    AZStd::string ROS2FrameEditorComponent::GetParentFrameID() const
-    {
-        return m_controller.GetParentFrameID();
-    }
-
-    AZStd::string ROS2FrameEditorComponent::GetFrameID() const
-    {
-        return m_controller.GetFrameID();
-    }
-
-    void ROS2FrameEditorComponent::SetFrameID(const AZStd::string& frameId)
-    {
-        m_controller.SetFrameID(frameId);
-    }
-
-    AZStd::string ROS2FrameEditorComponent::GetNamespace() const
-    {
-        return m_controller.GetNamespace();
-    }
-
-    AZ::Name ROS2FrameEditorComponent::GetJointName() const
-    {
-        return m_controller.GetJointName();
-    }
-
-    void ROS2FrameEditorComponent::SetJointName(const AZStd::string& jointNameString)
-    {
-        m_controller.SetJointName(jointNameString);
-    }
-
     void ROS2FrameEditorComponent::Reflect(AZ::ReflectContext* context)
     {
         ROS2FrameEditorComponentBase::Reflect(context);

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -23,11 +23,13 @@ namespace ROS2
 
     void ROS2FrameEditorComponent::Activate()
     {
+        ROS2FrameComponentBus::Handler::BusConnect(GetEntityId());
         ROS2FrameEditorComponentBase::Activate();
     }
 
     void ROS2FrameEditorComponent::Deactivate()
     {
+        ROS2FrameComponentBus::Handler::BusDisconnect();
         ROS2FrameEditorComponentBase::Deactivate();
     }
 
@@ -127,6 +129,11 @@ namespace ROS2
     }
 
     bool ROS2FrameEditorComponent::ShouldActivateController() const
+    {
+        return true;
+    }
+
+    bool ROS2FrameEditorComponent::IsFrame() const
     {
         return true;
     }

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -6,6 +6,10 @@
  *
  */
 
+#include "API/ToolsApplicationAPI.h"
+#include "AzCore/Component/EntityBus.h"
+#include "AzCore/Component/TransformBus.h"
+#include "ROS2/Frame/ROS2FrameBus.h"
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/EntityUtils.h>
 #include <AzCore/Serialization/EditContext.h>
@@ -20,16 +24,72 @@
 
 namespace ROS2
 {
+    namespace Internal
+    {
+        void PopulateNonFramePredecessors(AZ::EntityId entity, AZStd::set<AZ::EntityId>& nonFramePredecessors)
+        {
+            AZ::EntityId parentEntityId;
+            AZ::TransformBus::EventResult(parentEntityId, entity, &AZ::TransformBus::Events::GetParentId);
+            if (!parentEntityId.IsValid())
+            { // We have reached the top level, there is no parent entity so there can be no parent ROS2Frame
+                return;
+            }
+
+            bool hasFrame = false;
+            ROS2FrameComponentBus::EventResult(hasFrame, parentEntityId, &ROS2FrameComponentBus::Events::IsFrame);
+
+            if (hasFrame)
+            { // Found first frame predecessor
+                return;
+            }
+
+            nonFramePredecessors.insert(parentEntityId);
+            PopulateNonFramePredecessors(parentEntityId, nonFramePredecessors);
+        }
+
+        AZStd::set<AZ::EntityId> GetNonFramePredecessors(AZ::EntityId entity)
+        {
+            AZStd::set<AZ::EntityId> nonFramePredecessors;
+            PopulateNonFramePredecessors(entity, nonFramePredecessors);
+            return nonFramePredecessors;
+        }
+
+    } // namespace Internal
 
     void ROS2FrameEditorComponent::Activate()
     {
         ROS2FrameEditorComponentBase::Activate();
+
+        m_nonFramePredecessors = Internal::GetNonFramePredecessors(GetEntityId());
+
+        if (m_controller.IsTopLevel())
+        {
+            m_parentFrameEntity.SetInvalid();
+        }
+        else
+        {
+            m_parentFrameEntity = m_controller.GetParentROS2FrameEntityId();
+        }
+
         m_controller.PopulateNamespace(m_controller.IsTopLevel(), GetEntity()->GetName());
+        RefreshEffectiveNamespace();
+
+        ROS2FrameNotificationBus::Broadcast(&ROS2FrameNotificationBus::Events::OnActivate, GetEntityId(), m_parentFrameEntity);
+
+        ROS2FrameNotificationBus::Handler::BusConnect(GetEntityId());
+        AZ::EntityBus::Handler::BusConnect(GetEntityId());
+        AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusConnect();
     }
 
     void ROS2FrameEditorComponent::Deactivate()
     {
+        AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusDisconnect();
+        AZ::EntityBus::Handler::BusDisconnect();
+        ROS2FrameNotificationBus::Handler::BusDisconnect();
+
         ROS2FrameEditorComponentBase::Deactivate();
+
+        ROS2FrameNotificationBus::Broadcast(&ROS2FrameNotificationBus::Events::OnDeactivate, GetEntityId(), m_parentFrameEntity);
     }
 
     AZStd::string ROS2FrameEditorComponent::GetGlobalFrameName() const
@@ -87,7 +147,8 @@ namespace ROS2
         ROS2FrameEditorComponentBase::Reflect(context);
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<ROS2FrameEditorComponent, ROS2FrameEditorComponentBase>()->Version(1);
+            serialize->Class<ROS2FrameEditorComponent, ROS2FrameEditorComponentBase>()->Version(1)->Field(
+                "Effective namespace", &ROS2FrameEditorComponent::m_effectiveNamespace);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
@@ -95,7 +156,9 @@ namespace ROS2
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
                     ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
-                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2FrameEditorComponent::m_effectiveNamespace, "Effective namespace", "")
+                    ->Attribute(AZ::Edit::Attributes::ReadOnly, true);
             }
         }
     }
@@ -130,6 +193,93 @@ namespace ROS2
     bool ROS2FrameEditorComponent::ShouldActivateController() const
     {
         return true;
+    }
+
+    void ROS2FrameEditorComponent::OnActivate(AZ::EntityId entity, AZ::EntityId parentEntity)
+    {
+        if (m_parentFrameEntity == parentEntity && m_controller.GetParentROS2FrameEntityId() == entity)
+        {
+            m_parentFrameEntity = entity;
+            m_controller.PopulateNamespace(false, GetEntity()->GetName());
+            RefreshEffectiveNamespace();
+            ROS2FrameNotificationBus::Broadcast(&ROS2FrameNotificationBus::Events::OnReconfigure, GetEntityId());
+        }
+    }
+
+    void ROS2FrameEditorComponent::OnDeactivate(AZ::EntityId entity, AZ::EntityId parentEntity)
+    {
+        if (m_parentFrameEntity == entity)
+        {
+            m_parentFrameEntity = parentEntity;
+            m_controller.PopulateNamespace(parentEntity.IsValid(), GetEntity()->GetName());
+            RefreshEffectiveNamespace();
+            ROS2FrameNotificationBus::Broadcast(&ROS2FrameNotificationBus::Events::OnReconfigure, GetEntityId());
+        }
+    }
+
+    void ROS2FrameEditorComponent::OnConfigurationChange()
+    {
+        m_controller.PopulateNamespace(m_controller.IsTopLevel(), GetEntity()->GetName());
+        RefreshEffectiveNamespace();
+
+        ROS2FrameNotificationBus::Broadcast(&ROS2FrameNotificationBus::Events::OnReconfigure, GetEntityId());
+    }
+
+    void ROS2FrameEditorComponent::OnReconfigure(AZ::EntityId entity)
+    {
+        if (m_parentFrameEntity == entity)
+        {
+            m_controller.PopulateNamespace(false, GetEntity()->GetName());
+            RefreshEffectiveNamespace();
+
+            ROS2FrameNotificationBus::Broadcast(&ROS2FrameNotificationBus::Events::OnReconfigure, GetEntityId());
+        }
+    }
+
+    void ROS2FrameEditorComponent::EntityParentChanged(AZ::EntityId entityId, AZ::EntityId newParentId, AZ::EntityId oldParentId)
+    {
+        if (GetEntityId() == entityId || m_nonFramePredecessors.contains(entityId))
+        {
+            bool isTopLevel = m_controller.IsTopLevel();
+            m_controller.PopulateNamespace(isTopLevel, GetEntity()->GetName());
+            RefreshEffectiveNamespace();
+
+            m_nonFramePredecessors = Internal::GetNonFramePredecessors(GetEntityId());
+
+            ROS2FrameNotificationBus::Broadcast(&ROS2FrameNotificationBus::Events::OnDeactivate, GetEntityId(), m_parentFrameEntity);
+
+            if (isTopLevel)
+            {
+                m_parentFrameEntity.SetInvalid();
+            }
+            else
+            {
+                m_parentFrameEntity = m_controller.GetParentROS2FrameEntityId();
+            }
+
+            ROS2FrameNotificationBus::Broadcast(&ROS2FrameNotificationBus::Events::OnActivate, GetEntityId(), m_parentFrameEntity);
+        }
+    }
+
+    void ROS2FrameEditorComponent::OnEntityNameChanged(const AZStd::string& name)
+    {
+        (void)name;
+        m_controller.PopulateNamespace(false, GetEntity()->GetName());
+        RefreshEffectiveNamespace();
+
+        ROS2FrameNotificationBus::Broadcast(&ROS2FrameNotificationBus::Events::OnReconfigure, GetEntityId());
+    }
+
+    void ROS2FrameEditorComponent::RefreshEffectiveNamespace()
+    {
+        m_effectiveNamespace = m_controller.GetNamespace();
+        if (const AZ::Component* component = GetEntity()->FindComponent<ROS2FrameEditorComponent>())
+        {
+            AzToolsFramework::PropertyEditorEntityChangeNotificationBus::Event(
+                GetEntityId(),
+                &AzToolsFramework::PropertyEditorEntityChangeNotifications::OnEntityComponentPropertyChanged,
+                component->GetId());
+        }
     }
 
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Component/EntityUtils.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <ROS2/Frame/ROS2FrameComponent.h>
+#include <ROS2/Frame/ROS2FrameController.h>
+#include <ROS2/Frame/ROS2FrameEditorComponent.h>
+#include <ROS2/ROS2Bus.h>
+#include <ROS2/ROS2GemUtilities.h>
+#include <ROS2/Utilities/ROS2Names.h>
+
+namespace ROS2
+{
+
+    void ROS2FrameEditorComponent::Activate()
+    {
+        ROS2FrameEditorComponentBase::Activate();
+    }
+
+    void ROS2FrameEditorComponent::Deactivate()
+    {
+        ROS2FrameEditorComponentBase::Deactivate();
+    }
+
+    AZStd::string ROS2FrameEditorComponent::GetGlobalFrameName() const
+    {
+        return m_controller.GetGlobalFrameName<ROS2FrameEditorComponent>();
+    }
+
+    bool ROS2FrameEditorComponent::IsTopLevel() const
+    {
+        return m_controller.IsTopLevel<ROS2FrameEditorComponent>();
+    }
+
+    bool ROS2FrameEditorComponent::IsDynamic() const
+    {
+        return m_controller.IsDynamic();
+    }
+
+    const ROS2FrameEditorComponent* ROS2FrameEditorComponent::GetParentROS2FrameComponent() const
+    {
+        return m_controller.GetParentROS2FrameComponent<ROS2FrameEditorComponent>();
+    }
+
+    AZ::Transform ROS2FrameEditorComponent::GetFrameTransform() const
+    {
+        return m_controller.GetFrameTransform<ROS2FrameEditorComponent>();
+    }
+
+    AZStd::string ROS2FrameEditorComponent::GetParentFrameID() const
+    {
+        return m_controller.GetParentFrameID<ROS2FrameEditorComponent>();
+    }
+
+    AZStd::string ROS2FrameEditorComponent::GetFrameID() const
+    {
+        return m_controller.GetFrameID<ROS2FrameEditorComponent>();
+    }
+
+    void ROS2FrameEditorComponent::SetFrameID(const AZStd::string& frameId)
+    {
+        m_controller.SetFrameID(frameId);
+    }
+
+    AZStd::string ROS2FrameEditorComponent::GetNamespace() const
+    {
+        return m_controller.GetNamespace<ROS2FrameEditorComponent>();
+    }
+
+    AZ::Name ROS2FrameEditorComponent::GetJointName() const
+    {
+        return m_controller.GetJointName<ROS2FrameEditorComponent>();
+    }
+
+    void ROS2FrameEditorComponent::SetJointName(const AZStd::string& jointNameString)
+    {
+        m_controller.SetJointName(jointNameString);
+    }
+
+    void ROS2FrameEditorComponent::Reflect(AZ::ReflectContext* context)
+    {
+        ROS2FrameEditorComponentBase::Reflect(context);
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<ROS2FrameEditorComponent, ROS2FrameEditorComponentBase>()->Version(1);
+
+            if (AZ::EditContext* ec = serialize->GetEditContext())
+            {
+                ec->Class<ROS2FrameEditorComponent>("ROS2 Frame", "[ROS2 Frame component]")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
+            }
+        }
+    }
+
+    void ROS2FrameEditorComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("ROS2Frame"));
+    }
+
+    void ROS2FrameEditorComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("ROS2Frame"));
+    }
+
+    void ROS2FrameEditorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC_CE("TransformService"));
+    }
+
+    ROS2FrameEditorComponent::ROS2FrameEditorComponent() = default;
+
+    ROS2FrameEditorComponent::ROS2FrameEditorComponent(const AZStd::string& frameId)
+    {
+        SetFrameID(frameId);
+    }
+
+    ROS2FrameEditorComponent::ROS2FrameEditorComponent(const ROS2FrameConfiguration& config)
+    {
+        SetConfiguration(config);
+    }
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "ROS2GNSSSensorComponent.h"
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/ROS2GemUtilities.h>
@@ -14,12 +15,11 @@
 #include <ROS2/Utilities/ROS2Names.h>
 
 #include <AzCore/Math/Matrix4x4.h>
+#include <AzCore/Math/Transform.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 
-#include "AzCore/Math/Transform.h"
 #include "GNSSFormatConversions.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
 
 namespace ROS2
 {

--- a/Gems/ROS2/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
@@ -17,7 +17,9 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 
+#include "AzCore/Math/Transform.h"
 #include "GNSSFormatConversions.h"
+#include "ROS2/Frame/ROS2FrameBus.h"
 
 namespace ROS2
 {
@@ -106,7 +108,8 @@ namespace ROS2
 
     AZ::Transform ROS2GNSSSensorComponent::GetCurrentPose() const
     {
-        auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
-        return ros2Frame->GetFrameTransform();
+        AZ::Transform frameTransform;
+        ROS2FrameComponentBus::EventResult(frameTransform, GetEntityId(), &ROS2FrameComponentBus::Events::GetFrameTransform);
+        return frameTransform;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Gripper/GripperActionServerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Gripper/GripperActionServerComponent.cpp
@@ -7,14 +7,14 @@
  *
  */
 
-#include "AzCore/std/string/string.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
+#include "GripperActionServerComponent.h"
 #include "Utils.h"
 
-#include "GripperActionServerComponent.h"
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/string/string.h>
 #include <AzFramework/Components/TransformComponent.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2GemUtilities.h>
 #include <ROS2/Utilities/ROS2Names.h>

--- a/Gems/ROS2/Code/Source/Gripper/GripperActionServerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Gripper/GripperActionServerComponent.cpp
@@ -7,6 +7,8 @@
  *
  */
 
+#include "AzCore/std/string/string.h"
+#include "ROS2/Frame/ROS2FrameBus.h"
 #include "Utils.h"
 
 #include "GripperActionServerComponent.h"
@@ -21,9 +23,12 @@ namespace ROS2
 {
     void GripperActionServerComponent::Activate()
     {
-        auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
-        AZ_Assert(ros2Frame, "Missing Frame Component!");
-        AZStd::string namespacedAction = ROS2Names::GetNamespacedName(ros2Frame->GetNamespace(), m_gripperActionServerName);
+        bool hasFrameComponent = false;
+        ROS2FrameComponentBus::EventResult(hasFrameComponent, GetEntityId(), &ROS2FrameComponentBus::Events::IsFrame);
+        AZ_Assert(hasFrameComponent, "Missing Frame Component!");
+        AZStd::string frameNamespace;
+        ROS2FrameComponentBus::EventResult(frameNamespace, GetEntityId(), &ROS2FrameComponentBus::Events::GetFrameID);
+        AZStd::string namespacedAction = ROS2Names::GetNamespacedName(frameNamespace, m_gripperActionServerName);
         AZ_Printf("GripperActionServerComponent", "Creating Gripper Action Server: %s\n", namespacedAction.c_str());
         m_gripperActionServer = AZStd::make_unique<GripperActionServer>(namespacedAction, GetEntityId());
         AZ::TickBus::Handler::BusConnect();

--- a/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.cpp
@@ -6,12 +6,12 @@
  *
  */
 
-#include "ROS2/Frame/ROS2FrameBus.h"
 #include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
 #include <Atom/RPI.Public/Scene.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
 #include <Lidar/LidarRegistrarSystemComponent.h>
 #include <Lidar/ROS2Lidar2DSensorComponent.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/Utilities/ROS2Names.h>

--- a/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include "ROS2/Frame/ROS2FrameBus.h"
 #include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
 #include <Atom/RPI.Public/Scene.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
@@ -204,9 +205,10 @@ namespace ROS2
             m_visualizationPoints = m_lastScanResults.m_points;
         }
 
-        auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
         auto message = sensor_msgs::msg::LaserScan();
-        message.header.frame_id = ros2Frame->GetFrameID().data();
+        AZStd::string frameId;
+        ROS2FrameComponentBus::EventResult(frameId, GetEntityId(), &ROS2FrameComponentBus::Events::GetFrameID);
+        message.header.frame_id = frameId.data();
         message.header.stamp = ROS2Interface::Get()->GetROSTimestamp();
         message.angle_min = AZ::DegToRad(m_lidarConfiguration.m_lidarParameters.m_minHAngle);
         message.angle_max = AZ::DegToRad(m_lidarConfiguration.m_lidarParameters.m_maxHAngle);

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -6,13 +6,13 @@
  *
  */
 
-#include "AzCore/std/string/string.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
 #include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
 #include <Atom/RPI.Public/Scene.h>
+#include <AzCore/std/string/string.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
 #include <Lidar/LidarRegistrarSystemComponent.h>
 #include <Lidar/ROS2LidarSensorComponent.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/Utilities/ROS2Names.h>

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -6,6 +6,8 @@
  *
  */
 
+#include "AzCore/std/string/string.h"
+#include "ROS2/Frame/ROS2FrameBus.h"
 #include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
 #include <Atom/RPI.Public/Scene.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
@@ -111,13 +113,14 @@ namespace ROS2
         if (m_lidarConfiguration.m_lidarSystemFeatures & LidarSystemFeatures::PointcloudPublishing)
         {
             const TopicConfiguration& publisherConfig = m_sensorConfiguration.m_publishersConfigurations[Internal::kPointCloudType];
-            auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
+            AZStd::string frameId;
+            ROS2FrameComponentBus::EventResult(frameId, GetEntityId(), &ROS2FrameComponentBus::Events::GetFrameID);
 
             LidarRaycasterRequestBus::Event(
                 m_lidarRaycasterId,
                 &LidarRaycasterRequestBus::Events::ConfigurePointCloudPublisher,
                 ROS2Names::GetNamespacedName(GetNamespace(), publisherConfig.m_topic),
-                ros2Frame->GetFrameID().data(),
+                frameId.data(),
                 publisherConfig.GetQoS());
         }
     }
@@ -244,9 +247,10 @@ namespace ROS2
             point = inverseLidarTM.TransformPoint(point);
         }
 
-        auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
+        AZStd::string frameId;
+        ROS2FrameComponentBus::EventResult(frameId, GetEntityId(), &ROS2FrameComponentBus::Events::GetFrameID);
         auto message = sensor_msgs::msg::PointCloud2();
-        message.header.frame_id = ros2Frame->GetFrameID().data();
+        message.header.frame_id = frameId.data();
         message.header.stamp = ROS2Interface::Get()->GetROSTimestamp();
         message.height = 1;
         message.width = m_lastScanResults.m_points.size();

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
@@ -7,16 +7,17 @@
  */
 
 #include "JointsManipulationComponent.h"
-#include "AzCore/Name/Name.h"
 #include "Controllers/JointsArticulationControllerComponent.h"
 #include "Controllers/JointsPIDControllerComponent.h"
 #include "JointStatePublisher.h"
 #include "ManipulationUtils.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Debug/Trace.h>
+#include <AzCore/Name/Name.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/Manipulation/Controllers/JointsPositionControllerRequests.h>
 #include <ROS2/Utilities/ROS2Names.h>

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
@@ -7,6 +7,8 @@
  */
 
 #include "JointsTrajectoryComponent.h"
+#include "AzCore/std/string/string.h"
+#include "ROS2/Frame/ROS2FrameBus.h"
 #include <AzCore/Serialization/EditContext.h>
 #include <PhysX/ArticulationJointBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
@@ -18,9 +20,12 @@ namespace ROS2
 {
     void JointsTrajectoryComponent::Activate()
     {
-        auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
-        AZ_Assert(ros2Frame, "Missing Frame Component!");
-        AZStd::string namespacedAction = ROS2Names::GetNamespacedName(ros2Frame->GetNamespace(), m_followTrajectoryActionName);
+        bool hasFrameComponent = false;
+        ROS2FrameComponentBus::EventResult(hasFrameComponent, GetEntityId(), &ROS2FrameComponentBus::Events::IsFrame);
+        AZ_Assert(hasFrameComponent, "Missing Frame Component!");
+        AZStd::string frameNamespace;
+        ROS2FrameComponentBus::EventResult(frameNamespace, GetEntityId(), &ROS2FrameComponentBus::Events::GetNamespace);
+        AZStd::string namespacedAction = ROS2Names::GetNamespacedName(frameNamespace, m_followTrajectoryActionName);
         m_followTrajectoryServer = AZStd::make_unique<FollowJointTrajectoryActionServer>(namespacedAction, GetEntityId());
         AZ::TickBus::Handler::BusConnect();
         JointsTrajectoryRequestBus::Handler::BusConnect(GetEntityId());

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
@@ -7,10 +7,10 @@
  */
 
 #include "JointsTrajectoryComponent.h"
-#include "AzCore/std/string/string.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/std/string/string.h>
 #include <PhysX/ArticulationJointBus.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/Manipulation/JointsManipulationRequests.h>
 #include <ROS2/ROS2Bus.h>

--- a/Gems/ROS2/Code/Source/ROS2EditorModule.cpp
+++ b/Gems/ROS2/Code/Source/ROS2EditorModule.cpp
@@ -10,6 +10,7 @@
 #include <Camera/ROS2CameraSensorEditorComponent.h>
 #include <Lidar/LidarRegistrarEditorSystemComponent.h>
 #include <Manipulation/JointsManipulationEditorComponent.h>
+#include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <ROS2EditorSystemComponent.h>
 #include <ROS2ModuleInterface.h>
 #include <RobotImporter/ROS2RobotImporterEditorSystemComponent.h>
@@ -48,7 +49,8 @@ namespace ROS2
                   ROS2SpawnerEditorComponent::CreateDescriptor(),
                   ROS2SpawnPointEditorComponent::CreateDescriptor(),
                   SdfAssetBuilderSystemComponent::CreateDescriptor(),
-                  JointsManipulationEditorComponent::CreateDescriptor() });
+                  JointsManipulationEditorComponent::CreateDescriptor(),
+                  ROS2FrameEditorComponent::CreateDescriptor() });
         }
 
         /**

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -9,7 +9,6 @@
 #include "URDFPrefabMaker.h"
 #include "CollidersMaker.h"
 #include "PrefabMakerUtils.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
 #include <API/EditorAssetSystemAPI.h>
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/IO/FileIO.h>
@@ -23,6 +22,7 @@
 #include <AzToolsFramework/Prefab/Procedural/ProceduralPrefabAsset.h>
 #include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <ROS2/ROS2GemUtilities.h>
 #include <RobotControl/ROS2RobotControlComponent.h>

--- a/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -6,6 +6,8 @@
  *
  */
 
+#include "AzCore/std/string/string.h"
+#include "ROS2/Frame/ROS2FrameBus.h"
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
@@ -53,14 +55,16 @@ namespace ROS2
 
     AZStd::string ROS2SensorComponent::GetNamespace() const
     {
-        auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
-        return ros2Frame->GetNamespace();
+        AZStd::string frameNamespace;
+        ROS2FrameComponentBus::EventResult(frameNamespace, GetEntityId(), &ROS2FrameComponentBus::Events::GetNamespace);
+        return frameNamespace;
     };
 
     AZStd::string ROS2SensorComponent::GetFrameID() const
     {
-        auto* ros2Frame = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(GetEntity());
-        return ros2Frame->GetFrameID();
+        AZStd::string frameId;
+        ROS2FrameComponentBus::EventResult(frameId, GetEntityId(), &ROS2FrameComponentBus::Events::GetFrameID);
+        return frameId;
     }
 
     void ROS2SensorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)

--- a/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -6,12 +6,12 @@
  *
  */
 
-#include "AzCore/std/string/string.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/string/string.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/ROS2GemUtilities.h>

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "ROS2SpawnerComponent.h"
+#include "ROS2/Frame/ROS2FrameBus.h"
 #include "Spawner/ROS2SpawnerComponentController.h"
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
@@ -170,8 +171,9 @@ namespace ROS2
         AZStd::string instanceName = AZStd::string::format("%s_%d", spawnableName.c_str(), m_counter++);
         for (AZ::Entity* entity : view)
         { // Update name for the first entity with ROS2Frame in hierarchy (left to right)
-            auto* frameComponent = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(entity);
-            if (frameComponent)
+            bool hasFrameComponent = false;
+            ROS2FrameComponentBus::EventResult(hasFrameComponent, entity->GetId(), &ROS2FrameComponentBus::Events::IsFrame);
+            if (hasFrameComponent)
             {
                 entity->SetName(instanceName);
                 if (!spawnableNamespace.empty())

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -178,7 +178,7 @@ namespace ROS2
                 entity->SetName(instanceName);
                 if (!spawnableNamespace.empty())
                 {
-                    frameComponent->UpdateNamespaceConfiguration(spawnableNamespace, NamespaceConfiguration::NamespaceStrategy::Custom);
+                    ROS2FrameComponentBus::Event(entity->GetId(), &ROS2FrameComponentBus::Events::UpdateNamespaceConfiguration, spawnableNamespace, NamespaceConfiguration::NamespaceStrategy::Custom);
                 }
                 break;
             }

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -7,11 +7,11 @@
  */
 
 #include "ROS2SpawnerComponent.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
 #include "Spawner/ROS2SpawnerComponentController.h"
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/Spawnable/Spawnable.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/ROS2GemUtilities.h>

--- a/Gems/ROS2/Code/Source/Utilities/JointUtilities.cpp
+++ b/Gems/ROS2/Code/Source/Utilities/JointUtilities.cpp
@@ -7,6 +7,8 @@
  */
 
 #include "JointUtilities.h"
+#include "AzCore/Name/Name.h"
+#include "ROS2/Frame/ROS2FrameBus.h"
 #include <ROS2/Frame/ROS2FrameComponent.h>
 
 namespace ROS2::Utils
@@ -18,10 +20,13 @@ namespace ROS2::Utils
         AZ_Assert(entity, "Entity %s not found.", entityId.ToString().c_str());
         if (entity)
         {
-            ROS2FrameComponent* component = entity->FindComponent<ROS2FrameComponent>();
-            if (component)
+            bool hasFrameComponent = false;
+            ROS2FrameComponentBus::EventResult(hasFrameComponent, entity->GetId(), &ROS2FrameComponentBus::Events::IsFrame);
+            if (hasFrameComponent)
             {
-                return component->GetJointName().GetStringView();
+                AZ::Name jointName;
+                ROS2FrameComponentBus::EventResult(jointName, entity->GetId(), &ROS2FrameComponentBus::Events::GetJointName);
+                return jointName.GetStringView();
             }
         }
         return AZStd::string();

--- a/Gems/ROS2/Code/Source/Utilities/JointUtilities.cpp
+++ b/Gems/ROS2/Code/Source/Utilities/JointUtilities.cpp
@@ -7,8 +7,8 @@
  */
 
 #include "JointUtilities.h"
-#include "AzCore/Name/Name.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
+#include <AzCore/Name/Name.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 
 namespace ROS2::Utils

--- a/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
+++ b/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
@@ -1,0 +1,155 @@
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Asset/AssetManagerComponent.h>
+#include <AzCore/Component/ComponentApplication.h>
+#include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Slice/SliceAssetHandler.h>
+#include <AzCore/UserSettings/UserSettingsComponent.h>
+#include <AzCore/std/containers/array.h>
+#include <AzCore/std/string/string_view.h>
+#include <AzQtComponents/Utilities/QtPluginPaths.h>
+#include <AzTest/GemTestEnvironment.h>
+#include <AzToolsFramework/Commands/PreemptiveUndoCache.h>
+#include <AzToolsFramework/Entity/EditorEntityContextComponent.h>
+#include <AzToolsFramework/ToolsComponents/TransformComponent.h>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
+#include <AzToolsFramework/UnitTest/ToolsTestApplication.h>
+#include <ROS2/Frame/ROS2FrameComponent.h>
+#include <ROS2/ROS2Bus.h>
+#include <ROS2/Sensor/ROS2SensorComponent.h>
+#include <ROS2SystemComponent.h>
+
+#include <QApplication>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace UnitTest
+{
+    class ROS2FrameComponentTestEnviroment : public AZ::Test::GemTestEnvironment
+    {
+        // AZ::Test::GemTestEnvironment overrides ...
+        void AddGemsAndComponents() override;
+        AZ::ComponentApplication* CreateApplicationInstance() override;
+        void PostSystemEntityActivate() override;
+
+    public:
+        ROS2FrameComponentTestEnviroment() = default;
+        ~ROS2FrameComponentTestEnviroment() override = default;
+    };
+
+    void ROS2FrameComponentTestEnviroment::AddGemsAndComponents()
+    {
+        AddActiveGems(AZStd::to_array<AZStd::string_view>({ "ROS2" }));
+        AddDynamicModulePaths({});
+        AddComponentDescriptors(AZStd::initializer_list<AZ::ComponentDescriptor*>{ ROS2::ROS2FrameComponent::CreateDescriptor(),
+                                                                                   ROS2::ROS2SystemComponent::CreateDescriptor() });
+        AddRequiredComponents(AZStd::to_array<AZ::TypeId const>({ ROS2::ROS2SystemComponent::TYPEINFO_Uuid() }));
+    }
+
+    AZ::ComponentApplication* ROS2FrameComponentTestEnviroment::CreateApplicationInstance()
+    {
+        // Using ToolsTestApplication to have AzFramework and AzToolsFramework components.
+        return aznew UnitTest::ToolsTestApplication("ROS2FrameComponent");
+    }
+
+    void ROS2FrameComponentTestEnviroment::PostSystemEntityActivate()
+    {
+        AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
+    }
+
+    class ROS2FrameComponentFixture : public ::testing::Test
+    {
+    };
+
+    TEST_F(ROS2FrameComponentFixture, SingleFrameDefault)
+    {
+        ROS2::ROS2FrameConfiguration config;
+
+        AZ::Entity entity;
+        const std::string entityName = entity.GetName().c_str();
+        entity.CreateComponent<AzToolsFramework::Components::TransformComponent>();
+        auto frame = entity.CreateComponent<ROS2::ROS2FrameComponent>(config);
+
+        entity.Init();
+        entity.Activate();
+
+        const std::string jointName(frame->GetJointName().GetCStr());
+        const std::string frameId(frame->GetFrameID().c_str());
+
+        EXPECT_EQ(entity.GetState(), AZ::Entity::State::Active);
+        EXPECT_STRCASEEQ(jointName.c_str(), ("o3de_" + entityName + "/").c_str());
+        EXPECT_STRCASEEQ(frameId.c_str(), ("o3de_" + entityName + "/sensor_frame").c_str());
+    }
+
+    TEST_F(ROS2FrameComponentFixture, ThreeFramesDefault)
+    {
+        ROS2::ROS2FrameConfiguration config;
+
+        std::vector<AZStd::unique_ptr<AZ::Entity>> entities;
+        std::vector<const ROS2::ROS2FrameComponent*> frames;
+
+        constexpr int numOfEntities = 3;
+
+        for (int i = 0; i < numOfEntities; i++)
+        {
+            entities.push_back(AZStd::make_unique<AZ::Entity>());
+        }
+
+        for (int i = 0; i < numOfEntities; i++)
+        {
+            entities[i]->CreateComponent<AzToolsFramework::Components::TransformComponent>();
+            entities[i]->SetName(("entity" + std::to_string(i)).c_str());
+            entities[i]->Init();
+            entities[i]->Activate();
+            if (i != 0)
+            {
+                AZ::TransformBus::Event(entities[i]->GetId(), &AZ::TransformBus::Events::SetParent, entities[i - 1]->GetId());
+            }
+            entities[i]->Deactivate();
+
+            auto frame = entities[i]->CreateComponent<ROS2::ROS2FrameComponent>(config);
+            frames.push_back(frame);
+
+            entities[i]->Activate();
+        }
+
+        for (int i = 0; i < numOfEntities; i++)
+        {
+            const std::string jointName(frames[i]->GetJointName().GetCStr());
+            const std::string frameId(frames[i]->GetFrameID().c_str());
+
+            EXPECT_EQ(entities[i]->GetState(), AZ::Entity::State::Active);
+            EXPECT_STRCASEEQ(jointName.c_str(), (entities[0]->GetName() + "/").c_str());
+            EXPECT_STRCASEEQ(frameId.c_str(), (entities[0]->GetName() + "/sensor_frame").c_str());
+        }
+    }
+
+} // namespace UnitTest
+
+// required to support running integration tests with Qt and PhysX
+AZTEST_EXPORT int AZ_UNIT_TEST_HOOK_NAME(int argc, char** argv)
+{
+    ::testing::InitGoogleMock(&argc, argv);
+    AzQtComponents::PrepareQtPaths();
+    QApplication app(argc, argv);
+    AZ::Test::printUnusedParametersWarning(argc, argv);
+    AZ::Test::addTestEnvironments({ new UnitTest::ROS2FrameComponentTestEnviroment() });
+    int result = RUN_ALL_TESTS();
+    return result;
+}
+
+IMPLEMENT_TEST_EXECUTABLE_MAIN();

--- a/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
+++ b/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
@@ -7,20 +7,18 @@
  *
  */
 
-#include "AzCore/Name/Name.h"
-#include "AzCore/std/string/string.h"
-#include "ROS2/Frame/ROS2FrameBus.h"
-#include "ROS2/Frame/ROS2FrameEditorComponent.h"
 #include <AzCore/Asset/AssetManagerComponent.h>
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/EntityId.h>
+#include <AzCore/Name/Name.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Slice/SliceAssetHandler.h>
 #include <AzCore/UserSettings/UserSettingsComponent.h>
 #include <AzCore/std/containers/array.h>
+#include <AzCore/std/string/string.h>
 #include <AzCore/std/string/string_view.h>
 #include <AzQtComponents/Utilities/QtPluginPaths.h>
 #include <AzTest/GemTestEnvironment.h>
@@ -29,6 +27,7 @@
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
 #include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 #include <AzToolsFramework/UnitTest/ToolsTestApplication.h>
+#include <ROS2/Frame/ROS2FrameBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <ROS2/ROS2Bus.h>

--- a/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
+++ b/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
@@ -7,6 +7,7 @@
  *
  */
 
+#include "AzCore/Name/Name.h"
 #include "AzCore/std/string/string.h"
 #include "ROS2/Frame/ROS2FrameBus.h"
 #include "ROS2/Frame/ROS2FrameEditorComponent.h"
@@ -87,13 +88,19 @@ namespace UnitTest
         AZ::Entity entity;
         const std::string entityName = entity.GetName().c_str();
         entity.CreateComponent<AzToolsFramework::Components::TransformComponent>();
-        auto frame = entity.CreateComponent<ROS2::ROS2FrameComponent>(config);
+        entity.CreateComponent<ROS2::ROS2FrameComponent>(config);
 
         entity.Init();
         entity.Activate();
 
-        const std::string jointName(frame->GetJointName().GetCStr());
-        const std::string frameId(frame->GetFrameID().c_str());
+        AZ::Name jointNameResult;
+        AZStd::string frameIdResult;
+
+        ROS2::ROS2FrameComponentBus::EventResult(jointNameResult, entity.GetId(), &ROS2::ROS2FrameComponentBus::Events::GetJointName);
+        ROS2::ROS2FrameComponentBus::EventResult(frameIdResult, entity.GetId(), &ROS2::ROS2FrameComponentBus::Events::GetFrameID);
+
+        const std::string jointName(jointNameResult.GetCStr());
+        const std::string frameId(frameIdResult.c_str());
 
         EXPECT_EQ(entity.GetState(), AZ::Entity::State::Active);
         EXPECT_STRCASEEQ(jointName.c_str(), ("o3de_" + entityName + "/").c_str());
@@ -134,8 +141,15 @@ namespace UnitTest
 
         for (int i = 0; i < numOfEntities; i++)
         {
-            const std::string jointName(frames[i]->GetJointName().GetCStr());
-            const std::string frameId(frames[i]->GetFrameID().c_str());
+            AZ::Name jointNameResult;
+            AZStd::string frameIdResult;
+
+            ROS2::ROS2FrameComponentBus::EventResult(
+                jointNameResult, entities[i]->GetId(), &ROS2::ROS2FrameComponentBus::Events::GetJointName);
+            ROS2::ROS2FrameComponentBus::EventResult(frameIdResult, entities[i]->GetId(), &ROS2::ROS2FrameComponentBus::Events::GetFrameID);
+
+            const std::string jointName(jointNameResult.GetCStr());
+            const std::string frameId(frameIdResult.c_str());
 
             EXPECT_EQ(entities[i]->GetState(), AZ::Entity::State::Active);
             EXPECT_STRCASEEQ(jointName.c_str(), (entities[0]->GetName() + "/").c_str());

--- a/Gems/ROS2/Code/frame_test_files.cmake
+++ b/Gems/ROS2/Code/frame_test_files.cmake
@@ -1,0 +1,3 @@
+set(FILES
+        Tests/Frame/ROS2FrameComponentTest.cpp
+        )

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -70,4 +70,5 @@ set(FILES
     Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
     Source/SdfAssetBuilder/SdfAssetBuilderSystemComponent.cpp
     Source/SdfAssetBuilder/SdfAssetBuilderSystemComponent.h
+    Source/Frame/ROS2FrameEditorComponent.cpp
 )

--- a/Gems/ROS2/Code/ros2_files.cmake
+++ b/Gems/ROS2/Code/ros2_files.cmake
@@ -34,6 +34,7 @@ set(FILES
         Source/ContactSensor/ROS2ContactSensorComponent.cpp
         Source/ContactSensor/ROS2ContactSensorComponent.h
         Source/Frame/NamespaceConfiguration.cpp
+        Source/Frame/ROS2FrameController.cpp
         Source/Frame/ROS2FrameComponent.cpp
         Source/Frame/ROS2Transform.cpp
         Source/Gripper/GripperActionServer.cpp

--- a/Gems/ROS2/Code/ros2_header_files.cmake
+++ b/Gems/ROS2/Code/ros2_header_files.cmake
@@ -13,6 +13,8 @@ set(FILES
         Include/ROS2/Communication/QoS.h
         Include/ROS2/Frame/NamespaceConfiguration.h
         Include/ROS2/Frame/ROS2FrameComponent.h
+        Include/ROS2/Frame/ROS2FrameController.h
+        Include/ROS2/Frame/ROS2FrameEditorComponent.h
         Include/ROS2/Frame/ROS2Transform.h
         Include/ROS2/Gripper/GripperRequestBus.h
         Include/ROS2/Manipulation/Controllers/JointsPositionControllerRequests.h


### PR DESCRIPTION
I've added an editor component for the ROS2 frame component. 

I've modified the implementation of the ROS2 frame component to use EBus to communicate between frames.

I've also added simple tests for the component that checks if the frameID and joint names are adequately constructed with namespaces.