### PR TITLE
Updating ROS2 RobotImporter to use libsdformat

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -140,8 +140,10 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 3rdParty::sdformat
     )
 
-    find_package(urdfdom)
-    target_link_libraries(${gem_name}.Editor.Static PUBLIC urdfdom::urdfdom_model)
+    #find_package(urdfdom REQUIRED)
+    find_package(sdformat13 REQUIRED)
+    #target_link_libraries(${gem_name}.Editor.Static PUBLIC urdfdom::urdfdom_model ${sdformat13_LIBRARIES})
+    target_link_libraries(${gem_name}.Editor.Static PUBLIC ${sdformat13_LIBRARIES})
 
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE

--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -140,11 +140,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 3rdParty::sdformat
     )
 
-    #find_package(urdfdom REQUIRED)
-    find_package(sdformat13 REQUIRED)
-    #target_link_libraries(${gem_name}.Editor.Static PUBLIC urdfdom::urdfdom_model ${sdformat13_LIBRARIES})
-    target_link_libraries(${gem_name}.Editor.Static PUBLIC ${sdformat13_LIBRARIES})
-
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem

--- a/Gems/ROS2/Code/FindROS2.cmake
+++ b/Gems/ROS2/Code/FindROS2.cmake
@@ -5,6 +5,7 @@
 
 # Note that this does not find any ros2 package in particular, but determines whether a distro is sourced properly
 # Can be extended to handle supported / unsupported distros
+message(STATUS "Ros Distro is \"$ENV{ROS_DISTRO}\"")
 if (NOT DEFINED ENV{ROS_DISTRO} OR NOT DEFINED ENV{AMENT_PREFIX_PATH})
     message(WARNING, "To build ROS2 Gem a ROS distribution needs to be sourced, but none detected")
     set(ROS2_FOUND FALSE)

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.cpp
@@ -19,7 +19,7 @@ namespace ROS2
     {
         m_fileDialog = new QFileDialog(this);
         m_fileDialog->setDirectory(QString::fromUtf8(AZ::Utils::GetProjectPath().data()));
-        m_fileDialog->setNameFilter("URDF, XACRO (*.urdf *.xacro)");
+        m_fileDialog->setNameFilter("URDF, XACRO, SDF (*.urdf *.xacro *.sdf)");
         m_button = new QPushButton("...", this);
         m_textEdit = new QLineEdit("", this);
         m_copyFiles = new QCheckBox(tr("Import meshes during URDF load"), this);

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.cpp
@@ -19,7 +19,7 @@ namespace ROS2
     {
         m_fileDialog = new QFileDialog(this);
         m_fileDialog->setDirectory(QString::fromUtf8(AZ::Utils::GetProjectPath().data()));
-        m_fileDialog->setNameFilter("URDF, XACRO, SDF (*.urdf *.xacro *.sdf)");
+        m_fileDialog->setNameFilter("URDF, XACRO (*.urdf *.xacro)");
         m_button = new QPushButton("...", this);
         m_textEdit = new QLineEdit("", this);
         m_copyFiles = new QCheckBox(tr("Import meshes during URDF load"), this);

--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -112,6 +112,7 @@ namespace ROS2
                     errorMessage += AZStd::string::format(", Line=%d", sdfError.LineNumber().value());
                 }
                 aggregateErrorMessages += errorMessage;
+                aggregateErrorMessages += '\n';
             }
             AZ_Warning("ROS2EditorSystemComponent", false, "URDF parsing failed with errors: %s\nRefer to %s",
                 aggregateErrorMessages.c_str(), log.c_str());

--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.h
@@ -13,7 +13,6 @@
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <ROS2/RobotImporter/RobotImporterBus.h>
 #include <RobotImporter/Utils/SourceAssetsStorage.h>
-#include <urdf_parser/urdf_parser.h>
 namespace ROS2
 {
 

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -90,43 +90,51 @@ namespace ROS2
             if (Utils::IsFileXacro(m_urdfPath))
             {
                 Utils::xacro::ExecutionOutcome outcome = Utils::xacro::ParseXacro(m_urdfPath.String(), m_params);
+                // Store off the URDF parsing outcome which will be output later in this function
+                parsedUrdfOutcome = outcome.m_urdfHandle;
                 if (outcome)
                 {
-                    parsedUrdfOutcome = outcome.m_urdfHandle;
                     report += "# " + tr("XACRO execution succeeded") + "\n";
                     m_assetPage->ClearAssetsList();
                 }
                 else
                 {
-                    report += "# " + tr("XACRO parsing failed") + "\n";
-                    report += "\n\n## " + tr("Command called") + "\n\n`" + QString::fromUtf8(outcome.m_called.data()) + "`";
-                    report += "\n\n" + tr("Process failed");
-                    report += "\n\n## " + tr("Error output") + "\n\n";
-                    report += "```\n";
-                    if (outcome.m_logErrorOutput.size())
+                    if (outcome.m_succeed)
                     {
-                        report +=
-                            QString::fromLocal8Bit(outcome.m_logErrorOutput.data(), static_cast<int>(outcome.m_logErrorOutput.size()));
+                        report += "# " + tr("XACRO execution succeeded, but URDF parsing failed") + "\n";
                     }
                     else
                     {
-                        report += tr("(EMPTY)");
+                        report += "# " + tr("XACRO parsing failed") + "\n";
+                        report += "\n\n## " + tr("Command called") + "\n\n`" + QString::fromUtf8(outcome.m_called.data()) + "`";
+                        report += "\n\n" + tr("Process failed");
+                        report += "\n\n## " + tr("Error output") + "\n\n";
+                        report += "```\n";
+                        if (outcome.m_logErrorOutput.size())
+                        {
+                            report +=
+                                QString::fromUtf8(outcome.m_logErrorOutput.data(), static_cast<int>(outcome.m_logErrorOutput.size()));
+                        }
+                        else
+                        {
+                            report += tr("(EMPTY)");
+                        }
+                        report += "\n```";
+                        report += "\n\n## " + tr("Standard output") + "\n\n";
+                        report += "```\n";
+                        if (outcome.m_logStandardOutput.size())
+                        {
+                            report += QString::fromUtf8(
+                                outcome.m_logStandardOutput.data(), static_cast<int>(outcome.m_logStandardOutput.size()));
+                        }
+                        else
+                        {
+                            report += tr("(EMPTY)");
+                        }
+                        report += "\n```";
+                        m_checkUrdfPage->ReportURDFResult(report, false);
+                        return;
                     }
-                    report += "\n```";
-                    report += "\n\n## " + tr("Standard output") + "\n\n";
-                    report += "```\n";
-                    if (outcome.m_logStandardOutput.size())
-                    {
-                        report += QString::fromLocal8Bit(
-                            outcome.m_logStandardOutput.data(), static_cast<int>(outcome.m_logStandardOutput.size()));
-                    }
-                    else
-                    {
-                        report += tr("(EMPTY)");
-                    }
-                    report += "\n```";
-                    m_checkUrdfPage->ReportURDFResult(report, false);
-                    return;
                 }
             }
             else if (Utils::IsFileUrdf(m_urdfPath))

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -143,7 +143,7 @@ namespace ROS2
                 m_prefabMaker.reset();
                 // Report the status of skipping this page
                 AZ_Printf("Wizard", "Wizard skips m_checkUrdfPage since there is no errors in URDF\n");
-                m_meshNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), true, true);
+                m_meshNames = Utils::GetMeshesFilenames(m_parsedUrdf, true, true);
                 m_assetPage->ClearAssetsList();
             }
             else
@@ -179,8 +179,8 @@ namespace ROS2
     {
         if (m_parsedUrdf && m_assetPage->IsEmpty())
         {
-            auto collidersNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), false, true);
-            auto visualNames = Utils::GetMeshesFilenames(m_parsedUrdf->getRoot(), true, false);
+            auto collidersNames = Utils::GetMeshesFilenames(m_parsedUrdf, false, true);
+            auto visualNames = Utils::GetMeshesFilenames(m_parsedUrdf, true, false);
 
             AZ::Uuid::FixedString dirSuffix;
             if (!m_params.empty())
@@ -267,7 +267,7 @@ namespace ROS2
     {
         if (m_parsedUrdf)
         {
-            AZStd::string robotName = AZStd::string(m_parsedUrdf->getName().c_str(), m_parsedUrdf->getName().size()) + ".prefab";
+            AZStd::string robotName = AZStd::string(m_parsedUrdf->Model()->Name().c_str(), m_parsedUrdf->Model()->Name().size()) + ".prefab";
             m_prefabMakerPage->setProposedPrefabName(robotName);
             QWizard::button(PrefabCreationButtonId)->setText(tr("Create Prefab"));
             QWizard::setOption(HavePrefabCreationButton, true);
@@ -372,7 +372,7 @@ namespace ROS2
         const bool useArticulation = m_prefabMakerPage->IsUseArticulations();
         m_prefabMaker = AZStd::make_unique<URDFPrefabMaker>(
             m_urdfPath.String(),
-            m_parsedUrdf,
+            &m_parsedUrdf,
             prefabPath.String(),
             m_urdfAssetsMapping,
             useArticulation,

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -69,7 +69,7 @@ namespace ROS2
         PrefabMakerPage* m_prefabMakerPage;
         XacroParamsPage* m_xacroParamsPage;
         AZ::IO::Path m_urdfPath;
-        sdf::Root* m_parsedUrdf {nullptr};
+        sdf::Root m_parsedUrdf{};
 
         //! User's choice to copy meshes during urdf import
         bool m_importAssetWithUrdf{ false };

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -69,7 +69,7 @@ namespace ROS2
         PrefabMakerPage* m_prefabMakerPage;
         XacroParamsPage* m_xacroParamsPage;
         AZ::IO::Path m_urdfPath;
-        urdf::ModelInterfaceSharedPtr m_parsedUrdf;
+        sdf::Root* m_parsedUrdf {nullptr};
 
         //! User's choice to copy meshes during urdf import
         bool m_importAssetWithUrdf{ false };

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.cpp
@@ -102,9 +102,8 @@ namespace ROS2
 
         articulationLinkConfiguration = AddToArticulationConfig(articulationLinkConfiguration, link->Inertial());
 
-        // TODO: Figure out parent/child relationships
         constexpr bool getNestedModelJoints = true;
-        AZStd::string_view linkName(link->Name().c_str(), link->Name().size());
+        AZStd::string linkName(link->Name().c_str(), link->Name().size());
         for (const sdf::Joint* joint : Utils::GetJointsForChildLink(model, linkName, getNestedModelJoints))
         {
             articulationLinkConfiguration = AddToArticulationConfig(articulationLinkConfiguration, joint);

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.cpp
@@ -46,15 +46,15 @@ namespace ROS2
             const auto type = supportedArticulationType->second;
             articulationLinkConfiguration.m_articulationJointType = type;
             const AZ::Vector3 o3deJointDir{ 1.0, 0.0, 0.0 };
-            AZ::Vector3 jointCoorAxis = AZ::Vector3::CreateZero();
+            AZ::Vector3 jointCoordinateAxis = AZ::Vector3::CreateZero();
             auto quaternion = AZ::Quaternion::CreateIdentity();
 
             const sdf::JointAxis* jointAxis = joint->Axis();
             if (jointAxis != nullptr)
             {
-                jointCoorAxis = URDF::TypeConversions::ConvertVector3(jointAxis->Xyz());
+                jointCoordinateAxis = URDF::TypeConversions::ConvertVector3(jointAxis->Xyz());
                 quaternion =
-                    jointCoorAxis.IsZero() ? AZ::Quaternion::CreateIdentity() : AZ::Quaternion::CreateShortestArc(o3deJointDir, jointCoorAxis);
+                    jointCoordinateAxis.IsZero() ? AZ::Quaternion::CreateIdentity() : AZ::Quaternion::CreateShortestArc(o3deJointDir, jointCoordinateAxis);
             }
 
             const AZ::Vector3 rotation = quaternion.GetEulerDegrees();

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.h
@@ -22,6 +22,6 @@ namespace ROS2
         //! Add zero or one inertial and joints elements to a given entity (depending on link content).
         //! @param link A pointer to a parsed URDF link.
         //! @param entityId A non-active entity which will be populated according to inertial content.
-        void AddArticulationLink(urdf::LinkSharedPtr link, AZ::EntityId entityId) const;
+        void AddArticulationLink(const sdf::Link* link, AZ::EntityId entityId) const;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.h
@@ -20,8 +20,10 @@ namespace ROS2
     {
     public:
         //! Add zero or one inertial and joints elements to a given entity (depending on link content).
+        //! @param model SDF model object which can be queried to locate the joints needed to determine if the supplied
+        //!              link is a child link within a joint
         //! @param link A pointer to a parsed URDF link.
         //! @param entityId A non-active entity which will be populated according to inertial content.
-        void AddArticulationLink(const sdf::Link* link, AZ::EntityId entityId) const;
+        void AddArticulationLink(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId) const;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
@@ -205,10 +205,10 @@ namespace ROS2
         }
     }
 
-    void CollidersMaker::AddColliders(const sdf::Link* link, AZ::EntityId entityId)
+    void CollidersMaker::AddColliders(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId)
     {
         AZStd::string typeString = "collider";
-        const bool isWheelEntity = Utils::IsWheelURDFHeuristics(link);
+        const bool isWheelEntity = Utils::IsWheelURDFHeuristics(model, link);
         if (isWheelEntity)
         {
             AZ_Printf(Internal::CollidersMakerLoggingTag, "Due to its name, %s is considered a wheel entity\n", link->Name().c_str());

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
@@ -98,7 +98,7 @@ namespace ROS2
             {
                 return;
             }
-            const AZStd::string& azMeshPath = asset->m_sourceAssetGlobalPath;
+            const auto& azMeshPath = asset->m_sourceAssetGlobalPath;
 
             AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> scene;
             AZ::SceneAPI::Events::SceneSerializationBus::BroadcastResult(

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
@@ -211,10 +211,12 @@ namespace ROS2
         const bool isWheelEntity = Utils::IsWheelURDFHeuristics(link);
         if (isWheelEntity)
         {
-            AZ_Printf(Internal::CollidersMakerLoggingTag, "Due to its name, %s is considered a wheel entity\n", link->Name()c_str());
+            AZ_Printf(Internal::CollidersMakerLoggingTag, "Due to its name, %s is considered a wheel entity\n", link->Name().c_str());
             if (!m_wheelMaterial.GetId().IsValid())
             {
                 FindWheelMaterial();
+            }
+        }
         const AZ::Data::Asset<Physics::MaterialAsset> materialAsset =
             isWheelEntity ? m_wheelMaterial : AZ::Data::Asset<Physics::MaterialAsset>();
         size_t nameSuffixIndex = 0; // For disambiguation when multiple unnamed colliders are present. The order does not matter here

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
@@ -64,36 +64,36 @@ namespace ROS2
         }
     }
 
-    void CollidersMaker::BuildColliders(urdf::LinkSharedPtr link)
+    void CollidersMaker::BuildColliders(const sdf::Link* link)
     {
-        for (auto collider : link->collision_array)
+        if (!link)
         {
-            BuildCollider(collider);
+            return;
         }
 
-        if (link->collision_array.empty())
+        for (uint64_t index = 0; index < link->CollisionCount(); index++)
         {
-            BuildCollider(link->collision);
+            BuildCollider(link->CollisionByIndex(index));
         }
     }
 
-    void CollidersMaker::BuildCollider(urdf::CollisionSharedPtr collision)
+    void CollidersMaker::BuildCollider(const sdf::Collision* collision)
     {
         if (!collision)
         { // it is ok not to have collision in a link
             return;
         }
 
-        auto geometry = collision->geometry;
-        bool isPrimitiveShape = geometry->type != urdf::Geometry::MESH;
+        auto geometry = collision->Geom();
+        bool isPrimitiveShape = geometry->Type() != sdf::GeometryType::MESH;
         if (!isPrimitiveShape)
         {
-            auto meshGeometry = std::dynamic_pointer_cast<urdf::Mesh>(geometry);
+            auto meshGeometry = geometry->MeshShape();
             if (!meshGeometry)
             {
                 return;
             }
-            const auto asset = PrefabMakerUtils::GetAssetFromPath(*m_urdfAssetsMapping, meshGeometry->filename);
+            const auto asset = PrefabMakerUtils::GetAssetFromPath(*m_urdfAssetsMapping, meshGeometry->Uri());
             if (!asset)
             {
                 return;
@@ -110,7 +110,7 @@ namespace ROS2
                     false,
                     "Error loading collider. Invalid scene: %s, URDF path: %s",
                     azMeshPath.c_str(),
-                    meshGeometry->filename.c_str());
+                    meshGeometry->Uri().c_str());
                 return;
             }
 
@@ -205,36 +205,29 @@ namespace ROS2
         }
     }
 
-    void CollidersMaker::AddColliders(urdf::LinkSharedPtr link, AZ::EntityId entityId)
+    void CollidersMaker::AddColliders(const sdf::Link* link, AZ::EntityId entityId)
     {
         AZStd::string typeString = "collider";
         const bool isWheelEntity = Utils::IsWheelURDFHeuristics(link);
         if (isWheelEntity)
         {
-            AZ_Printf(Internal::CollidersMakerLoggingTag, "Due to its name, %s is considered a wheel entity\n", link->name.c_str());
+            AZ_Printf(Internal::CollidersMakerLoggingTag, "Due to its name, %s is considered a wheel entity\n", link->Name()c_str());
             if (!m_wheelMaterial.GetId().IsValid())
             {
                 FindWheelMaterial();
-            }
-        }
         const AZ::Data::Asset<Physics::MaterialAsset> materialAsset =
             isWheelEntity ? m_wheelMaterial : AZ::Data::Asset<Physics::MaterialAsset>();
         size_t nameSuffixIndex = 0; // For disambiguation when multiple unnamed colliders are present. The order does not matter here
-        for (auto collider : link->collision_array)
+        for (uint64_t index = 0; index < link->CollisionCount(); index++)
         { // Add colliders (if any) from the collision array
             AddCollider(
-                collider, entityId, PrefabMakerUtils::MakeEntityName(link->name.c_str(), typeString, nameSuffixIndex), materialAsset);
+                link->CollisionByIndex(index), entityId, PrefabMakerUtils::MakeEntityName(link->Name().c_str(), typeString, nameSuffixIndex), materialAsset);
             nameSuffixIndex++;
-        }
-
-        if (nameSuffixIndex == 0)
-        { // If there are no colliders in the array, the element member is used instead
-            AddCollider(link->collision, entityId, PrefabMakerUtils::MakeEntityName(link->name.c_str(), typeString), materialAsset);
         }
     }
 
     void CollidersMaker::AddCollider(
-        urdf::CollisionSharedPtr collision,
+        const sdf::Collision* collision,
         AZ::EntityId entityId,
         const AZStd::string& generatedName,
         const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset)
@@ -245,7 +238,7 @@ namespace ROS2
         }
         AZ_Trace(Internal::CollidersMakerLoggingTag, "Processing collisions for entity id:%s\n", entityId.ToString().c_str());
 
-        auto geometry = collision->geometry;
+        auto geometry = collision->Geom();
         if (!geometry)
         { // non-empty visual should have a geometry
             AZ_Warning(Internal::CollidersMakerLoggingTag, false, "No Geometry for a collider of entity %s", entityId.ToString().c_str());
@@ -256,25 +249,25 @@ namespace ROS2
     }
 
     void CollidersMaker::AddColliderToEntity(
-        urdf::CollisionSharedPtr collision, AZ::EntityId entityId, const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset) const
+        const sdf::Collision* collision, AZ::EntityId entityId, const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset) const
     {
         AZ::Entity* entity = AzToolsFramework::GetEntityById(entityId);
         AZ_Assert(entity, "AddColliderToEntity called with invalid entityId");
-        auto geometry = collision->geometry;
-        bool isPrimitiveShape = geometry->type != urdf::Geometry::MESH;
+        auto geometry = collision->Geom();
+        bool isPrimitiveShape = geometry->Type() != sdf::GeometryType::MESH;
 
         Physics::ColliderConfiguration colliderConfig;
 
         colliderConfig.m_materialSlots.SetMaterialAsset(0, materialAsset);
-        colliderConfig.m_position = URDF::TypeConversions::ConvertVector3(collision->origin.position);
-        colliderConfig.m_rotation = URDF::TypeConversions::ConvertQuaternion(collision->origin.rotation);
+        colliderConfig.m_position = URDF::TypeConversions::ConvertVector3(collision->RawPose().Pos());
+        colliderConfig.m_rotation = URDF::TypeConversions::ConvertQuaternion(collision->RawPose().Rot());
         if (!isPrimitiveShape)
         {
             AZ_Printf(Internal::CollidersMakerLoggingTag, "Adding mesh collider to %s\n", entityId.ToString().c_str());
-            auto meshGeometry = std::dynamic_pointer_cast<urdf::Mesh>(geometry);
+            auto meshGeometry = geometry->MeshShape();
             AZ_Assert(meshGeometry, "geometry is not meshGeometry");
 
-            auto asset = PrefabMakerUtils::GetAssetFromPath(*m_urdfAssetsMapping, meshGeometry->filename);
+            auto asset = PrefabMakerUtils::GetAssetFromPath(*m_urdfAssetsMapping, meshGeometry->Uri());
             if (!asset)
             {
                 return;
@@ -310,28 +303,28 @@ namespace ROS2
             return;
         }
 
-        AZ_Printf(Internal::CollidersMakerLoggingTag, "URDF geometry type: %d\n", geometry->type);
-        switch (geometry->type)
+        AZ_Printf(Internal::CollidersMakerLoggingTag, "URDF geometry type: %d\n", (int)geometry->Type());
+        switch (geometry->Type())
         {
-        case urdf::Geometry::SPHERE:
+        case sdf::GeometryType::SPHERE:
             {
-                auto sphereGeometry = std::dynamic_pointer_cast<urdf::Sphere>(geometry);
+                auto sphereGeometry = geometry->SphereShape();
                 AZ_Assert(sphereGeometry, "geometry is not sphereGeometry");
-                const Physics::SphereShapeConfiguration cfg{ static_cast<float>(sphereGeometry->radius) };
+                const Physics::SphereShapeConfiguration cfg{ static_cast<float>(sphereGeometry->Radius()) };
                 entity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, cfg);
             }
             break;
-        case urdf::Geometry::BOX:
+        case sdf::GeometryType::BOX:
             {
-                const auto boxGeometry = std::dynamic_pointer_cast<urdf::Box>(geometry);
+                const auto boxGeometry = geometry->BoxShape();
                 AZ_Assert(boxGeometry, "geometry is not boxGeometry");
-                const Physics::BoxShapeConfiguration cfg{ URDF::TypeConversions::ConvertVector3(boxGeometry->dim) };
+                const Physics::BoxShapeConfiguration cfg{ URDF::TypeConversions::ConvertVector3(boxGeometry->Size()) };
                 entity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, cfg);
             }
             break;
-        case urdf::Geometry::CYLINDER:
+        case sdf::GeometryType::CYLINDER:
             {
-                auto cylinderGeometry = std::dynamic_pointer_cast<urdf::Cylinder>(geometry);
+                auto cylinderGeometry = geometry->CylinderShape();
                 AZ_Assert(cylinderGeometry, "geometry is not cylinderGeometry");
                 Physics::BoxShapeConfiguration cfg;
                 auto* component = entity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, cfg);
@@ -345,11 +338,11 @@ namespace ROS2
                     PhysX::EditorPrimitiveColliderComponentRequestBus::Event(
                         AZ::EntityComponentIdPair(entityId, component->GetId()),
                         &PhysX::EditorPrimitiveColliderComponentRequests::SetCylinderHeight,
-                        cylinderGeometry->length);
+                        cylinderGeometry->Length());
                     PhysX::EditorPrimitiveColliderComponentRequestBus::Event(
                         AZ::EntityComponentIdPair(entityId, component->GetId()),
                         &PhysX::EditorPrimitiveColliderComponentRequests::SetCylinderRadius,
-                        cylinderGeometry->radius);
+                        cylinderGeometry->Radius());
                     PhysX::EditorPrimitiveColliderComponentRequestBus::Event(
                         AZ::EntityComponentIdPair(entityId, component->GetId()),
                         &PhysX::EditorPrimitiveColliderComponentRequests::SetCylinderSubdivisionCount,
@@ -363,7 +356,7 @@ namespace ROS2
             }
             break;
         default:
-            AZ_Warning(Internal::CollidersMakerLoggingTag, false, "Unsupported collider geometry type: %d", geometry->type);
+            AZ_Warning(Internal::CollidersMakerLoggingTag, false, "Unsupported collider geometry type: %d", (int)geometry->Type());
             break;
         }
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.h
@@ -41,9 +41,10 @@ namespace ROS2
         //! @param link A parsed URDF tree link node which could hold information about colliders.
         void BuildColliders(const sdf::Link* link);
         //! Add zero, one or many collider elements (depending on link content).
+        //! @param model An SDF model object provided by libsdformat from a parsed URDF
         //! @param link A parsed URDF tree link node which could hold information about colliders.
         //! @param entityId A non-active entity which will be affected.
-        void AddColliders(const sdf::Link* link, AZ::EntityId entityId);
+        void AddColliders(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId);
         //! Sends meshes required for colliders to asset processor.
         //! @param buildReadyCb Function to call when the processing finishes.
         void ProcessMeshes(BuildReadyCallback notifyBuildReadyCb);

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.h
@@ -39,25 +39,25 @@ namespace ROS2
 
         //! Builds .pxmeshes for every collider in link collider mesh.
         //! @param link A parsed URDF tree link node which could hold information about colliders.
-        void BuildColliders(urdf::LinkSharedPtr link);
+        void BuildColliders(const sdf::Link* link);
         //! Add zero, one or many collider elements (depending on link content).
         //! @param link A parsed URDF tree link node which could hold information about colliders.
         //! @param entityId A non-active entity which will be affected.
-        void AddColliders(urdf::LinkSharedPtr link, AZ::EntityId entityId);
+        void AddColliders(const sdf::Link* link, AZ::EntityId entityId);
         //! Sends meshes required for colliders to asset processor.
         //! @param buildReadyCb Function to call when the processing finishes.
         void ProcessMeshes(BuildReadyCallback notifyBuildReadyCb);
 
     private:
         void FindWheelMaterial();
-        void BuildCollider(urdf::CollisionSharedPtr collision);
+        void BuildCollider(const sdf::Collision* collision);
         void AddCollider(
-            urdf::CollisionSharedPtr collision,
+            const sdf::Collision* collision,
             AZ::EntityId entityId,
             const AZStd::string& generatedName,
             const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset);
         void AddColliderToEntity(
-            urdf::CollisionSharedPtr collision, AZ::EntityId entityId, const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset) const;
+            const sdf::Collision* collision, AZ::EntityId entityId, const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset) const;
 
         AZ::Data::Asset<Physics::MaterialAsset> m_wheelMaterial;
         AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
@@ -17,10 +17,6 @@ namespace ROS2
 {
     void InertialsMaker::AddInertial(const gz::math::Inertiald& inertial, AZ::EntityId entityId) const
     {
-        if (!inertial)
-        { // it is ok not to have inertia in a link
-            return;
-        }
         AZ_Trace("AddInertial", "Processing inertial for entity id: %s\n", entityId.ToString().c_str());
 
         AZ::Entity* entity = AzToolsFramework::GetEntityById(entityId);

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
@@ -15,7 +15,7 @@
 
 namespace ROS2
 {
-    void InertialsMaker::AddInertial(urdf::InertialSharedPtr inertial, AZ::EntityId entityId) const
+    void InertialsMaker::AddInertial(const gz::math::Inertiald& inertial, AZ::EntityId entityId) const
     {
         if (!inertial)
         { // it is ok not to have inertia in a link
@@ -31,22 +31,24 @@ namespace ROS2
         physxSpecificConfiguration.m_solverVelocityIterations =
             AZStd::max(physxSpecificConfiguration.m_solverVelocityIterations, URDF::DefaultNumberVelSolver);
 
-        rigidBodyConfiguration.m_mass = inertial->mass;
+        rigidBodyConfiguration.m_mass = inertial.MassMatrix().Mass();
         rigidBodyConfiguration.m_computeMass = false;
 
-        rigidBodyConfiguration.m_centerOfMassOffset = URDF::TypeConversions::ConvertVector3(inertial->origin.position);
+        rigidBodyConfiguration.m_centerOfMassOffset = URDF::TypeConversions::ConvertVector3(inertial.Pose().Pos());
         rigidBodyConfiguration.m_computeCenterOfMass = false;
 
-        if (!URDF::TypeConversions::ConvertQuaternion(inertial->origin.rotation).IsIdentity())
+        if (!URDF::TypeConversions::ConvertQuaternion(inertial.Pose().Rot()).IsIdentity())
         { // There is a rotation component in URDF that we are not able to apply
             AZ_Warning("AddInertial", false, "Ignoring URDF inertial origin rotation (no such field in rigid body configuration)");
         }
 
+        auto moi = inertial.Moi();
+
         // Inertia tensor is symmetrical
         auto inertiaMatrix = AZ::Matrix3x3::CreateFromRows(
-            AZ::Vector3(inertial->ixx, inertial->ixy, inertial->ixz),
-            AZ::Vector3(inertial->ixy, inertial->iyy, inertial->iyz),
-            AZ::Vector3(inertial->ixz, inertial->iyz, inertial->izz));
+            AZ::Vector3(moi(0, 0), moi(0, 1), moi(0, 2)),
+            AZ::Vector3(moi(0, 1), moi(1, 1), moi(1, 2)),
+            AZ::Vector3(moi(0, 2), moi(1, 2), moi(2, 2)));
         rigidBodyConfiguration.m_inertiaTensor = inertiaMatrix;
         rigidBodyConfiguration.m_computeInertiaTensor = false;
 

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/InertialsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/InertialsMaker.h
@@ -20,6 +20,6 @@ namespace ROS2
         //! Add zero or one inertial elements to a given entity (depending on link content).
         //! @param inertial A pointer to a parsed URDF inertial structure, might be null.
         //! @param entityId A non-active entity which will be populated according to inertial content.
-        void AddInertial(urdf::InertialSharedPtr inertial, AZ::EntityId entityId) const;
+        void AddInertial(const gz::math::Inertiald& inertial, AZ::EntityId entityId) const;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.cpp
@@ -93,8 +93,13 @@ namespace ROS2
                 jointComponent = followColliderEntity->CreateComponent<PhysX::EditorHingeJointComponent>();
                 followColliderEntity->Activate();
 
-                const double limitUpper = AZ::RadToDeg(joint->Axis()->Upper());
-                const double limitLower = AZ::RadToDeg(joint->Axis()->Lower());
+                using LimitType = decltype(joint->Axis()->Upper());
+                const double limitUpper = joint->Axis()->Upper() != AZStd::numeric_limits<LimitType>::infinity()
+                    ? AZ::RadToDeg(joint->Axis()->Upper())
+                    : AZ::RadToDeg(AZ::Constants::TwoPi);
+                const double limitLower = joint->Axis()->Lower() != -AZStd::numeric_limits<LimitType>::infinity()
+                    ? AZ::RadToDeg(joint->Axis()->Lower())
+                    : -AZ::RadToDeg(AZ::Constants::TwoPi);
                 AZ_Printf(
                     "JointsMaker",
                     "Setting limits : upper: %.1f lower: %.1f (URDF:%f,%f)",

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.cpp
@@ -18,7 +18,6 @@
 
 namespace ROS2
 {
-
     JointsMaker::JointsMakerResult JointsMaker::AddJointComponent(
         const sdf::Joint* joint, AZ::EntityId followColliderEntityId, AZ::EntityId leadColliderEntityId) const
     {

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.cpp
@@ -120,8 +120,9 @@ namespace ROS2
             }
             break;
         default:
-            AZ_Warning("AddJointComponent", false, "Unknown or unsupported joint type %d for joint %s", (int)joint->Type(), joint->Name().c_str());
-            return AZ::Failure(AZStd::string::format("unsupported joint type : %d", (int)joint->Type()));
+            AZ_Warning("AddJointComponent", false, "Unknown or unsupported joint type %d for joint %s",
+                static_cast<int>(joint->Type()), joint->Name().c_str());
+            return AZ::Failure(AZStd::string::format("unsupported joint type : %d", static_cast<int>(joint->Type())));
         }
 
         followColliderEntity->Activate();

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.cpp
@@ -103,9 +103,9 @@ namespace ROS2
 
                 if (jointAxis != nullptr)
                 {
-                    const bool enableJointLimits = jointAxis->Upper() != AZStd::numeric_limits<LimitType>::infinity()
-                        || jointAxis->Lower() != -AZStd::numeric_limits<LimitType>::infinity()
                     using LimitType = decltype(jointAxis->Upper());
+                    const bool enableJointLimits = jointAxis->Upper() != AZStd::numeric_limits<LimitType>::infinity()
+                        || jointAxis->Lower() != -AZStd::numeric_limits<LimitType>::infinity();
                     const double limitUpper = jointAxis->Upper() != AZStd::numeric_limits<LimitType>::infinity()
                         ? AZ::RadToDeg(jointAxis->Upper())
                         : AZ::RadToDeg(AZ::Constants::TwoPi);

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.h
@@ -28,6 +28,6 @@ namespace ROS2
         //! @param leadColliderEntityId An entity higher in hierarchy which is connected through the joint with the child entity.
         //! @returns created components Id or string with fail
         JointsMakerResult AddJointComponent(
-            urdf::JointSharedPtr joint, AZ::EntityId followColliderEntityId, AZ::EntityId leadColliderEntityId) const;
+            const sdf::Joint* joint, AZ::EntityId followColliderEntityId, AZ::EntityId leadColliderEntityId) const;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/PrefabMakerUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/PrefabMakerUtils.cpp
@@ -45,10 +45,10 @@ namespace ROS2::PrefabMakerUtils
         return assetPath;
     }
 
-    void SetEntityTransformLocal(const urdf::Pose& origin, AZ::EntityId entityId)
+    void SetEntityTransformLocal(const gz::math::Pose3d& origin, AZ::EntityId entityId)
     {
-        urdf::Vector3 urdfPosition = origin.position;
-        urdf::Rotation urdfRotation = origin.rotation;
+        gz::math::Vector3 urdfPosition = origin.Pos();
+        gz::math::Quaternion urdfRotation = origin.Rot();
         AZ::Quaternion azRotation = URDF::TypeConversions::ConvertQuaternion(urdfRotation);
         AZ::Vector3 azPosition = URDF::TypeConversions::ConvertVector3(urdfPosition);
         AZ::Transform tf(azPosition, azRotation, 1.0f);

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/PrefabMakerUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/PrefabMakerUtils.h
@@ -32,7 +32,7 @@ namespace ROS2::PrefabMakerUtils
     //! Set the transform for an entity.
     //! @param origin pose for the entity to set.
     //! @param entityId entity which will be modified.
-    void SetEntityTransformLocal(const urdf::Pose& origin, AZ::EntityId entityId);
+    void SetEntityTransformLocal(const gz::math::Pose3d& origin, AZ::EntityId entityId);
 
     //! Create a prefab entity in a hierarchy. The new entity will not yet be active.
     //! @param parentEntityId id of parent entity for this new entity.

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -51,7 +51,7 @@ namespace ROS2
         {
             AZ_Assert(GetFirstModel(), "SDF Model is nullptr");
 
-            VisualsMaker::MaterialMap materialMap;
+            VisualsMaker::MaterialNameMap materialMap;
             auto GetVisualsFromModel = [&materialMap](const sdf::Model& model)
             {
                 for (uint64_t linkIndex{}; linkIndex < model.LinkCount(); ++linkIndex)

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -264,15 +264,31 @@ namespace ROS2
 
             const std::string& jointName = jointPtr->Name();
             AZStd::string azJointName(jointName.c_str(), jointName.size());
+            AZStd::string parentLinkName(jointPtr->ParentName().c_str(), jointPtr->ParentName().size());
+            AZStd::string childLinkName(jointPtr->ChildName().c_str(), jointPtr->ChildName().size());
+
+            auto parentLinkIter = createdLinks.find(parentLinkName);
+            if (parentLinkIter == createdLinks.end())
+            {
+                AZ_Warning("CreatePrefabFromURDF", false, "Joint %s has no parent link %s. Cannot create", azJointName.c_str(), parentLinkName.c_str());
+                continue;
+            }
+            auto leadEntity = parentLinkIter->second;
+
+            auto childLinkIter = createdLinks.find(childLinkName);
+            if (childLinkIter == createdLinks.end())
+            {
+                AZ_Warning("CreatePrefabFromURDF", false, "Joint %s has no child link %s. Cannot create", azJointName.c_str(), childLinkName.c_str());
+                continue;
+            }
+            auto childEntity = childLinkIter->second;
+
             AZ_Trace(
                 "CreatePrefabFromURDF",
                 "Creating joint %s : %s -> %s\n",
                 azJointName.c_str(),
                 jointPtr->ParentName().c_str(),
                 jointPtr->ChildName().c_str());
-
-            auto leadEntity = createdLinks.at(jointPtr->ParentName().c_str());
-            auto childEntity = createdLinks.at(jointPtr->ChildName().c_str());
 
 
             AZ::Entity* childEntityPtr = AzToolsFramework::GetEntityById(childEntity.GetValue());

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -51,7 +51,7 @@ namespace ROS2
         {
             AZ_Assert(GetFirstModel(), "SDF Model is nullptr");
 
-            AZStd::unordered_map<AZStd::string, const sdf::Material*> materialMap;
+            VisualsMaker::MaterialMap materialMap;
             auto GetVisualsFromModel = [&materialMap](const sdf::Model& model)
             {
                 for (uint64_t linkIndex{}; linkIndex < model.LinkCount(); ++linkIndex)

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -315,9 +315,12 @@ namespace ROS2
         }
 
         // Use the first entity based on a link that is not parented to any other link
-        AZ::EntityId contentEntityId = !linkEntityIdsWithoutParent.empty() ? linkEntityIdsWithoutParent.front() : AZ::EntityId{};
-        MoveEntityToDefaultSpawnPoint(contentEntityId, m_spawnPosition);
-        AddRobotControl(contentEntityId);
+        if (!linkEntityIdsWithoutParent.empty() && linkEntityIdsWithoutParent.front().IsValid())
+        {
+            AZ::EntityId contentEntityId = linkEntityIdsWithoutParent.front();
+            MoveEntityToDefaultSpawnPoint(contentEntityId, m_spawnPosition);
+            AddRobotControl(contentEntityId);
+        }
 
         // Create prefab, save it to disk immediately
         // Remove prefab, if it was already created.

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -74,6 +74,9 @@ namespace ROS2
         void AddRobotControl(AZ::EntityId rootEntityId);
         static void MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId, AZStd::optional<AZ::Transform> spawnPosition);
 
+        // Returns the <model> at the root of the SDF or the first <world><model> if it exist
+        const sdf::Model* GetFirstModel() const;
+
         const sdf::Root* m_root;
         AZStd::string m_prefabPath;
         VisualsMaker m_visualsMaker;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -33,14 +33,13 @@ namespace ROS2
     public:
         //! Construct URDFPrefabMaker from arguments.
         //! @param modelFilePath path to the source URDF model.
-        //! @param model parsed model.
+        //! @param root parsed SDF root object.
         //! @param prefabPath path to the prefab which will be created as a result of import.
         //! @param urdfAssetsMapping prepared mapping of URDF meshes to Assets.
         //! @param useArticulations allows urdfImporter to create PhysXArticulations instead of multiple rigid bodies and joints.
         URDFPrefabMaker(
             const AZStd::string& modelFilePath,
             const sdf::Root* root,
-            const sdf::Model* model,
             AZStd::string prefabPath,
             const AZStd::shared_ptr<Utils::UrdfAssetMap> urdfAssetsMapping,
             bool useArticulations = false,
@@ -71,15 +70,16 @@ namespace ROS2
 
     private:
         AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(const sdf::Link* link, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities);
+        void BuildAssetsForLink(const sdf::Link* link);
+        void AddRobotControl(AZ::EntityId rootEntityId);
         static void MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId, AZStd::optional<AZ::Transform> spawnPosition);
 
         const sdf::Root* m_root;
-        const sdf::Model* m_model;
         AZStd::string m_prefabPath;
         VisualsMaker m_visualsMaker;
         CollidersMaker m_collidersMaker;
         InertialsMaker m_inertialsMaker;
-        //JointsMaker m_jointsMaker;
+        JointsMaker m_jointsMaker;
         ArticulationsMaker m_articulationsMaker;
 
         AZStd::mutex m_statusLock;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -39,7 +39,8 @@ namespace ROS2
         //! @param useArticulations allows urdfImporter to create PhysXArticulations instead of multiple rigid bodies and joints.
         URDFPrefabMaker(
             const AZStd::string& modelFilePath,
-            urdf::ModelInterfaceSharedPtr model,
+            const sdf::Root* root,
+            const sdf::Model* model,
             AZStd::string prefabPath,
             const AZStd::shared_ptr<Utils::UrdfAssetMap> urdfAssetsMapping,
             bool useArticulations = false,
@@ -69,17 +70,16 @@ namespace ROS2
         AZStd::string GetStatus();
 
     private:
-        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(urdf::LinkSharedPtr link, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities);
-        void BuildAssetsForLink(urdf::LinkSharedPtr link);
-        void AddRobotControl(AZ::EntityId rootEntityId);
+        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(const sdf::Link* link, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities);
         static void MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId, AZStd::optional<AZ::Transform> spawnPosition);
 
-        urdf::ModelInterfaceSharedPtr m_model;
+        const sdf::Root* m_root;
+        const sdf::Model* m_model;
         AZStd::string m_prefabPath;
         VisualsMaker m_visualsMaker;
         CollidersMaker m_collidersMaker;
         InertialsMaker m_inertialsMaker;
-        JointsMaker m_jointsMaker;
+        //JointsMaker m_jointsMaker;
         ArticulationsMaker m_articulationsMaker;
 
         AZStd::mutex m_statusLock;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
@@ -14,84 +14,97 @@
 #include <AzCore/std/string/string.h>
 #include <console_bridge/console.h>
 
-namespace ROS2
+namespace ROS2::UrdfParser::Internal
 {
-    namespace UrdfParser::Internal
+    void CheckIfCurrentLocaleHasDotAsADecimalSeparator()
     {
-        void CheckIfCurrentLocaleHasDotAsADecimalSeparator()
+        // Due to the fact that URDF parser takes into account the locale information, incompatibility between URDF file locale and
+        // system locale might lead to incorrect URDF parsing. Mainly it affects floating point numbers, and the decimal separator. When
+        // locales are set to system with comma as decimal separator and URDF file is created with dot as decimal separator, URDF parser
+        // will trim the floating point number after comma. For example, if parsing 0.1, URDF parser will parse it as 0.
+        // This might lead to incorrect URDF loading. If the current locale is not a dot (as per standard ROS locale), we warn the user.
+        std::locale currentLocale("");
+        if (std::use_facet<std::numpunct<char>>(currentLocale).decimal_point() != '.')
         {
-            // Due to the fact that URDF parser takes into account the locale information, incompatibility between URDF file locale and
-            // system locale might lead to incorrect URDF parsing. Mainly it affects floating point numbers, and the decimal separator. When
-            // locales are set to system with comma as decimal separator and URDF file is created with dot as decimal separator, URDF parser
-            // will trim the floating point number after comma. For example, if parsing 0.1, URDF parser will parse it as 0.
-            // This might lead to incorrect URDF loading. If the current locale is not a dot (as per standard ROS locale), we warn the user.
-            std::locale currentLocale("");
-            if (std::use_facet<std::numpunct<char>>(currentLocale).decimal_point() != '.')
-            {
-                AZ_Warning(
-                    "UrdfParser", false, "Locale %s might be incompatible with the URDF file content.\n", currentLocale.name().c_str());
-            }
+            AZ_Warning(
+                "UrdfParser", false, "Locale %s might be incompatible with the URDF file content.\n", currentLocale.name().c_str());
         }
+    }
 
-        class CustomConsoleHandler : public console_bridge::OutputHandler
-        {
-        private:
-            std::stringstream console_ss;
+    class CustomConsoleHandler : public console_bridge::OutputHandler
+    {
+    private:
+        std::stringstream console_ss;
 
-        public:
-            void log(const std::string& text, console_bridge::LogLevel level, const char* filename, int line) override final;
+    public:
+        void log(const std::string& text, console_bridge::LogLevel level, const char* filename, int line) override final;
 
-            //! Clears accumulated log
-            void Clear();
+        //! Clears accumulated log
+        void Clear();
 
-            //! Read accumulated log to a string
-            AZStd::string GetLog();
-        };
+        //! Read accumulated log to a string
+        AZStd::string GetLog();
+    };
 
-        void CustomConsoleHandler::log(const std::string& text, console_bridge::LogLevel level, const char* filename, int line)
-        {
-            AZ_Printf("UrdfParser", "%s\n", text.c_str());
-            console_ss << text << "\n";
-        }
+    void CustomConsoleHandler::log(const std::string& text, console_bridge::LogLevel level, const char* filename, int line)
+    {
+        AZ_Printf("UrdfParser", "%s\n", text.c_str());
+        console_ss << text << "\n";
+    }
 
-        void CustomConsoleHandler::Clear()
-        {
-            console_ss = std::stringstream();
-        }
+    void CustomConsoleHandler::Clear()
+    {
+        console_ss = std::stringstream();
+    }
 
-        AZStd::string CustomConsoleHandler::GetLog()
-        {
-            return AZStd::string(console_ss.str().c_str(), console_ss.str().size());
-        }
+    AZStd::string CustomConsoleHandler::GetLog()
+    {
+        return AZStd::string(console_ss.str().c_str(), console_ss.str().size());
+    }
 
-        CustomConsoleHandler customConsoleHandler;
-    } // namespace UrdfParser::Internal
+    CustomConsoleHandler customConsoleHandler;
+} // namespace ROS2::UrdfParser::Internal
 
-    sdf::Root* UrdfParser::Parse(const AZStd::string& xmlString)
+namespace ROS2::UrdfParser
+{
+    RootObjectOutcome Parse(const std::string& xmlString)
     {
         // TODO: Figure out how to route the output handler
         //console_bridge::useOutputHandler(&Internal::customConsoleHandler);
         Internal::CheckIfCurrentLocaleHasDotAsADecimalSeparator();
-        sdf::Root* root = new sdf::Root();
-        [[maybe_unused]] auto ret = root->LoadSdfString(xmlString.c_str());
+        sdf::Root root;
+        auto parseRootErrors = root.LoadSdfString(xmlString);
         //console_bridge::restorePreviousOutputHandler();
-        return root;
+
+        // if there are no parse errors return the sdf Root object otherwise return the errors
+        return parseRootErrors.empty() ? RootObjectOutcome(root) : RootObjectOutcome(AZStd::unexpect, parseRootErrors);
     }
 
-    sdf::Root* UrdfParser::ParseFromFile(const AZStd::string& filePath)
+    RootObjectOutcome ParseFromFile(AZ::IO::PathView filePath)
     {
-        std::ifstream istream(filePath.c_str());
+        // Store path in a AZ::IO::FixedMaxPath which is stack based structure that provides memory
+        // for the path string and is null terminated.
+        // It is backed by an AZStd::fixed_string<1024> which is a char buffer of 1025 internally
+        AZ::IO::FixedMaxPath urdfFilePath = filePath.FixedMaxPathString();
+        std::ifstream istream(urdfFilePath.c_str());
         if (!istream)
         {
-            AZ_Error("UrdfParser", false, "File %s does not exist", filePath.c_str());
-            return nullptr;
+            auto fileNotFoundMessage = AZStd::fixed_string<1024>::format("File %.*s does not exist", AZ_PATH_ARG(urdfFilePath));
+            RootObjectOutcome fileNotExistOutcome;
+            fileNotExistOutcome = AZStd::unexpected<sdf::Errors>(AZStd::in_place,
+                {
+                    sdf::Error{ sdf::ErrorCode::FILE_READ,
+                        std::string{ fileNotFoundMessage.c_str(), fileNotFoundMessage.size() },
+                        std::string{ urdfFilePath.c_str(), urdfFilePath.Native().size() } }
+                });
+            return fileNotExistOutcome;
         }
 
         std::string xmlStr((std::istreambuf_iterator<char>(istream)), std::istreambuf_iterator<char>());
-        return Parse(xmlStr.c_str());
+        return Parse(xmlStr);
     }
 
-    AZStd::string UrdfParser::GetUrdfParsingLog()
+    AZStd::string GetUrdfParsingLog()
     {
         return Internal::customConsoleHandler.GetLog();
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
@@ -13,7 +13,6 @@
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/std/string/string.h>
 #include <console_bridge/console.h>
-#include <urdf_model/model.h>
 
 namespace ROS2
 {
@@ -68,16 +67,18 @@ namespace ROS2
         CustomConsoleHandler customConsoleHandler;
     } // namespace UrdfParser::Internal
 
-    urdf::ModelInterfaceSharedPtr UrdfParser::Parse(const AZStd::string& xmlString)
+    sdf::Root* UrdfParser::Parse(const AZStd::string& xmlString)
     {
-        console_bridge::useOutputHandler(&Internal::customConsoleHandler);
+        // TODO: Figure out how to route the output handler
+        //console_bridge::useOutputHandler(&Internal::customConsoleHandler);
         Internal::CheckIfCurrentLocaleHasDotAsADecimalSeparator();
-        const auto ret = urdf::parseURDF(xmlString.c_str());
-        console_bridge::restorePreviousOutputHandler();
-        return ret;
+        sdf::Root* root = new sdf::Root();
+        [[maybe_unused]] auto ret = root->LoadSdfString(xmlString.c_str());
+        //console_bridge::restorePreviousOutputHandler();
+        return root;
     }
 
-    urdf::ModelInterfaceSharedPtr UrdfParser::ParseFromFile(const AZStd::string& filePath)
+    sdf::Root* UrdfParser::ParseFromFile(const AZStd::string& filePath)
     {
         std::ifstream istream(filePath.c_str());
         if (!istream)

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
@@ -14,77 +14,22 @@
 #include <AzCore/std/string/string.h>
 #include <console_bridge/console.h>
 
-namespace ROS2::UrdfParser::Internal
-{
-    void CheckIfCurrentLocaleHasDotAsADecimalSeparator()
-    {
-        // Due to the fact that URDF parser takes into account the locale information, incompatibility between URDF file locale and
-        // system locale might lead to incorrect URDF parsing. Mainly it affects floating point numbers, and the decimal separator. When
-        // locales are set to system with comma as decimal separator and URDF file is created with dot as decimal separator, URDF parser
-        // will trim the floating point number after comma. For example, if parsing 0.1, URDF parser will parse it as 0.
-        // This might lead to incorrect URDF loading. If the current locale is not a dot (as per standard ROS locale), we warn the user.
-        std::locale currentLocale("");
-        if (std::use_facet<std::numpunct<char>>(currentLocale).decimal_point() != '.')
-        {
-            AZ_Warning(
-                "UrdfParser", false, "Locale %s might be incompatible with the URDF file content.\n", currentLocale.name().c_str());
-        }
-    }
-
-    class CustomConsoleHandler : public console_bridge::OutputHandler
-    {
-    private:
-        std::stringstream console_ss;
-
-    public:
-        void log(const std::string& text, console_bridge::LogLevel level, const char* filename, int line) override final;
-
-        //! Clears accumulated log
-        void Clear();
-
-        //! Read accumulated log to a string
-        AZStd::string GetLog();
-    };
-
-    void CustomConsoleHandler::log(const std::string& text, console_bridge::LogLevel level, const char* filename, int line)
-    {
-        AZ_Printf("UrdfParser", "%s\n", text.c_str());
-        console_ss << text << "\n";
-    }
-
-    void CustomConsoleHandler::Clear()
-    {
-        console_ss = std::stringstream();
-    }
-
-    AZStd::string CustomConsoleHandler::GetLog()
-    {
-        return AZStd::string(console_ss.str().c_str(), console_ss.str().size());
-    }
-
-    CustomConsoleHandler customConsoleHandler;
-} // namespace ROS2::UrdfParser::Internal
-
 namespace ROS2::UrdfParser
 {
-    RootObjectOutcome Parse(AZStd::string_view xmlString)
+    RootObjectOutcome Parse(AZStd::string_view xmlString, const sdf::ParserConfig& parserConfig)
     {
-        return Parse(std::string(xmlString.data(), xmlString.size()));
+        return Parse(std::string(xmlString.data(), xmlString.size()), parserConfig);
     }
-    RootObjectOutcome Parse(const std::string& xmlString)
+    RootObjectOutcome Parse(const std::string& xmlString, const sdf::ParserConfig& parserConfig)
     {
-        // TODO: Figure out how to route the output handler
-        //console_bridge::useOutputHandler(&Internal::customConsoleHandler);
-        Internal::CheckIfCurrentLocaleHasDotAsADecimalSeparator();
         sdf::Root root;
-        auto parseRootErrors = root.LoadSdfString(xmlString);
-        //console_bridge::restorePreviousOutputHandler();
+        auto parseRootErrors = root.LoadSdfString(xmlString, parserConfig);
 
         // if there are no parse errors return the sdf Root object otherwise return the errors
         return parseRootErrors.empty() ? RootObjectOutcome(root) : RootObjectOutcome(AZStd::unexpect, parseRootErrors);
     }
 
-    RootObjectOutcome ParseFromFile(AZ::IO::PathView filePath)
+    RootObjectOutcome ParseFromFile(AZ::IO::PathView filePath, const sdf::ParserConfig& parserConfig)
     {
         // Store path in a AZ::IO::FixedMaxPath which is stack based structure that provides memory
         // for the path string and is null terminated.
@@ -105,12 +50,6 @@ namespace ROS2::UrdfParser
         }
 
         std::string xmlStr((std::istreambuf_iterator<char>(istream)), std::istreambuf_iterator<char>());
-        return Parse(xmlStr);
+        return Parse(xmlStr, parserConfig);
     }
-
-    AZStd::string GetUrdfParsingLog()
-    {
-        return Internal::customConsoleHandler.GetLog();
-    }
-
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
@@ -67,6 +67,10 @@ namespace ROS2::UrdfParser::Internal
 
 namespace ROS2::UrdfParser
 {
+    RootObjectOutcome Parse(AZStd::string_view xmlString)
+    {
+        return Parse(std::string(xmlString.data(), xmlString.size()));
+    }
     RootObjectOutcome Parse(const std::string& xmlString)
     {
         // TODO: Figure out how to route the output handler

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
@@ -8,11 +8,8 @@
 
 #include "UrdfParser.h"
 
-#include <fstream>
-
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/std/string/string.h>
-#include <console_bridge/console.h>
 
 namespace ROS2::UrdfParser
 {

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
@@ -8,7 +8,8 @@
 
 #pragma once
 
-#include <AzCore/std/string/string.h>
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/std/utility/expected.h>
 #include <sdf/Root.hh>
 #include <sdf/Link.hh>
 #include <sdf/Mesh.hh>
@@ -25,15 +26,20 @@ namespace ROS2
     //! Class for parsing URDF data.
     namespace UrdfParser
     {
+        //! Stores the result of parsing URDF data
+        //! On success the sdf::Root object is returned
+        //! On failure the sdf::Errors vector is returned
+        using RootObjectOutcome = AZStd::expected<sdf::Root, sdf::Errors>;
+
         //! Parse string with URDF data and generate model.
         //! @param xmlString a string that contains URDF data (XML format).
         //! @return model represented as a tree of parsed links.
-        sdf::Root* Parse(const AZStd::string& xmlString);
+        RootObjectOutcome Parse(const std::string& xmlString);
 
         //! Parse file with URDF data and generate model.
         //! @param filePath is a path to file with URDF data that will be loaded and parsed.
         //! @return model represented as a tree of parsed links.
-        sdf::Root* ParseFromFile(const AZStd::string& filePath);
+        RootObjectOutcome ParseFromFile(AZ::IO::PathView filePath);
 
         //! Retrieve console log from URDF parsing
         //! @return a log with output from urdf_parser

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
@@ -9,7 +9,16 @@
 #pragma once
 
 #include <AzCore/std/string/string.h>
-#include <urdf_parser/urdf_parser.h>
+#include <sdf/Root.hh>
+#include <sdf/Link.hh>
+#include <sdf/Mesh.hh>
+#include <sdf/Material.hh>
+#include <sdf/Model.hh>
+#include <sdf/Joint.hh>
+#include <sdf/JointAxis.hh>
+#include <sdf/Visual.hh>
+#include <sdf/Geometry.hh>
+#include <sdf/Collision.hh>
 
 namespace ROS2
 {
@@ -19,12 +28,12 @@ namespace ROS2
         //! Parse string with URDF data and generate model.
         //! @param xmlString a string that contains URDF data (XML format).
         //! @return model represented as a tree of parsed links.
-        urdf::ModelInterfaceSharedPtr Parse(const AZStd::string& xmlString);
+        sdf::Root* Parse(const AZStd::string& xmlString);
 
         //! Parse file with URDF data and generate model.
         //! @param filePath is a path to file with URDF data that will be loaded and parsed.
         //! @return model represented as a tree of parsed links.
-        urdf::ModelInterfaceSharedPtr ParseFromFile(const AZStd::string& filePath);
+        sdf::Root* ParseFromFile(const AZStd::string& filePath);
 
         //! Retrieve console log from URDF parsing
         //! @return a log with output from urdf_parser

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
@@ -33,18 +33,21 @@ namespace ROS2
 
         //! Parse string with URDF data and generate model.
         //! @param xmlString a string that contains URDF data (XML format).
-        //! @return model represented as a tree of parsed links.
-        RootObjectOutcome Parse(AZStd::string_view xmlString);
-        RootObjectOutcome Parse(const std::string& xmlString);
+        //! @param parserConfig structure that contains configuration options for the SDFormater parser
+        //!        The relevant ParserConfig functions for URDF importing are
+        //!        URDFPreserveFixedJoint() function to prevent merging of robot links bound by fixed joint
+        //!        AddURIPath() function to provide a mapping of package:// and model:// references to the local filesystem
+        //! @return SDF root object containing parsed <world> or <model> tags
+        RootObjectOutcome Parse(AZStd::string_view xmlString, const sdf::ParserConfig& parserConfig);
+        RootObjectOutcome Parse(const std::string& xmlString, const sdf::ParserConfig& parserConfig);
 
         //! Parse file with URDF data and generate model.
         //! @param filePath is a path to file with URDF data that will be loaded and parsed.
-        //! @return model represented as a tree of parsed links.
-        RootObjectOutcome ParseFromFile(AZ::IO::PathView filePath);
-
-        //! Retrieve console log from URDF parsing
-        //! @return a log with output from urdf_parser
-        AZStd::string GetUrdfParsingLog();
-
+        //! @param parserConfig structure that contains configuration options for the SDFormater parser
+        //!        The relevant ParserConfig functions for URDF importing are
+        //!        URDFPreserveFixedJoint() function to prevent merging of robot links bound by fixed joint
+        //!        AddURIPath() function to provide a mapping of package:// and model:// references to the local filesystem
+        //! @return SDF root object containing parsed <world> or <model> tags
+        RootObjectOutcome ParseFromFile(AZ::IO::PathView filePath, const sdf::ParserConfig& parserConfig);
     }; // namespace UrdfParser
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
@@ -33,7 +33,7 @@ namespace ROS2
 
         //! Parse string with URDF data and generate model.
         //! @param xmlString a string that contains URDF data (XML format).
-        //! @param parserConfig structure that contains configuration options for the SDFormater parser
+        //! @param parserConfig structure that contains configuration options for the SDFormatter parser
         //!        The relevant ParserConfig functions for URDF importing are
         //!        URDFPreserveFixedJoint() function to prevent merging of robot links bound by fixed joint
         //!        AddURIPath() function to provide a mapping of package:// and model:// references to the local filesystem

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
@@ -34,6 +34,7 @@ namespace ROS2
         //! Parse string with URDF data and generate model.
         //! @param xmlString a string that contains URDF data (XML format).
         //! @return model represented as a tree of parsed links.
+        RootObjectOutcome Parse(AZStd::string_view xmlString);
         RootObjectOutcome Parse(const std::string& xmlString);
 
         //! Parse file with URDF data and generate model.

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -45,7 +45,7 @@ namespace ROS2
         if (link->VisualCount() < 1)
         { 
             // For zero visuals, element is used
-            auto createdEntity = AddVisual(nullptr, entityId, PrefabMakerUtils::MakeEntityName(link->name.c_str(), typeString));
+            auto createdEntity = AddVisual(nullptr, entityId, PrefabMakerUtils::MakeEntityName(link->Name().c_str(), typeString));
             if (createdEntity.IsValid())
             {
                 createdEntities.emplace_back(createdEntity);

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -27,7 +27,7 @@ namespace ROS2
 {
     VisualsMaker::VisualsMaker() = default;
     VisualsMaker::VisualsMaker(
-        AZStd::unordered_map<AZStd::string, const sdf::Material*> materials, const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping)
+        MaterialNameMap materials, const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping)
         : m_materials(AZStd::move(materials))
         , m_urdfAssetsMapping(urdfAssetsMapping)
     {

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.h
@@ -22,7 +22,7 @@ namespace ROS2
     {
     public:
         VisualsMaker(
-            const std::map<std::string, urdf::MaterialSharedPtr>& materials,
+            const std::map<std::string, const sdf::Material*>& materials,
             const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping);
 
         //! Add zero, one or many visual elements to a given entity (depending on link content).
@@ -30,14 +30,14 @@ namespace ROS2
         //! @param link A parsed URDF tree link node which could hold information about visuals.
         //! @param entityId A non-active entity which will be affected.
         //! @return List containing any entities created.
-        AZStd::vector<AZ::EntityId> AddVisuals(urdf::LinkSharedPtr link, AZ::EntityId entityId) const;
+        AZStd::vector<AZ::EntityId> AddVisuals(const sdf::Link* link, AZ::EntityId entityId) const;
 
     private:
-        AZ::EntityId AddVisual(urdf::VisualSharedPtr visual, AZ::EntityId entityId, const AZStd::string& generatedName) const;
-        void AddVisualToEntity(urdf::VisualSharedPtr visual, AZ::EntityId entityId) const;
-        void AddMaterialForVisual(urdf::VisualSharedPtr visual, AZ::EntityId entityId) const;
+        AZ::EntityId AddVisual(const sdf::Visual* visual, AZ::EntityId entityId, const AZStd::string& generatedName) const;
+        void AddVisualToEntity(const sdf::Visual* visual, AZ::EntityId entityId) const;
+        void AddMaterialForVisual(const sdf::Visual* visual, AZ::EntityId entityId) const;
 
-        AZStd::unordered_map<AZStd::string, urdf::MaterialSharedPtr> m_materials;
+        AZStd::unordered_map<AZStd::string, const sdf::Material*> m_materials;
         AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.h
@@ -21,9 +21,11 @@ namespace ROS2
     class VisualsMaker
     {
     public:
+        using MaterialNameMap = AZStd::unordered_map<AZStd::string, const sdf::Material*>;
+
         VisualsMaker();
         VisualsMaker(
-            AZStd::unordered_map<AZStd::string, const sdf::Material*> materials,
+            MaterialNameMap materials,
             const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping);
 
         //! Add zero, one or many visual elements to a given entity (depending on link content).
@@ -38,7 +40,7 @@ namespace ROS2
         void AddVisualToEntity(const sdf::Visual* visual, AZ::EntityId entityId) const;
         void AddMaterialForVisual(const sdf::Visual* visual, AZ::EntityId entityId) const;
 
-        AZStd::unordered_map<AZStd::string, const sdf::Material*> m_materials;
+        MaterialNameMap m_materials;
         AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.h
@@ -21,8 +21,9 @@ namespace ROS2
     class VisualsMaker
     {
     public:
+        VisualsMaker();
         VisualsMaker(
-            const std::map<std::string, const sdf::Material*>& materials,
+            AZStd::unordered_map<AZStd::string, const sdf::Material*> materials,
             const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping);
 
         //! Add zero, one or many visual elements to a given entity (depending on link content).

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/ErrorUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/ErrorUtils.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ErrorUtils.h"
+
+#include <sdf/sdf.hh>
+
+namespace ROS2::Utils
+{
+    AZStd::string JoinSdfErrorsToString(AZStd::span<const sdf::Error> sdfErrors)
+    {
+        AZStd::string aggregateErrorMessages;
+        AppendSdfErrorsToString(aggregateErrorMessages, sdfErrors);
+        return aggregateErrorMessages;
+    }
+
+    void AppendSdfErrorsToString(AZStd::string& outputResult, AZStd::span<const sdf::Error> sdfErrors)
+    {
+        for (const sdf::Error& sdfError : sdfErrors)
+        {
+            AZStd::string errorMessage = AZStd::string::format("ErrorCode=%d", static_cast<int32_t>(sdfError.Code()));
+            errorMessage += AZStd::string::format(", Message=%s", sdfError.Message().c_str());
+            if (sdfError.LineNumber().has_value())
+            {
+                errorMessage += AZStd::string::format(", Line=%d", sdfError.LineNumber().value());
+            }
+            outputResult += errorMessage;
+            outputResult += '\n';
+        }
+    }
+} // namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/ErrorUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/ErrorUtils.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/IO/SystemFile.h>
+#include <AzCore/Math/Transform.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/function/function_template.h>
+#include <AzCore/std/string/string.h>
+#include <RobotImporter/URDF/UrdfParser.h>
+
+#include <sdf/sdf.hh>
+
+namespace sdf
+{
+    inline namespace v13
+    {
+        class Error;
+    } // namespace v13
+} // namespace sdf
+
+
+namespace AZStd
+{
+    // Allow std::vector<sdf::Error> to meet the requirements of contiguous iterator in C++17
+    // This allows constructing an AZStd::span from a std::vector
+    template<>
+    struct iterator_traits<typename std::vector<sdf::v13::Error>::iterator>
+    {
+        // Use the standard library iterator traits for all traits except for the iterator_concept
+        using difference_type = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::iterator>::difference_type;
+        using value_type = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::iterator>::value_type;
+        using pointer = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::iterator>::pointer;
+        using reference = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::iterator>::reference;
+        using iterator_category = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::iterator>::iterator_category;
+        using iterator_concept = contiguous_iterator_tag;
+    };
+}
+
+namespace ROS2::Utils
+{
+    //! Converts each sdf::Error from an sdf::Errors vector into an AZStd::string
+    //! @param sdfErrors A span of sdf::Error objects
+    //! @return AZStd::string which contains each error formatted for human readable output
+    AZStd::string JoinSdfErrorsToString(AZStd::span<const sdf::Error> sdfErrors);
+    //! Converts each sdf::Error from an sdf::Errors vector into an AZStd::string
+    //! @param outputResult Appends to output string each sdf error
+    //! @param sdfErrors A span of sdf::Error objects
+    void AppendSdfErrorsToString(AZStd::string& outputResult, AZStd::span<const sdf::Error> sdfErrors);
+} // namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/ErrorUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/ErrorUtils.h
@@ -43,6 +43,18 @@ namespace AZStd
         using iterator_category = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::iterator>::iterator_category;
         using iterator_concept = contiguous_iterator_tag;
     };
+
+    template<>
+    struct iterator_traits<typename std::vector<sdf::v13::Error>::const_iterator>
+    {
+        // Use the standard library iterator traits for all traits except for the iterator_concept
+        using difference_type = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::const_iterator>::difference_type;
+        using value_type = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::const_iterator>::value_type;
+        using pointer = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::const_iterator>::pointer;
+        using reference = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::const_iterator>::reference;
+        using iterator_category = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::const_iterator>::iterator_category;
+        using iterator_concept = contiguous_iterator_tag;
+    };
 }
 
 namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/FilePath.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/FilePath.cpp
@@ -34,5 +34,10 @@ namespace ROS2
         {
             return GetCapitalizedExtension(filename) == ".URDF";
         }
+
+        bool IsFileSDF(const AZ::IO::Path& filename)
+        {
+            return GetCapitalizedExtension(filename) == ".SDF";
+        }
     } // namespace Utils
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/FilePath.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/FilePath.cpp
@@ -18,7 +18,7 @@ namespace ROS2
         {
             if (!filename.HasExtension())
             {
-                return "";
+                return AZStd::string{};
             }
             AZStd::string extension{ filename.Extension().Native() };
             AZStd::to_upper(extension.begin(), extension.end());
@@ -37,7 +37,7 @@ namespace ROS2
 
         bool IsFileSDF(const AZ::IO::Path& filename)
         {
-            return GetCapitalizedExtension(filename) == ".SDF";
+            return GetCapitalizedExtension(filename) == ".SDF" || GetCapitalizedExtension(filename) == ".WORLD";
         }
     } // namespace Utils
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -136,13 +136,16 @@ namespace ROS2::Utils
         if (!joints.empty())
         {
             const sdf::Joint* potentialWheelJoint = joints.front();
-            using LimitType = decltype(potentialWheelJoint->Axis()->Lower());
-            // There should only be 1 element for URDF, however that will not be verified
-            // in case this function is called on link from an SDF file
-            isWheel = potentialWheelJoint->Type() == sdf::JointType::CONTINUOUS;
-            isWheel = isWheel || (potentialWheelJoint->Type() == sdf::JointType::REVOLUTE
-                && potentialWheelJoint->Axis()->Lower() == -AZStd::numeric_limits<LimitType>::infinity()
-                && potentialWheelJoint->Axis()->Upper() == AZStd::numeric_limits<LimitType>::infinity());
+            if (const sdf::JointAxis* jointAxis = potentialWheelJoint->Axis(); jointAxis != nullptr)
+            {
+                using LimitType = decltype(jointAxis->Lower());
+                // There should only be 1 element for URDF, however that will not be verified
+                // in case this function is called on link from an SDF file
+                isWheel = potentialWheelJoint->Type() == sdf::JointType::CONTINUOUS;
+                isWheel = isWheel || (potentialWheelJoint->Type() == sdf::JointType::REVOLUTE
+                    && jointAxis->Lower() == -AZStd::numeric_limits<LimitType>::infinity()
+                    && jointAxis->Upper() == AZStd::numeric_limits<LimitType>::infinity());
+            }
         }
 
         return isWheel;

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -267,7 +267,10 @@ namespace ROS2::Utils
                 for (uint64_t jointIndex{}; jointIndex < currentModel.JointCount(); ++jointIndex)
                 {
                     const sdf::Joint* joint = currentModel.JointByIndex(jointIndex);
-                    if (joint != nullptr)
+                    // Skip any joints whose parent and child link references
+                    // don't have an actual sdf::link in the parsed model
+                    if (joint != nullptr && currentModel.LinkNameExists(joint->ParentName())
+                        && currentModel.LinkByName(joint->ChildName()))
                     {
                         if (!m_jointVisitorCB(*joint))
                         {

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -35,24 +35,24 @@ namespace ROS2
         //! This can be useful to provide a good default behavior - for example, to add Vehicle Dynamics components to this link's entity.
         //! @param link the link that will be subjected to the heuristic.
         //! @return true if the link is likely a wheel link.
-        bool IsWheelURDFHeuristics(const urdf::LinkConstSharedPtr& link);
+        bool IsWheelURDFHeuristics(const sdf::Link* link);
 
         //! The recursive function for the given link goes through URDF and finds world-to-entity transformation for us.
         //! @param link pointer to URDF link that root of robot description
         //! @param t initial transform, should be identity for non-recursive call.
         //! @returns root to entity transform
-        AZ::Transform GetWorldTransformURDF(const urdf::LinkSharedPtr& link, AZ::Transform t = AZ::Transform::Identity());
+        AZ::Transform GetWorldTransformURDF(const sdf::Link* link, AZ::Transform t = AZ::Transform::Identity());
 
         //! Retrieve all links in URDF as a map, where a key is link's name and a value is a pointer to link.
         //! Allows to retrieve a pointer to a link given it name.
         //! @param childLinks list of links in a query
         //! @returns mapping from link name to link pointer
-        AZStd::unordered_map<AZStd::string, urdf::LinkSharedPtr> GetAllLinks(const std::vector<urdf::LinkSharedPtr>& childLinks);
+        AZStd::unordered_map<AZStd::string, const sdf::Link*> GetAllLinks(const std::vector<const sdf::Link*>& childLinks);
 
         //! Retrieve all joints in URDF.
         //! @param childLinks list of links in a query
         //! @returns mapping from joint name to joint pointer
-        AZStd::unordered_map<AZStd::string, urdf::JointSharedPtr> GetAllJoints(const std::vector<urdf::LinkSharedPtr>& childLinks);
+        AZStd::unordered_map<AZStd::string, const sdf::Joint*> GetAllJoints(const std::vector<const sdf::Link*>& childLinks);
 
         //! Retrieve all meshes referenced in URDF as unresolved URDF patches.
         //! Note that returned filenames are unresolved URDF patches.
@@ -60,7 +60,7 @@ namespace ROS2
         //! @param colliders - search for collider meshes.
         //! @param rootLink - pointer to URDF link that is a root of robot description
         //! @returns set of meshes' filenames.
-        AZStd::unordered_set<AZStd::string> GetMeshesFilenames(const urdf::LinkConstSharedPtr& rootLink, bool visual, bool colliders);
+        AZStd::unordered_set<AZStd::string> GetMeshesFilenames(const sdf::Root* rootLink, bool visual, bool colliders);
 
         //! Resolves path from unresolved URDF path.
         //! @param unresolvedPath - unresolved URDF path, example : `package://meshes/foo.dae`.

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -28,80 +28,119 @@ namespace ROS2
             return AZ::IO::SystemFile::Exists(filename.c_str());
         };
     } // namespace
+}
 
-    namespace Utils
-    {
-        //! Determine whether a given link is likely a wheel link.
-        //! This can be useful to provide a good default behavior - for example, to add Vehicle Dynamics components to this link's entity.
-        //! @param link the link that will be subjected to the heuristic.
-        //! @return true if the link is likely a wheel link.
-        bool IsWheelURDFHeuristics(const sdf::Link* link);
+namespace ROS2::Utils
+{
+    //! Determine whether a given link is likely a wheel link.
+    //! This can be useful to provide a good default behavior - for example, to add Vehicle Dynamics components to this link's entity.
+    //! @param sdfModel Model object which is used to query the joints from SDF format data
+    //! @param link the link that will be subjected to the heuristic.
+    //! @return true if the link is likely a wheel link.
+    bool IsWheelURDFHeuristics(const sdf::Model& model, const sdf::Link* link);
 
-        //! The recursive function for the given link goes through URDF and finds world-to-entity transformation for us.
-        //! @param link pointer to URDF link that root of robot description
-        //! @param t initial transform, should be identity for non-recursive call.
-        //! @returns root to entity transform
-        AZ::Transform GetWorldTransformURDF(const sdf::Link* link, AZ::Transform t = AZ::Transform::Identity());
+    //! The recursive function for the given link goes through URDF and finds world-to-entity transformation for us.
+    //! @param link pointer to URDF link that root of robot description
+    //! @param t initial transform, should be identity for non-recursive call.
+    //! @returns root to entity transform
+    AZ::Transform GetWorldTransformURDF(const sdf::Link* link, AZ::Transform t = AZ::Transform::Identity());
 
-        //! Retrieve all links in URDF as a map, where a key is link's name and a value is a pointer to link.
-        //! Allows to retrieve a pointer to a link given it name.
-        //! @param childLinks list of links in a query
-        //! @returns mapping from link name to link pointer
-        AZStd::unordered_map<AZStd::string, const sdf::Link*> GetAllLinks(const std::vector<const sdf::Link*>& childLinks);
+    //! Callback which is invoke for each link within a model
+    using LinkVisitorCallback = AZStd::function<void(const sdf::Link&)>;
+    //! Visit links from URDF or SDF
+    //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query link
+    //! @param visitNestedModelLinks When true recurses to any nested <model> tags of the Model object and invoke visitor on their links as well
+    //! @returns void
+    void VisitLinks(const sdf::Model& sdfModel, const LinkVisitorCallback& linkVisitorCB,
+        bool visitNestedModelLinks = false);
 
-        //! Retrieve all joints in URDF.
-        //! @param childLinks list of links in a query
-        //! @returns mapping from joint name to joint pointer
-        AZStd::unordered_map<AZStd::string, const sdf::Joint*> GetAllJoints(const std::vector<const sdf::Link*>& childLinks);
+    //! Retrieve all links in URDF as a map, where a key is link's name and a value is a pointer to link.
+    //! Allows to retrieve a pointer to a link given it name.
+    //! @param sdfModel object of SDF document corresponding to the <model> tag. It used to query links
+    //! @param gatherNestedModelLinks When true recurses to any nested <model> tags of the Model object and also gathers their links as well
+    //! @returns mapping from link name to link pointer
+    AZStd::unordered_map<AZStd::string, const sdf::Link*> GetAllLinks(const sdf::Model& sdfModel,
+        bool gatherNestedModelLinks = false);
 
-        //! Retrieve all meshes referenced in URDF as unresolved URDF patches.
-        //! Note that returned filenames are unresolved URDF patches.
-        //! @param visual - search for visual meshes.
-        //! @param colliders - search for collider meshes.
-        //! @param rootLink - pointer to URDF link that is a root of robot description
-        //! @returns set of meshes' filenames.
-        AZStd::unordered_set<AZStd::string> GetMeshesFilenames(const sdf::Root* rootLink, bool visual, bool colliders);
+    //! Callback which is invoke for each valid joint for a given model
+    using JointVisitorCallback = AZStd::function<void(const sdf::Joint&)>;
+    //! Visit joints from URDF
+    //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
+    //! @param visitNestedModelJoints When true recurses to any nested <model> tags of the Model object and invoke visitor on their joints as well
+    //! @returns void
+    void VisitJoints(const sdf::Model& sdfModel, const JointVisitorCallback& jointVisitorCB,
+        bool visitNestedModelJoints = false);
 
-        //! Resolves path from unresolved URDF path.
-        //! @param unresolvedPath - unresolved URDF path, example : `package://meshes/foo.dae`.
-        //! @param urdfFilePath - the absolute path of URDF file which contains the path that is to be resolved.
-        //! @param amentPrefixPath - the string that contains available packages' path, separated by ':' signs.
-        //! @param fileExists - functor to check if the given file exists. Exposed for unit test, default one should be used.
-        //! @returns resolved path to the mesh
-        AZStd::string ResolveURDFPath(
-            AZStd::string unresolvedPath,
-            const AZStd::string& urdfFilePath,
-            const AZStd::string& amentPrefixPath,
-            const AZStd::function<bool(const AZStd::string&)>& fileExists = FileExistsCall);
+    //! Retrieve all joints in URDF.
+    //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
+    //! @returns mapping from joint name to joint pointer
+    AZStd::unordered_map<AZStd::string, const sdf::Joint*> GetAllJoints(const sdf::Model& sdfModel,
+        bool gatherNestedModelJoints = false);
 
-        //! Waits for asset processor to process provided assets.
-        //! This function will timeout after the time specified in /O3DE/ROS2/RobotImporter/AssetProcessorTimeoutInSeconds
-        //! settings registry.
-        //! @param sourceAssetsPaths - set of all non relative paths to assets for which we want to wait for processing
-        //! @returns false if a timeout or error occurs, otherwise true
-        bool WaitForAssetsToProcess(const AZStd::unordered_map<AZStd::string, AZ::IO::Path>& sourceAssetsPaths);
+    //! Retrieve all joints from URDF in which the specified link is a child in a sdf::Joint.
+    //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
+    //! @param linkName Name of link which to query in joint objects ChildName()
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
+    //! @returns vector of joints where link is a child
+    AZStd::vector<const sdf::Joint*> GetJointsForChildLink(const sdf::Model& sdfModel, AZStd::string_view linkName,
+        bool gatherNestedModelJoints = false);
 
-        namespace SDFormat
-        {
-            //! Retrieve plugin's filename. The filepath is converted into the filename if necessary.
-            //! @param plugin plugin in the parsed SDFormat data
-            //! @returns filename (including extension) without path
-            AZStd::string GetPluginFilename(const sdf::Plugin& plugin);
+    //! Retrieve all joints from URDF in which the specified link is a parent in a sdf::Joint.
+    //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
+    //! @param linkName Name of link which to query in joint objects ParentName()
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
+    //! @returns vector of joints where link is a parent
+    AZStd::vector<const sdf::Joint*> GetJointsForParentLink(const sdf::Model& sdfModel, AZStd::string_view linkName,
+        bool gatherNestedModelJoints = false);
 
-            //! Retrieve all parameters that were defined for an element in XML data that are not supported in O3DE.
-            //! Allows to store the list of unsupported parameters in metadata and logs. It is typically used with sensors and plugins.
-            //! @param rootElement pointer to a root Element in parsed XML data that will be a subject to heuristics
-            //! @param supportedParams set of predefined parameters that are supported
-            //! @returns list of unsupported parameters defined for given element
-            AZStd::vector<AZStd::string> GetUnsupportedParams(
-                const sdf::ElementPtr& rootElement, const AZStd::unordered_set<AZStd::string>& supportedParams);
+    //! Retrieve all meshes referenced in URDF as unresolved URDF patches.
+    //! Note that returned filenames are unresolved URDF patches.
+    //! @param visual - search for visual meshes.
+    //! @param colliders - search for collider meshes.
+    //! @param rootLink - pointer to sdf Rootobject that corresponds to to root of robot description after it hasbeen converted from URDF to SDF
+    //! @returns set of meshes' filenames.
+    AZStd::unordered_set<AZStd::string> GetMeshesFilenames(const sdf::Root* root, bool visual, bool colliders);
 
-            //! Check if plugin is supported by using it's filename. The filepath is converted into the filename if necessary.
-            //! @param plugin plugin in the parsed SDFormat data
-            //! @param supportedPlugins set of predefined plugins that are supported
-            //! @returns true if plugin is supported
-            bool IsPluginSupported(const sdf::Plugin& plugin, const AZStd::unordered_set<AZStd::string>& supportedPlugins);
-        } // namespace SDFormat
+    //! Resolves path from unresolved URDF path.
+    //! @param unresolvedPath - unresolved URDF path, example : `package://meshes/foo.dae`.
+    //! @param urdfFilePath - the absolute path of URDF file which contains the path that is to be resolved.
+    //! @param amentPrefixPath - the string that contains available packages' path, separated by ':' signs.
+    //! @param fileExists - functor to check if the given file exists. Exposed for unit test, default one should be used.
+    //! @returns resolved path to the mesh
+    AZStd::string ResolveURDFPath(
+        AZStd::string unresolvedPath,
+        const AZStd::string& urdfFilePath,
+        const AZStd::string& amentPrefixPath,
+        const AZStd::function<bool(const AZStd::string&)>& fileExists = FileExistsCall);
 
-    } // namespace Utils
-} // namespace ROS2
+    //! Waits for asset processor to process provided assets.
+    //! This function will timeout after the time specified in /O3DE/ROS2/RobotImporter/AssetProcessorTimeoutInSeconds
+    //! settings registry.
+    //! @param sourceAssetsPaths - set of all non relative paths to assets for which we want to wait for processing
+    //! @returns false if a timeout or error occurs, otherwise true
+    bool WaitForAssetsToProcess(const AZStd::unordered_map<AZStd::string, AZ::IO::Path>& sourceAssetsPaths);
+
+} // namespace ROS2::Utils
+
+namespace ROS2::Utils::SDFormat
+{
+    //! Retrieve plugin's filename. The filepath is converted into the filename if necessary.
+    //! @param plugin plugin in the parsed SDFormat data
+    //! @returns filename (including extension) without path
+    AZStd::string GetPluginFilename(const sdf::Plugin& plugin);
+
+    //! Retrieve all parameters that were defined for an element in XML data that are not supported in O3DE.
+    //! Allows to store the list of unsupported parameters in metadata and logs. It is typically used with sensors and plugins.
+    //! @param rootElement pointer to a root Element in parsed XML data that will be a subject to heuristics
+    //! @param supportedParams set of predefined parameters that are supported
+    //! @returns list of unsupported parameters defined for given element
+    AZStd::vector<AZStd::string> GetUnsupportedParams(
+        const sdf::ElementPtr& rootElement, const AZStd::unordered_set<AZStd::string>& supportedParams);
+
+    //! Check if plugin is supported by using it's filename. The filepath is converted into the filename if necessary.
+    //! @param plugin plugin in the parsed SDFormat data
+    //! @param supportedPlugins set of predefined plugins that are supported
+    //! @returns true if plugin is supported
+    bool IsPluginSupported(const sdf::Plugin& plugin, const AZStd::unordered_set<AZStd::string>& supportedPlugins);
+} // namespace ROS2::Utils::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -13,6 +13,7 @@
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/IO/FileIO.h>
+#include <AzCore/IO/Path/Path.h>
 #include <AzCore/Math/Crc.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/containers/unordered_set.h>
@@ -25,13 +26,13 @@ namespace ROS2::Utils
     struct AvailableAsset
     {
         //! Relative path to source asset eg `Assets/foo_robot/meshes/bar_link.dae`.
-        AZStd::string m_sourceAssetRelativePath;
+        AZ::IO::Path m_sourceAssetRelativePath;
 
         //! Relative path to source asset eg `/home/user/project/Assets/foo_robot/meshes/bar_link.dae`.
-        AZStd::string m_sourceAssetGlobalPath;
+        AZ::IO::Path m_sourceAssetGlobalPath;
 
         //! Relative path to source asset eg `foo_robot/meshes/bar_link.azmodel`.
-        AZStd::string m_productAssetRelativePath;
+        AZ::IO::Path m_productAssetRelativePath;
 
         //! Source GUID of source asset
         AZ::Uuid m_sourceGuid = AZ::Uuid::CreateNull();
@@ -41,10 +42,10 @@ namespace ROS2::Utils
     struct UrdfAsset
     {
         //! Unresolved URDF path to mesh, eg `package://meshes/bar_link.dae`.
-        AZStd::string m_urdfPath;
+        AZ::IO::Path m_urdfPath;
 
         //! Resolved URDF path, points to the valid mesh in the filestystem, eg `/home/user/ros_ws/src/foo_robot/meshes/bar_link.dae'
-        AZStd::string m_resolvedUrdfPath;
+        AZ::IO::Path m_resolvedUrdfPath;
 
         //! Checksum of the file located pointed by `m_resolvedUrdfPath`.
         AZ::Crc32 m_urdfFileCRC;
@@ -54,10 +55,10 @@ namespace ROS2::Utils
     };
 
     /// Type that hold result of mapping from URDF path to asset info
-    using UrdfAssetMap = AZStd::unordered_map<AZStd::string, Utils::UrdfAsset>;
+    using UrdfAssetMap = AZStd::unordered_map<AZ::IO::Path, Utils::UrdfAsset>;
 
     //! Function computes CRC32 on first kilobyte of file.
-    AZ::Crc32 GetFileCRC(const AZStd::string& filename);
+    AZ::Crc32 GetFileCRC(const AZ::IO::Path& filename);
 
     //! Compute CRC for every source mesh from the assets catalog.
     //! @returns map where key is crc of source file and value is AvailableAsset.
@@ -113,7 +114,7 @@ namespace ROS2::Utils
     //! @param collider - create assetinfo section for collider product asset
     //! @param visual - create assetinfo section for visual mesh
     //! @returns true if succeed
-    bool CreateSceneManifest(const AZStd::string& sourceAssetPath, bool collider, bool visual);
+    bool CreateSceneManifest(const AZ::IO::Path& sourceAssetPath, bool collider, bool visual);
 
     //! Creates side-car file (.assetinfo) that configures the imported scene (eg DAE file).
     //! @param sourceAssetPath - global path to source asset
@@ -121,7 +122,7 @@ namespace ROS2::Utils
     //! @param collider - create assetinfo section for collider product asset
     //! @param visual - create assetinfo section for visual mesh
     //! @returns true if succeed
-    bool CreateSceneManifest(const AZStd::string& sourceAssetPath, const AZStd::string& assetInfoFile, bool collider, bool visual);
+    bool CreateSceneManifest(const AZ::IO::Path& sourceAssetPath, const AZ::IO::Path& assetInfoFile, bool collider, bool visual);
 
     //! A function that copies and prepares meshes that are referenced in URDF.
     //! It resolves every mesh, creates a directory in Project's Asset directory, copies files, and prepares assets info.

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/TypeConversions.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/TypeConversions.cpp
@@ -10,25 +10,25 @@
 
 namespace ROS2::URDF
 {
-    AZ::Vector3 TypeConversions::ConvertVector3(const urdf::Vector3& urdfVector)
+    AZ::Vector3 TypeConversions::ConvertVector3(const gz::math::Vector3d& urdfVector)
     {
-        return AZ::Vector3(urdfVector.x, urdfVector.y, urdfVector.z);
+        return AZ::Vector3(urdfVector.X(), urdfVector.Y(), urdfVector.Z());
     }
 
-    AZ::Quaternion TypeConversions::ConvertQuaternion(const urdf::Rotation& urdfQuaternion)
+    AZ::Quaternion TypeConversions::ConvertQuaternion(const gz::math::Quaterniond& urdfQuaternion)
     {
-        return AZ::Quaternion(urdfQuaternion.x, urdfQuaternion.y, urdfQuaternion.z, urdfQuaternion.w);
+        return AZ::Quaternion(urdfQuaternion.X(), urdfQuaternion.Y(), urdfQuaternion.Z(), urdfQuaternion.W());
     }
 
-    AZ::Color TypeConversions::ConvertColor(const urdf::Color& color)
+    AZ::Color TypeConversions::ConvertColor(const gz::math::Color& color)
     {
-        return AZ::Color(color.r, color.g, color.b, color.a);
+        return AZ::Color(color.R(), color.G(), color.B(), color.A());
     }
 
-    AZ::Transform TypeConversions::ConvertPose(const urdf::Pose& pose)
+    AZ::Transform TypeConversions::ConvertPose(const gz::math::Pose3d& pose)
     {
-        AZ::Quaternion azRotation = URDF::TypeConversions::ConvertQuaternion(pose.rotation);
-        AZ::Vector3 azPosition = URDF::TypeConversions::ConvertVector3(pose.position);
+        AZ::Quaternion azRotation = URDF::TypeConversions::ConvertQuaternion(pose.Rot());
+        AZ::Vector3 azPosition = URDF::TypeConversions::ConvertVector3(pose.Pos());
         return AZ::Transform(azPosition, azRotation, 1.0f);
     }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/TypeConversions.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/TypeConversions.h
@@ -19,9 +19,9 @@ namespace ROS2::URDF
     //! Common types conversion between urdf and AZ formats
     namespace TypeConversions
     {
-        AZ::Vector3 ConvertVector3(const urdf::Vector3& urdfVector);
-        AZ::Quaternion ConvertQuaternion(const urdf::Rotation& urdfQuaternion);
-        AZ::Color ConvertColor(const urdf::Color& color);
-        AZ::Transform ConvertPose(const urdf::Pose& pose);
+        AZ::Vector3 ConvertVector3(const gz::math::Vector3d& urdfVector);
+        AZ::Quaternion ConvertQuaternion(const gz::math::Quaterniond& urdfQuaternion);
+        AZ::Color ConvertColor(const gz::math::Color& color);
+        AZ::Transform ConvertPose(const gz::math::Pose3d& pose);
     }; // namespace TypeConversions
 } // namespace ROS2::URDF

--- a/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
@@ -65,7 +65,7 @@ namespace ROS2::Utils::xacro
         {
             AZ_Printf("ParseXacro", "xacro finished with success \n");
             const auto& output = process_output.outputResult;
-            outcome.m_urdfHandle = UrdfParser::Parse({ output.c_str(), output.size() });
+            outcome.m_urdfHandle = UrdfParser::Parse(output);
             outcome.m_succeed = true;
         }
         else

--- a/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
@@ -18,12 +18,11 @@
 
 namespace ROS2::Utils::xacro
 {
-
     ExecutionOutcome ParseXacro(const AZStd::string& filename, const Params& params)
     {
         ExecutionOutcome outcome;
         // test if xacro exists
-        AZStd::string xacroPath = "xacro";
+        AZ::IO::Path xacroPath = "xacro";
         auto settingsRegistry = AZ::SettingsRegistry::Get();
         AZStd::string xacroExecutablePath;
         if (settingsRegistry && settingsRegistry->Get(xacroExecutablePath, "/O3DE/ROS2/xacro_executable_path"))
@@ -37,16 +36,40 @@ namespace ROS2::Utils::xacro
             }
         }
 
-        AZ_Warning("ParseXacro", !xacroPath.empty(), "There is xacro executable in your path");
-        if (xacroPath.empty())
+        AzFramework::ProcessLauncher::ProcessLaunchInfo processLaunchInfo;
+        processLaunchInfo.m_processExecutableString = xacroPath.Native();
+        processLaunchInfo.m_commandlineParameters.emplace<AZStd::vector<AZStd::string>>({ AZStd::string("--help") });
+        if (AZStd::unique_ptr<AzFramework::ProcessWatcher> xacroHelpProcess(AzFramework::ProcessWatcher::LaunchProcess(processLaunchInfo,
+            AzFramework::ProcessCommunicationType::COMMUNICATOR_TYPE_STDINOUT));
+            xacroHelpProcess != nullptr)
         {
-            return ExecutionOutcome{};
+            // 60 seconds is used as a cap on how long it should take to run the `xacro --help` command
+            // In reality this should take less than a second, but there has been a couple of occurrences
+            // where it takes over a second to run. 60 seconds is a fail fase value
+            constexpr AZStd::chrono::seconds helpCommandWaitTime{ 60 };
+
+            AZ::u32 exitCode{ AZStd::numeric_limits<AZ::u32>::max() };
+            xacroHelpProcess->WaitForProcessToExit(static_cast<AZ::u32>(helpCommandWaitTime.count()), &exitCode);
+            if (exitCode != 0)
+            {
+                const auto fullProcessCommand = AZStd::string::format("%s %s",
+                    processLaunchInfo.m_processExecutableString.c_str(),
+                    processLaunchInfo.GetCommandLineParametersAsString().c_str());
+                AZ_Warning(
+                    "ParseXacro",
+                    false,
+                    "Attempted to run validate xacro existence with command: %s",
+                    fullProcessCommand.c_str());
+                outcome.m_called = fullProcessCommand;
+                return outcome;
+            }
         }
+
         AZ_Printf("ParseXacro", "xacro executable : %s \n", xacroPath.c_str());
         AZ_Printf("ParseXacro", "Convert xacro file : %s \n", filename.c_str());
-        const QString program = QString::fromUtf8(xacroPath.data(), xacroPath.size());
-        AzFramework::ProcessLauncher::ProcessLaunchInfo processLaunchInfo;
-        processLaunchInfo.m_processExecutableString = xacroPath;
+        // Clear out the processLanunchInfo structure
+        processLaunchInfo = {};
+        processLaunchInfo.m_processExecutableString = xacroPath.Native();
         processLaunchInfo.m_commandlineParameters.emplace<AZStd::vector<AZStd::string>>({ filename });
         for (const auto& param : params)
         {

--- a/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
@@ -14,6 +14,8 @@
 #include <AzFramework/Process/ProcessWatcher.h>
 #include <QString>
 
+#include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
+
 namespace ROS2::Utils::xacro
 {
 
@@ -65,7 +67,13 @@ namespace ROS2::Utils::xacro
         {
             AZ_Printf("ParseXacro", "xacro finished with success \n");
             const auto& output = process_output.outputResult;
-            outcome.m_urdfHandle = UrdfParser::Parse(output);
+            // Read the SDF Settings from the Settings Registry into a local struct
+            SdfAssetBuilderSettings sdfBuilderSettings;
+            sdfBuilderSettings.LoadSettings();
+            // Set the parser config settings for URDF content
+            sdf::ParserConfig parserConfig;
+            parserConfig.URDFSetPreserveFixedJoint(sdfBuilderSettings.m_urdfPreserveFixedJoints);
+            outcome.m_urdfHandle = UrdfParser::Parse(output, parserConfig);
             outcome.m_succeed = true;
         }
         else

--- a/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
@@ -65,7 +65,7 @@ namespace ROS2::Utils::xacro
         {
             AZ_Printf("ParseXacro", "xacro finished with success \n");
             const auto& output = process_output.outputResult;
-            outcome.m_urdfHandle = UrdfParser::Parse(output.data());
+            outcome.m_urdfHandle = UrdfParser::Parse({ output.c_str(), output.size() });
             outcome.m_succeed = true;
         }
         else

--- a/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.h
@@ -21,7 +21,7 @@ namespace ROS2::Utils::xacro
     struct ExecutionOutcome
     {
         //! Parsed URDF from successful xacro's output
-        sdf::Root* m_urdfHandle;
+        UrdfParser::RootObjectOutcome m_urdfHandle;
         //! Return code of 'xacro' program
         bool m_succeed{ false };
         //! Called program name
@@ -34,7 +34,7 @@ namespace ROS2::Utils::xacro
         //! Gets if execution was a success
         explicit operator bool() const
         {
-            return m_succeed && m_urdfHandle != nullptr;
+            return m_succeed && m_urdfHandle;
         }
     };
 

--- a/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.h
@@ -21,7 +21,7 @@ namespace ROS2::Utils::xacro
     struct ExecutionOutcome
     {
         //! Parsed URDF from successful xacro's output
-        urdf::ModelInterfaceSharedPtr m_urdfHandle;
+        sdf::Root* m_urdfHandle;
         //! Return code of 'xacro' program
         bool m_succeed{ false };
         //! Called program name

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
@@ -41,7 +41,7 @@ namespace ROS2
         AZStd::string GetFingerprint() const;
 
         //! Create a mapping of all the asset references in the source file.
-        Utils::UrdfAssetMap FindAssets(const urdf::LinkConstSharedPtr& rootLink, const AZStd::string& sourceFilename) const;
+        Utils::UrdfAssetMap FindAssets(const sdf::Root& root, const AZStd::string& sourceFilename) const;
 
         SdfAssetBuilderSettings m_globalSettings;
         AZStd::string m_fingerprint;

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
@@ -17,6 +17,8 @@
 
 namespace ROS2
 {
+    [[maybe_unused]] constexpr const char* SdfAssetBuilderName = "SdfAssetBuilder";
+
     //! Builder to convert the following file types into procedural prefab assets:
     //! * sdf (Simulation Description Format: http://sdformat.org/ )
     //! * urdf (Unified Robotics Description Format: http://wiki.ros.org/urdf )

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
@@ -13,11 +13,11 @@
 
 namespace ROS2
 {
-        namespace
-        {
-            constexpr const char* SdfAssetBuilderSupportedFileExtensionsRegistryKey = "/O3DE/ROS2/SdfAssetBuilder/SupportedFileTypeExtensions";
-            constexpr const char* SdfAssetBuilderUseArticulationsRegistryKey = "/O3DE/ROS2/SdfAssetBuilder/UseArticulations";
-        }
+    namespace
+    {
+        constexpr const char* SdfAssetBuilderSupportedFileExtensionsRegistryKey = "/O3DE/ROS2/SdfAssetBuilder/SupportedFileTypeExtensions";
+        constexpr const char* SdfAssetBuilderUseArticulationsRegistryKey = "/O3DE/ROS2/SdfAssetBuilder/UseArticulations";
+    }
 
     void SdfAssetBuilderSettings::Reflect(AZ::ReflectContext* context)
     {
@@ -30,7 +30,7 @@ namespace ROS2
                 // m_builderPatterns aren't serialized because we only use the serialization
                 // to detect when global settings changes cause us to rebuild our assets.
                 // A change to the builder patterns will cause the Asset Processor to add or
-                // remove the affected product assets, so we don't need to trigger any 
+                // remove the affected product assets, so we don't need to trigger any
                 // additional rebuilds beyond that.
              ;
         }

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
+#include <SdfAssetBuilder/SdfAssetBuilder.h>
 
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/Settings/SettingsRegistryVisitorUtils.h>
@@ -15,8 +16,40 @@ namespace ROS2
 {
     namespace
     {
-        constexpr const char* SdfAssetBuilderSupportedFileExtensionsRegistryKey = "/O3DE/ROS2/SdfAssetBuilder/SupportedFileTypeExtensions";
-        constexpr const char* SdfAssetBuilderUseArticulationsRegistryKey = "/O3DE/ROS2/SdfAssetBuilder/UseArticulations";
+        struct SDFSettingsRootKeyType
+        {
+            using StringType = AZStd::fixed_string<256>;
+
+            constexpr StringType operator()(AZStd::string_view name) const
+            {
+                constexpr size_t MaxTotalKeySize = StringType{}.max_size();
+                // The +1 is for the '/' separator
+                [[maybe_unused]] const size_t maxNameSize = MaxTotalKeySize - (SettingsPrefix.size() + 1);
+
+                AZ_Assert(name.size() <= maxNameSize,
+                    R"(The size of the event logger name "%.*s" is too long. It must be <= %zu characters)",
+                    AZ_STRING_ARG(name), maxNameSize);
+                StringType settingsKey(SettingsPrefix);
+                settingsKey += '/';
+                settingsKey += name;
+
+                return settingsKey;
+            }
+
+            constexpr operator AZStd::string_view() const
+            {
+                return SettingsPrefix;
+            }
+
+        private:
+            AZStd::string_view SettingsPrefix = "/O3DE/ROS2/SdfAssetBuilder";
+        };
+
+        constexpr SDFSettingsRootKeyType SDFSettingsRootKey;
+
+        constexpr auto SdfAssetBuilderSupportedFileExtensionsRegistryKey = SDFSettingsRootKey("SupportedFileTypeExtensions");
+        constexpr auto SdfAssetBuilderUseArticulationsRegistryKey = SDFSettingsRootKey("UseArticulations");
+        constexpr auto SdfAssetBuilderURDFPreserveFixedJointRegistryKey = SDFSettingsRootKey("URDFPreserveFixedJoint");
     }
 
     void SdfAssetBuilderSettings::Reflect(AZ::ReflectContext* context)
@@ -26,6 +59,7 @@ namespace ROS2
             serializeContext->Class<SdfAssetBuilderSettings>()
                 ->Version(0)
                 ->Field("UseArticulations", &SdfAssetBuilderSettings::m_useArticulations)
+                ->Field("URDFPreserveFixedJoint", &SdfAssetBuilderSettings::m_urdfPreserveFixedJoints)
 
                 // m_builderPatterns aren't serialized because we only use the serialization
                 // to detect when global settings changes cause us to rebuild our assets.
@@ -47,6 +81,9 @@ namespace ROS2
         // Set whether or not the outputs should use PhysX articulation components for joints.
         // Default to using articulations.
         settingsRegistry->Get(m_useArticulations, SdfAssetBuilderUseArticulationsRegistryKey);
+
+        // Query the option to preserve child links of fixed joints when parsing a URDF using libsdformat
+        settingsRegistry->Get(m_urdfPreserveFixedJoints, SdfAssetBuilderURDFPreserveFixedJointRegistryKey);
 
         // Visit each supported file type extension and create an asset builder wildcard pattern for it.
         auto VisitFileTypeExtensions = [&settingsRegistry, this]

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
@@ -35,4 +35,4 @@ namespace ROS2
         // By default, fixed joint in URDF files that are processed by libsdformat are preserved
         bool m_urdfPreserveFixedJoints = true;
     };
-} // ROS2
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
@@ -32,5 +32,7 @@ namespace ROS2
 
         AZStd::vector<AssetBuilderSDK::AssetBuilderPattern> m_builderPatterns;
         bool m_useArticulations = true;
+        // By default, fixed joint in URDF files that are processed by libsdformat are preserved
+        bool m_urdfPreserveFixedJoints = true;
     };
 } // ROS2

--- a/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/std/ranges/ranges_algorithm.h>
 #include <AzCore/std/string/string.h>
 #include <AzTest/AzTest.h>
 #include <RobotImporter/URDF/UrdfParser.h>
@@ -51,9 +52,9 @@ namespace UnitTest
                    "</robot>";
         }
 
-        AZStd::string GetUrdfWithTwoLinksAndJoint()
+        AZStd::string GetUrdfWithTwoLinksAndJoint(AZStd::string_view jointType = "fixed")
         {
-            return "<robot name=\"test_two_links_one_joint\">  "
+            return AZStd::string::format("<robot name=\"test_two_links_one_joint\">  "
                    "  <material name=\"some_material\">\n"
                    "    <color rgba=\"0 0 0 1\"/>\n"
                    "  </material>"
@@ -81,15 +82,20 @@ namespace UnitTest
                    "      <material name=\"some_material\"/>"
                    "    </visual>"
                    "  </link>"
-                   "  <joint name=\"joint12\" type=\"fixed\">"
+                   R"(  <joint name="joint12" type="%.*s">)"
                    "    <parent link=\"link1\"/>"
                    "    <child link=\"link2\"/>"
                    "    <origin rpy=\"0 0 0\" xyz=\"1.0 0.5 0.0\"/>"
                    "    <dynamics damping=\"10.0\" friction=\"5.0\"/>"
                    "    <limit lower=\"10.0\" upper=\"20.0\" effort=\"90.0\" velocity=\"10.0\"/>"
                    "  </joint>"
-                   "</robot>";
+                   "</robot>", AZ_STRING_ARG(jointType));
         }
+
+        // A URDF <model> can only represent structure which is configurable though the <joint> tags
+        // Therefore link can only appear as a child of a single joint.
+        // It cannot be a child of multiple joints
+        // https://wiki.ros.org/urdf/XML/model
         AZStd::string GetURDFWithTranforms()
         {
             return "<?xml version=\"1.0\"?>\n"
@@ -171,12 +177,6 @@ namespace UnitTest
                    "        <axis xyz=\"0. 0. 1.\"/>\n"
                    "        <origin rpy=\"0.000000 0.000000 2.094395\" xyz=\"-1.200000286102295 2.078460931777954 0.\"/>\n"
                    "    </joint> \n"
-                   "    <joint name=\"joint2\" type=\"continuous\">\n"
-                   "        <parent link=\"link1\"/>\n"
-                   "        <child link=\"link3\"/>\n"
-                   "        <axis xyz=\"0. 0. 1.\"/>\n"
-                   "        <origin rpy=\"0.000000 0.000000 -2.094395160675049\" xyz=\"-2.4000000953674316 0.0 0.0\"/>\n"
-                   "    </joint>\n"
                    "</robot>";
         }
 
@@ -227,161 +227,269 @@ namespace UnitTest
 
     TEST_F(UrdfParserTest, ParseUrdfWithOneLink)
     {
-
         const auto xmlStr = GetUrdfWithOneLink();
-        const auto urdf = ROS2::UrdfParser::Parse(xmlStr);
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr);
+        ASSERT_TRUE(sdfRootOutcome);
+        const sdf::Root& sdfRoot = sdfRootOutcome.value();
 
-        EXPECT_EQ(urdf->getName(), "test_one_link");
+        const sdf::Model* model = sdfRoot.Model();
+        EXPECT_EQ("test_one_link", model->Name());
+        ASSERT_NE(nullptr, model);
 
-        std::vector<urdf::LinkSharedPtr> links;
-        urdf->getLinks(links);
-        EXPECT_EQ(links.size(), 1U);
+        uint64_t linkCount = model->LinkCount();
+        EXPECT_EQ(1U, linkCount);
 
-        const auto link1 = urdf->getLink("link1");
+        const sdf::Link* link1 = model->LinkByName("link1");
 
-        ASSERT_TRUE(link1);
-        EXPECT_EQ(link1->inertial->mass, 1.0);
-        EXPECT_EQ(link1->inertial->ixx, 1.0);
-        EXPECT_EQ(link1->inertial->ixy, 0.0);
-        EXPECT_EQ(link1->inertial->ixz, 0.0);
-        EXPECT_EQ(link1->inertial->iyy, 1.0);
-        EXPECT_EQ(link1->inertial->iyz, 0.0);
-        EXPECT_EQ(link1->inertial->izz, 1.0);
+        ASSERT_NE(nullptr, link1);
+        EXPECT_EQ(1.0, link1->Inertial().MassMatrix().Mass());
+        EXPECT_EQ(1.0, link1->Inertial().MassMatrix().Ixx());
+        EXPECT_EQ(0.0, link1->Inertial().MassMatrix().Ixy());
+        EXPECT_EQ(0.0, link1->Inertial().MassMatrix().Ixz());
+        EXPECT_EQ(1.0, link1->Inertial().MassMatrix().Iyy());
+        EXPECT_EQ(0.0, link1->Inertial().MassMatrix().Iyz());
+        EXPECT_EQ(1.0, link1->Inertial().MassMatrix().Izz());
 
-        EXPECT_EQ(link1->visual->geometry->type, 1);
-        const auto visualBox = std::dynamic_pointer_cast<urdf::Box>(link1->visual->geometry);
-        EXPECT_EQ(visualBox->dim.x, 1.0);
-        EXPECT_EQ(visualBox->dim.y, 2.0);
-        EXPECT_EQ(visualBox->dim.z, 1.0);
+        ASSERT_EQ(1, link1->VisualCount());
+        const sdf::Visual* visual = link1->VisualByIndex(0);
+        ASSERT_NE(nullptr, visual);
+        const sdf::Geometry* geometryVis = visual->Geom();
+        ASSERT_NE(nullptr, geometryVis);
+        EXPECT_EQ(sdf::GeometryType::BOX, geometryVis->Type());
+        const sdf::Box* visualBox = geometryVis->BoxShape();
+        ASSERT_NE(nullptr, visualBox);
+        EXPECT_EQ(1.0, visualBox->Size().X());
+        EXPECT_EQ(2.0, visualBox->Size().Y());
+        EXPECT_EQ(1.0, visualBox->Size().Z());
 
-        EXPECT_EQ(link1->collision->geometry->type, 1);
-        const auto collisionBox = std::dynamic_pointer_cast<urdf::Box>(link1->visual->geometry);
-        EXPECT_EQ(collisionBox->dim.x, 1.0);
-        EXPECT_EQ(collisionBox->dim.y, 2.0);
-        EXPECT_EQ(collisionBox->dim.z, 1.0);
+        ASSERT_EQ(1, link1->CollisionCount());
+        const sdf::Collision* collision = link1->CollisionByIndex(0);
+        ASSERT_NE(nullptr, collision);
+        const sdf::Geometry* geometryCol = visual->Geom();
+        ASSERT_NE(nullptr, geometryCol);
+        EXPECT_EQ(sdf::GeometryType::BOX, geometryCol->Type());
+        const sdf::Box* collisionBox = geometryCol->BoxShape();
+        EXPECT_EQ(1.0, collisionBox->Size().X());
+        EXPECT_EQ(2.0, collisionBox->Size().Y());
+        EXPECT_EQ(1.0, collisionBox->Size().Z());
     }
 
-    TEST_F(UrdfParserTest, ParseUrdfWithTwoLinksAndJoint)
+    TEST_F(UrdfParserTest, ParseUrdfWithTwoLinksAndFixedJoint)
     {
-
         const auto xmlStr = GetUrdfWithTwoLinksAndJoint();
-        const auto urdf = ROS2::UrdfParser::Parse(xmlStr);
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr);
+        ASSERT_TRUE(sdfRootOutcome);
+        const sdf::Root& sdfRoot = sdfRootOutcome.value();
 
-        EXPECT_EQ(urdf->getName(), "test_two_links_one_joint");
+        const sdf::Model* model = sdfRoot.Model();
+        EXPECT_EQ("test_two_links_one_joint", model->Name());
+        ASSERT_NE(nullptr, model);
 
-        std::vector<urdf::LinkSharedPtr> links;
-        urdf->getLinks(links);
-        EXPECT_EQ(links.size(), 2U);
+        // The SDFormat URDF parser combines links in joints that are fixed
+        // together
+        // https://github.com/gazebosim/sdformat/pull/1149
+        // So for a URDF with 2 links that are combined with a single fixed joint
+        // The resulted SDF has one 1 link and no joints
+        //
+        // The SDFormat <gazebo> extension tag can be used to preserve fixed joint by adding
+        // a <gazebo><preserveFixedJoint>true</preserveFixedJoint></gazebo> XML element
+        // http://sdformat.org/tutorials?tut=sdformat_urdf_extensions&cat=specification&#gazebo-elements-for-joints
+        ASSERT_EQ(1, model->LinkCount());
 
-        const auto link1 = urdf->getLink("link1");
-        ASSERT_TRUE(link1);
+        EXPECT_TRUE(model->FrameNameExists("link2"));
+        EXPECT_TRUE(model->FrameNameExists("joint12"));
 
-        const auto link2 = urdf->getLink("link2");
-        ASSERT_TRUE(link2);
+        const sdf::Link* link1 = model->LinkByName("link1");
+        ASSERT_NE(nullptr, link1);
+    }
 
-        const auto joint12 = urdf->getJoint("joint12");
-        ASSERT_TRUE(joint12);
+    TEST_F(UrdfParserTest, ParseUrdfWithTwoLinksAndNonFixedJoint)
+    {
+        const auto xmlStr = GetUrdfWithTwoLinksAndJoint("continuous");
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr);
+        ASSERT_TRUE(sdfRootOutcome);
+        const sdf::Root& sdfRoot = sdfRootOutcome.value();
 
-        EXPECT_EQ(joint12->parent_link_name, "link1");
-        EXPECT_EQ(joint12->child_link_name, "link2");
+        const sdf::Model* model = sdfRoot.Model();
+        EXPECT_EQ("test_two_links_one_joint", model->Name());
+        ASSERT_NE(nullptr, model);
 
-        EXPECT_EQ(joint12->parent_to_joint_origin_transform.position.x, 1.0);
-        EXPECT_EQ(joint12->parent_to_joint_origin_transform.position.y, 0.5);
-        EXPECT_EQ(joint12->parent_to_joint_origin_transform.position.z, 0.0);
+        ASSERT_EQ(2, model->LinkCount());
+
+        const sdf::Link* link1 = model->LinkByName("link1");
+        ASSERT_NE(nullptr, link1);
+
+        const sdf::Link* link2 = model->LinkByName("link2");
+        ASSERT_NE(nullptr, link2);
+
+        const sdf::Joint* joint12 = model->JointByName("joint12");
+        ASSERT_NE(nullptr, joint12);
+
+        EXPECT_EQ("link1", joint12->ParentName());
+        EXPECT_EQ("link2", joint12->ChildName());
+
+        gz::math::Pose3d jointPose;
+        sdf::Errors poseResolveErrors = joint12->SemanticPose().Resolve(jointPose);
+        EXPECT_TRUE(poseResolveErrors.empty());
+        EXPECT_EQ(0.0, jointPose.X());
+        EXPECT_EQ(0.0, jointPose.Y());
+        EXPECT_EQ(0.0, jointPose.Z());
 
         double roll, pitch, yaw;
-        joint12->parent_to_joint_origin_transform.rotation.getRPY(roll, pitch, yaw);
+        const gz::math::Quaternion rot = jointPose.Rot();
+        roll = rot.Roll();
+        pitch = rot.Pitch();
+        yaw = rot.Yaw();
         EXPECT_DOUBLE_EQ(roll, 0.0);
         EXPECT_DOUBLE_EQ(pitch, 0.0);
         EXPECT_DOUBLE_EQ(yaw, 0.0);
 
-        EXPECT_EQ(joint12->dynamics->damping, 10.0);
-        EXPECT_EQ(joint12->dynamics->friction, 5.0);
+        const sdf::JointAxis* joint12Axis = joint12->Axis();
+        ASSERT_NE(nullptr, joint12Axis);
 
-        EXPECT_EQ(joint12->limits->lower, 10.0);
-        EXPECT_EQ(joint12->limits->upper, 20.0);
-        EXPECT_EQ(joint12->limits->effort, 90.0);
-        EXPECT_EQ(joint12->limits->velocity, 10.0);
+        EXPECT_EQ(10.0, joint12Axis->Damping());
+        EXPECT_EQ(5.0, joint12Axis->Friction());
+
+        EXPECT_EQ(-AZStd::numeric_limits<double>::infinity(), joint12Axis->Lower());
+        EXPECT_EQ(AZStd::numeric_limits<double>::infinity(), joint12Axis->Upper());
+        EXPECT_EQ(90.0, joint12Axis->Effort());
+        EXPECT_EQ(10.0, joint12Axis->MaxVelocity());
     }
 
     TEST_F(UrdfParserTest, WheelHeuristicNameValid)
     {
-        const AZStd::string wheel_name("wheel_left_link");
-        const auto xmlStr = GetURDFWithWheel(wheel_name, "continuous");
-        const auto urdf = ROS2::UrdfParser::Parse(xmlStr);
-        auto wheel_candidate = urdf->getLink(wheel_name.c_str());
-        ASSERT_TRUE(wheel_candidate);
-        EXPECT_EQ(ROS2::Utils::IsWheelURDFHeuristics(wheel_candidate), true);
+        const AZStd::string_view wheelName("wheel_left_link");
+        const auto xmlStr = GetURDFWithWheel(wheelName, "continuous");
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr);
+        ASSERT_TRUE(sdfRootOutcome);
+        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Model* model = sdfRoot.Model();
+        ASSERT_NE(nullptr, model);
+        auto wheelCandidate = model->LinkByName(std::string(wheelName.data(), wheelName.size()));
+        ASSERT_NE(nullptr, wheelCandidate);
+        EXPECT_TRUE(ROS2::Utils::IsWheelURDFHeuristics(*model, wheelCandidate));
     }
 
     TEST_F(UrdfParserTest, WheelHeuristicNameNotValid1)
     {
-        const AZStd::string wheel_name("wheel_left_joint");
-        const auto xmlStr = GetURDFWithWheel(wheel_name, "continuous");
-        const auto urdf = ROS2::UrdfParser::Parse(xmlStr);
-        auto wheel_candidate = urdf->getLink(wheel_name.c_str());
-        ASSERT_TRUE(wheel_candidate);
-        EXPECT_EQ(ROS2::Utils::IsWheelURDFHeuristics(wheel_candidate), false);
+        const AZStd::string wheelName("wheel_left_joint");
+        const auto xmlStr = GetURDFWithWheel(wheelName, "continuous");
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr);
+        ASSERT_TRUE(sdfRootOutcome);
+        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Model* model = sdfRoot.Model();
+        ASSERT_NE(nullptr, model);
+        auto wheelCandidate = model->LinkByName(std::string(wheelName.data(), wheelName.size()));
+        ASSERT_NE(nullptr, wheelCandidate);
+        EXPECT_FALSE(ROS2::Utils::IsWheelURDFHeuristics(*model, wheelCandidate));
     }
 
     TEST_F(UrdfParserTest, WheelHeuristicJointNotValid)
     {
-        const AZStd::string wheel_name("wheel_left_link");
-        const auto xmlStr = GetURDFWithWheel(wheel_name, "fixed");
-        const auto urdf = ROS2::UrdfParser::Parse(xmlStr);
-        auto wheel_candidate = urdf->getLink(wheel_name.c_str());
-        ASSERT_TRUE(wheel_candidate);
-        EXPECT_EQ(ROS2::Utils::IsWheelURDFHeuristics(wheel_candidate), false);
+        const AZStd::string wheelName("wheel_left_link");
+        const auto xmlStr = GetURDFWithWheel(wheelName, "fixed");
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr);
+        ASSERT_TRUE(sdfRootOutcome);
+        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Model* model = sdfRoot.Model();
+        ASSERT_NE(nullptr, model);
+        // SDFormat converts combines the links of a joint with a fixed type
+        // into a single link
+        // It does however create a Frame with the name of the child link and joint that was combined
+        EXPECT_EQ(1, model->LinkCount());
+
+        auto wheelCandidate = model->LinkByName("base_link");
+        ASSERT_NE(nullptr, wheelCandidate);
+
+        EXPECT_TRUE(model->FrameNameExists(std::string{ wheelName.c_str(), wheelName.size() }));
+        EXPECT_TRUE(model->FrameNameExists("joint0"));
+        EXPECT_FALSE(ROS2::Utils::IsWheelURDFHeuristics(*model, wheelCandidate));
     }
 
     TEST_F(UrdfParserTest, WheelHeuristicJointVisualNotValid)
     {
-        const AZStd::string wheel_name("wheel_left_link");
-        const auto xmlStr = GetURDFWithWheel(wheel_name, "continuous", false, true);
-        const auto urdf = ROS2::UrdfParser::Parse(xmlStr);
-        auto wheel_candidate = urdf->getLink(wheel_name.c_str());
-        ASSERT_TRUE(wheel_candidate);
-        EXPECT_EQ(ROS2::Utils::IsWheelURDFHeuristics(wheel_candidate), false);
+        const AZStd::string wheelName("wheel_left_link");
+        const auto xmlStr = GetURDFWithWheel(wheelName, "continuous", false, true);
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr);
+        ASSERT_TRUE(sdfRootOutcome);
+        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Model* model = sdfRoot.Model();
+        ASSERT_NE(nullptr, model);
+        auto wheelCandidate = model->LinkByName(std::string(wheelName.c_str(), wheelName.size()));
+        ASSERT_NE(nullptr, wheelCandidate);
+        EXPECT_FALSE(ROS2::Utils::IsWheelURDFHeuristics(*model, wheelCandidate));
     }
 
     TEST_F(UrdfParserTest, WheelHeuristicJointColliderNotValid)
     {
-        const AZStd::string wheel_name("wheel_left_link");
-        const auto xmlStr = GetURDFWithWheel(wheel_name, "continuous", true, false);
-        const auto urdf = ROS2::UrdfParser::Parse(xmlStr);
-        auto wheel_candidate = urdf->getLink(wheel_name.c_str());
-        ASSERT_TRUE(wheel_candidate);
-        EXPECT_EQ(ROS2::Utils::IsWheelURDFHeuristics(wheel_candidate), false);
+        const AZStd::string wheelName("wheel_left_link");
+        const auto xmlStr = GetURDFWithWheel(wheelName, "continuous", true, false);
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr);
+        ASSERT_TRUE(sdfRootOutcome);
+        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Model* model = sdfRoot.Model();
+        ASSERT_NE(nullptr, model);
+        auto wheelCandidate = model->LinkByName(std::string(wheelName.c_str(), wheelName.size()));
+        ASSERT_NE(nullptr, wheelCandidate);
+        EXPECT_FALSE(ROS2::Utils::IsWheelURDFHeuristics(*model, wheelCandidate));
     }
 
     TEST_F(UrdfParserTest, TestLinkListing)
     {
         const auto xmlStr = GetURDFWithTranforms();
-        const auto urdf = ROS2::UrdfParser::Parse(xmlStr);
-        auto links = ROS2::Utils::GetAllLinks(urdf->getRoot()->child_links);
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr);
+        ASSERT_TRUE(sdfRootOutcome);
+        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Model* model = sdfRoot.Model();
+        ASSERT_NE(nullptr, model);
+        auto links = ROS2::Utils::GetAllLinks(*model);
+        // As the "joint_bs" is a fixed joint, it and it's child link are combined
+        // Therefore the "link1" child link and "joint_bs" fixed joint are combined
+        // into the base_link of the SDF
+        // However there are Frames for the combined links and joints
         EXPECT_EQ(links.size(), 3);
-        ASSERT_TRUE(links.contains("link1"));
+        ASSERT_TRUE(links.contains("base_link"));
         ASSERT_TRUE(links.contains("link2"));
         ASSERT_TRUE(links.contains("link3"));
-        EXPECT_EQ(links.at("link1")->name, "link1");
-        EXPECT_EQ(links.at("link2")->name, "link2");
-        EXPECT_EQ(links.at("link3")->name, "link3");
+        EXPECT_EQ("base_link", links.at("base_link")->Name());
+        EXPECT_EQ("link2", links.at("link2")->Name());
+        EXPECT_EQ("link3", links.at("link3")->Name());
+
+        // Check that the frame names exist on the model
+        EXPECT_TRUE(model->FrameNameExists("joint_bs"));
+        EXPECT_TRUE(model->FrameNameExists("link1"));
     }
 
     TEST_F(UrdfParserTest, TestJointLink)
     {
         const auto xmlStr = GetURDFWithTranforms();
-        const auto urdf = ROS2::UrdfParser::Parse(xmlStr);
-        auto joints = ROS2::Utils::GetAllJoints(urdf->getRoot()->child_links);
-        EXPECT_EQ(joints.size(), 3);
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr);
+        ASSERT_TRUE(sdfRootOutcome);
+        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Model* model = sdfRoot.Model();
+        ASSERT_NE(nullptr, model);
+        auto joints = ROS2::Utils::GetAllJoints(*model);
+        EXPECT_EQ(2, joints.size());
+        ASSERT_TRUE(joints.contains("joint0"));
+        ASSERT_TRUE(joints.contains("joint1"));
     }
 
     TEST_F(UrdfParserTest, TestTransforms)
     {
         const auto xmlStr = GetURDFWithTranforms();
-        const auto urdf = ROS2::UrdfParser::Parse(xmlStr);
-        const auto links = ROS2::Utils::GetAllLinks(urdf->getRoot()->child_links);
-        const auto link1_ptr = links.at("link1");
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr);
+        ASSERT_TRUE(sdfRootOutcome);
+        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Model* model = sdfRoot.Model();
+        ASSERT_NE(nullptr, model);
+        const auto links = ROS2::Utils::GetAllLinks(*model);
+        // The "link1" is combined with the base_link through
+        // joint reduction in the URDF->SDF parser logic
+        // https://github.com/gazebosim/sdformat/issues/1110
+        ASSERT_TRUE(links.contains("base_link"));
+        ASSERT_TRUE(links.contains("link2"));
+        ASSERT_TRUE(links.contains("link3"));
+        const auto base_link_ptr = links.at("base_link");
         const auto link2_ptr = links.at("link2");
         const auto link3_ptr = links.at("link3");
 
@@ -390,7 +498,7 @@ namespace UnitTest
         const AZ::Vector3 expected_translation_link2{ -1.2000000476837158, 2.0784599781036377, 0.0 };
         const AZ::Vector3 expected_translation_link3{ -2.4000000953674316, 0.0, 0.0 };
 
-        const AZ::Transform transform_from_urdf_link1 = ROS2::Utils::GetWorldTransformURDF(link1_ptr);
+        const AZ::Transform transform_from_urdf_link1 = ROS2::Utils::GetWorldTransformURDF(base_link_ptr);
         EXPECT_NEAR(expected_translation_link1.GetX(), transform_from_urdf_link1.GetTranslation().GetX(), 1e-5);
         EXPECT_NEAR(expected_translation_link1.GetY(), transform_from_urdf_link1.GetTranslation().GetY(), 1e-5);
         EXPECT_NEAR(expected_translation_link1.GetZ(), transform_from_urdf_link1.GetTranslation().GetZ(), 1e-5);
@@ -404,6 +512,54 @@ namespace UnitTest
         EXPECT_NEAR(expected_translation_link3.GetX(), transform_from_urdf_link3.GetTranslation().GetX(), 1e-5);
         EXPECT_NEAR(expected_translation_link3.GetY(), transform_from_urdf_link3.GetTranslation().GetY(), 1e-5);
         EXPECT_NEAR(expected_translation_link3.GetZ(), transform_from_urdf_link3.GetTranslation().GetZ(), 1e-5);
+    }
+
+    TEST_F(UrdfParserTest, TestQueryJointsForParentLink_Succeeds)
+    {
+        const auto xmlStr = GetURDFWithTranforms();
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr);
+        ASSERT_TRUE(sdfRootOutcome);
+        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Model* model = sdfRoot.Model();
+        ASSERT_NE(nullptr, model);
+        auto joints = ROS2::Utils::GetJointsForParentLink(*model, "base_link");
+        EXPECT_EQ(1, joints.size());
+
+        auto jointToNameProjection = [](const sdf::Joint* joint)
+        {
+            return AZStd::string_view(joint->Name().c_str(), joint->Name().size());
+        };
+        ASSERT_TRUE(AZStd::ranges::contains(joints, "joint0", jointToNameProjection));
+
+        // Now check the middle link of "link2"
+        joints = ROS2::Utils::GetJointsForParentLink(*model, "link2");
+        EXPECT_EQ(1, joints.size());
+
+        ASSERT_TRUE(AZStd::ranges::contains(joints, "joint1", jointToNameProjection));
+    }
+
+    TEST_F(UrdfParserTest, TestQueryJointsForChildLink_Succeeds)
+    {
+        const auto xmlStr = GetURDFWithTranforms();
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr);
+        ASSERT_TRUE(sdfRootOutcome);
+        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Model* model = sdfRoot.Model();
+        ASSERT_NE(nullptr, model);
+        auto joints = ROS2::Utils::GetJointsForChildLink(*model, "link2");
+        EXPECT_EQ(1, joints.size());
+
+        auto jointToNameProjection = [](const sdf::Joint* joint)
+        {
+            return AZStd::string_view(joint->Name().c_str(), joint->Name().size());
+        };
+        ASSERT_TRUE(AZStd::ranges::contains(joints, "joint0", jointToNameProjection));
+
+        // Now check the final link of "link3"
+        joints = ROS2::Utils::GetJointsForChildLink(*model, "link3");
+        EXPECT_EQ(1, joints.size());
+
+        ASSERT_TRUE(AZStd::ranges::contains(joints, "joint1", jointToNameProjection));
     }
 
     TEST_F(UrdfParserTest, TestPathResolvementGlobal)

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -49,6 +49,8 @@ set(FILES
     Source/RobotImporter/xacro/XacroUtils.cpp
     Source/RobotImporter/xacro/XacroUtils.h
     Source/RobotImporter/Utils/DefaultSolverConfiguration.h
+    Source/RobotImporter/Utils/ErrorUtils.cpp
+    Source/RobotImporter/Utils/ErrorUtils.h
     Source/RobotImporter/Utils/FilePath.cpp
     Source/RobotImporter/Utils/FilePath.h
     Source/RobotImporter/Utils/RobotImporterUtils.cpp

--- a/Gems/ROS2/Registry/sdfassetbuilder_settings.setreg
+++ b/Gems/ROS2/Registry/sdfassetbuilder_settings.setreg
@@ -12,7 +12,8 @@
                     "world",
                     "xacro"
                 ],
-                "UseArticulations": true
+                "UseArticulations": true,
+                "URDFPreserveFixedJoint": true
             }
         }
     }


### PR DESCRIPTION
Replaced references to URDFdom with SDFormat.

Updated the Link query logic in the RobotImporter

Joints in which a link is parent can be queried using the new `GetJointsForParentLink` function.

Joints in which a link is child can be queried using the new `GetJointsForChildLink` function.

A VisitJointsForModel and VisitLinksForModel function has been added to allow visting each joint or link on model.
It supports visiting joints or links on nested models as well

Fixed the URDF Parser Test to account for link and joints changes when using libsdformat for parsing a URDF.

SDFormat URDF parser uses joint reduction to combine two links joined together by fixed joint into the parent link itself.

That operation results in the removal of the child link and the joint.
SDFormat creates a Frame for the removed child link and joint using their "name" fields, so it is possible to still discover information about the child link.