### PR TITLE
Small Conveyor Belt Component fix

### DIFF
--- a/Gems/ROS2/Code/Source/FactorySimulation/ConveyorBeltComponent.cpp
+++ b/Gems/ROS2/Code/Source/FactorySimulation/ConveyorBeltComponent.cpp
@@ -27,7 +27,7 @@ namespace ROS2
         ConveyorBeltComponentConfiguration::Reflect(context);
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<ConveyorBeltComponent>()->Version(1)->Field("Configuration", &ConveyorBeltComponent::m_configuration);
+            serialize->Class<ConveyorBeltComponent, AZ::Component>()->Version(1)->Field("Configuration", &ConveyorBeltComponent::m_configuration);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {


### PR DESCRIPTION
Fixes the error described by this message:

[Error] (Serialize) - Programmer error:
Classes deriving from AZ::Component are not declaring their base class to SerializeContext.
This will cause unexpected behavior such as components shifting around, or duplicating themselves.
Affected components:
- ConveyorBeltComponent {B7F56411-01D4-48B0-8874-230C58A578BD}

Reflection code should look something like this:
serializeContext->Class<MyComponent, AZ::Component, ... (other base classes, if any) ...>()
Make sure the Reflect function is called for all base classes as well.