### PR TITLE
Added invalidation of fingerprints in asset processor.

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -79,7 +79,6 @@ namespace ROS2
                     }
                 }
             }
-
             if (allAssetProcessed && !assetProcessorFailed)
             {
                 AZ_Printf("RobotImporterUtils", "All assets processed");
@@ -88,6 +87,18 @@ namespace ROS2
         }
 
         return false;
+    }
+
+    void Utils::ClearFingerPrints(const AZStd::unordered_map<AZStd::string, AZ::IO::Path>& sourceAssetsPaths)
+    {
+        // clear fingerprint for the manifest file to force asset processor to reprocess the manifest file
+        for (const auto& [AssetFileName, AssetFilePath] : sourceAssetsPaths)
+        {
+            bool fingerprintCleared = false;
+            AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+                fingerprintCleared, &AzToolsFramework::AssetSystemRequestBus::Events::ClearFingerprintForAsset, AssetFilePath.String());
+
+        }
     }
 
     bool Utils::IsWheelURDFHeuristics(const urdf::LinkConstSharedPtr& link)

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -81,6 +81,11 @@ namespace ROS2
         //! @returns false if a timeout or error occurs, otherwise true
         bool WaitForAssetsToProcess(const AZStd::unordered_map<AZStd::string, AZ::IO::Path>& sourceAssetsPaths);
 
+        //! Invalidate fingerprints for provided assets in asset processor.
+        //! This function make us sure that assets will be reprocessed by asset processor, when the assetinfo file is created.
+        //! @param sourceAssetsPaths - set of all non relative paths to assets for which we want to invalidate fingerprints.
+        void ClearFingerPrints(const AZStd::unordered_map<AZStd::string, AZ::IO::Path>& sourceAssetsPaths);
+
         namespace SDFormat
         {
             //! Retrieve plugin's filename. The filepath is converted into the filename if necessary.

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -82,7 +82,7 @@ namespace ROS2
         bool WaitForAssetsToProcess(const AZStd::unordered_map<AZStd::string, AZ::IO::Path>& sourceAssetsPaths);
 
         //! Invalidate fingerprints for provided assets in asset processor.
-        //! This function make us sure that assets will be reprocessed by asset processor, when the assetinfo file is created.
+        //! This causes assets to be re-processed by asset processor when the .assetinfo file is created.
         //! @param sourceAssetsPaths - set of all non relative paths to assets for which we want to invalidate fingerprints.
         void ClearFingerPrints(const AZStd::unordered_map<AZStd::string, AZ::IO::Path>& sourceAssetsPaths);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -354,6 +354,9 @@ namespace ROS2::Utils
 
         // Wait for assets to be scanned by asset processor
         Utils::WaitForAssetsToProcess(copiedFiles);
+        // Invalidate fingerprints to force asset processor to reprocess files
+        Utils::ClearFingerPrints(copiedFiles);
+
         // Add available asset info
         for (const auto& [unresolvedUrfFileName, sourceAssetGlobalPath] : copiedFiles)
         {


### PR DESCRIPTION
Fixes #464.
Simply by invalidation fingerprint the asset processor will reprocess file:
![Screenshot from 2023-08-22 18-23-19](https://github.com/o3de/o3de-extras/assets/3209244/288509c0-2f2a-4467-9c2f-789525eaf915)
