### PR TITLE
Reverted PR #400, fixes to URDF importer

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -295,18 +295,20 @@ namespace ROS2
                 }
             }
             // check if both has RigidBody and we are not creating articulation
-            if (!m_useArticulations && leadEntity.IsSuccess() && childEntity.IsSuccess())
+            if (!m_useArticulations)
             {
-                AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
-                auto result = m_jointsMaker.AddJointComponent(jointPtr, childEntity.GetValue(), leadEntity.GetValue());
-                m_status.emplace(
-                    azJointName, AZStd::string::format(" %s %llu", result.IsSuccess() ? "created as" : "Failed", result.GetValue()));
+                if (leadEntity.IsSuccess() && childEntity.IsSuccess())
+                {
+                    AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
+                    auto result = m_jointsMaker.AddJointComponent(jointPtr, childEntity.GetValue(), leadEntity.GetValue());
+                    m_status.emplace(
+                        azJointName, AZStd::string::format(" %s %llu", result.IsSuccess() ? "created as" : "Failed", result.GetValue()));
+                }
+                else
+                {
+                    AZ_Warning("CreatePrefabFromURDF", false, "cannot create joint %s", azJointName.c_str());
+                }
             }
-            else
-            {
-                AZ_Warning("CreatePrefabFromURDF", false, "cannot create joint %s", azJointName.c_str());
-            }
-
             return true;
         };
 

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -118,13 +118,6 @@ namespace ROS2::Utils
         const AZ::IO::PathView& amentPrefixPath,
         const FileExistsCB& fileExists = &Internal::FileExistsCall);
 
-    //! Waits for asset processor to process provided assets.
-    //! This function will timeout after the time specified in /O3DE/ROS2/RobotImporter/AssetProcessorTimeoutInSeconds
-    //! settings registry.
-    //! @param sourceAssetsPaths - set of all non relative paths to assets for which we want to wait for processing
-    //! @returns false if a timeout or error occurs, otherwise true
-    bool WaitForAssetsToProcess(const AZStd::unordered_map<AZStd::string, AZ::IO::Path>& sourceAssetsPaths);
-
 } // namespace ROS2::Utils
 
 namespace ROS2::Utils::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -142,4 +142,12 @@ namespace ROS2::Utils
         AZStd::string_view outputDirSuffix = "",
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 
+    //! A function that blocks execution (with timeout) until the Asset Processor starts to report asset processing status.
+    //! It also escalates the source asset job.
+    //! @param relativePath - path to asset relative to project's root
+    //! @param timeout - timeout value for blocking operation
+    //! @returns job info container
+    AZ::Outcome<AzToolsFramework::AssetSystem::JobInfoContainer> WaitForAPAndEscalate(
+        const AZStd::string& relativePath, const AZStd::chrono::duration<int, AZStd::milli>& timeout = AZStd::chrono::milliseconds(5000));
+
 } // namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -142,12 +142,4 @@ namespace ROS2::Utils
         AZStd::string_view outputDirSuffix = "",
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 
-    //! A function that blocks execution (with timeout) until the Asset Processor starts to report asset processing status.
-    //! It also escalates the source asset job.
-    //! @param relativePath - path to asset relative to project's root
-    //! @param timeout - timeout value for blocking operation
-    //! @returns job info container
-    AZ::Outcome<AzToolsFramework::AssetSystem::JobInfoContainer> WaitForAPAndEscalate(
-        const AZStd::string& relativePath, const AZStd::chrono::duration<int, AZStd::milli>& timeout = AZStd::chrono::milliseconds(5000));
-
 } // namespace ROS2::Utils


### PR DESCRIPTION
Revert #400 using old better logic.
The #400 was used to circle navigate issue in asset processor. 
Also missing case for resolving package was added.