### PR TITLE
Adding SDFAssetBuilderSettings Reflected Property Editor to the Robot Importer

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.cpp
@@ -26,17 +26,14 @@ namespace ROS2
         m_fileDialog->setNameFilter("URDF, XACRO (*.urdf *.xacro)");
         m_button = new QPushButton("...", this);
         m_textEdit = new QLineEdit("", this);
-        m_copyFiles = new QCheckBox(tr("Import meshes during URDF load"), this);
-        m_copyFiles->setCheckState(Qt::CheckState::Checked);
         setTitle(tr("Load URDF file"));
         QVBoxLayout* layout = new QVBoxLayout;
         layout->addStretch();
         layout->addWidget(new QLabel(tr("URDF file path to load : "), this));
-        QHBoxLayout* layout_in = new QHBoxLayout;
-        layout_in->addWidget(m_button);
-        layout_in->addWidget(m_textEdit);
-        layout->addLayout(layout_in);
-        layout->addWidget(m_copyFiles);
+        QHBoxLayout* layoutHorizontal = new QHBoxLayout;
+        layoutHorizontal->addWidget(m_button);
+        layoutHorizontal->addWidget(m_textEdit);
+        layout->addLayout(layoutHorizontal);
 
         // Seed the SDF Asset Builder Settings with the values from the Settings Registry
         m_sdfAssetBuilderSettings->LoadSettings();
@@ -87,9 +84,9 @@ namespace ROS2
         return m_fileExists;
     }
 
-    bool FileSelectionPage::getIfCopyAssetsDuringUrdfImport() const
+    QString FileSelectionPage::getFileName() const
     {
-        return m_copyFiles->isChecked();
+        return isComplete() ? m_textEdit->text(): QString{};
     }
 
     const SdfAssetBuilderSettings& FileSelectionPage::GetSdfAssetBuilderSettings() const

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.h
@@ -18,14 +18,27 @@
 #include <QWizardPage>
 #endif
 
+namespace AzToolsFramework
+{
+    class ReflectedPropertyEditor;
+}
+
 namespace ROS2
 {
+    struct SdfAssetBuilderSettings;
+}
 
+
+namespace ROS2
+{
     class FileSelectionPage : public QWizardPage
     {
         Q_OBJECT
     public:
         explicit FileSelectionPage(QWizard* parent);
+        // The destructor is defaulted in the cpp file to allow the unique_ptr<SdfAssetBuilderSettings>
+        // to not need a complete type in the header
+        ~FileSelectionPage();
 
         bool isComplete() const override;
 
@@ -39,11 +52,16 @@ namespace ROS2
         }
         bool getIfCopyAssetsDuringUrdfImport() const;
 
+        const SdfAssetBuilderSettings& GetSdfAssetBuilderSettings() const;
+
     private:
         QFileDialog* m_fileDialog;
         QPushButton* m_button;
         QLineEdit* m_textEdit;
         QCheckBox* m_copyFiles;
+
+        AZStd::unique_ptr<SdfAssetBuilderSettings> m_sdfAssetBuilderSettings;
+        AzToolsFramework::ReflectedPropertyEditor* m_sdfAssetBuilderSettingsEditor{};
         void onLoadButtonPressed();
 
         void onFileSelected(const QString& file);

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.h
@@ -18,6 +18,8 @@
 #include <QWizardPage>
 #endif
 
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+
 namespace AzToolsFramework
 {
     class ReflectedPropertyEditor;
@@ -27,7 +29,6 @@ namespace ROS2
 {
     struct SdfAssetBuilderSettings;
 }
-
 
 namespace ROS2
 {
@@ -42,15 +43,7 @@ namespace ROS2
 
         bool isComplete() const override;
 
-        QString getFileName() const
-        {
-            if (m_fileExists)
-            {
-                return m_textEdit->text();
-            }
-            return "";
-        }
-        bool getIfCopyAssetsDuringUrdfImport() const;
+        QString getFileName() const;
 
         const SdfAssetBuilderSettings& GetSdfAssetBuilderSettings() const;
 

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
@@ -13,6 +13,7 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/string/string.h>
+
 #include <ROS2/Spawner/SpawnerBus.h>
 #include <ROS2/Spawner/SpawnerInfo.h>
 #include <RobotImporter/RobotImporterWidget.h>
@@ -22,11 +23,10 @@
 
 namespace ROS2
 {
-
     PrefabMakerPage::PrefabMakerPage(RobotImporterWidget* parent)
         : QWizardPage(parent)
-        , m_parentImporterWidget(parent)
         , m_success(false)
+        , m_parentImporterWidget(parent)
     {
         AZ::EBusAggregateResults<AZStd::unordered_map<AZStd::string, SpawnPointInfo>> allActiveSpawnPoints;
         SpawnerRequestsBus::BroadcastResult(allActiveSpawnPoints, &SpawnerRequestsBus::Events::GetAllSpawnPointInfos);
@@ -45,14 +45,13 @@ namespace ROS2
         m_prefabName = new QLineEdit(this);
         m_createButton = new QPushButton(tr("Create Prefab"), this);
         m_log = new QTextEdit(this);
-        m_useArticulation = new QCheckBox(tr("Use articulation for joints and rigid bodies"), this);
+
         setTitle(tr("Prefab creation"));
         QVBoxLayout* layout = new QVBoxLayout;
         QHBoxLayout* layoutInner = new QHBoxLayout;
         layoutInner->addWidget(m_prefabName);
         layoutInner->addWidget(m_createButton);
         layout->addLayout(layoutInner);
-        layout->addWidget(m_useArticulation);
         QLabel* spawnPointListLabel;
         if (allActiveSpawnPoints.values.size() == 0)
         {
@@ -68,6 +67,7 @@ namespace ROS2
         setLayout(layout);
         connect(m_createButton, &QPushButton::pressed, this, &PrefabMakerPage::onCreateButtonPressed);
     }
+
 
     void PrefabMakerPage::setProposedPrefabName(const AZStd::string prefabName)
     {
@@ -92,10 +92,6 @@ namespace ROS2
     {
         return m_success;
     }
-    bool PrefabMakerPage::IsUseArticulations() const
-    {
-        return m_useArticulation->isChecked();
-    }
     AZStd::optional<AZ::Transform> PrefabMakerPage::getSelectedSpawnPoint() const
     {
         if (!m_spawnPointsInfos.empty())
@@ -111,5 +107,4 @@ namespace ROS2
         }
         return AZStd::nullopt;
     }
-
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
@@ -68,7 +68,6 @@ namespace ROS2
         connect(m_createButton, &QPushButton::pressed, this, &PrefabMakerPage::onCreateButtonPressed);
     }
 
-
     void PrefabMakerPage::setProposedPrefabName(const AZStd::string prefabName)
     {
         m_prefabName->setText(QString::fromUtf8(prefabName.data(), int(prefabName.size())));

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.h
@@ -36,7 +36,6 @@ namespace ROS2
         void reportProgress(const AZStd::string& progressForUser);
         void setSuccess(bool success);
         bool isComplete() const override;
-        bool IsUseArticulations() const;
         AZStd::optional<AZ::Transform> getSelectedSpawnPoint() const;
     Q_SIGNALS:
         void onCreateButtonPressed();
@@ -46,7 +45,6 @@ namespace ROS2
         QLineEdit* m_prefabName;
         QPushButton* m_createButton;
         QTextEdit* m_log;
-        QCheckBox* m_useArticulation;
         QComboBox* m_spawnPointsComboBox;
         AZStd::vector<SpawnPointInfoMap> m_spawnPointsInfos;
         RobotImporterWidget* m_parentImporterWidget;

--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -109,7 +109,7 @@ namespace ROS2
         auto parsedUrdfOutcome = UrdfParser::ParseFromFile(filePath, parserConfig);
         if (!parsedUrdfOutcome)
         {
-            const AZStd::string log = Utils::JoinSdfErrorsToString(parsedUrdfOutcome.error());
+            const AZStd::string log = Utils::JoinSdfErrorsToString(parsedUrdfOutcome.GetSdfErrors());
 
             AZ_Warning("ROS2RobotImporterEditorSystemComponent", false, "URDF parsing failed with errors:\nRefer to %s",
                 log.c_str());
@@ -117,7 +117,7 @@ namespace ROS2
         }
 
         // Urdf Root has been parsed successfully retrieve it from the Outcome
-        const sdf::Root& parsedUrdfRoot = parsedUrdfOutcome.value();
+        const sdf::Root& parsedUrdfRoot = parsedUrdfOutcome.GetRoot();
 
         auto collidersNames = Utils::GetMeshesFilenames(&parsedUrdfRoot, false, true);
         auto visualNames = Utils::GetMeshesFilenames(&parsedUrdfRoot, true, false);

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -314,7 +314,7 @@ namespace ROS2
             {
                 OpenUrdf();
             }
-            m_importAssetWithUrdf = m_fileSelectPage->getIfCopyAssetsDuringUrdfImport();
+            m_importAssetWithUrdf = m_fileSelectPage->GetSdfAssetBuilderSettings().m_importReferencedMeshFiles;
         }
         if (currentPage() == m_xacroParamsPage)
         {

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -83,15 +83,22 @@ namespace ROS2
 
     void RobotImporterWidget::OpenUrdf()
     {
-        UrdfParser::RootObjectOutcome parsedUrdfOutcome(AZStd::unexpect);
+        UrdfParser::RootObjectOutcome parsedUrdfOutcome;
         QString report;
         if (!m_urdfPath.empty())
         {
+            // Read the SDF Settings from PrefabMakerPage
+            const SdfAssetBuilderSettings& sdfBuilderSettings = m_fileSelectPage->GetSdfAssetBuilderSettings();
+
+            // Set the parser config settings for URDF content
+            sdf::ParserConfig parserConfig;
+            parserConfig.URDFSetPreserveFixedJoint(sdfBuilderSettings.m_urdfPreserveFixedJoints);
+
             if (Utils::IsFileXacro(m_urdfPath))
             {
-                Utils::xacro::ExecutionOutcome outcome = Utils::xacro::ParseXacro(m_urdfPath.String(), m_params);
+                Utils::xacro::ExecutionOutcome outcome = Utils::xacro::ParseXacro(m_urdfPath.String(), m_params, parserConfig);
                 // Store off the URDF parsing outcome which will be output later in this function
-                parsedUrdfOutcome = outcome.m_urdfHandle;
+                parsedUrdfOutcome = AZStd::move(outcome.m_urdfHandle);
                 if (outcome)
                 {
                     report += "# " + tr("XACRO execution succeeded") + "\n";
@@ -140,12 +147,6 @@ namespace ROS2
             else if (Utils::IsFileUrdf(m_urdfPath))
             {
                 // standard URDF
-                // Read the SDF Settings from the Settings Registry into a local struct
-                SdfAssetBuilderSettings sdfBuilderSettings;
-                sdfBuilderSettings.LoadSettings();
-                // Set the parser config settings for URDF content
-                sdf::ParserConfig parserConfig;
-                parserConfig.URDFSetPreserveFixedJoint(sdfBuilderSettings.m_urdfPreserveFixedJoints);
                 parsedUrdfOutcome = UrdfParser::ParseFromFile(m_urdfPath, parserConfig);
             }
             else
@@ -153,10 +154,10 @@ namespace ROS2
                 AZ_Assert(false, "Unknown file extension : %s \n", m_urdfPath.c_str());
             }
             AZStd::string log;
-            bool urdfParsedSuccess = parsedUrdfOutcome.has_value();
+            bool urdfParsedSuccess{ parsedUrdfOutcome };
             if (urdfParsedSuccess)
             {
-                m_parsedUrdf = AZStd::move(parsedUrdfOutcome.value());
+                m_parsedUrdf = AZStd::move(parsedUrdfOutcome.GetRoot());
                 report += "# " + tr("The URDF was parsed and opened successfully") + "\n";
                 m_prefabMaker.reset();
                 // Report the status of skipping this page
@@ -166,7 +167,7 @@ namespace ROS2
             }
             else
             {
-                log = Utils::JoinSdfErrorsToString(parsedUrdfOutcome.error());
+                log = Utils::JoinSdfErrorsToString(parsedUrdfOutcome.GetSdfErrors());
                 report += "# " + tr("The URDF was not opened") + "\n";
                 report += tr("URDF parser returned following errors:") + "\n\n";
             }
@@ -395,7 +396,9 @@ namespace ROS2
                 return;
             }
         }
-        const bool useArticulation = m_prefabMakerPage->IsUseArticulations();
+
+        const auto& sdfAssetBuilderSettings = m_fileSelectPage->GetSdfAssetBuilderSettings();
+        const bool useArticulation = sdfAssetBuilderSettings.m_useArticulations;
         m_prefabMaker = AZStd::make_unique<URDFPrefabMaker>(
             m_urdfPath.String(),
             &m_parsedUrdf,

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
@@ -27,9 +27,45 @@ namespace ROS2
     namespace UrdfParser
     {
         //! Stores the result of parsing URDF data
-        //! On success the sdf::Root object is returned
-        //! On failure the sdf::Errors vector is returned
-        using RootObjectOutcome = AZStd::expected<sdf::Root, sdf::Errors>;
+        //! The operator bool returns true if the sdf::Errors vector is empty
+        struct ParseResult
+        {
+        private:
+            // Provides custom sdf::ErrorCode values when parsing is done through O3DE
+            inline static constexpr auto O3DESdfErrorCodeStart = static_cast<sdf::ErrorCode>(1000);
+        public:
+           inline static constexpr auto O3DESdfErrorParseNotStarted = static_cast<sdf::ErrorCode>(static_cast<int>(O3DESdfErrorCodeStart) + 1);
+
+            //! Ref qualifer overloads for retrieving sdf::Root
+            //! it supports a non-const lvalue overload to allow
+            //! modification of the sdf::Root objec directly
+            sdf::Root& GetRoot() &;
+            const sdf::Root& GetRoot() const&;
+            sdf::Root&& GetRoot() &&;
+
+            //! Property getters for retrieving parsing messages
+            //! logged during libsdformat parsing of the URDF content
+            //! This does not support a non-const lvalue overload
+            //! As modification the result structure parser messages
+            //! have no need to be modified inplace
+            const AZStd::string& GetParseMessages() const&;
+            AZStd::string&& GetParseMessages() &&;
+
+            //! Returns the sdf::Error vector containing any parser errors
+            //! This does not support a non-const lvalue overload
+            //! As modification the result structure sdf Errors
+            //! have no need to be modified inplace
+            const sdf::Errors& GetSdfErrors() const&;
+            sdf::Errors&& GetSdfErrors() &&;
+
+            //! Returns if the parsing of the SDF file has succeeded
+            explicit operator bool() const;
+
+            sdf::Root m_root;
+            AZStd::string m_parseMessages;
+            sdf::Errors m_sdfErrors{ sdf::Error{ O3DESdfErrorParseNotStarted, std::string{"No Parsing has occured yet"}} };
+        };
+        using RootObjectOutcome = ParseResult;
 
         //! Parse string with URDF data and generate model.
         //! @param xmlString a string that contains URDF data (XML format).

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
@@ -36,9 +36,9 @@ namespace ROS2
         public:
            inline static constexpr auto O3DESdfErrorParseNotStarted = static_cast<sdf::ErrorCode>(static_cast<int>(O3DESdfErrorCodeStart) + 1);
 
-            //! Ref qualifer overloads for retrieving sdf::Root
+            //! Ref qualifier overloads for retrieving sdf::Root
             //! it supports a non-const lvalue overload to allow
-            //! modification of the sdf::Root objec directly
+            //! modification of the sdf::Root object directly
             sdf::Root& GetRoot() &;
             const sdf::Root& GetRoot() const&;
             sdf::Root&& GetRoot() &&;
@@ -63,7 +63,7 @@ namespace ROS2
 
             sdf::Root m_root;
             AZStd::string m_parseMessages;
-            sdf::Errors m_sdfErrors{ sdf::Error{ O3DESdfErrorParseNotStarted, std::string{"No Parsing has occured yet"}} };
+            sdf::Errors m_sdfErrors{ sdf::Error{ O3DESdfErrorParseNotStarted, std::string{"No Parsing has occurred yet"}} };
         };
         using RootObjectOutcome = ParseResult;
 

--- a/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.cpp
@@ -18,7 +18,7 @@
 
 namespace ROS2::Utils::xacro
 {
-    ExecutionOutcome ParseXacro(const AZStd::string& filename, const Params& params)
+    ExecutionOutcome ParseXacro(const AZStd::string& filename, const Params& params, const sdf::ParserConfig& parserConfig)
     {
         ExecutionOutcome outcome;
         // test if xacro exists
@@ -90,12 +90,6 @@ namespace ROS2::Utils::xacro
         {
             AZ_Printf("ParseXacro", "xacro finished with success \n");
             const auto& output = process_output.outputResult;
-            // Read the SDF Settings from the Settings Registry into a local struct
-            SdfAssetBuilderSettings sdfBuilderSettings;
-            sdfBuilderSettings.LoadSettings();
-            // Set the parser config settings for URDF content
-            sdf::ParserConfig parserConfig;
-            parserConfig.URDFSetPreserveFixedJoint(sdfBuilderSettings.m_urdfPreserveFixedJoints);
             outcome.m_urdfHandle = UrdfParser::Parse(output, parserConfig);
             outcome.m_succeed = true;
         }

--- a/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/xacro/XacroUtils.h
@@ -41,7 +41,7 @@ namespace ROS2::Utils::xacro
     AZStd::unordered_map<AZStd::string, AZStd::string> GetParameterFromXacroData(const AZStd::string& data);
     AZStd::unordered_map<AZStd::string, AZStd::string> GetParameterFromXacroFile(const AZStd::string& filename);
 
-    ExecutionOutcome ParseXacro(const AZStd::string& filename, const Params& params);
+    ExecutionOutcome ParseXacro(const AZStd::string& filename, const Params& params, const sdf::ParserConfig& parserConfig);
 
 
 } // namespace ROS2::Utils::xacro

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
@@ -197,13 +197,13 @@ namespace ROS2
         auto parsedSdfRootOutcome = UrdfParser::ParseFromFile(fullSourcePath, parserConfig);
         if (!parsedSdfRootOutcome)
         {
-            const AZStd::string sdfParseErrors = Utils::JoinSdfErrorsToString(parsedSdfRootOutcome.error());
+            const AZStd::string sdfParseErrors = Utils::JoinSdfErrorsToString(parsedSdfRootOutcome.GetSdfErrors());
             AZ_Error(SdfAssetBuilderName, false, R"(Failed to parse source file "%s". Errors: "%s")",
                 fullSourcePath.c_str(), sdfParseErrors.c_str());
             return;
         }
 
-        const sdf::Root& sdfRoot = parsedSdfRootOutcome.value();
+        const sdf::Root& sdfRoot = parsedSdfRootOutcome.GetRoot();
 
         AZ_Info(SdfAssetBuilderName, "Finding asset IDs for all mesh and collider assets.");
         auto sourceAssetMap = AZStd::make_shared<Utils::UrdfAssetMap>(FindAssets(sdfRoot, fullSourcePath.String()));
@@ -260,14 +260,14 @@ namespace ROS2
         auto parsedSdfRootOutcome = UrdfParser::ParseFromFile(AZ::IO::PathView(request.m_fullPath), parserConfig);
         if (!parsedSdfRootOutcome)
         {
-            const AZStd::string sdfParseErrors = Utils::JoinSdfErrorsToString(parsedSdfRootOutcome.error());
+            const AZStd::string sdfParseErrors = Utils::JoinSdfErrorsToString(parsedSdfRootOutcome.GetSdfErrors());
             AZ_Error(SdfAssetBuilderName, false, R"(Failed to parse source file "%s". Errors: "%s")",
                 request.m_fullPath.c_str(), sdfParseErrors.c_str());
             response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
             return;
         }
 
-        const sdf::Root& sdfRoot = parsedSdfRootOutcome.value();
+        const sdf::Root& sdfRoot = parsedSdfRootOutcome.GetRoot();
 
         // Resolve all the URI references into source asset GUIDs.
         AZ_Info(SdfAssetBuilderName, "Finding asset IDs for all mesh and collider assets.");

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
@@ -50,6 +50,7 @@ namespace ROS2
         constexpr auto SdfAssetBuilderSupportedFileExtensionsRegistryKey = SDFSettingsRootKey("SupportedFileTypeExtensions");
         constexpr auto SdfAssetBuilderUseArticulationsRegistryKey = SDFSettingsRootKey("UseArticulations");
         constexpr auto SdfAssetBuilderURDFPreserveFixedJointRegistryKey = SDFSettingsRootKey("URDFPreserveFixedJoint");
+        constexpr auto SdfAssetBuilderImportMeshesJointRegistryKey = SDFSettingsRootKey("ImportMeshes");
     }
 
     void SdfAssetBuilderSettings::Reflect(AZ::ReflectContext* context)
@@ -60,6 +61,7 @@ namespace ROS2
                 ->Version(0)
                 ->Field("UseArticulations", &SdfAssetBuilderSettings::m_useArticulations)
                 ->Field("URDFPreserveFixedJoint", &SdfAssetBuilderSettings::m_urdfPreserveFixedJoints)
+                ->Field("ImportReferencedMeshFiles", &SdfAssetBuilderSettings::m_importReferencedMeshFiles)
 
                 // m_builderPatterns aren't serialized because we only use the serialization
                 // to detect when global settings changes cause us to rebuild our assets.
@@ -82,8 +84,13 @@ namespace ROS2
                         AZ::Edit::UIHandlers::Default,
                         &SdfAssetBuilderSettings::m_urdfPreserveFixedJoints,
                         "Preserve URDF fixed joints",
-                        "When set, preserves any fixed joints found when importing a URDF/XACRO file."
-                        " This prevents the joint reduction logic in libsdformat from merging links of those joints.");
+                        "When set, preserves any fixed joints found when importing a URDF file."
+                        " This prevents the joint reduction logic in libsdformat from merging links of those joints.")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &SdfAssetBuilderSettings::m_importReferencedMeshFiles,
+                        "Import meshes",
+                        "Allows importing of referenced mesh content files such as .dae or .stl files when importing the URDF/SDF.");
             }
         }
     }
@@ -102,6 +109,9 @@ namespace ROS2
 
         // Query the option to preserve child links of fixed joints when parsing a URDF using libsdformat
         settingsRegistry->Get(m_urdfPreserveFixedJoints, SdfAssetBuilderURDFPreserveFixedJointRegistryKey);
+
+        // Query the import references meshes option from the Settings Registry to determine if mesh source assets are copied
+        settingsRegistry->Get(m_importReferencedMeshFiles, SdfAssetBuilderImportMeshesJointRegistryKey);
 
         // Visit each supported file type extension and create an asset builder wildcard pattern for it.
         auto VisitFileTypeExtensions = [&settingsRegistry, this]

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.cpp
@@ -67,6 +67,24 @@ namespace ROS2
                 // remove the affected product assets, so we don't need to trigger any
                 // additional rebuilds beyond that.
              ;
+
+            if (auto editContext = serializeContext->GetEditContext(); editContext != nullptr)
+            {
+                editContext
+                    ->Class<SdfAssetBuilderSettings>(
+                        "SDF Asset Import Settings", "Exposes settings which alters importing of URDF/XACRO/SDF files")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &SdfAssetBuilderSettings::m_useArticulations,
+                        "Use Articulations",
+                        "Determines whether PhysX articulation components should be used for joints and rigid bodies")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &SdfAssetBuilderSettings::m_urdfPreserveFixedJoints,
+                        "Preserve URDF fixed joints",
+                        "When set, preserves any fixed joints found when importing a URDF/XACRO file."
+                        " This prevents the joint reduction logic in libsdformat from merging links of those joints.");
+            }
         }
     }
 

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilderSettings.h
@@ -34,5 +34,7 @@ namespace ROS2
         bool m_useArticulations = true;
         // By default, fixed joint in URDF files that are processed by libsdformat are preserved
         bool m_urdfPreserveFixedJoints = true;
+        // When true, .dae/.stl mesh files are imported into the project folder to allow the AP to process them
+        bool m_importReferencedMeshFiles = true;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
@@ -308,7 +308,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
         const sdf::Model* model = sdfRoot.Model();
         EXPECT_EQ("test_one_link", model->Name());
@@ -358,7 +358,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
         const sdf::Model* model = sdfRoot.Model();
         EXPECT_EQ("test_two_links_one_joint", model->Name());
@@ -389,7 +389,7 @@ namespace UnitTest
         parserConfig.URDFSetPreserveFixedJoint(true);
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
         const sdf::Model* model = sdfRoot.Model();
         EXPECT_EQ("test_two_links_one_joint", model->Name());
@@ -439,7 +439,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
         const sdf::Model* model = sdfRoot.Model();
         EXPECT_EQ("test_two_links_one_joint", model->Name());
@@ -485,14 +485,14 @@ namespace UnitTest
         EXPECT_DOUBLE_EQ(10.0, joint12Axis->MaxVelocity());
     }
 
-        TEST_F(UrdfParserTest, ParseURDF_WithTwoLinks_AndBaseLinkWithNoInertia_WithUrdfFixedJointPreservationOn_Fails)
+    TEST_F(UrdfParserTest, ParseURDF_WithTwoLinks_AndBaseLinkWithNoInertia_WithUrdfFixedJointPreservationOn_Fails)
     {
         const auto xmlStr = GetURDFWithTwoLinksAndBaseLinkNoInertia();
         sdf::ParserConfig parserConfig;
         parserConfig.URDFSetPreserveFixedJoint(true);
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_FALSE(sdfRootOutcome);
-        AZStd::string errorString = ROS2::Utils::JoinSdfErrorsToString(sdfRootOutcome.error());
+        AZStd::string errorString = ROS2::Utils::JoinSdfErrorsToString(sdfRootOutcome.GetSdfErrors());
         printf("URDF with single link and no inertia: %s\n", errorString.c_str());
     }
 
@@ -503,7 +503,7 @@ namespace UnitTest
         parserConfig.URDFSetPreserveFixedJoint(false);
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
         const sdf::Model* model = sdfRoot.Model();
         EXPECT_EQ("always_ignored", model->Name());
@@ -537,7 +537,7 @@ namespace UnitTest
         parserConfig.URDFSetPreserveFixedJoint(false);
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
         const sdf::Model* model = sdfRoot.Model();
         EXPECT_EQ("FooRobot", model->Name());
@@ -582,7 +582,7 @@ namespace UnitTest
         parserConfig.URDFSetPreserveFixedJoint(false);
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
         const sdf::Model* model = sdfRoot.Model();
         EXPECT_EQ("FooRobot", model->Name());
@@ -626,7 +626,7 @@ namespace UnitTest
         const auto xmlStr = GetURDFWithWheel(wheelName, "continuous");
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         auto wheelCandidate = model->LinkByName(std::string(wheelName.data(), wheelName.size()));
@@ -637,7 +637,7 @@ namespace UnitTest
         const auto xmlStr2 = GetURDFWithWheel(wheelNameSuffix, "continuous");
         const auto sdfRootOutcome2 = ROS2::UrdfParser::Parse(xmlStr2, parserConfig);
         ASSERT_TRUE(sdfRootOutcome2);
-        const sdf::Root& sdfRoot2 = sdfRootOutcome2.value();
+        const sdf::Root& sdfRoot2 = sdfRootOutcome2.GetRoot();
         const sdf::Model* model2 = sdfRoot2.Model();
         ASSERT_NE(nullptr, model2);
         auto wheelCandidate2 = model2->LinkByName(std::string(wheelNameSuffix.data(), wheelNameSuffix.size()));
@@ -652,7 +652,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         auto wheelCandidate = model->LinkByName(std::string(wheelName.data(), wheelName.size()));
@@ -667,7 +667,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         // SDFormat converts combines the links of a joint with a fixed type
@@ -690,7 +690,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         auto wheelCandidate = model->LinkByName(std::string(wheelName.c_str(), wheelName.size()));
@@ -705,7 +705,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         auto wheelCandidate = model->LinkByName(std::string(wheelName.c_str(), wheelName.size()));
@@ -719,7 +719,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         auto links = ROS2::Utils::GetAllLinks(*model);
@@ -746,7 +746,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         auto joints = ROS2::Utils::GetAllJoints(*model);
@@ -761,7 +761,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         const auto links = ROS2::Utils::GetAllLinks(*model);
@@ -802,7 +802,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         auto joints = ROS2::Utils::GetJointsForParentLink(*model, "base_link");
@@ -827,7 +827,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
-        const sdf::Root& sdfRoot = sdfRootOutcome.value();
+        const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         auto joints = ROS2::Utils::GetJointsForChildLink(*model, "link2");


### PR DESCRIPTION
An `SDFAssetBuilderSettings` object is being exposed via the File Select page in the Robot Importer to allow users to alter the preserve URDF fixed joints object. The settings are sourced from their current values within the Settings Registry.

Refactored the `UrdfParser::Parse` functions to support capturing the sdf::Console messages logged during URDF/SDF parsing.

![image](https://github.com/o3de/o3de-extras/assets/56135373/653be842-29c6-46f2-9e27-b5d0b67b60f5)
