### PR TITLE
Fix Camera Sensor Reflection to work in GameLauncher

### DIFF
--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorComponent.cpp
@@ -29,6 +29,8 @@ namespace ROS2
 
     void ROS2CameraSensorComponent::Reflect(AZ::ReflectContext* context)
     {
+        CameraSensorConfiguration::Reflect(context);
+
         auto* serialize = azrtti_cast<AZ::SerializeContext*>(context);
         if (serialize)
         {

--- a/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Camera/ROS2CameraSensorEditorComponent.cpp
@@ -37,8 +37,6 @@ namespace ROS2
 
     void ROS2CameraSensorEditorComponent::Reflect(AZ::ReflectContext* context)
     {
-        CameraSensorConfiguration::Reflect(context);
-
         if (auto* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<ROS2CameraSensorEditorComponent, AzToolsFramework::Components::EditorComponentBase>()


### PR DESCRIPTION
Game Launcher does not reflect Editor Components, this means that `CameraSensorConfiguration` was not reflected in Game Launcher at all.
This PR fixes this problem.