### PR TITLE
Ros2ProjectTemplate fixes to monolithic build

### DIFF
--- a/Gems/ROS2/Code/Source/Gripper/VacuumGripperComponent.cpp
+++ b/Gems/ROS2/Code/Source/Gripper/VacuumGripperComponent.cpp
@@ -104,8 +104,7 @@ namespace ROS2
 
     void VacuumGripperComponent::OnTick(float delta, AZ::ScriptTimePoint timePoint)
     {
-        AzPhysics::SystemInterface* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
-        AZ_Assert(physicsSystem, "No physics system.");
+        AZ_Assert(AZ::Interface<AzPhysics::SystemInterface>::Get(), "No physics system.");
 
         AzPhysics::SceneInterface* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         AZ_Assert(sceneInterface, "No scene intreface.");
@@ -186,8 +185,7 @@ namespace ROS2
             // No object to grip
             return false;
         }
-        PhysX::ArticulationLinkComponent* component = m_entity->FindComponent<PhysX::ArticulationLinkComponent>();
-        AZ_Assert(component, "No PhysX::ArticulationLinkComponent found on entity ");
+        AZ_Assert(m_entity->FindComponent<PhysX::ArticulationLinkComponent>(), "No PhysX::ArticulationLinkComponent found on entity ");
 
         auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         AzPhysics::SceneHandle defaultSceneHandle = sceneInterface->GetSceneHandle(AzPhysics::DefaultPhysicsSceneName);

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
@@ -125,7 +125,7 @@ namespace ROS2
                 auto* prismaticComponent =
                     azrtti_cast<PhysX::JointComponent*>(Utils::GetGameOrEditorComponent<PhysX::PrismaticJointComponent>(entity));
                 auto* articulationComponent = Utils::GetGameOrEditorComponent<PhysX::ArticulationLinkComponent>(entity);
-                bool classicJoint = hingeComponent || prismaticComponent;
+                [[maybe_unused]] bool classicJoint = hingeComponent || prismaticComponent;
                 AZ_Warning(
                     "JointsManipulationComponent",
                     (classicJoint && supportsClassicJoints) || !classicJoint,

--- a/Gems/WarehouseAutomation/Code/Source/ConveyorBelt/ConveyorBeltComponent.cpp
+++ b/Gems/WarehouseAutomation/Code/Source/ConveyorBelt/ConveyorBeltComponent.cpp
@@ -61,8 +61,7 @@ namespace WarehouseAutomation
 
     void ConveyorBeltComponent::Activate()
     {
-        AzPhysics::SystemInterface* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
-        AZ_Assert(physicsSystem, "No physics system");
+        AZ_Assert(AZ::Interface<AzPhysics::SystemInterface>::Get(), "No physics system");
         AzPhysics::SceneInterface* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         AZ_Assert(sceneInterface, "No scene interface");
         AzPhysics::SceneHandle defaultSceneHandle = sceneInterface->GetSceneHandle(AzPhysics::DefaultPhysicsSceneName);

--- a/Templates/Ros2ProjectTemplate/Template/Gem/CMakeLists.txt
+++ b/Templates/Ros2ProjectTemplate/Template/Gem/CMakeLists.txt
@@ -112,21 +112,21 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 ${gem_name}.Private.Object
     )
 
-ly_add_target(
-    NAME ${gem_name}.Editor GEM_MODULE
-    NAMESPACE Gem
-    FILES_CMAKE
-        ${NameLower}_editor_shared_files.cmake
-    INCLUDE_DIRECTORIES
-        PRIVATE
-            Source
-        PUBLIC
-            Include
-    BUILD_DEPENDENCIES
-        PUBLIC
-            ${gem_name}.Editor.Static
-            Gem::Atom_Feature_Common.Static
-)
+    ly_add_target(
+        NAME ${gem_name}.Editor GEM_MODULE
+        NAMESPACE Gem
+        FILES_CMAKE
+            ${NameLower}_editor_shared_files.cmake
+        INCLUDE_DIRECTORIES
+            PRIVATE
+                Source
+            PUBLIC
+                Include
+        BUILD_DEPENDENCIES
+            PUBLIC
+                ${gem_name}.Editor.Static
+                Gem::Atom_Feature_Common.Static
+    )
 
 endif()
 

--- a/Templates/Ros2ProjectTemplate/Template/Gem/CMakeLists.txt
+++ b/Templates/Ros2ProjectTemplate/Template/Gem/CMakeLists.txt
@@ -128,11 +128,12 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::Atom_Feature_Common.Static
     )
 
+    ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
+    ly_create_alias(NAME ${gem_name}.Tools    NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
+
 endif()
 
 # if enabled, ${gem_name} is used by all kinds of applications
-ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
-ly_create_alias(NAME ${gem_name}.Tools    NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)
 ly_create_alias(NAME ${gem_name}.Clients  NAMESPACE Gem TARGETS Gem::${gem_name})
 ly_create_alias(NAME ${gem_name}.Servers  NAMESPACE Gem TARGETS Gem::${gem_name})
 

--- a/Templates/Ros2ProjectTemplate/Template/Gem/CMakeLists.txt
+++ b/Templates/Ros2ProjectTemplate/Template/Gem/CMakeLists.txt
@@ -86,31 +86,31 @@ ly_add_target(
             AZ::AzCore
 )
 
+if(PAL_TRAIT_BUILD_HOST_TOOLS)
 
-ly_add_target(
-    NAME ${gem_name}.Editor.Static STATIC
-    NAMESPACE Gem
-    AUTOMOC
-    AUTORCC
-    FILES_CMAKE
-        ${NameLower}_editor_files.cmake
-    INCLUDE_DIRECTORIES
-        PRIVATE
-            Source
-            Source/RobotImporter
-        PUBLIC
-            Include
-    BUILD_DEPENDENCIES
-        PUBLIC
-            Gem::ImGui.Static
-            Gem::ROS2.Static
-            AZ::AzToolsFramework
-            Gem::AtomLyIntegration_CommonFeatures.Editor.Static
-            Gem::LmbrCentral.API
-        PRIVATE
-            ${gem_name}.Private.Object
-)
-
+    ly_add_target(
+        NAME ${gem_name}.Editor.Static STATIC
+        NAMESPACE Gem
+        AUTOMOC
+        AUTORCC
+        FILES_CMAKE
+            ${NameLower}_editor_files.cmake
+        INCLUDE_DIRECTORIES
+            PRIVATE
+                Source
+                Source/RobotImporter
+            PUBLIC
+                Include
+        BUILD_DEPENDENCIES
+            PUBLIC
+                Gem::ImGui.Static
+                Gem::ROS2.Static
+                AZ::AzToolsFramework
+                Gem::AtomLyIntegration_CommonFeatures.Editor.Static
+                Gem::LmbrCentral.API
+            PRIVATE
+                ${gem_name}.Private.Object
+    )
 
 ly_add_target(
     NAME ${gem_name}.Editor GEM_MODULE
@@ -128,6 +128,7 @@ ly_add_target(
             Gem::Atom_Feature_Common.Static
 )
 
+endif()
 
 # if enabled, ${gem_name} is used by all kinds of applications
 ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)

--- a/Templates/Ros2ProjectTemplate/Template/Gem/enabled_gems.cmake
+++ b/Templates/Ros2ProjectTemplate/Template/Gem/enabled_gems.cmake
@@ -10,7 +10,6 @@ set(ENABLED_GEMS
     ${Name}
     Atom
     AudioSystem
-    AWSCore
     CameraFramework
     DebugDraw
     EditorPythonBindings


### PR DESCRIPTION
This applies suggestion from https://github.com/o3de/o3de-extras/issues/493.

~~There are linker issues still present after those changes.~~

The linker issues were caused by dependency on AWSCore Gem, that is now removed.
