### PR TITLE
Mainpulation Components - add support for initial positions namespaces.

### DIFF
--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
@@ -429,12 +429,31 @@ namespace ROS2
         }
     }
 
+    AZStd::string JointsManipulationComponent::GetManipulatorNamespace() const
+    {
+        auto* frameComponent = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(m_entity);
+        AZ_Assert(frameComponent, "ROS2FrameComponent is required for joints.");
+        return frameComponent->GetNamespace();
+    }
+
     void JointsManipulationComponent::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
         if (m_manipulationJoints.empty())
         {
+            const AZStd::string manipulatorNamespace = GetManipulatorNamespace();
+            AZStd::unordered_map<AZStd::string, JointPosition> intialPositonNamespaced;
+            AZStd::transform(
+                m_initialPositions.begin(),
+                m_initialPositions.end(),
+                AZStd::inserter(intialPositonNamespaced, intialPositonNamespaced.end()),
+                [&manipulatorNamespace](const auto& pair)
+                {
+                    return AZStd::make_pair(ROS2::ROS2Names::GetNamespacedName(manipulatorNamespace, pair.first), pair.second);
+                });
+
             m_manipulationJoints = Internal::GetAllEntityHierarchyJoints(GetEntityId());
-            Internal::SetInitialPositions(m_manipulationJoints, m_initialPositions);
+
+            Internal::SetInitialPositions(m_manipulationJoints, intialPositonNamespaced);
             if (m_manipulationJoints.empty())
             {
                 AZ_Warning("JointsManipulationComponent", false, "No manipulation joints to handle!");

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
@@ -71,13 +71,16 @@ namespace ROS2
 
         void MoveToSetPositions(float deltaTime);
 
+        AZStd::string GetManipulatorNamespace() const;
+
         AZ::Outcome<JointPosition, AZStd::string> GetJointPosition(const JointInfo& jointInfo);
         AZ::Outcome<JointVelocity, AZStd::string> GetJointVelocity(const JointInfo& jointInfo);
         AZ::Outcome<JointEffort, AZStd::string> GetJointEffort(const JointInfo& jointInfo);
 
         AZStd::unique_ptr<JointStatePublisher> m_jointStatePublisher;
         PublisherConfiguration m_jointStatePublisherConfiguration;
-        ManipulationJoints m_manipulationJoints;
-        AZStd::unordered_map<AZStd::string, JointPosition> m_initialPositions;
+        ManipulationJoints m_manipulationJoints; //!< Map of JointInfo where the key is a joint name (with namespace included)
+        AZStd::unordered_map<AZStd::string, JointPosition>
+            m_initialPositions; //!< Initial positions where the key is joint name (without namespace included)
     };
 } // namespace ROS2


### PR DESCRIPTION

Namespaces are required to support communication with multiple robots.