### PR TITLE
Robot Importer: set scale of colliders during import

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
@@ -295,6 +295,8 @@ namespace ROS2
                 assetId.ToString<AZStd::string>().c_str());
 
             Physics::PhysicsAssetShapeConfiguration shapeConfiguration;
+            auto scale = geometry->MeshShape()->Scale();
+            shapeConfiguration.m_assetScale = AZ::Vector3(scale.X(), scale.Y(), scale.Z());
             shapeConfiguration.m_useMaterialsFromAsset = false;
             if (assetId.IsValid())
             {


### PR DESCRIPTION
Fixes https://github.com/o3de/o3de-extras/issues/504.


on the left: before this change, collider is not scaled.
on the right: after change, the scale is applied correctly
![Screenshot from 2023-09-08 10-34-54](https://github.com/o3de/o3de-extras/assets/138626322/946a2d7b-c2b7-41cb-b277-667d9bb03498)


Collider has the scale set:
![image](https://github.com/o3de/o3de-extras/assets/138626322/7688c42c-29a8-4f33-a5b3-2816f1e2bc24)


