### PR TITLE
Robot Importer: Renaming duplicated asset filenames.

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -319,7 +319,7 @@ namespace ROS2::Utils
             return urdfAssetMap;
         }
         auto amentPrefixPath = Utils::GetAmentPrefixPath();
-        AZStd::set<AZStd::string> files;
+        AZStd::unordered_map<AZStd::string, unsigned int> countFilenames;
 
         for (const auto& unresolvedUrfFileName : meshesFilenames)
         {
@@ -335,8 +335,17 @@ namespace ROS2::Utils
             const bool needsVisual = visuals.contains(unresolvedUrfFileName);
             const bool needsCollider = colliders.contains(unresolvedUrfFileName);
 
-            AZ::IO::Path targetPathAssetDst(importDirectoryDst / resolvedPath.Filename());
-            AZ::IO::Path targetPathAssetTmp(importDirectoryTmp / resolvedPath.Filename());
+            AZStd::string filename = resolvedPath.Filename().String();
+            auto count = countFilenames[filename]++;
+            if (count > 0)
+            {
+                AZStd::string stem = resolvedPath.Stem().String();
+                AZStd::string extension = resolvedPath.Extension().String();
+                filename = AZStd::string::format("%s_dup_%u%s", stem.c_str(), count, extension.c_str());
+            }
+
+            AZ::IO::Path targetPathAssetDst(importDirectoryDst / filename);
+            AZ::IO::Path targetPathAssetTmp(importDirectoryTmp / filename);
 
             AZ::IO::Path targetPathAssetInfo(targetPathAssetDst.Native() + ".assetinfo");
 


### PR DESCRIPTION
Fixes https://github.com/o3de/o3de-extras/issues/514. Performs deduplication of filenames of assets by counting occurences of each filename and adding prefix to it if needed. 

With this change fanuc is imported correctly:

![Screenshot from 2023-09-12 14-24-42](https://github.com/o3de/o3de-extras/assets/138626322/edb070aa-4226-4ad8-ac9c-8be8ed5f68cb)


![Screenshot from 2023-09-12 14-25-37](https://github.com/o3de/o3de-extras/assets/138626322/146c13a4-62dd-4746-b98c-fbc490f5557b)
