### PR TITLE
Updating the Robot Importer to support importing in .sdf/.world files

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
@@ -17,7 +17,7 @@ namespace ROS2
 {
     namespace Columns
     {
-        constexpr int UrdfMeshPath{ 0 };
+        constexpr int SdfMeshPath{ 0 };
         constexpr int ResolvedMeshPath{ 1 };
         constexpr int SourceAsset{ 3 };
         constexpr int ProductAsset{ 2 };
@@ -48,10 +48,10 @@ namespace ROS2
         m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
         m_table->setSelectionMode(QAbstractItemView::SingleSelection);
         // Set the header items.
-        QTableWidgetItem* headerItem = new QTableWidgetItem(tr("URDF mesh path"));
+        QTableWidgetItem* headerItem = new QTableWidgetItem(tr("URDF/SDF mesh path"));
         headerItem->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
-        m_table->setHorizontalHeaderItem(Columns::UrdfMeshPath, headerItem);
-        headerItem = new QTableWidgetItem(tr("Resolved mesh from URDF"));
+        m_table->setHorizontalHeaderItem(Columns::SdfMeshPath, headerItem);
+        headerItem = new QTableWidgetItem(tr("Resolved mesh from URDF/SDF"));
         headerItem->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
         m_table->setHorizontalHeaderItem(Columns::ResolvedMeshPath, headerItem);
         headerItem = new QTableWidgetItem(tr("Type"));
@@ -63,7 +63,7 @@ namespace ROS2
         headerItem = new QTableWidgetItem(tr("Product asset"));
         headerItem->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
         m_table->setHorizontalHeaderItem(Columns::ProductAsset, headerItem);
-        m_table->horizontalHeader()->resizeSection(Columns::UrdfMeshPath, 200);
+        m_table->horizontalHeader()->resizeSection(Columns::SdfMeshPath, 200);
         m_table->horizontalHeader()->resizeSection(Columns::ResolvedMeshPath, 350);
         m_table->horizontalHeader()->resizeSection(Columns::Type, 50);
         m_table->horizontalHeader()->resizeSection(Columns::SourceAsset, 400);
@@ -96,11 +96,11 @@ namespace ROS2
 
     void CheckAssetPage::ReportAsset(
         const AZ::Uuid assetUuid,
-        const AZStd::string urdfPath,
+        const AZStd::string sdfPath,
         const QString& type,
         const AZStd::string assetSourcePath,
         const AZ::Crc32& crc32,
-        const AZStd::string resolvedUrdfPath)
+        const AZStd::string resolvedSdfPath)
     {
         int i = m_table->rowCount();
         m_table->setRowCount(i + 1);
@@ -112,14 +112,14 @@ namespace ROS2
         }
         SetTitle();
         AZStd::string crcStr = AZStd::to_string(crc32);
-        QTableWidgetItem* p = createCell(isOk, QString::fromUtf8(urdfPath.data(), urdfPath.size()));
+        QTableWidgetItem* p = createCell(isOk, QString::fromUtf8(sdfPath.data(), sdfPath.size()));
         if (crc32 != AZ::Crc32())
         {
             p->setToolTip(tr("CRC for file : ") + QString::fromUtf8(crcStr.data(), crcStr.size()));
         }
-        m_table->setItem(i, Columns::UrdfMeshPath, p);
+        m_table->setItem(i, Columns::SdfMeshPath, p);
         m_table->setItem(
-            i, Columns::ResolvedMeshPath, createCell(isOk, QString::fromUtf8(resolvedUrdfPath.data(), resolvedUrdfPath.size())));
+            i, Columns::ResolvedMeshPath, createCell(isOk, QString::fromUtf8(resolvedSdfPath.data(), resolvedSdfPath.size())));
         m_table->setItem(i, Columns::Type, createCell(isOk, type));
         m_table->setItem(i, Columns::SourceAsset, createCell(isOk, QString::fromUtf8(assetSourcePath.data(), assetSourcePath.size())));
         if (isOk)

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckUrdfPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckUrdfPage.cpp
@@ -17,7 +17,7 @@ namespace ROS2
         , m_warning(false)
     {
         m_log = new QTextEdit(this);
-        setTitle(tr("URDF opening results:"));
+        setTitle(tr("URDF/SDF opening results:"));
         QVBoxLayout* layout = new QVBoxLayout;
         layout->addWidget(m_log);
         m_log->acceptRichText();

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/FileSelectionPage.cpp
@@ -23,13 +23,13 @@ namespace ROS2
     {
         m_fileDialog = new QFileDialog(this);
         m_fileDialog->setDirectory(QString::fromUtf8(AZ::Utils::GetProjectPath().data()));
-        m_fileDialog->setNameFilter("URDF, XACRO (*.urdf *.xacro)");
+        m_fileDialog->setNameFilter("URDF, XACRO, SDF, WORLD (*.urdf *.xacro *.sdf *.world)");
         m_button = new QPushButton("...", this);
         m_textEdit = new QLineEdit("", this);
-        setTitle(tr("Load URDF file"));
+        setTitle(tr("Load URDF/SDF file"));
         QVBoxLayout* layout = new QVBoxLayout;
         layout->addStretch();
-        layout->addWidget(new QLabel(tr("URDF file path to load : "), this));
+        layout->addWidget(new QLabel(tr("URDF/SDF file path to load : "), this));
         QHBoxLayout* layoutHorizontal = new QHBoxLayout;
         layoutHorizontal->addWidget(m_button);
         layoutHorizontal->addWidget(m_textEdit);

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/IntroPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/IntroPage.cpp
@@ -17,7 +17,7 @@ namespace ROS2
         setTitle(QObject::tr("Introduction"));
 
         m_label = new QLabel(
-            QObject::tr("This wizard allows you to build a robot prefab using a URDF description file or object/environment prefab using a SDF file."
+            QObject::tr("This wizard allows you to build a robot prefab using a URDF description file or object/environment prefab using an SDF file."
                         " Before processing, please make sure that all of the robot's description packages have been built and sourced."
                         " Details can be found <a "
                         "href=\"https://www.o3de.org/docs/user-guide/interactivity/robotics/importing-robot/"

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/IntroPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/IntroPage.cpp
@@ -17,7 +17,7 @@ namespace ROS2
         setTitle(QObject::tr("Introduction"));
 
         m_label = new QLabel(
-            QObject::tr("This wizard allows you to build a robot prefab using a URDF description file."
+            QObject::tr("This wizard allows you to build a robot prefab using a URDF description file or object/environment prefab using a SDF file."
                         " Before processing, please make sure that all of the robot's description packages have been built and sourced."
                         " Details can be found <a "
                         "href=\"https://www.o3de.org/docs/user-guide/interactivity/robotics/importing-robot/"
@@ -25,7 +25,7 @@ namespace ROS2
                         " The Open 3D Engine can only use files in its internal <a "
                         "href=\"https://www.o3de.org/docs/user-guide/assets/asset-types/\">format</a>."
                         "During the import process, the assets will be imported and processed."
-                        "A level must be opened before using the URDF Importer."));
+                        "A level must be opened before using the URDF/SDF Importer."));
         m_label->setTextFormat(Qt::RichText);
         m_label->setOpenExternalLinks(true);
         m_label->setWordWrap(true);

--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -7,18 +7,17 @@
  */
 
 #include "ROS2RobotImporterEditorSystemComponent.h"
-#include <RobotImporter/URDF/UrdfParser.h>
-#include <RobotImporter/Utils/FilePath.h>
-#include <RobotImporter/Utils/ErrorUtils.h>
 #include "RobotImporterWidget.h"
-#include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/StringFunc/StringFunc.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzCore/std/chrono/chrono.h>
 #include <AzCore/std/string/string.h>
-#include <AzCore/StringFunc/StringFunc.h>
 #include <AzToolsFramework/API/ViewPaneOptions.h>
-
+#include <RobotImporter/URDF/UrdfParser.h>
+#include <RobotImporter/Utils/ErrorUtils.h>
+#include <RobotImporter/Utils/FilePath.h>
+#include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
 
 #include <sdf/sdf.hh>
 
@@ -111,17 +110,16 @@ namespace ROS2
         {
             const AZStd::string log = Utils::JoinSdfErrorsToString(parsedSdfOutcome.GetSdfErrors());
 
-            AZ_Warning("ROS2RobotImporterEditorSystemComponent", false, "URDF/SDF parsing failed with errors:\nRefer to %s",
-                log.c_str());
+            AZ_Warning("ROS2RobotImporterEditorSystemComponent", false, "URDF/SDF parsing failed with errors:\nRefer to %s", log.c_str());
             return false;
         }
 
         // Urdf Root has been parsed successfully retrieve it from the Outcome
         const sdf::Root& parsedSdfRoot = parsedSdfOutcome.GetRoot();
 
-        auto collidersNames = Utils::GetMeshesFilenames(&parsedSdfRoot, false, true);
-        auto visualNames = Utils::GetMeshesFilenames(&parsedSdfRoot, true, false);
-        auto meshNames = Utils::GetMeshesFilenames(&parsedSdfRoot, true, true);
+        auto collidersNames = Utils::GetMeshesFilenames(parsedSdfRoot, false, true);
+        auto visualNames = Utils::GetMeshesFilenames(parsedSdfRoot, true, false);
+        auto meshNames = Utils::GetMeshesFilenames(parsedSdfRoot, true, true);
         AZStd::shared_ptr<Utils::UrdfAssetMap> urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>();
         if (importAssetWithUrdf)
         {
@@ -176,33 +174,26 @@ namespace ROS2
                 {
                     if (job.m_status == JobStatus::Queued || job.m_status == JobStatus::InProgress)
                     {
-                        AZ_Printf("ROS2RobotImporterEditorSystemComponent", "asset %s is being processed", sourceAssetFullPath.c_str());
+                        AZ_Printf("ROS2RobotImporterEditorSystemComponent", "asset %s is being processed\n", sourceAssetFullPath.c_str());
                         allAssetProcessed = false;
                     }
                     else
                     {
-                        AZ_Printf("ROS2RobotImporterEditorSystemComponent", "asset %s is done", sourceAssetFullPath.c_str());
+                        AZ_Printf("ROS2RobotImporterEditorSystemComponent", "asset %s is done\n", sourceAssetFullPath.c_str());
                     }
                 }
             }
 
             if (allAssetProcessed && !assetProcessorFailed)
             {
-                AZ_Printf("ROS2RobotImporterEditorSystemComponent", "All assets processed");
+                AZ_Printf("ROS2RobotImporterEditorSystemComponent", "All assets processed\n");
             }
         };
 
-        // Use the name of the first model tag in the SDF for the prefab
-        // Otherwise use the name of the first world tag in the SDF
+        // Use the name of the first world model tag in the SDF for the prefab
+        // Otherwise use the name of the first model that can be found in the SDF root or world tag
         AZStd::string prefabName;
-        if (const sdf::Model* model = parsedSdfRoot.Model();
-            model != nullptr)
-        {
-            prefabName = AZStd::string(model->Name().c_str(), model->Name().size()) + ".prefab";
-        }
-
-        if (uint64_t urdfWorldCount = parsedSdfRoot.WorldCount();
-            prefabName.empty() && urdfWorldCount > 0)
+        if (uint64_t urdfWorldCount = parsedSdfRoot.WorldCount(); urdfWorldCount > 0)
         {
             const sdf::World* parsedUrdfWorld = parsedSdfRoot.WorldByIndex(0);
             prefabName = AZStd::string(parsedUrdfWorld->Name().c_str(), parsedUrdfWorld->Name().size()) + ".prefab";
@@ -210,21 +201,46 @@ namespace ROS2
 
         if (prefabName.empty())
         {
-            AZ_Error("ROS2RobotImporterEditorSystemComponent", false, R"(URDF/SDF doesn't contain a <model> or <world> "%.*s".)"
-                " O3DE Prefab cannot be created", AZ_STRING_ARG(filePath));
+            auto GetFirstModelName = [&prefabName](const sdf::Model& model) -> Utils::VisitModelResponse
+            {
+                prefabName = AZStd::string(model.Name().c_str(), model.Name().size()) + ".prefab";
+                // Stop visitation after the first call to this functor
+                return Utils::VisitModelResponse::Stop;
+            };
+            Utils::VisitModels(parsedSdfRoot, GetFirstModelName);
+        }
+
+        // Use the file path stem as a fallback name for the prefab
+        if (prefabName.empty())
+        {
+            prefabName = AZStd::string(AZ::IO::PathView(prefabName).Stem().Native());
+        }
+
+        if (prefabName.empty())
+        {
+            AZ_Error(
+                "ROS2RobotImporterEditorSystemComponent",
+                false,
+                R"(URDF/SDF doesn't contain a <model> or <world> "%.*s".)"
+                " O3DE Prefab cannot be created",
+                AZ_STRING_ARG(filePath));
             return false;
         }
 
-
         const AZ::IO::Path prefabPathRelative(AZ::IO::Path("Assets") / "Importer" / prefabName);
         const AZ::IO::Path prefabPath(AZ::IO::Path(AZ::Utils::GetProjectPath()) / prefabPathRelative);
-        AZStd::unique_ptr<URDFPrefabMaker> prefabMaker = AZStd::make_unique<URDFPrefabMaker>(filePath, &parsedSdfRoot, prefabPath.String(), urdfAssetsMapping, useArticulation);
+        AZStd::unique_ptr<URDFPrefabMaker> prefabMaker =
+            AZStd::make_unique<URDFPrefabMaker>(filePath, &parsedSdfRoot, prefabPath.String(), urdfAssetsMapping, useArticulation);
 
         auto prefabOutcome = prefabMaker->CreatePrefabFromUrdfOrSdf();
 
         if (!prefabOutcome.IsSuccess())
         {
-            AZ_Error("ROS2RobotImporterEditorSystemComponent", false, "Unable to create Prefab from URDF/SDF file %s", filePath.data());
+            AZ_Error(
+                "ROS2RobotImporterEditorSystemComponent",
+                false,
+                "Unable to create Prefab from URDF/SDF file %.*s",
+                AZ_STRING_ARG(filePath));
             return false;
         }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -190,38 +190,15 @@ namespace ROS2
             }
         };
 
-        // Use the name of the first world model tag in the SDF for the prefab
-        // Otherwise use the name of the first model that can be found in the SDF root or world tag
-        AZStd::string prefabName;
-        if (uint64_t urdfWorldCount = parsedSdfRoot.WorldCount(); urdfWorldCount > 0)
-        {
-            const sdf::World* parsedUrdfWorld = parsedSdfRoot.WorldByIndex(0);
-            prefabName = AZStd::string(parsedUrdfWorld->Name().c_str(), parsedUrdfWorld->Name().size()) + ".prefab";
-        }
-
-        if (prefabName.empty())
-        {
-            auto GetFirstModelName = [&prefabName](const sdf::Model& model) -> Utils::VisitModelResponse
-            {
-                prefabName = AZStd::string(model.Name().c_str(), model.Name().size()) + ".prefab";
-                // Stop visitation after the first call to this functor
-                return Utils::VisitModelResponse::Stop;
-            };
-            Utils::VisitModels(parsedSdfRoot, GetFirstModelName);
-        }
-
-        // Use the file path stem as a fallback name for the prefab
-        if (prefabName.empty())
-        {
-            prefabName = AZStd::string(AZ::IO::PathView(prefabName).Stem().Native());
-        }
+        // Use the URDF/SDF file name stem the prefab name
+        AZStd::string prefabName = AZStd::string(AZ::IO::PathView(filePath).Stem().Native());
 
         if (prefabName.empty())
         {
             AZ_Error(
                 "ROS2RobotImporterEditorSystemComponent",
                 false,
-                R"(URDF/SDF doesn't contain a <model> or <world> "%.*s".)"
+                R"(URDF/SDF doesn't filename doesn't contain a stem "%.*s".)"
                 " O3DE Prefab cannot be created",
                 AZ_STRING_ARG(filePath));
             return false;

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -310,32 +310,8 @@ namespace ROS2
 
     void RobotImporterWidget::FillPrefabMakerPage()
     {
-        // Use the name of the first world tag for the prefab,
-        // followed by the name of the first model that can be found if there is no world tag
-        // otherwise fallback to using the URDF/SDF file name stem
-        AZStd::string robotName;
-        if (uint64_t urdfWorldCount = m_parsedSdf.WorldCount(); urdfWorldCount > 0)
-        {
-            const sdf::World* parsedUrdfWorld = m_parsedSdf.WorldByIndex(0);
-            robotName = AZStd::string(parsedUrdfWorld->Name().c_str(), parsedUrdfWorld->Name().size()) + ".prefab";
-        }
-
-        if (robotName.empty())
-        {
-            auto GetFirstModelName = [&robotName](const sdf::Model& model) -> Utils::VisitModelResponse
-            {
-                robotName = AZStd::string(model.Name().c_str(), model.Name().size()) + ".prefab";
-                // Stop visitation after the first call to this functor
-                return Utils::VisitModelResponse::Stop;
-            };
-            Utils::VisitModels(m_parsedSdf, GetFirstModelName);
-        }
-
-        // Use the URDF/SDF file name as fallback for the prefab name
-        if (robotName.empty())
-        {
-            robotName = AZStd::string(m_urdfPath.Stem().Native());
-        }
+        // Use the URDF/SDF file name stem the prefab name
+        AZStd::string robotName = AZStd::string(m_urdfPath.Stem().Native());
         m_prefabMakerPage->setProposedPrefabName(robotName);
         QWizard::button(PrefabCreationButtonId)->setText(tr("Create Prefab"));
         QWizard::setOption(HavePrefabCreationButton, true);

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -69,7 +69,7 @@ namespace ROS2
         PrefabMakerPage* m_prefabMakerPage;
         XacroParamsPage* m_xacroParamsPage;
         AZ::IO::Path m_urdfPath;
-        sdf::Root m_parsedUrdf{};
+        sdf::Root m_parsedSdf{};
 
         //! User's choice to copy meshes during urdf import
         bool m_importAssetWithUrdf{ false };

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.cpp
@@ -38,7 +38,7 @@ namespace ROS2
         AZ_Warning(
             "ArticulationsMaker",
             supportedArticulationType != SupportedJointTypes.end(),
-            "Articulations do not support type %d for URDF joint %s.",
+            "Articulations do not support type %d for URDF/SDF joint %s.",
             static_cast<int>(joint->Type()),
             joint->Name().c_str());
         if (supportedArticulationType != SupportedJointTypes.end())
@@ -95,7 +95,7 @@ namespace ROS2
 
         if (!URDF::TypeConversions::ConvertQuaternion(inertial.Pose().Rot()).IsIdentity())
         { // There is a rotation component in URDF that we are not able to apply
-            AZ_Warning("AddArticulationLink", false, "Ignoring URDF inertial origin rotation (no such field in rigid body configuration)");
+            AZ_Warning("AddArticulationLink", false, "Ignoring URDF/SDF inertial origin rotation (no such field in rigid body configuration)");
         }
         return articulationLinkConfiguration;
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.h
@@ -22,7 +22,7 @@ namespace ROS2
         //! Add zero or one inertial and joints elements to a given entity (depending on link content).
         //! @param model SDF model object which can be queried to locate the joints needed to determine if the supplied
         //!              link is a child link within a joint
-        //! @param link A pointer to a parsed URDF link.
+        //! @param link A pointer to a parsed SDF link.
         //! @param entityId A non-active entity which will be populated according to inertial content.
         void AddArticulationLink(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId) const;
     };

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
@@ -108,7 +108,7 @@ namespace ROS2
                 AZ_Error(
                     Internal::CollidersMakerLoggingTag,
                     false,
-                    "Error loading collider. Invalid scene: %s, URDF path: %s",
+                    "Error loading collider. Invalid scene: %s, URDF/SDF path: %s",
                     azMeshPath.c_str(),
                     meshGeometry->Uri().c_str());
                 return;
@@ -305,7 +305,7 @@ namespace ROS2
             return;
         }
 
-        AZ_Printf(Internal::CollidersMakerLoggingTag, "URDF geometry type: %d\n", (int)geometry->Type());
+        AZ_Printf(Internal::CollidersMakerLoggingTag, "URDF/SDF geometry type: %d\n", (int)geometry->Type());
         switch (geometry->Type())
         {
         case sdf::GeometryType::SPHERE:

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.h
@@ -30,19 +30,19 @@ namespace ROS2
     class CollidersMaker
     {
     public:
-        //! Construct the class based on URDF asset mapping.
-        //! @param urdfAssetsMapping a prepared mapping of Assets used by the source URDF.
-        CollidersMaker(const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping);
+        //! Construct the class based on SDF asset mapping.
+        //! @param sdfAssetsMapping a prepared mapping of Assets used by the source URDF/SDF.
+        CollidersMaker(const AZStd::shared_ptr<Utils::UrdfAssetMap>& sdfAssetsMapping);
 
         //! Prevent copying of existing CollidersMaker
         CollidersMaker(const CollidersMaker& other) = delete;
 
         //! Builds .pxmeshes for every collider in link collider mesh.
-        //! @param link A parsed URDF tree link node which could hold information about colliders.
+        //! @param link A parsed SDF tree link node which could hold information about colliders.
         void BuildColliders(const sdf::Link* link);
         //! Add zero, one or many collider elements (depending on link content).
-        //! @param model An SDF model object provided by libsdformat from a parsed URDF
-        //! @param link A parsed URDF tree link node which could hold information about colliders.
+        //! @param model An SDF model object provided by libsdformat from a parsed URDF/SDF
+        //! @param link A parsed SDF tree link node which could hold information about colliders.
         //! @param entityId A non-active entity which will be affected.
         void AddColliders(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId);
         //! Sends meshes required for colliders to asset processor.

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
@@ -35,7 +35,7 @@ namespace ROS2
 
         if (!URDF::TypeConversions::ConvertQuaternion(inertial.Pose().Rot()).IsIdentity())
         { // There is a rotation component in URDF that we are not able to apply
-            AZ_Warning("AddInertial", false, "Ignoring URDF inertial origin rotation (no such field in rigid body configuration)");
+            AZ_Warning("AddInertial", false, "Ignoring URDF/SDF inertial origin rotation (no such field in rigid body configuration)");
         }
 
         auto moi = inertial.Moi();

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/InertialsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/InertialsMaker.h
@@ -18,7 +18,7 @@ namespace ROS2
     {
     public:
         //! Add zero or one inertial elements to a given entity (depending on link content).
-        //! @param inertial A pointer to a parsed URDF inertial structure, might be null.
+        //! @param inertial A pointer to a parsed SDF inertial structure, might be null.
         //! @param entityId A non-active entity which will be populated according to inertial content.
         void AddInertial(const gz::math::Inertiald& inertial, AZ::EntityId entityId) const;
     };

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.cpp
@@ -24,10 +24,10 @@ namespace ROS2
         AZ::Entity* followColliderEntity = AzToolsFramework::GetEntityById(followColliderEntityId);
         PhysX::EditorJointComponent* jointComponent = nullptr;
 
-        // URDF has a joint axis configurable by a normalized vector - that is given by the 'axis' sub-element in the joint element.
+        // URDF/SDF has a joint axis configurable by a normalized vector - that is given by the 'axis' sub-element in the joint element.
         // The o3de has a slightly different way of configuring the axis of the joint. The o3de has an axis around positive `X` and rotation
         // with Euler angles can be applied to configure the desirable direction of the joint. A quaternion that transforms a unit vector X
-        // {1,0,0} to a vector given by the URDF joint need to be found. Heavily suboptimal element in this conversion is needed of
+        // {1,0,0} to a vector given by the URDF/SDF joint need to be found. Heavily suboptimal element in this conversion is needed of
         // converting the unit quaternion to Euler vector.
         const AZ::Vector3 o3deJointDir{ 1.0, 0.0, 0.0 };
         const sdf::JointAxis* jointAxis = joint->Axis();
@@ -42,7 +42,7 @@ namespace ROS2
 
         AZ_Printf(
             "JointsMaker",
-            "Quaternion from URDF to o3de %f, %f, %f, %f",
+            "Quaternion from URDF/SDF to o3de %f, %f, %f, %f",
             quaternion.GetX(),
             quaternion.GetY(),
             quaternion.GetZ(),
@@ -114,7 +114,7 @@ namespace ROS2
                         : -AZ::RadToDeg(AZ::Constants::TwoPi);
                     AZ_Printf(
                         "JointsMaker",
-                        "Setting limits : upper: %.1f lower: %.1f (URDF:%f,%f)",
+                        "Setting limits : upper: %.1f lower: %.1f (URDF/SDF:%f,%f)",
                         limitUpper,
                         limitLower,
                         jointAxis->Upper(),

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/JointsMaker.h
@@ -16,13 +16,13 @@
 namespace ROS2
 {
     //! Populates a given entity with all the contents of the <joint> tag in robot description.
-    //! In URDF, joints are specified between two given links, but in PhysX they are between two Bodies / Colliders.
+    //! In URDF/SDF, joints are specified between two given links, but in PhysX they are between two Bodies / Colliders.
     class JointsMaker
     {
     public:
         using JointsMakerResult = AZ::Outcome<AZ::ComponentId, AZStd::string>;
 
-        //! Add a joint to an entity and sets it accordingly to urdf::Joint
+        //! Add a joint to an entity and sets it accordingly to sdf::Joint
         //! @param joint Joint data
         //! @param followColliderEntityId A non-active entity which will be populated with Joint components.
         //! @param leadColliderEntityId An entity higher in hierarchy which is connected through the joint with the child entity.

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/PrefabMakerUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/PrefabMakerUtils.h
@@ -48,19 +48,19 @@ namespace ROS2::PrefabMakerUtils
 
     //! Create an entity name from arguments.
     //! @param rootName root of entity's name.
-    //! @param type type of entity, depending on corresponding URDF tag. For example, "visual".
+    //! @param type type of entity, depending on corresponding SDF tag. For example, "visual".
     //! @param index index of entity, useful when multiple visuals or colliders are present for a single link.
     //! @return entity name, for example "robotBumper_visual_1".
     AZStd::string MakeEntityName(const AZStd::string& rootName, const AZStd::string& type, size_t index = 0);
 
     //! Get an Asset for a specified mesh given its path and mapping.
-    //! @param urdfAssetsMapping mapping of URDF assets.
-    //! @param urdfMeshPath a path to the mesh for which the Asset is requested.
+    //! @param sdfAssetsMapping mapping of SDF assets.
+    //! @param sdfMeshPath a path to the mesh for which the Asset is requested.
     //! @return Asset for the mesh, if found in the mapping.
     AZStd::optional<Utils::AvailableAsset> GetAssetFromPath(
-        const Utils::UrdfAssetMap& urdfAssetsMapping, const AZStd::string& urdfMeshPath);
+        const Utils::UrdfAssetMap& sdfAssetsMapping, const AZStd::string& sdfMeshPath);
 
     //! Get Asset from path. Version for std::string.
     //! @see GetAssetFromPath.
-    AZStd::optional<Utils::AvailableAsset> GetAssetFromPath(const Utils::UrdfAssetMap& urdfAssetsMapping, const std::string& urdfMeshPath);
+    AZStd::optional<Utils::AvailableAsset> GetAssetFromPath(const Utils::UrdfAssetMap& sdfAssetsMapping, const std::string& sdfMeshPath);
 } // namespace ROS2::PrefabMakerUtils

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -116,7 +116,7 @@ namespace ROS2
         Utils::VisitJoints(*GetFirstModel(), BuildAssetsFromJointChildLinks, visitNestedModelLinks);
     }
 
-    URDFPrefabMaker::CreatePrefabTemplateResult URDFPrefabMaker::CreatePrefabTemplateFromURDF()
+    URDFPrefabMaker::CreatePrefabTemplateResult URDFPrefabMaker::CreatePrefabTemplateFromUrdfOrSdf()
     {
         {
             AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
@@ -141,7 +141,7 @@ namespace ROS2
         for (const auto& [name, result] : createdLinks)
         {
             AZ_Trace(
-                "CreatePrefabFromURDF",
+                "CreatePrefabFromUrdfOrSdf",
                 "Link with name %s was created as: %s\n",
                 name.c_str(),
                 result.IsSuccess() ? (result.GetValue().ToString().c_str()) : ("[Failed]"));
@@ -170,7 +170,7 @@ namespace ROS2
                     if (transformInterface)
                     {
                         AZ_Trace(
-                            "CreatePrefabFromURDF",
+                            "CreatePrefabFromUrdfOrSdf",
                             "Setting transform %s %s to [%f %f %f] [%f %f %f %f]\n",
                             name.c_str(),
                             thisEntry.GetValue().ToString().c_str(),
@@ -185,7 +185,7 @@ namespace ROS2
                     }
                     else
                     {
-                        AZ_Trace("CreatePrefabFromURDF", "Setting transform failed: %s does not have transform interface\n", name.c_str());
+                        AZ_Trace("CreatePrefabFromUrdfOrSdf", "Setting transform failed: %s does not have transform interface\n", name.c_str());
                     }
                 }
             }
@@ -198,7 +198,7 @@ namespace ROS2
             const auto linkPrefabResult = createdLinks.at(linkName);
             if (!linkPrefabResult.IsSuccess())
             {
-                AZ_Trace("CreatePrefabFromURDF", "Link %s creation failed\n", linkName.c_str());
+                AZ_Trace("CreatePrefabFromUrdfOrSdf", "Link %s creation failed\n", linkName.c_str());
                 continue;
             }
 
@@ -213,7 +213,7 @@ namespace ROS2
                 {
                     linkEntityIdsWithoutParent.emplace_back(linkPrefabResult.GetValue());
                 }
-                AZ_Trace("CreatePrefabFromURDF", "Link %s has no parents\n", linkName.c_str());
+                AZ_Trace("CreatePrefabFromUrdfOrSdf", "Link %s has no parents\n", linkName.c_str());
                 continue;
             }
 
@@ -235,20 +235,20 @@ namespace ROS2
             const auto parentEntry = createdLinks.find(parentName);
             if (parentEntry == createdLinks.end())
             {
-                AZ_Trace("CreatePrefabFromURDF", "Link %s has invalid parent name %s\n", linkName.c_str(), parentName.c_str());
+                AZ_Trace("CreatePrefabFromUrdfOrSdf", "Link %s has invalid parent name %s\n", linkName.c_str(), parentName.c_str());
                 continue;
             }
             if (!parentEntry->second.IsSuccess())
             {
-                AZ_Trace("CreatePrefabFromURDF", "Link %s has parent %s which has failed to create\n", linkName.c_str(), parentName.c_str());
+                AZ_Trace("CreatePrefabFromUrdfOrSdf", "Link %s has parent %s which has failed to create\n", linkName.c_str(), parentName.c_str());
                 continue;
             }
             AZ_Trace(
-                "CreatePrefabFromURDF",
+                "CreatePrefabFromUrdfOrSdf",
                 "Link %s setting parent to %s\n",
                 linkPrefabResult.GetValue().ToString().c_str(),
                 parentEntry->second.GetValue().ToString().c_str());
-            AZ_Trace("CreatePrefabFromURDF", "Link %s setting parent to %s\n", linkName.c_str(), parentName.c_str());
+            AZ_Trace("CreatePrefabFromUrdfOrSdf", "Link %s setting parent to %s\n", linkName.c_str(), parentName.c_str());
             PrefabMakerUtils::SetEntityParent(linkPrefabResult.GetValue(), parentEntry->second.GetValue());
         }
 
@@ -264,7 +264,7 @@ namespace ROS2
             auto parentLinkIter = createdLinks.find(parentLinkName);
             if (parentLinkIter == createdLinks.end())
             {
-                AZ_Warning("CreatePrefabFromURDF", false, "Joint %s has no parent link %s. Cannot create", azJointName.c_str(), parentLinkName.c_str());
+                AZ_Warning("CreatePrefabFromUrdfOrSdf", false, "Joint %s has no parent link %s. Cannot create", azJointName.c_str(), parentLinkName.c_str());
                 return true;
             }
             auto leadEntity = parentLinkIter->second;
@@ -272,13 +272,13 @@ namespace ROS2
             auto childLinkIter = createdLinks.find(childLinkName);
             if (childLinkIter == createdLinks.end())
             {
-                AZ_Warning("CreatePrefabFromURDF", false, "Joint %s has no child link %s. Cannot create", azJointName.c_str(), childLinkName.c_str());
+                AZ_Warning("CreatePrefabFromUrdfOrSdf", false, "Joint %s has no child link %s. Cannot create", azJointName.c_str(), childLinkName.c_str());
                 return true;
             }
             auto childEntity = childLinkIter->second;
 
             AZ_Trace(
-                "CreatePrefabFromURDF",
+                "CreatePrefabFromUrdfOrSdf",
                 "Creating joint %s : %s -> %s\n",
                 azJointName.c_str(),
                 parentLinkName.c_str(),
@@ -306,7 +306,7 @@ namespace ROS2
                 }
                 else
                 {
-                    AZ_Warning("CreatePrefabFromURDF", false, "cannot create joint %s", azJointName.c_str());
+                    AZ_Warning("CreatePrefabFromUrdfOrSdf", false, "cannot create joint %s", azJointName.c_str());
                 }
             }
             return true;
@@ -353,16 +353,16 @@ namespace ROS2
 
         if (prefabTemplateId == AzToolsFramework::Prefab::InvalidTemplateId)
         {
-            AZ_Error("CreatePrefabFromURDF", false, "Could not create a prefab template for entities.");
+            AZ_Error("CreatePrefabFromUrdfOrSdf", false, "Could not create a prefab template for entities.");
             return AZ::Failure("Could not create a prefab template for entities.");
         }
 
-        AZ_Info("CreatePrefabFromURDF", "Successfully created prefab %s\n", m_prefabPath.c_str());
+        AZ_Info("CreatePrefabFromUrdfOrSdf", "Successfully created prefab %s\n", m_prefabPath.c_str());
 
         return AZ::Success(prefabTemplateId);
     }
 
-    URDFPrefabMaker::CreatePrefabTemplateResult URDFPrefabMaker::CreatePrefabFromURDF()
+    URDFPrefabMaker::CreatePrefabTemplateResult URDFPrefabMaker::CreatePrefabFromUrdfOrSdf()
     {
         // Begin an undo batch for prefab creation process
         AzToolsFramework::UndoSystem::URSequencePoint* currentUndoBatch = nullptr;
@@ -373,7 +373,7 @@ namespace ROS2
             AZ_Warning("URDF Prefab Maker", false, "Unable to start undobatch, EBus might not be listening");
         }
 
-        auto result = CreatePrefabTemplateFromURDF();
+        auto result = CreatePrefabTemplateFromUrdfOrSdf();
         if (!result.IsSuccess())
         {
             // End undo batch labeled "Robot Importer prefab creation" preemptively if an error occurs

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -127,7 +127,7 @@ namespace ROS2
 
         if (!ContainsModel())
         {
-            return AZ::Failure(AZStd::string("URDF/SDF doesn't containg any models."));
+            return AZ::Failure(AZStd::string("URDF/SDF doesn't contain any models."));
         }
 
         // Build up a list of all entities created as a part of processing the file.

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -74,8 +74,8 @@ namespace ROS2
         void AddRobotControl(AZ::EntityId rootEntityId);
         static void MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId, AZStd::optional<AZ::Transform> spawnPosition);
 
-        // Returns the <model> at the root of the SDF or the first <world><model> if it exist
-        const sdf::Model* GetFirstModel() const;
+        // Returns if SDF document contains any model objects, be that at the root or within an <world> tag
+        bool ContainsModel() const;
 
         const sdf::Root* m_root;
         AZStd::string m_prefabPath;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -27,21 +27,21 @@
 
 namespace ROS2
 {
-    //! Encapsulates constructive mapping of URDF elements to a complete prefab with entities and components
+    //! Encapsulates constructive mapping of SDF elements to a complete prefab with entities and components
     class URDFPrefabMaker
     {
     public:
-        //! Construct URDFPrefabMaker from arguments.
-        //! @param modelFilePath path to the source URDF model.
+        //! Construct PrefabMaker from arguments.
+        //! @param modelFilePath path to the source URDF/SDF model or world.
         //! @param root parsed SDF root object.
         //! @param prefabPath path to the prefab which will be created as a result of import.
-        //! @param urdfAssetsMapping prepared mapping of URDF meshes to Assets.
-        //! @param useArticulations allows urdfImporter to create PhysXArticulations instead of multiple rigid bodies and joints.
+        //! @param urdfAssetsMapping prepared mapping of SDF meshes to Assets.
+        //! @param useArticulations allows sdfImporter to create PhysXArticulations instead of multiple rigid bodies and joints.
         URDFPrefabMaker(
             const AZStd::string& modelFilePath,
             const sdf::Root* root,
             AZStd::string prefabPath,
-            const AZStd::shared_ptr<Utils::UrdfAssetMap> urdfAssetsMapping,
+            const AZStd::shared_ptr<Utils::UrdfAssetMap> sdfAssetsMapping,
             bool useArticulations = false,
             AZStd::optional<AZ::Transform> spawnPosition = AZStd::nullopt);
 
@@ -51,14 +51,14 @@ namespace ROS2
         //! and an error string on failure.
         using CreatePrefabTemplateResult = AZ::Outcome<AzToolsFramework::Prefab::TemplateId, AZStd::string>;
 
-        //! Create and return a prefab template corresponding to the URDF model as set through the constructor.
+        //! Create and return a prefab template corresponding to the SDF model as set through the constructor.
         //! This will also instantiate the prefab template into the level.
         //! @return result which is either the prefab template id containing the imported model or an error message.
-        CreatePrefabTemplateResult CreatePrefabFromURDF();
+        CreatePrefabTemplateResult CreatePrefabFromUrdfOrSdf();
 
-        //! Create and return a prefab template id corresponding to the URDF model set in the constructor.
+        //! Create and return a prefab template id corresponding to the URDF/SDF model/world set in the constructor.
         //! @return result which is either the prefab template id or an error message.
-        CreatePrefabTemplateResult CreatePrefabTemplateFromURDF();
+        CreatePrefabTemplateResult CreatePrefabTemplateFromUrdfOrSdf();
 
         //! Get path to the prefab resulting from the import.
         //! @return path to the prefab.

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
@@ -102,15 +102,14 @@ namespace ROS2::UrdfParser
         {
             RedirectSDFOutputStream redirectConsoleStreamMsg(sdf::Console::Instance()->GetMsgStream(), parseStringStream);
             parseResult.m_sdfErrors = parseResult.m_root.LoadSdfString(xmlString, parserConfig);
-            // Get any captured sdf::Error messages
         }
-        const auto & parseMessages = parseStringStream.str();
+        // Get any captured sdf::Console messages
+        const auto& parseMessages = parseStringStream.str();
 
-        // regular exprsion to escape console's color codes
+        // regular expression to escape console's color codes
         const AZStd::regex escapeColor("\x1B\\[[0-9;]*[A-Za-z]");
 
         parseResult.m_parseMessages =  AZStd::regex_replace(AZStd::string(parseMessages.c_str(), parseMessages.size()),escapeColor, "");
-        AZ_Printf("ROS2", "SDF Stream: %s", parseResult.m_parseMessages.c_str());
 
         // if there are no parse errors return the sdf Root object otherwise return the errors
         return parseResult;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.h
@@ -23,82 +23,86 @@
 #include <sdf/Root.hh>
 #include <sdf/Visual.hh>
 
-namespace ROS2
+namespace ROS2::UrdfParser
 {
-    //! Class for parsing URDF data.
-    namespace UrdfParser
+    //! Functions for parsing URDF/SDF data.
+
+    //! Stores the result of parsing URDF/SDF data
+    //! The operator bool returns true if the sdf::Errors vector is empty
+    struct ParseResult
     {
-        //! Stores the result of parsing URDF data
-        //! The operator bool returns true if the sdf::Errors vector is empty
-        struct ParseResult
-        {
-        private:
-            // Provides custom sdf::ErrorCode values when parsing is done through O3DE
-            inline static constexpr auto O3DESdfErrorCodeStart = static_cast<sdf::ErrorCode>(1000);
+    private:
+        // Provides custom sdf::ErrorCode values when parsing is done through O3DE
+        inline static constexpr auto O3DESdfErrorCodeStart = static_cast<sdf::ErrorCode>(1000);
 
-        public:
-            inline static constexpr auto O3DESdfErrorParseNotStarted =
-                static_cast<sdf::ErrorCode>(static_cast<int>(O3DESdfErrorCodeStart) + 1);
+    public:
+        inline static constexpr auto O3DESdfErrorParseNotStarted = static_cast<sdf::ErrorCode>(static_cast<int>(O3DESdfErrorCodeStart) + 1);
 
-            //! Ref qualifier overloads for retrieving sdf::Root
-            //! it supports a non-const lvalue overload to allow
-            //! modification of the sdf::Root object directly
-            sdf::Root& GetRoot() &;
-            const sdf::Root& GetRoot() const&;
-            sdf::Root&& GetRoot() &&;
+        //! Ref qualifier overloads for retrieving sdf::Root
+        //! it supports a non-const lvalue overload to allow
+        //! modification of the sdf::Root object directly
+        sdf::Root& GetRoot() &;
+        const sdf::Root& GetRoot() const&;
+        sdf::Root&& GetRoot() &&;
 
-            //! Property getters for retrieving parsing messages
-            //! logged during libsdformat parsing of the URDF content
-            //! This does not support a non-const lvalue overload
-            //! As modification the result structure parser messages
-            //! have no need to be modified inplace
-            const AZStd::string& GetParseMessages() const&;
-            AZStd::string&& GetParseMessages() &&;
+        //! Property getters for retrieving parsing messages
+        //! logged during libsdformat parsing of the URDF content
+        //! This does not support a non-const lvalue overload
+        //! As modification the result structure parser messages
+        //! have no need to be modified inplace
+        const AZStd::string& GetParseMessages() const&;
+        AZStd::string&& GetParseMessages() &&;
 
-            //! Returns the sdf::Error vector containing any parser errors
-            //! This does not support a non-const lvalue overload
-            //! As modification the result structure sdf Errors
-            //! have no need to be modified inplace
-            const sdf::Errors& GetSdfErrors() const&;
-            sdf::Errors&& GetSdfErrors() &&;
+        //! Returns the sdf::Error vector containing any parser errors
+        //! This does not support a non-const lvalue overload
+        //! As modification the result structure sdf Errors
+        //! have no need to be modified inplace
+        const sdf::Errors& GetSdfErrors() const&;
+        sdf::Errors&& GetSdfErrors() &&;
 
-            //! Returns if the parsing of the SDF file has succeeded
-            explicit operator bool() const;
+        //! Returns if the parsing of the SDF file has succeeded
+        //! This will return false if the sdf::Errors vector is non-empty
+        explicit operator bool() const;
 
-            //! Returns if the URDF content was modified during parsing
-            bool UrdfParsedWithModifiedContent() const;
+        //! Returns if the URDF content was modified during parsing
+        bool UrdfParsedWithModifiedContent() const;
 
-            sdf::Root m_root;
-            AZStd::string m_parseMessages;
-            sdf::Errors m_sdfErrors{ sdf::Error{ O3DESdfErrorParseNotStarted, std::string{ "No Parsing has occurred yet" } } };
+        //! Root SDF object containing parsed SDF XML content if successful
+        sdf::Root m_root;
+        //! Contains any messages that are output to the sdf::Console during parsing
+        //! These messages are captured and provided to the caller to allow outputting in
+        //! any manner they choose
+        AZStd::string m_parseMessages;
+        //! Vector structure populated with sdf::Error objects indicating that parsing of the .sdf/.urdf
+        //! file has failed with an error
+        sdf::Errors m_sdfErrors{ sdf::Error{ O3DESdfErrorParseNotStarted, std::string{ "No Parsing has occurred yet" } } };
 
-            //! Stores the modified URDF content after parsing, empty if no modification occurred
-            std::string m_modifiedURDFContent;
+        //! Stores the modified URDF content after parsing, empty if no modification occurred
+        std::string m_modifiedURDFContent;
 
-            //! Stores the modified URDF tags after parsing, empty if no modification occurred
-            AZStd::vector<AZStd::string> m_modifiedURDFTags;
-        };
-        using RootObjectOutcome = ParseResult;
+        //! Stores the modified URDF tags after parsing, empty if no modification occurred
+        AZStd::vector<AZStd::string> m_modifiedURDFTags;
+    };
+    using RootObjectOutcome = ParseResult;
 
-        //! Parse string with URDF data and generate model.
-        //! @param xmlString a string that contains URDF data (XML format).
-        //! @param parserConfig structure that contains configuration options for the SDFormatter parser
-        //!        The relevant ParserConfig functions for URDF importing are
-        //!        URDFPreserveFixedJoint() function to prevent merging of robot links bound by fixed joint
-        //!        AddURIPath() function to provide a mapping of package:// and model:// references to the local filesystem
-        //! @return SDF root object containing parsed <world> or <model> tags
-        RootObjectOutcome Parse(AZStd::string_view xmlString, const sdf::ParserConfig& parserConfig);
-        RootObjectOutcome Parse(const std::string& xmlString, const sdf::ParserConfig& parserConfig);
+    //! Parse string with URDF/SDF data and generate root SDF object.
+    //! @param xmlString a string that contains URDF data (XML format).
+    //! @param parserConfig structure that contains configuration options for the SDFormatter parser
+    //!        The relevant ParserConfig functions for URDF importing are
+    //!        URDFPreserveFixedJoint() function to prevent merging of robot links bound by fixed joint
+    //!        AddURIPath() function to provide a mapping of package:// and model:// references to the local filesystem
+    //! @return SDF root object containing parsed <world> or <model> tags
+    RootObjectOutcome Parse(AZStd::string_view xmlString, const sdf::ParserConfig& parserConfig);
+    RootObjectOutcome Parse(const std::string& xmlString, const sdf::ParserConfig& parserConfig);
 
-        //! Parse file with URDF data and generate model.
-        //! @param filePath is a path to file with URDF data that will be loaded and parsed.
-        //! @param parserConfig structure that contains configuration options for the SDFormater parser
-        //!        The relevant ParserConfig functions for URDF importing are
-        //!        URDFPreserveFixedJoint() function to prevent merging of robot links bound by fixed joint
-        //!        AddURIPath() function to provide a mapping of package:// and model:// references to the local filesystem
-        //! @param settings structure that contains configuration options for the SDFAssetBuilder
-        //! @return SDF root object containing parsed <world> or <model> tags
-        RootObjectOutcome ParseFromFile(
-            AZ::IO::PathView filePath, const sdf::ParserConfig& parserConfig, const SdfAssetBuilderSettings& settings);
-    }; // namespace UrdfParser
-} // namespace ROS2
+    //! Parse file with URDF data and generate model.
+    //! @param filePath is a path to file with URDF data that will be loaded and parsed.
+    //! @param parserConfig structure that contains configuration options for the SDFormater parser
+    //!        The relevant ParserConfig functions for URDF importing are
+    //!        URDFPreserveFixedJoint() function to prevent merging of robot links bound by fixed joint
+    //!        AddURIPath() function to provide a mapping of package:// and model:// references to the local filesystem
+    //! @param settings structure that contains configuration options for the SDFAssetBuilder
+    //! @return SDF root object containing parsed <world> or <model> tags
+    RootObjectOutcome ParseFromFile(
+        AZ::IO::PathView filePath, const sdf::ParserConfig& parserConfig, const SdfAssetBuilderSettings& settings);
+} // namespace ROS2::UrdfParser

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/FilePath.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/FilePath.cpp
@@ -8,36 +8,43 @@
 
 #include "FilePath.h"
 
-namespace ROS2
+namespace ROS2::Utils
 {
-    namespace Utils
+    //! @returns the capitalized extention of provided file.
+    //! In the case that the file does not have an extension an empty string will be returned.
+    AZ::IO::FixedMaxPathString GetCapitalizedExtension(AZ::IO::PathView filename)
     {
-        //! @returns the capitalized extention of provided file.
-        //! In the case that the file does not have an extension an empty string will be returned.
-        AZStd::string GetCapitalizedExtension(const AZ::IO::Path& filename)
+        if (!filename.HasExtension())
         {
-            if (!filename.HasExtension())
-            {
-                return AZStd::string{};
-            }
-            AZStd::string extension{ filename.Extension().Native() };
-            AZStd::to_upper(extension.begin(), extension.end());
-            return extension;
+            return AZ::IO::FixedMaxPathString{};
         }
+        AZ::IO::FixedMaxPathString extension{ filename.Extension().Native() };
+        AZStd::to_upper(extension.begin(), extension.end());
+        return extension;
+    }
 
-        bool IsFileXacro(const AZ::IO::Path& filename)
-        {
-            return GetCapitalizedExtension(filename) == ".XACRO";
-        }
+    bool IsFileXacro(AZ::IO::PathView filename)
+    {
+        return GetCapitalizedExtension(filename) == ".XACRO";
+    }
 
-        bool IsFileUrdf(const AZ::IO::Path& filename)
-        {
-            return GetCapitalizedExtension(filename) == ".URDF";
-        }
+    bool IsFileUrdf(AZ::IO::PathView filename)
+    {
+        return GetCapitalizedExtension(filename) == ".URDF";
+    }
 
-        bool IsFileSDF(const AZ::IO::Path& filename)
-        {
-            return GetCapitalizedExtension(filename) == ".SDF" || GetCapitalizedExtension(filename) == ".WORLD";
-        }
-    } // namespace Utils
-} // namespace ROS2
+    bool IsFileSdf(AZ::IO::PathView filename)
+    {
+        return GetCapitalizedExtension(filename) == ".SDF" || GetCapitalizedExtension(filename) == ".WORLD";
+    }
+
+    bool IsFileUrdfOrSdf(AZ::IO::PathView filename)
+    {
+        return IsFileUrdf(filename) || IsFileSdf(filename);
+    }
+
+    bool IsFileXacroOrUrdfOrSdf(AZ::IO::PathView filename)
+    {
+        return IsFileXacro(filename) || IsFileUrdf(filename) || IsFileSdf(filename);
+    }
+} // namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/FilePath.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/FilePath.cpp
@@ -8,11 +8,14 @@
 
 #include "FilePath.h"
 
+#include <AzCore/std/string/conversions.h>
+#include <AzCore/IO/Path/Path.h>
+
 namespace ROS2::Utils
 {
     //! @returns the capitalized extention of provided file.
     //! In the case that the file does not have an extension an empty string will be returned.
-    AZ::IO::FixedMaxPathString GetCapitalizedExtension(AZ::IO::PathView filename)
+    static AZ::IO::FixedMaxPathString GetCapitalizedExtension(AZ::IO::PathView filename)
     {
         if (!filename.HasExtension())
         {
@@ -35,16 +38,19 @@ namespace ROS2::Utils
 
     bool IsFileSdf(AZ::IO::PathView filename)
     {
-        return GetCapitalizedExtension(filename) == ".SDF" || GetCapitalizedExtension(filename) == ".WORLD";
+        AZ::IO::FixedMaxPathString extension = GetCapitalizedExtension(filename);
+        return extension == ".SDF" || extension == ".WORLD";
     }
 
     bool IsFileUrdfOrSdf(AZ::IO::PathView filename)
     {
-        return IsFileUrdf(filename) || IsFileSdf(filename);
+        AZ::IO::FixedMaxPathString extension = GetCapitalizedExtension(filename);
+        return extension == ".URDF" || extension == ".SDF" || extension == ".WORLD";
     }
 
     bool IsFileXacroOrUrdfOrSdf(AZ::IO::PathView filename)
     {
-        return IsFileXacro(filename) || IsFileUrdf(filename) || IsFileSdf(filename);
+        AZ::IO::FixedMaxPathString extension = GetCapitalizedExtension(filename);
+        return extension == ".XACRO" || extension == ".URDF" || extension == ".SDF" || extension == ".WORLD";
     }
 } // namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/FilePath.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/FilePath.h
@@ -10,14 +10,18 @@
 
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 
-namespace ROS2
+namespace ROS2::Utils
 {
-    namespace Utils
-    {
-        AZStd::string GetCapitalizedExtension(const AZ::IO::Path& filename);
+    //! Returns true if the specified file path extension is .xacro
+    bool IsFileXacro(AZ::IO::PathView filename);
+    //! Returns true if the specified file path extension is .urdf
+    bool IsFileUrdf(AZ::IO::PathView filename);
+    //! Returns true if the specified file path extension is .sdf or .world
+    bool IsFileSdf(AZ::IO::PathView filename);
 
-        bool IsFileXacro(const AZ::IO::Path& filename);
+    //! Returns true if file is either a URDF or SDF file
+    bool IsFileUrdfOrSdf(AZ::IO::PathView filename);
 
-        bool IsFileUrdf(const AZ::IO::Path& filename);
-    } // namespace Utils
-} // namespace ROS2
+    //! Returns true if file is either a Xacro, URDF or SDF file
+    bool IsFileXacroOrUrdfOrSdf(AZ::IO::PathView filename);
+} // namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/FilePath.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/FilePath.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzCore/IO/Path/Path_fwd.h>
 
 namespace ROS2::Utils
 {
@@ -19,9 +19,9 @@ namespace ROS2::Utils
     //! Returns true if the specified file path extension is .sdf or .world
     bool IsFileSdf(AZ::IO::PathView filename);
 
-    //! Returns true if file is either a URDF or SDF file
+    //! Returns true if the specified file path is either a URDF or SDF file
     bool IsFileUrdfOrSdf(AZ::IO::PathView filename);
 
-    //! Returns true if file is either a Xacro, URDF or SDF file
+    //! Returns true if true specified file path is either a Xacro, URDF or SDF file
     bool IsFileXacroOrUrdfOrSdf(AZ::IO::PathView filename);
 } // namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -37,7 +37,7 @@ namespace ROS2::Utils
     bool IsWheelURDFHeuristics(const sdf::Model& model, const sdf::Link* link);
 
     //! The recursive function for the given link goes through URDF and finds world-to-entity transformation for us.
-    //! @param link pointer to URDF link that root of robot description
+    //! @param link pointer to URDF/SDF link that root of robot description
     //! @param t initial transform, should be identity for non-recursive call.
     //! @returns root to entity transform
     AZ::Transform GetWorldTransformURDF(const sdf::Link* link, AZ::Transform t = AZ::Transform::Identity());
@@ -45,61 +45,102 @@ namespace ROS2::Utils
     //! Callback which is invoke for each link within a model
     //! @return Return true to continue visiting links or false to halt
     using LinkVisitorCallback = AZStd::function<bool(const sdf::Link&)>;
-    //! Visit links from URDF or SDF
+    //! Visit links from URDF/SDF
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query link
-    //! @param visitNestedModelLinks When true recurses to any nested <model> tags of the Model object and invoke visitor on their links as well
+    //! @param visitNestedModelLinks When true recurses to any nested <model> tags of the Model object and invoke visitor on their links as
+    //! well
     //! @returns void
-    void VisitLinks(const sdf::Model& sdfModel, const LinkVisitorCallback& linkVisitorCB,
-        bool visitNestedModelLinks = false);
+    void VisitLinks(const sdf::Model& sdfModel, const LinkVisitorCallback& linkVisitorCB, bool visitNestedModelLinks = false);
 
-    //! Retrieve all links in URDF as a map, where a key is link's name and a value is a pointer to link.
+    //! Retrieve all links in URDF/SDF as a map, where a key is link's name and a value is a pointer to link.
     //! Allows to retrieve a pointer to a link given it name.
     //! @param sdfModel object of SDF document corresponding to the <model> tag. It used to query links
     //! @param gatherNestedModelLinks When true recurses to any nested <model> tags of the Model object and also gathers their links as well
     //! @returns mapping from link name to link pointer
-    AZStd::unordered_map<AZStd::string, const sdf::Link*> GetAllLinks(const sdf::Model& sdfModel,
-        bool gatherNestedModelLinks = false);
+    AZStd::unordered_map<AZStd::string, const sdf::Link*> GetAllLinks(const sdf::Model& sdfModel, bool gatherNestedModelLinks = false);
 
     //! Callback which is invoke for each valid joint for a given model
     //! @return Return true to continue visiting joint or false to halt
     using JointVisitorCallback = AZStd::function<bool(const sdf::Joint&)>;
-    //! Visit joints from URDF
+    //! Visit joints from URDF/SDF
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
-    //! @param visitNestedModelJoints When true recurses to any nested <model> tags of the Model object and invoke visitor on their joints as well
+    //! @param visitNestedModelJoints When true recurses to any nested <model> tags of the Model object and invoke visitor on their joints
+    //! as well
     //! @returns void
-    void VisitJoints(const sdf::Model& sdfModel, const JointVisitorCallback& jointVisitorCB,
-        bool visitNestedModelJoints = false);
+    void VisitJoints(const sdf::Model& sdfModel, const JointVisitorCallback& jointVisitorCB, bool visitNestedModelJoints = false);
 
-    //! Retrieve all joints in URDF.
+    //! Retrieve all joints in URDF/SDF.
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
-    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
+    //! well
     //! @returns mapping from joint name to joint pointer
-    AZStd::unordered_map<AZStd::string, const sdf::Joint*> GetAllJoints(const sdf::Model& sdfModel,
-        bool gatherNestedModelJoints = false);
+    AZStd::unordered_map<AZStd::string, const sdf::Joint*> GetAllJoints(const sdf::Model& sdfModel, bool gatherNestedModelJoints = false);
 
-    //! Retrieve all joints from URDF in which the specified link is a child in a sdf::Joint.
+    //! Retrieve all joints from URDF/SDF in which the specified link is a child in a sdf::Joint.
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
     //! @param linkName Name of link which to query in joint objects ChildName()
-    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
+    //! well
     //! @returns vector of joints where link is a child
-    AZStd::vector<const sdf::Joint*> GetJointsForChildLink(const sdf::Model& sdfModel, AZStd::string_view linkName,
-        bool gatherNestedModelJoints = false);
+    AZStd::vector<const sdf::Joint*> GetJointsForChildLink(
+        const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints = false);
 
-    //! Retrieve all joints from URDF in which the specified link is a parent in a sdf::Joint.
+    //! Retrieve all joints from URDF/SDF in which the specified link is a parent in a sdf::Joint.
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
     //! @param linkName Name of link which to query in joint objects ParentName()
-    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
+    //! well
     //! @returns vector of joints where link is a parent
-    AZStd::vector<const sdf::Joint*> GetJointsForParentLink(const sdf::Model& sdfModel, AZStd::string_view linkName,
-        bool gatherNestedModelJoints = false);
+    AZStd::vector<const sdf::Joint*> GetJointsForParentLink(
+        const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints = false);
+
+    //! Visitation Enum to determine if visiting models should halt, continue to visit sibling models or continue to visit
+    //! sibling and nested models of the current model
+    enum class VisitModelResponse
+    {
+        //! Visit any nested model of the current model, and then continue to visit sibling models
+        VisitNestedAndSiblings,
+        //! If returned, sibling <model> to the current model will be visited,
+        //! but not any nested children
+        VisitSiblings,
+        //! Stop visitation of future sibling <model> tags or nested <model> to the current model
+        Stop,
+    };
+
+    //! Callback which is invoke for each model in the SDF
+    //! This function visits any <model> tags in the root of the SDF XML content
+    //! as well as any <model> tags in any <world> tags that are in the root of the SDF XML content
+    //! @return Return true to continue visiting models or false to halt
+    using ModelVisitorCallback = AZStd::function<VisitModelResponse(const sdf::Model&)>;
+    //! Visit Models from URDF/SDF
+    //! @param sdfRoot Root object of SDF document
+    //! @param visitNestedModels When true recurses to any nested <model> tags of the Model objects and invoke the visitor on them
+    //! @returns void
+    void VisitModels(const sdf::Root& sdfRoot, const ModelVisitorCallback& modelVisitorCB, bool visitNestedModels = true);
 
     //! Retrieve all meshes referenced in URDF as unresolved URDF patches.
     //! Note that returned filenames are unresolved URDF patches.
+    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
     //! @param visual - search for visual meshes.
     //! @param colliders - search for collider meshes.
-    //! @param rootLink - pointer to sdf Rootobject that corresponds to to root of robot description after it hasbeen converted from URDF to SDF
     //! @returns set of meshes' filenames.
-    AZStd::unordered_set<AZStd::string> GetMeshesFilenames(const sdf::Root* root, bool visual, bool colliders);
+    AZStd::unordered_set<AZStd::string> GetMeshesFilenames(const sdf::Root& root, bool visual, bool colliders);
+
+    //! Returns the SDF model object which contains the specified link
+    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param linkName - Name of SDF link to lookup in the SDF document
+    const sdf::Model* GetModelContainingLink(const sdf::Root& root, AZStd::string_view linkName);
+    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param link - SDF link object to lookup in the SDF document
+    const sdf::Model* GetModelContainingLink(const sdf::Root& root, const sdf::Link& link);
+
+    //! Returns the SDF model object which contains the specified joint
+    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param jointName - Name of SDF joint to lookup in the SDF document
+    const sdf::Model* GetModelContainingJoint(const sdf::Root& root, AZStd::string_view jointName);
+    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param jointName - Name of SDF joint to lookup in the SDF document
+    const sdf::Model* GetModelContainingJoint(const sdf::Root& root, const sdf::Joint& joint);
 
     //! Callback used to check for file exist of a path referenced within a URDF/SDF file
     //! @param path Candidate local filesystem path to check for existence

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
@@ -86,7 +86,7 @@ namespace ROS2
     Utils::UrdfAssetMap SdfAssetBuilder::FindAssets(const sdf::Root& root, const AZStd::string& sourceFilename) const
     {
         AZ_Info(SdfAssetBuilderName, "Parsing mesh and collider names");
-        auto assetNames = Utils::GetMeshesFilenames(&root, true, true);
+        auto assetNames = Utils::GetMeshesFilenames(root, true, true);
 
         Utils::UrdfAssetMap assetMap;
 

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
@@ -277,7 +277,7 @@ namespace ROS2
         AZ_Info(SdfAssetBuilderName, "Creating prefab from source file.");
         auto prefabMaker = AZStd::make_unique<URDFPrefabMaker>(
             request.m_fullPath, &sdfRoot, tempAssetOutputPath.String(), assetMap, useArticulation);
-        auto prefabResult = prefabMaker->CreatePrefabTemplateFromURDF();
+        auto prefabResult = prefabMaker->CreatePrefabTemplateFromUrdfOrSdf();
         if (!prefabResult.IsSuccess())
         {
             AZ_Error(

--- a/Gems/ROS2/Code/Tests/SdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/SdfParserTest.cpp
@@ -10,32 +10,16 @@
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzTest/AzTest.h>
 #include <RobotImporter/SDFormat/ROS2SensorHooks.h>
+#include <RobotImporter/Utils/ErrorUtils.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
-
-#include <sdf/sdf.hh>
+#include <RobotImporter/URDF/UrdfParser.h>
 
 namespace UnitTest
 {
-
-    class SdfParserTest : public LeakDetectionFixture
+    class SdfParserTest
+      : public LeakDetectionFixture
     {
     public:
-        AZStd::shared_ptr<sdf::Root> Parse(const std::string& xmlString)
-        {
-            sdf::SDFPtr sdfElement(new sdf::SDF());
-            sdf::init(sdfElement);
-            sdf::Errors readErrors;
-            const bool success = sdf::readString(xmlString, sdfElement, readErrors);
-            if (!success)
-            {
-                return nullptr;
-            }
-
-            auto sdfDom = AZStd::make_shared<sdf::Root>();
-            sdf::Errors parseErrors = sdfDom->Load(sdfElement);
-            return sdfDom;
-        }
-
         std::string GetSdfWithTwoSensors()
         {
             return R"(<?xml version="1.0"?>
@@ -89,7 +73,7 @@ namespace UnitTest
                       </sdf>)";
         }
 
-        std::string GetSdfWithImuSensor()
+        static std::string GetSdfWithImuSensor()
         {
             return R"(<?xml version="1.0"?>
                       <sdf version="1.6">
@@ -150,16 +134,95 @@ namespace UnitTest
                         </model>
                       </sdf>)";
         }
+
+        static std::string GetSdfWithDuplicateModelName()
+        {
+          return R"(<?xml version="1.0"?>
+            <sdf version="1.7">
+            <model name="root_model">
+              <link name="root_link"/>
+            </model>
+            <world name="default">
+              <model name="my_model">
+                <link name="link1"/>
+              </model>
+              <model name="your_model">
+                <link name="link2"/>
+              </model>
+              <model name="my_model">
+                <link name="link3"/>
+              </model>
+            </world>
+          </sdf>)";
+        }
+
+        static std::string GetSdfWithWorldThatHasMultipleModels()
+        {
+          return R"(<?xml version="1.0"?>
+            <sdf version="1.8">
+            <model name="root_model">
+              <link name="root_link"/>
+            </model>
+            <world name="default">
+              <model name="my_model">
+                <link name="link1"/>
+              </model>
+              <model name="your_model">
+                <link name="link2"/>
+              </model>
+            </world>
+          </sdf>)";
+        }
     };
+
+    TEST_F(SdfParserTest, SdfWithDuplicateModelNames_ResultsInError)
+    {
+        const auto xmlStr = GetSdfWithDuplicateModelName();
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, {});
+        ASSERT_FALSE(sdfRootOutcome);
+        const auto& sdfErrors = sdfRootOutcome.GetSdfErrors();
+        EXPECT_FALSE(sdfErrors.empty());
+        AZStd::string errorString = ROS2::Utils::JoinSdfErrorsToString(sdfRootOutcome.GetSdfErrors());
+        printf("SDF with duplicate model names failed to parse with errors: %s\n", errorString.c_str());
+    }
+
+    TEST_F(SdfParserTest, SdfWithTwoModels_ParsesSuccessfully)
+    {
+        const auto xmlStr = GetSdfWithWorldThatHasMultipleModels();
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, {});
+        ASSERT_TRUE(sdfRootOutcome);
+        const auto& sdfRoot = sdfRootOutcome.GetRoot();
+        // This SDF should have a model on the root that points to root model
+        const auto* rootSdfModel = sdfRoot.Model();
+        ASSERT_EQ(nullptr, rootSdfModel);
+        EXPECT_EQ("root_model", rootSdfModel->Name());
+        EXPECT_TRUE(rootSdfModel->LinkNameExists("root_link"));
+
+        // The SDF should also have a world on the root as well
+        ASSERT_EQ(1, sdfRoot.WorldCount());
+        const auto* sdfWorld = sdfRoot.WorldByIndex(0);
+        ASSERT_NE(nullptr, sdfWorld);
+
+        EXPECT_EQ(2, sdfWorld->ModelCount());
+
+        const auto* myModel = sdfWorld->ModelByName("my_model");
+        ASSERT_NE(nullptr, myModel);
+        EXPECT_TRUE(myModel->LinkNameExists("link1"));
+
+        const auto* yourModel = sdfWorld->ModelByName("your_model");
+        ASSERT_NE(nullptr, yourModel);
+        EXPECT_TRUE(yourModel->LinkNameExists("link2"));
+    }
 
     TEST_F(SdfParserTest, CheckModelCorrectness)
     {
         {
             const auto xmlStr = GetSdfWithTwoSensors();
-            const auto sdfRoot = Parse(xmlStr);
-            ASSERT_TRUE(sdfRoot);
-            const auto* sdfModel = sdfRoot->Model();
-            ASSERT_TRUE(sdfModel);
+            const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, {});
+            ASSERT_TRUE(sdfRootOutcome);
+            const auto& sdfRoot = sdfRootOutcome.GetRoot();
+            const auto* sdfModel = sdfRoot.Model();
+            ASSERT_NE(nullptr, sdfModel);
 
             EXPECT_EQ(sdfModel->Name(), "test_two_sensors");
             EXPECT_EQ(sdfModel->LinkCount(), 2U);
@@ -205,10 +268,11 @@ namespace UnitTest
 
         {
             const auto xmlStr = GetSdfWithImuSensor();
-            const auto sdfRoot = Parse(xmlStr);
-            ASSERT_TRUE(sdfRoot);
-            const auto* sdfModel = sdfRoot->Model();
-            ASSERT_TRUE(sdfModel);
+            const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, {});
+            ASSERT_TRUE(sdfRootOutcome);
+            const auto& sdfRoot = sdfRootOutcome.GetRoot();
+            const auto* sdfModel = sdfRoot.Model();
+            ASSERT_NE(nullptr, sdfModel);
 
             EXPECT_EQ(sdfModel->Name(), "test_imu_sensor");
             EXPECT_EQ(sdfModel->LinkCount(), 1U);
@@ -276,8 +340,11 @@ namespace UnitTest
         };
 
         const auto xmlStr = GetSdfWithTwoSensors();
-        const auto sdfRoot = Parse(xmlStr);
-        const auto* sdfModel = sdfRoot->Model();
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, {});
+        ASSERT_TRUE(sdfRootOutcome);
+        const auto& sdfRoot = sdfRootOutcome.GetRoot();
+        const auto* sdfModel = sdfRoot.Model();
+        ASSERT_NE(nullptr, sdfModel);
         const sdf::ElementPtr cameraElement = sdfModel->LinkByName("link1")->SensorByIndex(0U)->Element();
         const sdf::ElementPtr laserElement = sdfModel->LinkByName("link2")->SensorByIndex(0U)->Element();
 
@@ -323,8 +390,11 @@ namespace UnitTest
     {
         {
             const auto xmlStr = GetSdfWithTwoSensors();
-            const auto sdfRoot = Parse(xmlStr);
-            const auto* sdfModel = sdfRoot->Model();
+            const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, {});
+            ASSERT_TRUE(sdfRootOutcome);
+            const auto& sdfRoot = sdfRootOutcome.GetRoot();
+            const auto* sdfModel = sdfRoot.Model();
+            ASSERT_NE(nullptr, sdfModel);
             const sdf::ElementPtr cameraElement = sdfModel->LinkByName("link1")->SensorByIndex(0U)->Element();
             const auto& cameraImporterHook = ROS2::SDFormat::ROS2SensorHooks::ROS2CameraSensor();
 
@@ -361,8 +431,11 @@ namespace UnitTest
         }
         {
             const auto xmlStr = GetSdfWithImuSensor();
-            const auto sdfRoot = Parse(xmlStr);
-            const auto* sdfModel = sdfRoot->Model();
+            const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, {});
+            ASSERT_TRUE(sdfRootOutcome);
+            const auto& sdfRoot = sdfRootOutcome.GetRoot();
+            const auto* sdfModel = sdfRoot.Model();
+            ASSERT_NE(nullptr, sdfModel);
             const sdf::ElementPtr imuElement = sdfModel->LinkByName("link1")->SensorByIndex(0U)->Element();
             const auto& importerHook = ROS2::SDFormat::ROS2SensorHooks::ROS2ImuSensor();
 


### PR DESCRIPTION
UI references to "URDF" have been updated to mention "URDF/SDF"

Added additional UnitTest to validate loading SDF files

### Preliminary multi model support
Added a VisitModels utility function that can visit all models within an SDF

Updated the GetMeshesFilename function to support gather mesh data from all models within an SDF including nested models and models from world tags

Updated the URDFPrefabMaker to visit all the models with an SDF instead of only the first model found within the SDF root or the first model found within the first world tag of an SDF.


### Unit Test Results
```
LIB: libROS2.Editor.Tests
Loading: libROS2.Editor.Tests
OKAY Library loaded: libROS2.Editor.Tests
OKAY Symbol found: AzRunUnitTests
[==========] Running 30 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 5 tests from SdfParserTest
[ RUN      ] SdfParserTest.SdfWithDuplicateModelNames_ResultsInError
SDF with duplicate model names failed to parse with errors: ErrorCode=2, Message=model with name[my_model] already exists.
ErrorCode=9, Message=Failed to load a world.

[       OK ] SdfParserTest.SdfWithDuplicateModelNames_ResultsInError (3612 ms)
[ RUN      ] SdfParserTest.SdfWithTwoModels_ParsesSuccessfully
[       OK ] SdfParserTest.SdfWithTwoModels_ParsesSuccessfully (12763 ms)
[ RUN      ] SdfParserTest.CheckModelCorrectness
[       OK ] SdfParserTest.CheckModelCorrectness (142 ms)
[ RUN      ] SdfParserTest.RobotImporterUtils
[       OK ] SdfParserTest.RobotImporterUtils (5877 ms)
[ RUN      ] SdfParserTest.SensorPluginImporterHookCheck
[       OK ] SdfParserTest.SensorPluginImporterHookCheck (104 ms)
[----------] 5 tests from SdfParserTest (22498 ms total)

[----------] 25 tests from UrdfParserTest
[ RUN      ] UrdfParserTest.ParseUrdfWithOneLink
[       OK ] UrdfParserTest.ParseUrdfWithOneLink (48 ms)
[ RUN      ] UrdfParserTest.ParseUrdfWithTwoLinksAndFixedJoint_WithPreserveFixedJoint_False
[       OK ] UrdfParserTest.ParseUrdfWithTwoLinksAndFixedJoint_WithPreserveFixedJoint_False (49 ms)
[ RUN      ] UrdfParserTest.ParseUrdfWithTwoLinksAndFixedJoint_WithPreserveFixedJoint_True
[       OK ] UrdfParserTest.ParseUrdfWithTwoLinksAndFixedJoint_WithPreserveFixedJoint_True (52 ms)
[ RUN      ] UrdfParserTest.ParseUrdfWithTwoLinksAndNonFixedJoint
[       OK ] UrdfParserTest.ParseUrdfWithTwoLinksAndNonFixedJoint (53 ms)
[ RUN      ] UrdfParserTest.ParseURDF_WithTwoLinks_AndBaseLinkWithNoInertia_WithUrdfFixedJointPreservationOn_Fails
URDF with single link and no inertia: ErrorCode=17, Message=A model must have at least one link.
ErrorCode=17, Message=A model must have at least one link.
ErrorCode=25, Message=FrameAttachedToGraph error: scope context name[] does not match __model__ or world.

[       OK ] UrdfParserTest.ParseURDF_WithTwoLinks_AndBaseLinkWithNoInertia_WithUrdfFixedJointPreservationOn_Fails (3107 ms)
[ RUN      ] UrdfParserTest.ParseURDF_WithTwoLinks_AndBaseLinkWithNoInertia_WithUrdfFixedJointPreservationOff_Succeeds
[       OK ] UrdfParserTest.ParseURDF_WithTwoLinks_AndBaseLinkWithNoInertia_WithUrdfFixedJointPreservationOff_Succeeds (63 ms)
[ RUN      ] UrdfParserTest.ParseUrdf_WithRootLink_WithName_world_DoesNotContain_world_Link
[       OK ] UrdfParserTest.ParseUrdf_WithRootLink_WithName_world_DoesNotContain_world_Link (53 ms)
[ RUN      ] UrdfParserTest.ParseUrdf_WithRootLink_WithoutName_world_DoesContainThatLink
[       OK ] UrdfParserTest.ParseUrdf_WithRootLink_WithoutName_world_DoesContainThatLink (51 ms)
[ RUN      ] UrdfParserTest.WheelHeuristicNameValid
[       OK ] UrdfParserTest.WheelHeuristicNameValid (129 ms)
[ RUN      ] UrdfParserTest.WheelHeuristicNameNotValid1
[       OK ] UrdfParserTest.WheelHeuristicNameNotValid1 (54 ms)
[ RUN      ] UrdfParserTest.WheelHeuristicJointNotValid
[       OK ] UrdfParserTest.WheelHeuristicJointNotValid (47 ms)
[ RUN      ] UrdfParserTest.WheelHeuristicJointVisualNotValid
[       OK ] UrdfParserTest.WheelHeuristicJointVisualNotValid (60 ms)
[ RUN      ] UrdfParserTest.WheelHeuristicJointColliderNotValid
[       OK ] UrdfParserTest.WheelHeuristicJointColliderNotValid (54 ms)
[ RUN      ] UrdfParserTest.TestLinkListing
[       OK ] UrdfParserTest.TestLinkListing (71 ms)
[ RUN      ] UrdfParserTest.TestJointLink
[       OK ] UrdfParserTest.TestJointLink (56 ms)
[ RUN      ] UrdfParserTest.TestTransforms
[       OK ] UrdfParserTest.TestTransforms (63 ms)
[ RUN      ] UrdfParserTest.TestQueryJointsForParentLink_Succeeds
[       OK ] UrdfParserTest.TestQueryJointsForParentLink_Succeeds (64 ms)
[ RUN      ] UrdfParserTest.TestQueryJointsForChildLink_Succeeds
[       OK ] UrdfParserTest.TestQueryJointsForChildLink_Succeeds (62 ms)
[ RUN      ] UrdfParserTest.TestPathResolvementGlobal
[       OK ] UrdfParserTest.TestPathResolvementGlobal (1 ms)
[ RUN      ] UrdfParserTest.TestPathResolvementRelative
[       OK ] UrdfParserTest.TestPathResolvementRelative (0 ms)
[ RUN      ] UrdfParserTest.TestPathResolvementRelativePackage
[       OK ] UrdfParserTest.TestPathResolvementRelativePackage (0 ms)
[ RUN      ] UrdfParserTest.TestPathResolvementExplicitPackageName
[       OK ] UrdfParserTest.TestPathResolvementExplicitPackageName (0 ms)
[ RUN      ] UrdfParserTest.ResolvePath_UsingModelUriScheme_Succeeds
[       OK ] UrdfParserTest.ResolvePath_UsingModelUriScheme_Succeeds (0 ms)
[ RUN      ] UrdfParserTest.XacroParseArgsInvalid
[       OK ] UrdfParserTest.XacroParseArgsInvalid (1 ms)
[ RUN      ] UrdfParserTest.XacroParseArgs
[       OK ] UrdfParserTest.XacroParseArgs (51 ms)
[----------] 25 tests from UrdfParserTest (4189 ms total)

[----------] Global test environment tear-down
[==========] 30 tests from 2 test cases ran. (26687 ms total)
[  PASSED  ] 30 tests.
OKAY AzRunUnitTests() returned 0
```