### PR TITLE
Misc importer fixes

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -171,8 +171,12 @@ namespace ROS2
                 const AZ::Vector3 scaleVector = URDF::TypeConversions::ConvertVector3(meshGeometry->Scale());
 
                 const auto asset = PrefabMakerUtils::GetAssetFromPath(*m_urdfAssetsMapping, AZStd::string(meshGeometry->Uri().c_str()));
-                AZ::Data::AssetId assetId = Utils::GetModelProductAssetId(asset->m_sourceGuid);
-                AZ_Warning("AddVisual", assetId.IsValid(), "There is no product asset for %s.", asset->m_sourceAssetRelativePath.c_str());
+                AZ::Data::AssetId assetId;
+                if (asset)
+                {
+                    assetId = Utils::GetModelProductAssetId(asset->m_sourceGuid);
+                    AZ_Warning("AddVisual", assetId.IsValid(), "There is no product asset for %s.", asset->m_sourceAssetRelativePath.c_str());
+                }
 
                 AddVisualAssetToEntity(entityId, assetId, scaleVector);
             }

--- a/Gems/ROS2/Registry/sdfassetbuilder_settings.setreg
+++ b/Gems/ROS2/Registry/sdfassetbuilder_settings.setreg
@@ -20,7 +20,7 @@
                     "UseAncestorPaths": true,
                     "URIPrefixMap": 
                     {
-                        "model://": [""],
+                        "model://": ["", "../models"],
                         "package://": [""],
                         "file://":  [""]
                     }                


### PR DESCRIPTION
1. Fixes a crash that can occur if you try to create a prefab on a model where one or more assets haven't resolved.
2. Adds "../models" to the standard path resolvers, since I hit several cases in our test repositories that all needed this same resolver.