### PR TITLE
Resolve failing asset builder jobs for ROS2 components.

### DIFF
--- a/Gems/ROS2/Code/Source/Lidar/LidarRegistrarSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRegistrarSystemComponent.cpp
@@ -114,7 +114,9 @@ namespace ROS2
 
     AZStd::string Details::GetDefaultLidarSystem()
     {
-        const auto& lidarSystemList = LidarRegistrarInterface::Get()->GetRegisteredLidarSystems();
+        const auto& lidarInterface = LidarRegistrarInterface::Get();
+        AZ_Assert(lidarInterface, "LidarRegistrarInterface is not registered.");
+        const auto& lidarSystemList = lidarInterface->GetRegisteredLidarSystems();
         if (lidarSystemList.empty())
         {
             AZ_Warning("ROS2LidarSensorComponent", false, "No LIDAR system for the sensor to use.");

--- a/Gems/ROS2/Code/Source/Lidar/LidarSensorConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSensorConfiguration.cpp
@@ -79,8 +79,6 @@ namespace ROS2
         m_lidarModel = m_availableModels.front();
         m_lidarParameters = LidarTemplateUtils::GetTemplate(m_lidarModel);
         m_lidarModelName = m_lidarParameters.m_name;
-
-        FetchLidarImplementationFeatures();
     }
 
     void LidarSensorConfiguration::FetchLidarImplementationFeatures()

--- a/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.cpp
@@ -99,6 +99,11 @@ namespace ROS2
         m_lidarCore.Deinit();
     }
 
+    void ROS2Lidar2DSensorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC_CE("ROS2Frame"));
+    }
+
     void ROS2Lidar2DSensorComponent::FrequencyTick()
     {
         RaycastResult lastScanResults = m_lidarCore.PerformRaycast();

--- a/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.h
@@ -32,6 +32,7 @@ namespace ROS2
         ROS2Lidar2DSensorComponent();
         ROS2Lidar2DSensorComponent(const SensorConfiguration& sensorConfiguration, const LidarSensorConfiguration& lidarConfiguration);
         ~ROS2Lidar2DSensorComponent() = default;
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
         static void Reflect(AZ::ReflectContext* context);
         //////////////////////////////////////////////////////////////////////////
         // Component overrides

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -43,6 +43,11 @@ namespace ROS2
         }
     }
 
+    void ROS2LidarSensorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC_CE("ROS2Frame"));
+    }
+
     ROS2LidarSensorComponent::ROS2LidarSensorComponent()
         : m_lidarCore(LidarTemplateUtils::Get3DModels())
     {

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -34,6 +34,7 @@ namespace ROS2
         ROS2LidarSensorComponent(const SensorConfiguration& sensorConfiguration, const LidarSensorConfiguration& lidarConfiguration);
         ~ROS2LidarSensorComponent() = default;
         static void Reflect(AZ::ReflectContext* context);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
         //////////////////////////////////////////////////////////////////////////
         // Component overrides
         void Activate() override;


### PR DESCRIPTION
This PR fixes an issue that was introduced in #482.
There was an extra call to the non-existent `LidarRegistrarSystemComponent` from a simple configuration structure. When Asset Builder tried to run parse prefab (in serialize context) but ended up dereferencing non-existent pointer to System Component.
The call is `Details::GetDefaultLidarSystem()` in the constructor `LidarSensorConfiguration::LidarSensorConfiguration`, because setting up the default Lidar system is done in EditContext of the respective component.
I also added some assertions and missing required services. 