### PR TITLE
Updated the URDFPrefabMaker to avoid referencing SDF link names 

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -222,7 +222,8 @@ namespace ROS2
         };
 
         // Use the URDF/SDF file name stem the prefab name
-        AZStd::string prefabName = AZStd::string(AZ::IO::PathView(filePath).Stem().Native());
+        auto fileStem = AZ::IO::PathView(filePath).Stem();
+        AZStd::string prefabName = AZStd::string::format("%.*s.prefab", AZ_PATH_ARG(fileStem));
 
         if (prefabName.empty())
         {

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -315,7 +315,7 @@ namespace ROS2
     void RobotImporterWidget::FillPrefabMakerPage()
     {
         // Use the URDF/SDF file name stem the prefab name
-        AZStd::string robotName = AZStd::string(m_urdfPath.Stem().Native()) + ".prefab";
+        AZStd::string robotName = AZStd::string::format("%.*s.prefab", AZ_PATH_ARG(m_urdfPath.Stem()));
         m_prefabMakerPage->setProposedPrefabName(robotName);
         QWizard::button(PrefabCreationButtonId)->setText(tr("Create Prefab"));
         QWizard::setOption(HavePrefabCreationButton, true);
@@ -406,7 +406,6 @@ namespace ROS2
         const AZ::IO::Path prefabPath(AZ::IO::Path(AZ::Utils::GetProjectPath()) / prefabPathRelative);
         bool fileExists = AZ::IO::FileIOBase::GetInstance()->Exists(prefabPath.c_str());
 
-        if (CheckCyclicalDependency(prefabPathRelative))
         {
             m_prefabMakerPage->setSuccess(false);
             return;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -72,7 +72,7 @@ namespace ROS2
             };
 
             // Iterate over all visuals to get their materials
-            auto VisitAllModels = [&GetVisualsFromModel](const sdf::Model& model) -> Utils::VisitModelResponse
+            auto VisitAllModels = [&GetVisualsFromModel](const sdf::Model& model, const Utils::ModelStack&) -> Utils::VisitModelResponse
             {
                 GetVisualsFromModel(model);
                 // Continue to visit all models within the SDF document and query their <visual> tags
@@ -82,40 +82,6 @@ namespace ROS2
 
             m_visualsMaker = VisualsMaker(AZStd::move(materialMap), urdfAssetsMapping);
         }
-    }
-
-    void URDFPrefabMaker::BuildAssetsForLink(const sdf::Link* link)
-    {
-        m_collidersMaker.BuildColliders(link);
-
-        auto GetAssetsForLinkInModel = [this, link](const sdf::Model& model) -> Utils::VisitModelResponse
-        {
-            // Find the links which are children in a joint where this link is a parent
-            auto BuildAssetsFromJointChildLinks = [this, &model](const sdf::Joint& joint)
-            {
-                if (const sdf::Link* childLink = model.LinkByName(joint.ChildName()); childLink != nullptr)
-                {
-                    BuildAssetsForLink(childLink);
-                }
-
-                return true;
-            };
-
-            // Make sure the link is a child of the model being visited
-            // Before visiting the joints of the model
-            if (const sdf::Link* searchLink = model.LinkByName(link->Name()); searchLink != nullptr)
-            {
-                // Don't visit nested models using the VisitJoints function as the outer call
-                // to VisitModels already visits nested models
-                constexpr bool visitNestedModelLinks = false;
-                Utils::VisitJoints(model, BuildAssetsFromJointChildLinks, visitNestedModelLinks);
-            }
-
-            return Utils::VisitModelResponse::VisitNestedAndSiblings;
-        };
-
-        constexpr bool visitNestedModels = true;
-        Utils::VisitModels(*m_root, GetAssetsForLinkInModel, visitNestedModels);
     }
 
     URDFPrefabMaker::CreatePrefabTemplateResult URDFPrefabMaker::CreatePrefabTemplateFromUrdfOrSdf()
@@ -130,55 +96,128 @@ namespace ROS2
             return AZ::Failure(AZStd::string("URDF/SDF doesn't contain any models."));
         }
 
-        // Build up a list of all entities created as a part of processing the file.
-        AZStd::vector<AZ::EntityId> createdEntities;
-        AZStd::unordered_map<AZStd::string, AzToolsFramework::Prefab::PrefabEntityResult> createdLinks;
-        AZStd::unordered_map<AZStd::string, const sdf::Link*> links;
-        // Gather all links from all the models in the SDF
-        auto GetAllLinksFromModel = [&links](const sdf::Model& model) -> Utils::VisitModelResponse
+        // Visit any nested models in the SDF as well
+        constexpr bool visitNestedModels = true;
+
+        // Maintains references to all joints and a mapping from the joints to their parent and child links
+        struct JointsMapper
+        {
+            struct JointToAttachedModel
+            {
+                AZStd::string m_fullyQualifiedName;
+                const sdf::Joint* m_joint;
+                const sdf::Model* m_attachedModel;
+            };
+            // this is a unique ordered vector
+            AZStd::vector<JointToAttachedModel> m_joints;
+            AZStd::unordered_map<const sdf::Joint*, const sdf::Link*> m_jointToParentLinks;
+            AZStd::unordered_map<const sdf::Joint*, const sdf::Link*> m_jointToChildLinks;
+        };
+        JointsMapper jointsMapper;
+        auto GetAllJointsFromModel = [&jointsMapper](const sdf::Model& model, const Utils::ModelStack&) -> Utils::VisitModelResponse
+        {
+            // As the VisitModels function visits nested models by default, gatherNestedModelJoints is set to false
+            constexpr bool gatherNestedModelJoints = false;
+            auto jointsForModel = Utils::GetAllJoints(model, gatherNestedModelJoints);
+            for (const auto& [fullyQualifiedName, joint] : jointsForModel)
+            {
+                JointsMapper::JointToAttachedModel jointToAttachedModel{
+                    AZStd::string(fullyQualifiedName.c_str(), fullyQualifiedName.size()), joint, &model
+                };
+                jointsMapper.m_joints.push_back(AZStd::move(jointToAttachedModel));
+
+                // add mapping from joint to child link
+                std::string childName = joint->ChildName();
+                if (const sdf::Link* link = model.LinkByName(childName); link != nullptr)
+                {
+                    // Add a mapping of joint to child link
+                    jointsMapper.m_jointToChildLinks[joint] = link;
+                }
+
+                // add mapping from joint to parent link
+                std::string parentName = joint->ParentName();
+                if (const sdf::Link* link = model.LinkByName(parentName); link != nullptr)
+                {
+                    jointsMapper.m_jointToParentLinks[joint] = link;
+                }
+            }
+
+            return Utils::VisitModelResponse::VisitNestedAndSiblings;
+        };
+        // Gather all Joints in SDF including in nested models
+        Utils::VisitModels(*m_root, GetAllJointsFromModel, visitNestedModels);
+
+        // Maintains references to all Links in the SDF and a mapping of links to the model it is attached to
+        struct LinksMapper
+        {
+            struct LinkToAttachedModel
+            {
+                AZStd::string m_fullyQualifiedName;
+                const sdf::Link* m_link;
+                const sdf::Model* m_attachedModel;
+            };
+            // this is a unique ordered vector
+            AZStd::vector<LinkToAttachedModel> m_links;
+        };
+        LinksMapper linksMapper;
+
+        auto GetAllLinksFromModel = [&linksMapper](const sdf::Model& model, const Utils::ModelStack&) -> Utils::VisitModelResponse
         {
             // As the VisitModels function visits nested models by default, gatherNestedModelLinks is set to false
             constexpr bool gatherNestedModelLinks = false;
             auto linksForModel = Utils::GetAllLinks(model, gatherNestedModelLinks);
-            links.insert(linksForModel.begin(), linksForModel.end());
-
+            for (const auto& [fullyQualifiedName, link] : linksForModel)
+            {
+                // Push back the mapping of link to attached model into the orderd vector
+                LinksMapper::LinkToAttachedModel linkToAttachedModel{ AZStd::string(fullyQualifiedName.c_str(), fullyQualifiedName.size()),
+                                                                      link,
+                                                                      &model };
+                linksMapper.m_links.push_back(AZStd::move(linkToAttachedModel));
+            }
             return Utils::VisitModelResponse::VisitNestedAndSiblings;
         };
 
-        // Visit any nested models in the SDF as well
-        constexpr bool visitNestedModels = true;
+        // Gather all links from all the models in the SDF
         Utils::VisitModels(*m_root, GetAllLinksFromModel, visitNestedModels);
 
-        for (const auto& [name, linkPtr] : links)
+        // Build up a list of all entities created as a part of processing the file.
+        AZStd::vector<AZ::EntityId> createdEntities;
+        AZStd::unordered_map<const sdf::Link*, AzToolsFramework::Prefab::PrefabEntityResult> createdLinks;
+        AZStd::unordered_map<AZStd::string, const sdf::Link*> links;
+        for ([[maybe_unused]] const auto& [fullLinkName, linkPtr, _] : linksMapper.m_links)
         {
-            createdLinks[name] = AddEntitiesForLink(linkPtr, AZ::EntityId{}, createdEntities);
+            createdLinks[linkPtr] = AddEntitiesForLink(linkPtr, AZ::EntityId{}, createdEntities);
         }
 
-        for (const auto& [name, result] : createdLinks)
+        for (const auto& [linkPtr, result] : createdLinks)
         {
+            std::string linkName = linkPtr->Name();
+            AZStd::string azLinkName(linkName.c_str(), linkName.size());
             AZ_Trace(
                 "CreatePrefabFromUrdfOrSdf",
                 "Link with name %s was created as: %s\n",
-                name.c_str(),
+                linkName.c_str(),
                 result.IsSuccess() ? (result.GetValue().ToString().c_str()) : ("[Failed]"));
             AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
             if (result.IsSuccess())
             {
-                m_status.emplace(name, AZStd::string::format("created as: %s", result.GetValue().ToString().c_str()));
+                m_status.emplace(azLinkName, AZStd::string::format("created as: %s", result.GetValue().ToString().c_str()));
             }
             else
             {
-                m_status.emplace(name, AZStd::string::format("failed : %s", result.GetError().c_str()));
+                m_status.emplace(azLinkName, AZStd::string::format("failed : %s", result.GetError().c_str()));
             }
         }
 
         // Set the transforms of links
-        for (const auto& [name, linkPtr] : links)
+        for ([[maybe_unused]] const auto& [fullLinkName, linkPtr, _] : linksMapper.m_links)
         {
-            if (const auto thisEntry = createdLinks.at(name); thisEntry.IsSuccess())
+            if (const auto createLinkEntityResult = createdLinks.at(linkPtr); createLinkEntityResult.IsSuccess())
             {
+                AZ::EntityId createdEntityId = createLinkEntityResult.GetValue();
+                std::string linkName = linkPtr->Name();
                 AZ::Transform tf = Utils::GetWorldTransformURDF(linkPtr);
-                auto* entity = AzToolsFramework::GetEntityById(thisEntry.GetValue());
+                auto* entity = AzToolsFramework::GetEntityById(createdEntityId);
                 if (entity)
                 {
                     auto* transformInterface = entity->FindComponent<AzToolsFramework::Components::TransformComponent>();
@@ -187,8 +226,8 @@ namespace ROS2
                         AZ_Trace(
                             "CreatePrefabFromUrdfOrSdf",
                             "Setting transform %s %s to [%f %f %f] [%f %f %f %f]\n",
-                            name.c_str(),
-                            thisEntry.GetValue().ToString().c_str(),
+                            linkName.c_str(),
+                            createdEntityId.ToString().c_str(),
                             tf.GetTranslation().GetX(),
                             tf.GetTranslation().GetY(),
                             tf.GetTranslation().GetZ(),
@@ -201,7 +240,9 @@ namespace ROS2
                     else
                     {
                         AZ_Trace(
-                            "CreatePrefabFromUrdfOrSdf", "Setting transform failed: %s does not have transform interface\n", name.c_str());
+                            "CreatePrefabFromUrdfOrSdf",
+                            "Setting transform failed: %s does not have transform interface\n",
+                            linkName.c_str());
                     }
                 }
             }
@@ -209,21 +250,20 @@ namespace ROS2
 
         // Set the hierarchy
         AZStd::vector<AZ::EntityId> linkEntityIdsWithoutParent;
-        for (const auto& [linkName, linkPtr] : links)
+        for (const auto& [fullLinkName, linkPtr, attachedModel] : linksMapper.m_links)
         {
-            const auto linkPrefabResult = createdLinks.at(linkName);
+            std::string linkName = linkPtr->Name();
+            AZStd::string azLinkName(linkName.c_str(), linkName.size());
+            const auto linkPrefabResult = createdLinks.at(linkPtr);
             if (!linkPrefabResult.IsSuccess())
             {
-                AZ_Trace("CreatePrefabFromUrdfOrSdf", "Link %s creation failed\n", linkName.c_str());
+                AZ_Trace("CreatePrefabFromUrdfOrSdf", "Link %s creation failed\n", fullLinkName.c_str());
                 continue;
             }
 
             AZStd::vector<const sdf::Joint*> jointsWhereLinkIsChild;
-            if (const sdf::Model* modelContainingLink = Utils::GetModelContainingLink(*m_root, *linkPtr); modelContainingLink != nullptr)
-            {
-                bool gatherNestedModelJoints = true;
-                jointsWhereLinkIsChild = Utils::GetJointsForChildLink(*modelContainingLink, linkName, gatherNestedModelJoints);
-            }
+            bool gatherNestedModelJoints = true;
+            jointsWhereLinkIsChild = Utils::GetJointsForChildLink(*attachedModel, azLinkName, gatherNestedModelJoints);
 
             if (jointsWhereLinkIsChild.empty())
             {
@@ -251,15 +291,22 @@ namespace ROS2
                 > defining the coordinate transformation from the parent link frame to the child link frame.
             */
 
-            AZStd::string parentName(
-                jointsWhereLinkIsChild.front()->ParentName().c_str(), jointsWhereLinkIsChild.front()->ParentName().size());
-            const auto parentEntry = createdLinks.find(parentName);
-            if (parentEntry == createdLinks.end())
+            // Use the first joint where this link is a child to locate the parent link pointer.
+            const sdf::Joint* joint = jointsWhereLinkIsChild.front();
+                        std::string parentLinkName = joint->ParentName();
+            AZStd::string parentName(parentLinkName.c_str(), parentLinkName.size());
+
+            // Lookup the entity created from the parent link using the JointMapper to locate the parent SDF link.
+            // followed by using SDF link address to lookup the O3DE created entity ID
+            auto parentLinkIter = jointsMapper.m_jointToParentLinks.find(joint);
+            auto parentEntityIter =
+                parentLinkIter != jointsMapper.m_jointToParentLinks.end() ? createdLinks.find(parentLinkIter->second) : createdLinks.end();
+            if (parentEntityIter == createdLinks.end())
             {
                 AZ_Trace("CreatePrefabFromUrdfOrSdf", "Link %s has invalid parent name %s\n", linkName.c_str(), parentName.c_str());
                 continue;
             }
-            if (!parentEntry->second.IsSuccess())
+            if (!parentEntityIter->second.IsSuccess())
             {
                 AZ_Trace(
                     "CreatePrefabFromUrdfOrSdf",
@@ -272,22 +319,25 @@ namespace ROS2
                 "CreatePrefabFromUrdfOrSdf",
                 "Link %s setting parent to %s\n",
                 linkPrefabResult.GetValue().ToString().c_str(),
-                parentEntry->second.GetValue().ToString().c_str());
+                parentEntityIter->second.GetValue().ToString().c_str());
             AZ_Trace("CreatePrefabFromUrdfOrSdf", "Link %s setting parent to %s\n", linkName.c_str(), parentName.c_str());
-            PrefabMakerUtils::SetEntityParent(linkPrefabResult.GetValue(), parentEntry->second.GetValue());
+            PrefabMakerUtils::SetEntityParent(linkPrefabResult.GetValue(), parentEntityIter->second.GetValue());
         }
 
-        auto JointVisitor = [this, &createdLinks](const sdf::Joint& joint)
+        // Iterate over all the joints and locate the entity associated with the link
+        for ([[maybe_unused]] const auto& [fullJointName, jointPtr, _] : jointsMapper.m_joints)
         {
-            auto jointPtr = &joint;
-
-            const std::string& jointName = jointPtr->Name();
+            std::string jointName = jointPtr->Name();
             AZStd::string azJointName(jointName.c_str(), jointName.size());
-            AZStd::string parentLinkName(jointPtr->ParentName().c_str(), jointPtr->ParentName().size());
-            AZStd::string childLinkName(jointPtr->ChildName().c_str(), jointPtr->ChildName().size());
+            std::string childLinkName = jointPtr->ChildName();
+            std::string parentLinkName = jointPtr->ParentName();
 
-            auto parentLinkIter = createdLinks.find(parentLinkName);
-            if (parentLinkIter == createdLinks.end())
+            // Look up the O3DE created entity by first locating the parent SDF link associated with the current joint
+            // and then using that SDF link to lookup the created entity
+            auto parentLinkIter = jointsMapper.m_jointToParentLinks.find(jointPtr);
+            auto parentEntityIter =
+                parentLinkIter != jointsMapper.m_jointToParentLinks.end() ? createdLinks.find(parentLinkIter->second) : createdLinks.end();
+            if (parentEntityIter == createdLinks.end())
             {
                 AZ_Warning(
                     "CreatePrefabFromUrdfOrSdf",
@@ -297,10 +347,13 @@ namespace ROS2
                     parentLinkName.c_str());
                 return true;
             }
-            auto leadEntity = parentLinkIter->second;
+            auto leadEntity = parentEntityIter->second;
 
-            auto childLinkIter = createdLinks.find(childLinkName);
-            if (childLinkIter == createdLinks.end())
+            // Use the joint to lookup the child SDF link which is used to look up the O3DE entity
+            auto childLinkIter = jointsMapper.m_jointToChildLinks.find(jointPtr);
+            auto childEntityIter =
+                childLinkIter != jointsMapper.m_jointToChildLinks.end() ? createdLinks.find(childLinkIter->second) : createdLinks.end();
+            if (childEntityIter == createdLinks.end())
             {
                 AZ_Warning(
                     "CreatePrefabFromUrdfOrSdf",
@@ -310,7 +363,7 @@ namespace ROS2
                     childLinkName.c_str());
                 return true;
             }
-            auto childEntity = childLinkIter->second;
+            auto childEntity = childEntityIter->second;
 
             AZ_Trace(
                 "CreatePrefabFromUrdfOrSdf",
@@ -344,23 +397,7 @@ namespace ROS2
                 }
             }
             return true;
-        };
-
-        // Visit all joints that has at least a parent or child link in every model inside of the SDF document
-        auto VisitJointsInModel = [&JointVisitor](const sdf::Model& model) -> Utils::VisitModelResponse
-        {
-            // The JointVisitor is used instead of iterating over the sdf::Model::JointCount
-            // as it will skip joints that exist that doesn't have an attached parent link or child link
-            // such as the root link when its name is "world"
-
-            // As the VisitModels function visits nested models by default, visitNestedJoints
-            // is set to false to prevent visiting joints twice
-            constexpr bool visitNestedJoints = false;
-            Utils::VisitJoints(model, JointVisitor, visitNestedJoints);
-            return Utils::VisitModelResponse::VisitNestedAndSiblings;
-        };
-
-        Utils::VisitModels(*m_root, VisitJointsInModel, visitNestedModels);
+        }
 
         // Use the first entity based on a link that is not parented to any other link
         if (!linkEntityIdsWithoutParent.empty() && linkEntityIdsWithoutParent.front().IsValid())
@@ -566,7 +603,7 @@ namespace ROS2
     bool URDFPrefabMaker::ContainsModel() const
     {
         const sdf::Model* sdfModel{};
-        auto GetModelAndStopIteration = [&sdfModel](const sdf::Model& model) -> Utils::VisitModelResponse
+        auto GetModelAndStopIteration = [&sdfModel](const sdf::Model& model, const Utils::ModelStack&) -> Utils::VisitModelResponse
         {
             sdfModel = &model;
             // Return stop to prevent further visitation of additional models

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -168,7 +168,7 @@ namespace ROS2
             auto linksForModel = Utils::GetAllLinks(model, gatherNestedModelLinks);
             for (const auto& [fullyQualifiedName, link] : linksForModel)
             {
-                // Push back the mapping of link to attached model into the orderd vector
+                // Push back the mapping of link to attached model into the ordered vector
                 LinksMapper::LinkToAttachedModel linkToAttachedModel{ AZStd::string(fullyQualifiedName.c_str(), fullyQualifiedName.size()),
                                                                       link,
                                                                       &model };
@@ -409,8 +409,6 @@ namespace ROS2
 
         // Create prefab, save it to disk immediately
         // Remove prefab, if it was already created.
-
-        AZ::IO::FixedMaxPath prefabTemplateName{ AZ::IO::PathView(m_prefabPath).FixedMaxPathStringAsPosix() };
 
         // clear out any previously created prefab template for this path
         auto* prefabSystemComponentInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabSystemComponentInterface>::Get();

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -70,9 +70,7 @@ namespace ROS2
         AZStd::string GetStatus();
 
     private:
-        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(
-            const sdf::Link* link, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities);
-        void BuildAssetsForLink(const sdf::Link* link);
+        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(const sdf::Link* link, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities);
         void AddRobotControl(AZ::EntityId rootEntityId);
         static void MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId, AZStd::optional<AZ::Transform> spawnPosition);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -74,23 +74,21 @@ namespace ROS2::Utils
     using JointVisitorCallback = AZStd::function<bool(const sdf::Joint& joint, const ModelStack& modelStack)>;
     //! Visit joints from URDF/SDF
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
-    //! @param visitNestedModelJoints When true recurses to any nested <model> tags of the Model object and invoke visitor on their joints
-    //! as well
+    //! @param visitNestedModelJoints When true recurses to any nested <model> tags of the Model object and invoke visitor on their joint as well
     //! @returns void
     void VisitJoints(const sdf::Model& sdfModel, const JointVisitorCallback& jointVisitorCB, bool visitNestedModelJoints = false);
 
-    //! Retrieve all joints in URDF/SDF wehre the key is the full
+    //! Retrieve all joints in URDF/SDF where the key is the full composed path following the name scoping proposal in SDF 1.8
+    //! http://sdformat.org/tutorials?tut=composition_proposal#1-nesting-and-encapsulation
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
     //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
-    //! well
     //! @returns mapping from fully qualified joint name(such as "model_name::joint_name") to joint pointer
     AZStd::unordered_map<AZStd::string, const sdf::Joint*> GetAllJoints(const sdf::Model& sdfModel, bool gatherNestedModelJoints = false);
 
     //! Retrieve all joints from URDF/SDF in which the specified link is a child in a sdf::Joint.
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
     //! @param linkName Name of link which to query in joint objects ChildName()
-    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
-    //! well
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
     //! @returns vector of joints where link is a child
     AZStd::vector<const sdf::Joint*> GetJointsForChildLink(
         const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints = false);
@@ -98,8 +96,7 @@ namespace ROS2::Utils
     //! Retrieve all joints from URDF/SDF in which the specified link is a parent in a sdf::Joint.
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
     //! @param linkName Name of link which to query in joint objects ParentName()
-    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
-    //! well
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
     //! @returns vector of joints where link is a parent
     AZStd::vector<const sdf::Joint*> GetJointsForParentLink(
         const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints = false);
@@ -133,28 +130,32 @@ namespace ROS2::Utils
 
     //! Retrieve all meshes referenced in URDF as unresolved URDF patches.
     //! Note that returned filenames are unresolved URDF patches.
-    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param visual - search for visual meshes.
-    //! @param colliders - search for collider meshes.
+    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param visual search for visual meshes.
+    //! @param colliders search for collider meshes.
     //! @returns set of meshes' filenames.
     AZStd::unordered_set<AZStd::string> GetMeshesFilenames(const sdf::Root& root, bool visual, bool colliders);
 
     //! Returns the SDF model object which contains the specified link
-    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param linkName - Fully qualified name of of SDF link to lookup in the SDF document
-    //! A fully qualified can be of the form "modelname1::nested_modelname1::linkname"
+    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param linkName Fully qualified name of SDF link to lookup in the SDF document
+    //! A fully qualified name has the form "modelname1::nested_modelname1::linkname"
+    //! This is detailed in the SDF format composition proposal: http://sdformat.org/tutorials?tut=composition_proposal#motivation
     const sdf::Model* GetModelContainingLink(const sdf::Root& root, AZStd::string_view linkName);
-    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param link - SDF link object to lookup in the SDF document
+
+    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param link SDF link object to lookup in the SDF document
     const sdf::Model* GetModelContainingLink(const sdf::Root& root, const sdf::Link& link);
 
     //! Returns the SDF model object which contains the specified joint
-    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param jointName - Name of SDF joint to lookup in the SDF document
-    //! A fully qualified can be of the form "modelname1::nested_modelname1::jointname"
+    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param jointName Name of SDF joint to lookup in the SDF document
+    //! A fully qualified name has the form "modelname1::nested_modelname1::jointname"
+    //! This is detailed in the SDF format composition proposal: http://sdformat.org/tutorials?tut=composition_proposal#motivation
     const sdf::Model* GetModelContainingJoint(const sdf::Root& root, AZStd::string_view jointName);
-    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param joint- SDF joint pointer to lookup in the SDF document
+
+    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param joint SDF joint pointer to lookup in the SDF document
     const sdf::Model* GetModelContainingJoint(const sdf::Root& root, const sdf::Joint& joint);
 
     //! Callback used to check for file exist of a path referenced within a URDF/SDF file
@@ -163,11 +164,11 @@ namespace ROS2::Utils
     using FileExistsCB = AZStd::function<bool(const AZ::IO::PathView&)>;
 
     //! Resolves path for an asset referenced in a URDF/SDF file.
-    //! @param unresolvedPath - unresolved URDF/SDF path, example : `model://meshes/foo.dae`.
-    //! @param baseFilePath - the absolute path of URDF/SDF file which contains the path that is to be resolved.
-    //! @param amentPrefixPath - the string that contains available packages' path, separated by ':' signs.
-    //! @param settings - the asset path resolution settings to use for attempting to locate the correct files
-    //! @param fileExists - functor to check if the given file exists. Exposed for unit test, default one should be used.
+    //! @param unresolvedPath unresolved URDF/SDF path, example : `model://meshes/foo.dae`.
+    //! @param baseFilePath the absolute path of URDF/SDF file which contains the path that is to be resolved.
+    //! @param amentPrefixPath the string that contains available packages' path, separated by ':' signs.
+    //! @param settings the asset path resolution settings to use for attempting to locate the correct files
+    //! @param fileExists functor to check if the given file exists. Exposed for unit test, default one should be used.
     //! @returns resolved path to the referenced file within the URDF/SDF, or the passed-in path if no resolution was possible.
     AZ::IO::Path ResolveAssetPath(
         AZ::IO::Path unresolvedPath,

--- a/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
@@ -576,7 +576,7 @@ namespace UnitTest
         // Check the ROS2 visitor logic to make sure the joint with "world" parent link isn't visited
         auto joints = ROS2::Utils::GetAllJoints(*model);
         EXPECT_EQ(1, joints.size());
-        EXPECT_THAT(joints, ::testing::UnorderedPointwise(UnorderedMapKeyMatcher(), { "base_inertia_child_joint" }));
+        EXPECT_THAT(joints, ::testing::UnorderedPointwise(UnorderedMapKeyMatcher(), { "FooRobot::base_inertia_child_joint" }));
 
         // The libsdformat sdf::Model::JointCount function however returns 2
         // as the "world_base_joint" is skipped over by joint reduction
@@ -601,10 +601,9 @@ namespace UnitTest
         EXPECT_EQ("FooRobot", model->Name());
         ASSERT_NE(nullptr, model);
 
-        // Due to joint reduction there should be 2 links and 43 frames
+        // Due to joint reduction there should be 2 links and 4 frames
         // This is different from the previous test, as the root link
-        // can now partipate in joint reduction because it has a name
-        // that isn't "world"
+        // can now partipate in joint reduction because its name isn't "world"
         ASSERT_EQ(2, model->LinkCount());
         ASSERT_EQ(4, model->FrameCount());
 
@@ -625,7 +624,7 @@ namespace UnitTest
         // there should only be a single one of the revolute joint
         auto joints = ROS2::Utils::GetAllJoints(*model);
         EXPECT_EQ(1, joints.size());
-        EXPECT_THAT(joints, ::testing::UnorderedPointwise(UnorderedMapKeyMatcher(), { "base_inertia_child_joint" }));
+        EXPECT_THAT(joints, ::testing::UnorderedPointwise(UnorderedMapKeyMatcher(), { "FooRobot::base_inertia_child_joint" }));
 
         // The libsdformat sdf::Model::JointCount function should match
         // the ROS2 Visitor logic as the root link of "not_world" is part of joint reduction
@@ -741,12 +740,12 @@ namespace UnitTest
         // into the base_link of the SDF
         // However there are Frames for the combined links and joints
         EXPECT_EQ(links.size(), 3);
-        ASSERT_TRUE(links.contains("base_link"));
-        ASSERT_TRUE(links.contains("link2"));
-        ASSERT_TRUE(links.contains("link3"));
-        EXPECT_EQ("base_link", links.at("base_link")->Name());
-        EXPECT_EQ("link2", links.at("link2")->Name());
-        EXPECT_EQ("link3", links.at("link3")->Name());
+        ASSERT_TRUE(links.contains("complicated::base_link"));
+        ASSERT_TRUE(links.contains("complicated::link2"));
+        ASSERT_TRUE(links.contains("complicated::link3"));
+        EXPECT_EQ("base_link", links.at("complicated::base_link")->Name());
+        EXPECT_EQ("link2", links.at("complicated::link2")->Name());
+        EXPECT_EQ("link3", links.at("complicated::link3")->Name());
 
         // Check that the frame names exist on the model
         EXPECT_TRUE(model->FrameNameExists("joint_bs"));
@@ -764,8 +763,8 @@ namespace UnitTest
         ASSERT_NE(nullptr, model);
         auto joints = ROS2::Utils::GetAllJoints(*model);
         EXPECT_EQ(2, joints.size());
-        ASSERT_TRUE(joints.contains("joint0"));
-        ASSERT_TRUE(joints.contains("joint1"));
+        ASSERT_TRUE(joints.contains("complicated::joint0"));
+        ASSERT_TRUE(joints.contains("complicated::joint1"));
     }
 
     TEST_F(UrdfParserTest, TestTransforms)
@@ -781,12 +780,12 @@ namespace UnitTest
         // The "link1" is combined with the base_link through
         // joint reduction in the URDF->SDF parser logic
         // https://github.com/gazebosim/sdformat/issues/1110
-        ASSERT_TRUE(links.contains("base_link"));
-        ASSERT_TRUE(links.contains("link2"));
-        ASSERT_TRUE(links.contains("link3"));
-        const auto base_link_ptr = links.at("base_link");
-        const auto link2_ptr = links.at("link2");
-        const auto link3_ptr = links.at("link3");
+        ASSERT_TRUE(links.contains("complicated::base_link"));
+        ASSERT_TRUE(links.contains("complicated::link2"));
+        ASSERT_TRUE(links.contains("complicated::link3"));
+        const auto base_link_ptr = links.at("complicated::base_link");
+        const auto link2_ptr = links.at("complicated::link2");
+        const auto link3_ptr = links.at("complicated::link3");
 
         // values exported from Blender
         const AZ::Vector3 expected_translation_link1{ 0.0, 0.0, 0.0 };
@@ -861,7 +860,7 @@ namespace UnitTest
 
     TEST_F(UrdfParserTest, TestPathResolve_ValidAbsolutePath_ResolvesCorrectly)
     {
-        // Verify that an absolute path that wouldn't be resolved by prefixes or ancestor paths 
+        // Verify that an absolute path that wouldn't be resolved by prefixes or ancestor paths
         // or the AMENT_PREFIX_PATH will still resolve correctly as long as the absolute path exists
         // (as determined by the mocked-out FileExistsCallback below).
         constexpr AZ::IO::PathView dae = "file:///usr/ros/humble/meshes/bar.dae";
@@ -944,7 +943,7 @@ namespace UnitTest
             [](const AZ::IO::PathView& p) -> bool
             {
                 // For an AMENT_PREFIX_PATH to be a valid match, the share/<package>/package.xml and share/<relative path>
-                // both need to exist. We'll return that both exist, but since the dae file entry doesn't start with 
+                // both need to exist. We'll return that both exist, but since the dae file entry doesn't start with
                 // "package://" or "model://", it shouldn't get resolved.
                 return (p == AZ::IO::PathView("/ament/path2/share/robot/package.xml")) || (p == "/ament/path2/share/robot/meshes/bar.dae");
             });
@@ -991,7 +990,7 @@ namespace UnitTest
         constexpr AZ::IO::PathView dae = "package://meshes/bar.dae";
         constexpr AZ::IO::PathView urdf = "/home/foo/ros_ws/install/foo_robot/description/foo_robot.urdf";
         constexpr AZ::IO::PathView resolvedDae = "/home/foo/ros_ws/install/foo_robot/meshes/bar.dae";
-        
+
         auto settings = GetTestSettings();
         settings.m_resolverSettings.m_useAncestorPaths = false;
 

--- a/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
@@ -539,8 +539,7 @@ namespace UnitTest
 
     TEST_F(UrdfParserTest, ParseUrdf_WithRootLink_WithName_world_DoesNotContain_world_Link)
     {
-        // The libsdformat URDF parser skips converting the root link if its
-        // name is "world"
+        // The libsdformat URDF parser skips converting the root link if its name is "world"
         // https://github.com/gazebosim/sdformat/blob/a1027c3ed96f2f663760df10f13b06f47f922c55/src/parser_urdf.cc#L3385-L3399
         // Therefore it will not be part of joint reduction
         constexpr const char* RootLinkName = "world";
@@ -603,7 +602,7 @@ namespace UnitTest
 
         // Due to joint reduction there should be 2 links and 4 frames
         // This is different from the previous test, as the root link
-        // can now partipate in joint reduction because its name isn't "world"
+        // can now participate in joint reduction because its name isn't "world"
         ASSERT_EQ(2, model->LinkCount());
         ASSERT_EQ(4, model->FrameCount());
 


### PR DESCRIPTION
Link names within an SDF are only unique with a <model> tag, not unique across the entire SDF document.

The `CreatePrefabTemplateFromUrdfOrSdf` function has been modified to create a JointMapper object which stores a mapping of joints to all their parent and child links. It also creates a mapping of joints to the model they are directly attached to.

A similar LinkMapper structure has been added for SDF links, which stores a mapping of the link to their attached model.

Instead of `CreatePrefabTemplateFromUrdfOrSdf` creating a mapping of SDF link name to O3DE Entity, that mapping has now been updated toi map the SDF link pointer to O3DE Entity. This ensures that SDF links with same name are not lost when mapping to O3DE entities. This is needed as SDF links and joints are only required to be unique relative to their attached model. Two links on different models, can have the same link name (http://sdformat.org/tutorials?tut=composition_proposal#1-6-proposed-parsing-stages)

Updated the Robot Importer Visitor callback to require "ModelStack" parameters, which passes in the stack of `sdf::Model` objects that were visited on the way to the sdf element being visited be that a link, joint or nested model. Also updated the GetAllJoints and GetAllLinks function to store a fully qualified name for the joint/link including the ancestor model names when returning the name to joint and name to link map respectively.