### PR TITLE
Add import optimization settings for obj files.

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -9,6 +9,7 @@
 #include "SourceAssetsStorage.h"
 #include "RobotImporterUtils.h"
 #include <AzCore/IO/FileIO.h>
+#include <AzCore/Serialization/Json/JsonImporter.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
@@ -20,7 +21,9 @@
 #include <SceneAPI/SceneCore/DataTypes/Groups/ISceneNodeGroup.h>
 #include <SceneAPI/SceneCore/Events/AssetImportRequest.h>
 #include <SceneAPI/SceneCore/Events/SceneSerializationBus.h>
+#include <SceneAPI/SceneCore/Import/SceneImportSettings.h>
 #include <SceneAPI/SceneCore/Utilities/SceneGraphSelector.h>
+#include <SceneAPI/SceneData/Groups/ImportGroup.h>
 #include <SceneAPI/SceneData/Groups/MeshGroup.h>
 #include <SceneAPI/SceneData/Rules/UVsRule.h>
 #include <Source/Pipeline/MeshGroup.h> // PhysX/Code/Source/Pipeline/MeshGroup.h
@@ -455,6 +458,28 @@ namespace ROS2::Utils
 
     bool CreateSceneManifest(const AZ::IO::Path& sourceAssetPath, const AZ::IO::Path& assetInfoFile, bool collider, bool visual)
     {
+        // Start with a default set of import settings.
+        AZ::SceneAPI::SceneImportSettings importSettings;
+
+        // OBJ files used for robotics might be authored with hundreds or thousands of tiny groups of meshes. By default,
+        // AssImp splits each object or group in an OBJ into a separate submesh, creating an extremely non-optimal result.
+        // By turning on the AssImp options to optimize the scene and the meshes, all of these submeshes will get recombined
+        // back into just a few submeshes.
+        if (sourceAssetPath.Extension() == ".obj")
+        {
+            importSettings.m_optimizeScene = true;
+            importSettings.m_optimizeMeshes = true;
+        }
+
+        // Set the import settings into the settings registry.
+        // This needs to happen before calling LoadScene so that the AssImp import settings are applied to the scene being
+        // read into memory. These settings affect the list of scene nodes referenced by the MeshGroup and PhysXGroup settings,
+        // so it's important to apply them here to get the proper node lists.
+        if (AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry)
+        {
+            settingsRegistry->SetObject(AZ::SceneAPI::DataTypes::IImportGroup::SceneImportSettingsRegistryKey, importSettings);
+        }
+
         const auto& azMeshPath = sourceAssetPath;
         AZ_Printf("CreateSceneManifest", "Creating manifest for asset %s at : %s ", sourceAssetPath.c_str(), assetInfoFile.c_str());
         AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> scene;
@@ -487,6 +512,12 @@ namespace ROS2::Utils
             AZ_Printf("CreateSceneManifest", "Deleting %s", obj->RTTI_GetType().ToString<AZStd::string>().c_str());
             manifest.RemoveEntry(obj);
         }
+
+        // Create an entry for the import settings. This will contain default settings for most mesh files,
+        // but will enable the import optimization settings for OBJ files.
+        auto sceneDataImportGroup = AZStd::make_shared<AZ::SceneAPI::SceneData::ImportGroup>();
+        sceneDataImportGroup->SetImportSettings(importSettings);
+        manifest.AddEntry(sceneDataImportGroup);
 
         if (visual)
         {


### PR DESCRIPTION
OBJ files such as the tm12-arm1 can have thousands of submeshes due to the way OBJ files are processed by AssImp. This PR changes the Robot Importer to turn on AssImp optimization settings for OBJ files only to collapse redundant submeshes down to the most optimal set.

This PR relies on the companion O3DE PR to introduce the concept of import settings:
https://github.com/o3de/o3de/pull/16753

These changes produce a tm12-arm1.obj.assetinfo file that looks like the following:
```
{
    "values": [
        {
            "$type": "{41DCBEAB-203C-4A05-96FA-98E1D8A96FA1} ImportGroup",
            "ImportSettings": {
                "OptimizeScene": true,
                "OptimizeMeshes": true
            }
        },
        {
            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
            "name": "tm12-arm1",
            "nodeSelectionList": {
                "selectedNodes": [
                    "$MergedNode_0",
                    "$MergedNode_0.$MergedNode_0_1",
                    "$MergedNode_0.$MergedNode_0_1.MTL0",
                    "$MergedNode_0.$MergedNode_0_1.MTL1",
                    "$MergedNode_0.$MergedNode_0_1.MTL2",
                    "$MergedNode_0.$MergedNode_0_1.UV0",
                    "$MergedNode_0.$MergedNode_0_2",
                    "$MergedNode_0.$MergedNode_0_2.MTL0",
                    "$MergedNode_0.$MergedNode_0_2.MTL1",
                    "$MergedNode_0.$MergedNode_0_2.MTL2",
                    "$MergedNode_0.$MergedNode_0_2.UV0"
                ]
            },
            "rules": {
                "rules": [
                    {
                        "$type": "UVsRule"
                    }
                ]
            },
            "id": "{9BCB3143-12B5-4D4A-8EE7-9F8339186E68}"
        }
    ]
}
```

Note that it only has two submeshes instead of 2000+.