### PR TITLE
Fix ROS2 remote gem compatibility

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -123,7 +123,7 @@
                 "ROS2"
             ],
             "compatible_engines": [
-                "o3de-sdk==1.2.0",
+                "o3de-sdk>=1.2.0",
                 "o3de>=1.2.0"
             ],
             "icon_path": "preview.png",

--- a/repo.json
+++ b/repo.json
@@ -123,8 +123,8 @@
                 "ROS2"
             ],
             "compatible_engines": [
-                "o3de-sdk>=1.2.0",
-                "o3de>=1.2.0"
+                "o3de-sdk>=2.1.0",
+                "o3de>=2.1.0"
             ],
             "icon_path": "preview.png",
             "requirements": "Requires ROS 2 installation (supported distributions: Humble). Source your workspace before building the Gem",


### PR DESCRIPTION
The repo.json gem compatibility does not match what is in the actual ROS2 gem.json causing the ROS2 gem to fail compatibility checks before downloading in Project Manager. 

*Testing*
I am not currently setup to test this on Linux, but at the very least this non-code change shouldn't break things any worse than before.