### PR TITLE
Merge repo.json fix for ROS2 gem version

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -123,8 +123,8 @@
                 "ROS2"
             ],
             "compatible_engines": [
-                "o3de-sdk==1.2.0",
-                "o3de>=1.2.0"
+                "o3de-sdk>=2.1.0",
+                "o3de>=2.1.0"
             ],
             "icon_path": "preview.png",
             "requirements": "Requires ROS 2 installation (supported distributions: Humble). Source your workspace before building the Gem",


### PR DESCRIPTION
This change merges the fix for the ROS2 gem version compatibility from `stabilization/2310` to `development`.