### PR TITLE
Fix Mismatched Gem versioning for the ROS gem

### DIFF
--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -18,8 +18,8 @@
         "ROS2"
     ],
     "compatible_engines": [
-        "o3de-sdk>=1.2.0",
-        "o3de>=1.2.0"
+        "o3de-sdk>=2.1.0",
+        "o3de>=2.1.0"
     ],
     "icon_path": "preview.png",
     "requirements": "Requires ROS 2 installation (supported distributions: Humble). Source your workspace before building the Gem",


### PR DESCRIPTION
The [recent update ](https://github.com/o3de/o3de-extras/pull/541)to fix the engine versioning for the ROS2 gem was not reflected in the ROS2 gem's `gem.json`.

This mismatch causes the following error:
```
[ERROR] o3de.download: SECURITY VIOLATION: Downloaded gem.json contents do not match the advertised manifest json contents.
[ERROR] o3de.download: Could not validate zip, deleting /home/o3de/.o3de/Cache/gems/ROS2/gem.zip
```
