### PR TITLE
Update ROS2 gem.json on repo.json compatible versions to o3de>=2.1.0

### DIFF
--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -18,8 +18,8 @@
         "ROS2"
     ],
     "compatible_engines": [
-        "o3de-sdk>=1.2.0",
-        "o3de>=1.2.0"
+        "o3de-sdk>=2.1.0",
+        "o3de>=2.1.0"
     ],
     "icon_path": "preview.png",
     "requirements": "Requires ROS 2 installation (supported distributions: Humble). Source your workspace before building the Gem",
@@ -32,9 +32,8 @@
         "PhysX",
         "PrimitiveAssets",
         "StartingPointInput"
-
     ],
     "restricted": "ROS2",
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-1.0.0-gem.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-2.0.0-gem.zip"
 }

--- a/repo.json
+++ b/repo.json
@@ -122,10 +122,6 @@
             "user_tags": [
                 "ROS2"
             ],
-            "compatible_engines": [
-                "o3de-sdk>=2.1.0",
-                "o3de>=2.1.0"
-            ],
             "icon_path": "preview.png",
             "requirements": "Requires ROS 2 installation (supported distributions: Humble). Source your workspace before building the Gem",
             "documentation_url": "https://o3de.org/docs/user-guide/gems/reference/design/ros2/",
@@ -139,13 +135,33 @@
             ],
             "restricted": "ROS2",
             "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-            "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-1.0.0-gem.zip",
-            "sha256": "fb17868ab3f10d4fb1fae66667281978f68c6f36ea4dd1d814dafdb4fbecc23d",
             "versions_data": [
                 {
+                    "compatible_engines": [
+                        "o3de-sdk==1.2.0",
+                        "o3de>=1.2.0"
+                    ],
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-1.0.0-gem.zip",
                     "sha256": "62db01423611893c366c7905b91b165ebfc5da4a09a08ddebddf188e98acdce4",
-                    "version": "1.0.0",
-                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-1.0.0-gem.zip"
+                    "version": "1.0.0"
+                },
+                {
+                    "version": "2.0.0",
+                    "compatible_engines": [
+                        "o3de-sdk>=2.1.0",
+                        "o3de>=2.1.0"
+                    ],
+                    "dependencies": [
+                        "Atom_RPI",
+                        "Atom_Feature_Common",
+                        "Atom_Component_DebugCamera",
+                        "CommonFeaturesAtom",
+                        "PhysX",
+                        "PrimitiveAssets",
+                        "StartingPointInput"
+                    ],
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-2.0.0-gem.zip",
+                    "sha256": "8910f69ffb7598a6c0880f44fb6785edfa90e7de47becdff4358c978be848fd4"
                 }
             ]
         },


### PR DESCRIPTION
This updates the `gem.json`, the `repo.json` and provides the download URL for the .zip containing the gem with the SHA256.
The generated .zip archive for ROS2 version 2.0.0 has been uploaded to the [2.0 release](https://github.com/o3de/o3de-extras/releases/tag/2.0)

These changes were made using the o3de CLI like so:
```bash
f:/o3de/scripts/o3de.bat edit-repo-properties --repo-path f:/git/o3de-extras/repo.json --add-gem f:/downloads/ros2-1.0.0 --release-archive-path f:\git\o3de-extras\build --download-prefix https://github.com/o3de/o3de-extras/releases/download/2.0

f:/o3de/scripts/o3de.bat edit-repo-properties --repo-path f:/git/o3de-extras/repo.json --add-gem f:\git\o3de-extras\Gems\ROS2 --release-archive-path f:\git\o3de-extras\build --download-prefix https://github.com/o3de/o3de-extras/releases/download/2.0
```
After the changes I went in and fixed the line endings on repo.json and gem.json

**Testing**
Added the o3de-extras repo locally and verified could download both versions of the ROS2 gem