### PR TITLE
Adding back inadvertent code deletion from the RobotImporterWidget.cpp

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -447,6 +447,7 @@ namespace ROS2
         const AZ::IO::Path prefabPath(AZ::IO::Path(AZ::Utils::GetProjectPath()) / prefabPathRelative);
         bool fileExists = AZ::IO::FileIOBase::GetInstance()->Exists(prefabPath.c_str());
 
+        if (CheckCyclicalDependency(prefabPathRelative))
         {
             m_prefabMakerPage->setSuccess(false);
             return;


### PR DESCRIPTION
The `RobotImporterWidget::CreatePrefab` function had its call to `CheckCyclicalDependency` removed as part of a conflict when resolving a rebase operations.

This change adds back the line that was removed in commit https://github.com/o3de/o3de-extras/commit/6acba55cc034d869a48ee590e7062cf18b3a8fc1#diff-a94c8f5626d21f747b96f4077dd8eb2119c48048840f5db593071a7a96c5a577