### PR TITLE
Create default seedList with required .pass Asset

### DIFF
--- a/Gems/ROS2/Assets/seedList.seed
+++ b/Gems/ROS2/Assets/seedList.seed
@@ -1,0 +1,14 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "AZStd::vector<SeedInfo, allocator>",
+    "ClassData": [
+        {
+            "assetId": {
+                "guid": "{58E05BD5-3187-58D7-9792-18DA2F6F63A0}"
+            },
+            "platformFlags": 2,
+            "pathHint": "passes/rospasstemplates.azasset"
+        }
+    ]
+}


### PR DESCRIPTION
This PR introduces default seedList to `ROS2 Gem` containing `rospasstemplates.azasset`.
Launching standalone GameLauncher without this asset results in segfault if any ROS2CameraSensorComponent is present in the scene

Default seedList is included by default if ROS2 Gem is enabled according to [documentation](https://development--o3deorg.netlify.app/docs/user-guide/programming/gems/creating/)

This change does not influence `ROS2 Gem` functionality 
