### PR TITLE
Update the ROS2 gem zip for stabilization

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -151,17 +151,8 @@
                         "o3de-sdk>=2.1.0",
                         "o3de>=2.1.0"
                     ],
-                    "dependencies": [
-                        "Atom_RPI",
-                        "Atom_Feature_Common",
-                        "Atom_Component_DebugCamera",
-                        "CommonFeaturesAtom",
-                        "PhysX",
-                        "PrimitiveAssets",
-                        "StartingPointInput"
-                    ],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-2.0.0-gem.zip",
-                    "sha256": "8910f69ffb7598a6c0880f44fb6785edfa90e7de47becdff4358c978be848fd4"
+                    "sha256": "93a51bebd7d5b931996025d6622bb09a6c20d6071da625d57eddf80f285444af"
                 }
             ]
         },


### PR DESCRIPTION
We need update the ROS2 gem based on the stabilization branch since it is different than the development branch