### PR TITLE
sensor importer: fix camera fov

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -47,7 +47,7 @@ namespace ROS2::SDFormat
             {
                 double aspectRatio = static_cast<double>(cameraConfiguration.m_height) / cameraConfiguration.m_width;
                 cameraConfiguration.m_verticalFieldOfViewDeg =
-                    2.0 * AZStd::atan(AZStd::tan(cameraSensor->HorizontalFov().Radian() / 2.0) * aspectRatio);
+                    AZ::RadToDeg(2.0 * AZStd::atan(AZStd::tan(cameraSensor->HorizontalFov().Radian() / 2.0) * aspectRatio));
             }
             if (sdfSensor.Type() != sdf::SensorType::DEPTH_CAMERA)
             {


### PR DESCRIPTION
The field of view of the newly created camera was stored in radians instead of degrees. Now it works as expected.

Tested with Robotis OP3 robot.