### PR TITLE
SDF Nested Model Support Changes

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
@@ -105,7 +105,9 @@ namespace ROS2
         int i = m_table->rowCount();
         m_table->setRowCount(i + 1);
 
-        bool isOk = assetSourcePath.has_value() && resolvedSdfPath.has_value();
+        // The Asset ID GUID not be null(all zeros) and the asset source path must not be empty
+        bool isOk = (assetSourcePath.has_value() && !assetSourcePath->empty() && assetSourcePath != "not found")
+            && (resolvedSdfPath.has_value() && !resolvedSdfPath->empty()) && !assetUuid.IsNull();
         if (!isOk)
         {
             m_missingCount++;
@@ -154,8 +156,13 @@ namespace ROS2
             m_table->item(i, Columns::ResolvedMeshPath)->setIcon(m_failureIcon);
             m_table->setItem(i, Columns::ProductAsset, createCell(false, QString()));
         }
-        m_assetsPaths.push_back(assetSourcePath ? *assetSourcePath : AZStd::string());
-        m_assetsUuids.push_back(assetUuid);
+
+        // Don't add an empty asset path to the list of resolved assets
+        if (isOk)
+        {
+            m_assetsPaths.push_back(AZStd::move(*assetSourcePath));
+            m_assetsUuids.push_back(assetUuid);
+        }
     }
 
     void CheckAssetPage::StartWatchAsset()

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
@@ -105,7 +105,7 @@ namespace ROS2
         int i = m_table->rowCount();
         m_table->setRowCount(i + 1);
 
-        // The Asset ID GUID not be null(all zeros) and the asset source path must not be empty
+        // The Asset ID GUID must not be null(all zeros) and the asset source path must not be empty
         bool isOk = (assetSourcePath.has_value() && !assetSourcePath->empty() && assetSourcePath != "not found")
             && (resolvedSdfPath.has_value() && !resolvedSdfPath->empty()) && !assetUuid.IsNull();
         if (!isOk)

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -330,14 +330,11 @@ namespace ROS2
                         type = tr("Collider");
                     }
 
-                    if (m_urdfAssetsMapping->contains(meshPath))
-                    {
-                        const auto& asset = m_urdfAssetsMapping->at(meshPath);
-                        sourceAssetUuid = asset.m_availableAssetInfo.m_sourceGuid;
-                        sourcePath = asset.m_availableAssetInfo.m_sourceAssetRelativePath.String();
-                        resolvedPath = asset.m_resolvedUrdfPath.String();
-                        crc = asset.m_urdfFileCRC;
-                    }
+                    const auto& asset = m_urdfAssetsMapping->at(meshPath);
+                    sourceAssetUuid = asset.m_availableAssetInfo.m_sourceGuid;
+                    sourcePath = asset.m_availableAssetInfo.m_sourceAssetRelativePath.String();
+                    resolvedPath = asset.m_resolvedUrdfPath.String();
+                    crc = asset.m_urdfFileCRC;
                 }
                 m_assetPage->ReportAsset(sourceAssetUuid, meshPath, type, sourcePath, crc, resolvedPath);
             }

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -535,7 +535,7 @@ namespace ROS2
             return createEntityResult;
         }
 
-        // Get the model entity and update it's transform component with the pose information
+        // Get the model entity and update its transform component with the pose information
         AZ::EntityId entityId = createEntityResult.GetValue();
         AZStd::unique_ptr<AZ::Entity> entity(AzToolsFramework::GetEntityById(entityId));
 

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -379,7 +379,7 @@ namespace ROS2
                     "Joint %s has no parent link %s. Cannot create",
                     azJointName.c_str(),
                     parentLinkName.c_str());
-                return true;
+                continue;
             }
             auto leadEntity = parentEntityIter->second;
 
@@ -395,7 +395,7 @@ namespace ROS2
                     "Joint %s has no child link %s. Cannot create",
                     azJointName.c_str(),
                     childLinkName.c_str());
-                return true;
+                continue;
             }
             auto childEntity = childEntityIter->second;
 
@@ -430,7 +430,6 @@ namespace ROS2
                     AZ_Warning("CreatePrefabFromUrdfOrSdf", false, "cannot create joint %s", azJointName.c_str());
                 }
             }
-            return true;
         }
 
         // Use the first entity based on a link that is not parented to any other link

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -70,7 +70,8 @@ namespace ROS2
         AZStd::string GetStatus();
 
     private:
-        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(const sdf::Link* link, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities);
+        AzToolsFramework::Prefab::PrefabEntityResult CreateEntityForModel(const sdf::Model& model);
+        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(const sdf::Link& link, const sdf::Model* attachedModel, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities);
         void AddRobotControl(AZ::EntityId rootEntityId);
         static void MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId, AZStd::optional<AZ::Transform> spawnPosition);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -144,7 +144,7 @@ namespace ROS2::Utils
     const sdf::Model* GetModelContainingLink(const sdf::Root& root, AZStd::string_view linkName);
 
     //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param link SDF link object to lookup in the SDF document
+    //! @param link SDF link reference to lookup in the SDF document
     const sdf::Model* GetModelContainingLink(const sdf::Root& root, const sdf::Link& link);
 
     //! Returns the SDF model object which contains the specified joint
@@ -155,8 +155,14 @@ namespace ROS2::Utils
     const sdf::Model* GetModelContainingJoint(const sdf::Root& root, AZStd::string_view jointName);
 
     //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param joint SDF joint pointer to lookup in the SDF document
+    //! @param joint SDF joint reference to lookup in the SDF document
     const sdf::Model* GetModelContainingJoint(const sdf::Root& root, const sdf::Joint& joint);
+
+    //! Returns the SDF model object which contains the specified model
+    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param model SDF model reference to lookup in the SDF document
+    //! @return pointer to parent model containing this model if the model is nested, otherwise nullptr
+    const sdf::Model* GetModelContainingModel(const sdf::Root& root, const sdf::Model& model);
 
     //! Callback used to check for file exist of a path referenced within a URDF/SDF file
     //! @param path Candidate local filesystem path to check for existence


### PR DESCRIPTION
Added a `GetModelContainingModel` function that can return the parent model of a nested model

Updated the URDFPrefabMaker to create an Entity for which represents the URDF/SDF model itself.

The AddEntitiesForLink function has been updated to to pass in the model that the link is attached to and in order to allow the CollidersMaker, ArticulationsMaker and SensorsMaker have access to the Model

Updated the Check Asset Page to not add Assets with empty source paths or null Asset IDs to the list of resolved assets