### PR TITLE
Fix not working lidars in ros2 fleet template

### DIFF
--- a/Templates/Ros2FleetRobotTemplate/Template/Prefabs/ProteusLaserScanner.prefab
+++ b/Templates/Ros2FleetRobotTemplate/Template/Prefabs/ProteusLaserScanner.prefab
@@ -133,7 +133,7 @@
                 {
                     "op": "replace",
                     "path": "/Entities/Entity_[15629654211104]/Components/Component_[17075084475750345983]/Configuration/Centre of mass offset/0",
-                    "value": 2.94287438862284e-9
+                    "value": 2.9428743886228403e-9
                 },
                 {
                     "op": "replace",
@@ -163,7 +163,7 @@
                 {
                     "op": "replace",
                     "path": "/Entities/Entity_[15672603884064]/Components/Component_[11685358238844952494]/Configuration/Centre of mass offset/0",
-                    "value": 2.94287438862284e-9
+                    "value": 2.9428743886228403e-9
                 },
                 {
                     "op": "replace",
@@ -263,8 +263,8 @@
                                         "Name": "CustomLidar2D",
                                         "Layers": 1,
                                         "Points per layer": 924,
-                                        "Min horizontal angle": -180.0,
-                                        "Max horizontal angle": 180.0,
+                                        "Min horizontal angle": -90.0,
+                                        "Max horizontal angle": 90.0,
                                         "Min vertical angle": 0.0,
                                         "Max vertical angle": 0.0,
                                         "Min range": 0.0,

--- a/Templates/Ros2FleetRobotTemplate/Template/Prefabs/ProteusLaserScanner.prefab
+++ b/Templates/Ros2FleetRobotTemplate/Template/Prefabs/ProteusLaserScanner.prefab
@@ -122,16 +122,6 @@
                 },
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[15659718982176]/Components/Component_[1153232506834696450]/ColliderConfiguration/CollisionLayer/Index",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[15659718982176]/Components/Component_[639102350977932618]/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
-                },
-                {
-                    "op": "replace",
                     "path": "/Entities/Entity_[15629654211104]/Components/Component_[12925256151907998248]/ColliderConfiguration/CollisionLayer/Index",
                     "value": 1
                 },
@@ -143,7 +133,7 @@
                 {
                     "op": "replace",
                     "path": "/Entities/Entity_[15629654211104]/Components/Component_[17075084475750345983]/Configuration/Centre of mass offset/0",
-                    "value": 2.9428743886228403e-9
+                    "value": 2.94287438862284e-9
                 },
                 {
                     "op": "replace",
@@ -153,7 +143,7 @@
                 {
                     "op": "replace",
                     "path": "/Entities/Entity_[15629654211104]/Components/Component_[17075084475750345983]/Configuration/Centre of mass offset/2",
-                    "value": -4.170040701634292e-10
+                    "value": -4.1700407016342917e-10
                 },
                 {
                     "op": "replace",
@@ -173,7 +163,7 @@
                 {
                     "op": "replace",
                     "path": "/Entities/Entity_[15672603884064]/Components/Component_[11685358238844952494]/Configuration/Centre of mass offset/0",
-                    "value": 2.9428743886228403e-9
+                    "value": 2.94287438862284e-9
                 },
                 {
                     "op": "replace",
@@ -183,7 +173,7 @@
                 {
                     "op": "replace",
                     "path": "/Entities/Entity_[15672603884064]/Components/Component_[11685358238844952494]/Configuration/Centre of mass offset/2",
-                    "value": -4.170040701634292e-10
+                    "value": -4.1700407016342917e-10
                 },
                 {
                     "op": "replace",
@@ -203,6 +193,26 @@
                 {
                     "op": "replace",
                     "path": "/Entities/Entity_[15642539112992]/Components/Component_[8110923963616165068]/ColliderConfiguration/CollisionLayer/Index",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[15659718982176]/Components/Component_[1153232506834696450]/ColliderConfiguration/CollisionLayer/Index",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[15659718982176]/Components/Component_[1153232506834696450]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
+                    "value": "proteus_chassis.fbx.pxmesh"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[15659718982176]/Components/Component_[1153232506834696450]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
+                    "value": "proteus_chassis.fbx.pxmesh"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[15659718982176]/Components/Component_[639102350977932618]/m_template/Namespace Configuration/Namespace Strategy",
                     "value": 1
                 },
                 {
@@ -245,31 +255,33 @@
                                     }
                                 }
                             },
-                            "lidarConfiguration": {
-                                "lidarModel": 6,
-                                "lidarImplementation": "Scene Queries",
-                                "LidarParameters": {
-                                    "Name": "CustomLidar2D",
-                                    "Layers": 1,
-                                    "Points per layer": 924,
-                                    "Min horizontal angle": -180.0,
-                                    "Max horizontal angle": 180.0,
-                                    "Min vertical angle": 0.0,
-                                    "Max vertical angle": 0.0,
-                                    "Min range": 0.0,
-                                    "Max range": 100.0,
-                                    "Enable Noise": true,
-                                    "Noise Parameters": {
-                                        "Angular noise standard deviation": 0.0,
-                                        "Distance noise standard deviation base": 0.019999999552965164,
-                                        "Distance noise standard deviation slope": 0.0010000000474974513
-                                    }
-                                },
-                                "IgnoredLayerIndices": [
-                                    1
-                                ],
-                                "ExcludedEntities": [],
-                                "PointsAtMax": false
+                            "lidarCore": {
+                                "lidarConfiguration": {
+                                    "lidarModelName": "CustomLidar2D",
+                                    "lidarImplementation": "Scene Queries",
+                                    "LidarParameters": {
+                                        "Name": "CustomLidar2D",
+                                        "Layers": 1,
+                                        "Points per layer": 924,
+                                        "Min horizontal angle": -180.0,
+                                        "Max horizontal angle": 180.0,
+                                        "Min vertical angle": 0.0,
+                                        "Max vertical angle": 0.0,
+                                        "Min range": 0.0,
+                                        "Max range": 100.0,
+                                        "Enable Noise": true,
+                                        "Noise Parameters": {
+                                            "Angular noise standard deviation": 0.0,
+                                            "Distance noise standard deviation base": 0.019999999552965164,
+                                            "Distance noise standard deviation slope": 0.0010000000474974513
+                                        }
+                                    },
+                                    "IgnoredLayerIndices": [
+                                        1
+                                    ],
+                                    "ExcludedEntities": [],
+                                    "PointsAtMax": false
+                                }
                             }
                         }
                     }

--- a/Templates/Ros2FleetRobotTemplate/Template/Prefabs/ProteusLaserScanner.prefab
+++ b/Templates/Ros2FleetRobotTemplate/Template/Prefabs/ProteusLaserScanner.prefab
@@ -107,29 +107,33 @@
             "Source": "Proteus.prefab",
             "Patches": [
                 {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[15672603884064]/Components/Component_[11685358238844952494]/Configuration/Centre of mass offset/0",
-                    "value": 2.9428743886228403e-9
+                    "op": "add",
+                    "path": "/Entities/Entity_[15633949178400]/Components/EditorDisabledCompositionComponent",
+                    "value": {
+                        "$type": "EditorDisabledCompositionComponent",
+                        "Id": 14784301335085961779,
+                        "DisabledComponents": []
+                    }
                 },
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[15672603884064]/Components/Component_[11685358238844952494]/Configuration/Centre of mass offset/1",
-                    "value": -2.702547352573248e-10
+                    "path": "/ContainerEntity/Components/Component_[15237572906287023176]/Parent Entity",
+                    "value": "../Entity_[112333485759082]"
                 },
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[15672603884064]/Components/Component_[11685358238844952494]/Configuration/Centre of mass offset/2",
-                    "value": -4.1700407016342917e-10
+                    "path": "/Entities/Entity_[15659718982176]/Components/Component_[1153232506834696450]/ColliderConfiguration/CollisionLayer/Index",
+                    "value": 1
                 },
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[15672603884064]/Components/Component_[11685358238844952494]/Configuration/Inertia tensor/4",
-                    "value": 0.002883758395910263
+                    "path": "/Entities/Entity_[15659718982176]/Components/Component_[639102350977932618]/m_template/Namespace Configuration/Namespace Strategy",
+                    "value": 1
                 },
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[15672603884064]/Components/Component_[7456975798968691780]/ShapeConfiguration/Cylinder/Configuration/CookedData",
-                    "value": "TlhTAUNWWE0OAAAAAAAAAElDRQFDTEhMCQAAAEAAAABgAAAAIgAAAMAAAADic4E8u3STPFOzor14ezYyu3STPFTjpb3Wc4G8u3STPFWzor0m7v28u3STPLJCmb0oUzi9u3STPEruib3dmWq9u3STPN+Zar1K7om9u3STPCtTOL2yQpm9u3STPDDu/bxTs6K9u3STPOBzgbxU46W9u3STPEpP87FVs6K9u3STPNhzgTyyQpm9u3STPCnu/TxK7om9u3STPCpTOD3fmWq9u3STPN2Zaj0rUzi9u3STPEruiT0t7v28u3STPLJCmT3dc4G8u3STPFOzoj1KT3Oxu3STPFTjpT3ac4E8u3STPFWzoj0p7v08u3STPLJCmT0qUzg9u3STPEruiT3fmWo9u3STPN+Zaj1K7ok9u3STPCtTOD2yQpk9u3STPC3u/TxTs6I9u3STPNtzgTxU46U9u3STPAAAAABVs6I9u3STPNVzgbyzQpk9u3STPCXu/bxM7ok9u3STPChTOL3gmWo9u3STPNyZar0uUzg9u3STPEruib0x7v08u3STPLJCmb1Vs6K9u3STvNhzgTyyQpm9u3STvCnu/TxU46W9u3STvEpP87EuUzg9u3STvEruib0x7v08u3STvLJCmb3gmWo9u3STvNyZar3Wc4G8u3STvFWzor0m7v28u3STvLJCmb14ezYyu3STvFTjpb1M7ok9u3STvChTOL2zQpk9u3STvCXu/bwrUzi9u3STvEruiT0t7v28u3STvLJCmT3fmWq9u3STvN2Zaj3ac4E8u3STvFWzoj0p7v08u3STvLJCmT1KT3Oxu3STvFTjpT1K7om9u3STvCtTOL2yQpm9u3STvDDu/bzdmWq9u3STvN+Zar1K7om9u3STvCpTOD1Vs6I9u3STvNVzgbxU46U9u3STvAAAAABTs6I9u3STvNtzgTyyQpk9u3STvC3u/TwqUzg9u3STvEruiT3fmWo9u3STvN+Zaj1K7ok9u3STvCtTOD0oUzi9u3STvEruib3ic4E8u3STvFOzor1Ts6K9u3STvOBzgbzdc4G8u3STvFOzoj0AAAAAAACAPwAAAAC9dJO8AAAgIAn6dL8AAAAANaCUPtUWpb0gAAQbbcR+vwAAAAAZvcg91RalvSQABBnzWvE+AAAAAJXFYb/XFqW9KAAEDqBnIj8AAAAA/uNFv9YWpb0sAAQNN6CUvgAAAAAJ+nS/1RalvTAABBIZvci9AAAAAG3Efr/VFqW9NAAEEQHkRT8AAAAAnWciv9YWpb04AAQNmcVhPwAAAADnWvG+1xalvTwABAv2WvG+AAAAAJPFYT/WFqW9QAAEHptnIr8AAAAAA+RFP9YWpb1EAAQeOaCUPgAAAAAJ+nQ/1halvUgABAIZvcg9AAAAAG3Efj/WFqW9TAAEAZPFYb8AAAAA/FrxvtYWpb1QAAQWA+RFvwAAAACbZyK/1halvVQABBUF5EW/AAAAAJdnIj/WFqW9WAAEHJXFYb8AAAAA81rxPtYWpb1cAAQcCvp0PwAAAAAooJS+1RalvWAABApvxH4/AAAAACa9yL3XFqW9ZAAECWvEfj8AAAAAmL3IPdYWpb1oAAQIDvp0PwAAAAAYoJQ+1RalvWwABAeTZyI/AAAAAAjkRT/VFqW9cAAEBPNa8T4AAAAAlcVhP9YWpb10AAQDk8VhPwAAAAD2WvE+1halvXgABAcG5EU/AAAAAJVnIj/WFqW9fAAEBpNnIr8AAAAACORFv9QWpb2AAAQU9FrxvgAAAACUxWG/1BalvYQABBSXvcg9AAAAAGzEfr/WFqW9iAAEEByglD4AAAAADvp0v9YWpb2MAAQPbMR+vwAAAACXvci91halvZAABBgO+nS/AAAAABqglL7VFqW9lAAEF5i9yL0AAAAAa8R+P9YWpb2YAAQAGqCUvgAAAAAO+nQ/1RalvZwABAAAAAAAAACAvwAAAAC9dJO8oAAgAAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4fICELCiAKCSIjJB8eIx4dJSYnAwImAgEoKSUdHCkcGyorLA8OKw4NLS4vExIuEhEwMTIHBjEGBTM0LQ0MNAwLITUqGxo1Ghk2NzYZGDcYFzg5OhUUORQTLzs4FxY7FhU6PDMFBDwEAyc9KAEAPQAfJD4iCQg+CAcyPzARED8QDyw/LCstNCEgIj4yMTM8JyYoPSQjJSkqNTY3ODs6OS8uMAAbAAYABQAaABkADgANAB4AHQACAAEAEAAPAAoACQAgAB8ADAALABYAFQAYABcAFAATABIAEQAIAAcABAADABwBIQEQAQICHQIhAyEDHAMEBAcEIQUhBRoFBgYbBiEHIQcICBEIIQkhCSAJCgoPCiELIQsWCwwMHwwhDSENHg0ODhkOIQ8hDxAQIREhERISExIhEyETFBQXFCEVIRUYFRYWIRchFxgYIRkhGRoaIRshGxwcIR0hHR4eIR8hHyAgIQAbHAAGGwAFBgAFGgAZGgAOGQANDgANHgAdHgACHQABAgABEAAPEAAKDwAJCgAJIAAfIAAMHwALDAALFgAVFgAVGAAXGAAUFwATFAASEwAREgAIEQAHCAAEBwADBAADHAECIQEQIQIdIQMEIQMcIQQHIQUGIQUaIQYbIQcIIQgRIQkKIQkgIQoPIQsMIQsWIQwfIQ0OIQ0eIQ4ZIQ8QIRESIRITIRMUIRQXIRUWIRUYIRcYIRkaIRscIR0eIR8gIQAAAABU46W9u3STvFTjpb1U46U9u3STPFTjpT2JRUE6Z/WrNSbbMhwzuxApJtsyHH5FITZ1hnenM7sQKXWGd6dn9as1mDtKMfmSlK8bQOWvAACAP0lDRQFTVVBNAAAAAElDRQFHQVVTAAAAABAAAAAABgAAJSUpKSoqNTY2Nzg4Ozs6OiUlKSkqKjU2Njc4ODs7OjolJSkpKio1NjY3ODg7Ozo6JSUpKSoqNTY2Nzg4Ozs6OiUlKSkqKjU2Njc4ODs7OjolJSkpKio1NjY3ODg7Ozo6JSUpKSoqNTY2Nzg4Ozs6OiUlKSkqKjU2Njc4ODs7OjodHRwcGxsaGRkYFxcWFhUVHR0cHBsbGhkZGBcXFhYVFR0dHBwbGxoZGRgXFxYWFRUdHRwcGxsaGRkYFxcWFhUVHR0cHBsbGhkZGBcXFhYVFR0dHBwbGxoZGRgXFxYWFRUdHRwcGxsaGRkYFxcWFhUVHR0cHBsbGhkZGBcXFhYVFTMzMTEyMj4iIiAhITQ0LS0zMzExMjI+IiIgISE0NC0tMzMxMTIyPiIiICEhNDQtLTMzMTEyMj4iIiAhITQ0LS0zMzExMjI+IiIgISE0NC0tMzMxMTIyPiIiICEhNDQtLTMzMTEyMj4iIiAhITQ0LS0zMzExMjI+IiIgISE0NC0tBQUGBgcHCAkJCgsLDAwNDQUFBgYHBwgJCQoLCwwMDQ0FBQYGBwcICQkKCwsMDA0NBQUGBgcHCAkJCgsLDAwNDQUFBgYHBwgJCQoLCwwMDQ0FBQYGBwcICQkKCwsMDA0NBQUGBgcHCAkJCgsLDAwNDQUFBgYHBwgJCQoLCwwMDQ0FBQQEAwMCAQEAHx8eHh0dBQUFBAQDAgEBAB8eHh0dHQYFBQQEAwIBAQAfHh4dHRwGBgYFBAQDAgAfHh4dHBwcBwYGBgUEAwIAHx4dHBwcGwcHBwYGBQQCAB4dHBwbGxsICAgHBwYFAx8dHBsbGhoaCQkJCAgIBwUdGxoaGhkZGQkJCQoKCgsNFRcYGBgZGRkKCgoLCwwNDxMVFhcXGBgYCwsLDAwNDhASFBUWFhcXFwsMDAwNDg8QEhMUFRYWFhcMDAwNDg4PEBITFBQVFhYWDA0NDg4PEBEREhMUFBUVFg0NDQ4ODxARERITFBQVFRUNDQ4ODw8QERESExMUFBUVMzM8PCcnJigoPSQkIyMlJTMzMzw8JyYoKD0kIyMlJSUxMzM8PCcmKCg9JCMjJSUpMTExMzw8JyY9JCMjJSkpKTIxMTEzPCcmPSQjJSkpKSoyMjIxMTM8Jj0jJSkpKioqPj4+MjIxMyckJSkqKjU1NSIiIj4+PjIzJSo1NTU2NjYiIiIgICAhLTo4Nzc3NjY2ICAgISE0LSwvOjs4ODc3NyEhITQ0LSs/Ljk6Ozs4ODghNDQ0LSssPy4vOTo7Ozs4NDQ0LSsrLD8uLzk5Ojs7OzQtLSsrLD8wMC4vOTk6OjstLS0rKyw/MDAuLzk5Ojo6LS0rKywsPzAwLi8vOTk6Oi0tLS0tLS0tDQ0NDQ0NDQ0tLS0tLS0tLQ0NDQ0NDQ0NKysrKysrKysODg4ODg4ODisrKysrKysrDg4ODg4ODg4sLCwsLCwsLA8PDw8PDw8PLCwsLCwsLCwPDw8PDw8PDz8/Pz8/Pz8/EBAQEBAQEBAwMDAwMDAwMBERERERERERMDAwMDAwMDARERERERERES4uLi4uLi4uEhISEhISEhIvLy8vLy8vLxMTExMTExMTLy8vLy8vLy8TExMTExMTEzk5OTk5OTk5FBQUFBQUFBQ5OTk5OTk5ORQUFBQUFBQUOjo6Ojo6OjoVFRUVFRUVFTo6Ojo6Ojo6FRUVFRUVFRUzMzMzMzMzMwUFBQUFBQUFMzMzMzMzMzMFBQUFBQUFBTw8PDw8PDw8BAQEBAQEBAQ8PDw8PDw8PAQEBAQEBAQEJycnJycnJycDAwMDAwMDAycnJycnJycnAwMDAwMDAwMmJiYmJiYmJgICAgICAgICKCgoKCgoKCgBAQEBAQEBASgoKCgoKCgoAQEBAQEBAQE9PT09PT09PQAAAAAAAAAAJCQkJCQkJCQfHx8fHx8fHyQkJCQkJCQkHx8fHx8fHx8jIyMjIyMjIx4eHh4eHh4eIyMjIyMjIyMeHh4eHh4eHiUlJSUlJSUlHR0dHR0dHR0lJSUlJSUlJR0dHR0dHR0dDQ0MDAsLCgkJCAcHBgYFBQ0NDAwLCwoJCQgHBwYGBQUNDQwMCwsKCQkIBwcGBgUFDQ0MDAsLCgkJCAcHBgYFBQ0NDAwLCwoJCQgHBwYGBQUNDQwMCwsKCQkIBwcGBgUFDQ0MDAsLCgkJCAcHBgYFBQ0NDAwLCwoJCQgHBwYGBQUtLTQ0ISEgIiI+MjIxMTMzLS00NCEhICIiPjIyMTEzMy0tNDQhISAiIj4yMjExMzMtLTQ0ISEgIiI+MjIxMTMzLS00NCEhICIiPjIyMTEzMy0tNDQhISAiIj4yMjExMzMtLTQ0ISEgIiI+MjIxMTMzLS00NCEhICIiPjIyMTEzMxUVFhYXFxgZGRobGxwcHR0VFRYWFxcYGRkaGxscHB0dFRUWFhcXGBkZGhsbHBwdHRUVFhYXFxgZGRobGxwcHR0VFRYWFxcYGRkaGxscHB0dFRUWFhcXGBkZGhsbHBwdHRUVFhYXFxgZGRobGxwcHR0VFRYWFxcYGRkaGxscHB0dOjo7Ozg4NzY2NSoqKSklJTo6Ozs4ODc2NjUqKikpJSU6Ojs7ODg3NjY1KiopKSUlOjo7Ozg4NzY2NSoqKSklJTo6Ozs4ODc2NjUqKikpJSU6Ojs7ODg3NjY1KiopKSUlOjo7Ozg4NzY2NSoqKSklJTo6Ozs4ODc2NjUqKikpJSU6Ojk5Ly8uMDA/LCwrKy0tOjo6OTkvLjAwPywrKy0tLTs6Ojk5Ly4wMD8sKystLTQ7Ozs6OTkvLj8sKystNDQ0ODs7Ozo5Ly4/LCstNDQ0ITg4ODs7OjkuPystNDQhISE3Nzc4ODs6LywtNCEhICAgNjY2Nzc3ODotISAgICIiIjY2NjU1NSolMzI+Pj4iIiI1NTUqKiklJCczMTIyPj4+KioqKSklIz0mPDMxMTIyMiopKSklIyQ9Jic8MzExMTIpKSklIyMkPSYnPDwzMTExKSUlIyMkPSgoJic8PDMzMSUlJSMjJD0oKCYnPDwzMzMlJSMjJCQ9KCgmJyc8PDMzFRUUFBMTEhEREA8PDg4NDRUVFRQUExIRERAPDg4NDQ0WFRUUFBMSEREQDw4ODQ0MFhYWFRQUExIQDw4ODQwMDBcWFhYVFBMSEA8ODQwMDAsXFxcWFhUUEhAODQwMCwsLGBgYFxcWFRMPDQwLCwoKChkZGRgYGBcVDQsKCgoJCQkZGRkaGhobHQUHCAgICQkJGhoaGxscHR8DBQYHBwgICBsbGxwcHR4AAgQFBgYHBwcbHBwcHR4fAAIDBAUGBgYHHBwcHR4eHwACAwQEBQYGBhwdHR4eHwABAQIDBAQFBQYdHR0eHh8AAQECAwQEBQUFHR0eHh8fAAEBAgMDBAQFBR0dHR0dHR0dJSUlJSUlJSUdHR0dHR0dHSUlJSUlJSUlHh4eHh4eHh4jIyMjIyMjIx4eHh4eHh4eIyMjIyMjIyMfHx8fHx8fHyQkJCQkJCQkHx8fHx8fHx8kJCQkJCQkJAAAAAAAAAAAPT09PT09PT0BAQEBAQEBASgoKCgoKCgoAQEBAQEBAQEoKCgoKCgoKAICAgICAgICJiYmJiYmJiYDAwMDAwMDAycnJycnJycnAwMDAwMDAwMnJycnJycnJwQEBAQEBAQEPDw8PDw8PDwEBAQEBAQEBDw8PDw8PDw8BQUFBQUFBQUzMzMzMzMzMwUFBQUFBQUFMzMzMzMzMzMVFRUVFRUVFTo6Ojo6Ojo6FRUVFRUVFRU6Ojo6Ojo6OhQUFBQUFBQUOTk5OTk5OTkUFBQUFBQUFDk5OTk5OTk5ExMTExMTExMvLy8vLy8vLxMTExMTExMTLy8vLy8vLy8SEhISEhISEi4uLi4uLi4uEREREREREREwMDAwMDAwMBERERERERERMDAwMDAwMDAQEBAQEBAQED8/Pz8/Pz8/Dw8PDw8PDw8sLCwsLCwsLA8PDw8PDw8PLCwsLCwsLCwODg4ODg4ODisrKysrKysrDg4ODg4ODg4rKysrKysrKw0NDQ0NDQ0NLS0tLS0tLS0NDQ0NDQ0NDS0tLS0tLS0tSUNFAVZBTEUCAAAAQAAAAMAAAAADAAAAAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwE9HwIoAAMmAQQnAgU8AwYzBAcxBQgyBgk+BwoiCAsgCQwhCg00Cw4tDA8rDRAsDhE/DxIwEBMuERQvEhU5ExY6FBc7FRg4Fhk3Fxo2GBs1GRwqGh0pGx4lHB8jHQAkHiEiCgs0ICA+CSQlHh89IyMpHScoAgM8JiY9ASUqHCk1GywtDg8/Kys0DS8wEhM5Li4/ETIzBgc+MTE8BS0hDCo2GjU3GTY4GDc7FzovFBU7OTg6FjMnBCgkACIyCDAsEAAAgL+9dJM8scqjPX1EKjx9RCo8"
+                    "path": "/Entities/Entity_[15629654211104]/Components/Component_[12925256151907998248]/ColliderConfiguration/CollisionLayer/Index",
+                    "value": 1
                 },
                 {
                     "op": "replace",
@@ -149,7 +153,7 @@
                 {
                     "op": "replace",
                     "path": "/Entities/Entity_[15629654211104]/Components/Component_[17075084475750345983]/Configuration/Centre of mass offset/2",
-                    "value": -4.1700407016342917e-10
+                    "value": -4.170040701634292e-10
                 },
                 {
                     "op": "replace",
@@ -157,18 +161,49 @@
                     "value": 0.002883758395910263
                 },
                 {
-                    "op": "add",
-                    "path": "/Entities/Entity_[15633949178400]/Components/EditorDisabledCompositionComponent",
-                    "value": {
-                        "$type": "EditorDisabledCompositionComponent",
-                        "Id": 14784301335085961779,
-                        "DisabledComponents": []
-                    }
+                    "op": "replace",
+                    "path": "/Entities/Entity_[15638244145696]/Components/Component_[143294533017561991]/Controller/Configuration/ModelAsset/assetHint",
+                    "value": "materialeditor/viewportmodels/cylinder.fbx.azmodel"
                 },
                 {
                     "op": "replace",
-                    "path": "/ContainerEntity/Components/Component_[15237572906287023176]/Parent Entity",
-                    "value": "../Entity_[112333485759082]"
+                    "path": "/Entities/Entity_[15694078720544]/Components/Component_[10518754877894589178]/Controller/Configuration/ModelAsset/assetHint",
+                    "value": "proteus2_lift.fbx.azmodel"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[15672603884064]/Components/Component_[11685358238844952494]/Configuration/Centre of mass offset/0",
+                    "value": 2.9428743886228403e-9
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[15672603884064]/Components/Component_[11685358238844952494]/Configuration/Centre of mass offset/1",
+                    "value": -2.702547352573248e-10
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[15672603884064]/Components/Component_[11685358238844952494]/Configuration/Centre of mass offset/2",
+                    "value": -4.170040701634292e-10
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[15672603884064]/Components/Component_[11685358238844952494]/Configuration/Inertia tensor/4",
+                    "value": 0.002883758395910263
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[15672603884064]/Components/Component_[7456975798968691780]/ColliderConfiguration/CollisionLayer/Index",
+                    "value": 1
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[15672603884064]/Components/Component_[7456975798968691780]/ShapeConfiguration/Cylinder/Configuration/CookedData",
+                    "value": "TlhTAUNWWE0OAAAAAAAAAElDRQFDTEhMCQAAAEAAAABgAAAAIgAAAMAAAADic4E8u3STPFOzor14ezYyu3STPFTjpb3Wc4G8u3STPFWzor0m7v28u3STPLJCmb0oUzi9u3STPEruib3dmWq9u3STPN+Zar1K7om9u3STPCtTOL2yQpm9u3STPDDu/bxTs6K9u3STPOBzgbxU46W9u3STPEpP87FVs6K9u3STPNhzgTyyQpm9u3STPCnu/TxK7om9u3STPCpTOD3fmWq9u3STPN2Zaj0rUzi9u3STPEruiT0t7v28u3STPLJCmT3dc4G8u3STPFOzoj1KT3Oxu3STPFTjpT3ac4E8u3STPFWzoj0p7v08u3STPLJCmT0qUzg9u3STPEruiT3fmWo9u3STPN+Zaj1K7ok9u3STPCtTOD2yQpk9u3STPC3u/TxTs6I9u3STPNtzgTxU46U9u3STPAAAAABVs6I9u3STPNVzgbyzQpk9u3STPCXu/bxM7ok9u3STPChTOL3gmWo9u3STPNyZar0uUzg9u3STPEruib0x7v08u3STPLJCmb1Vs6K9u3STvNhzgTyyQpm9u3STvCnu/TxU46W9u3STvEpP87EuUzg9u3STvEruib0x7v08u3STvLJCmb3gmWo9u3STvNyZar3Wc4G8u3STvFWzor0m7v28u3STvLJCmb14ezYyu3STvFTjpb1M7ok9u3STvChTOL2zQpk9u3STvCXu/bwrUzi9u3STvEruiT0t7v28u3STvLJCmT3fmWq9u3STvN2Zaj3ac4E8u3STvFWzoj0p7v08u3STvLJCmT1KT3Oxu3STvFTjpT1K7om9u3STvCtTOL2yQpm9u3STvDDu/bzdmWq9u3STvN+Zar1K7om9u3STvCpTOD1Vs6I9u3STvNVzgbxU46U9u3STvAAAAABTs6I9u3STvNtzgTyyQpk9u3STvC3u/TwqUzg9u3STvEruiT3fmWo9u3STvN+Zaj1K7ok9u3STvCtTOD0oUzi9u3STvEruib3ic4E8u3STvFOzor1Ts6K9u3STvOBzgbzdc4G8u3STvFOzoj0AAAAAAACAPwAAAAC9dJO8AAAgIAn6dL8AAAAANaCUPtUWpb0gAAQbbcR+vwAAAAAZvcg91RalvSQABBnzWvE+AAAAAJXFYb/XFqW9KAAEDqBnIj8AAAAA/uNFv9YWpb0sAAQNN6CUvgAAAAAJ+nS/1RalvTAABBIZvci9AAAAAG3Efr/VFqW9NAAEEQHkRT8AAAAAnWciv9YWpb04AAQNmcVhPwAAAADnWvG+1xalvTwABAv2WvG+AAAAAJPFYT/WFqW9QAAEHptnIr8AAAAAA+RFP9YWpb1EAAQeOaCUPgAAAAAJ+nQ/1halvUgABAIZvcg9AAAAAG3Efj/WFqW9TAAEAZPFYb8AAAAA/FrxvtYWpb1QAAQWA+RFvwAAAACbZyK/1halvVQABBUF5EW/AAAAAJdnIj/WFqW9WAAEHJXFYb8AAAAA81rxPtYWpb1cAAQcCvp0PwAAAAAooJS+1RalvWAABApvxH4/AAAAACa9yL3XFqW9ZAAECWvEfj8AAAAAmL3IPdYWpb1oAAQIDvp0PwAAAAAYoJQ+1RalvWwABAeTZyI/AAAAAAjkRT/VFqW9cAAEBPNa8T4AAAAAlcVhP9YWpb10AAQDk8VhPwAAAAD2WvE+1halvXgABAcG5EU/AAAAAJVnIj/WFqW9fAAEBpNnIr8AAAAACORFv9QWpb2AAAQU9FrxvgAAAACUxWG/1BalvYQABBSXvcg9AAAAAGzEfr/WFqW9iAAEEByglD4AAAAADvp0v9YWpb2MAAQPbMR+vwAAAACXvci91halvZAABBgO+nS/AAAAABqglL7VFqW9lAAEF5i9yL0AAAAAa8R+P9YWpb2YAAQAGqCUvgAAAAAO+nQ/1RalvZwABAAAAAAAAACAvwAAAAC9dJO8oAAgAAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4fICELCiAKCSIjJB8eIx4dJSYnAwImAgEoKSUdHCkcGyorLA8OKw4NLS4vExIuEhEwMTIHBjEGBTM0LQ0MNAwLITUqGxo1Ghk2NzYZGDcYFzg5OhUUORQTLzs4FxY7FhU6PDMFBDwEAyc9KAEAPQAfJD4iCQg+CAcyPzARED8QDyw/LCstNCEgIj4yMTM8JyYoPSQjJSkqNTY3ODs6OS8uMAAbAAYABQAaABkADgANAB4AHQACAAEAEAAPAAoACQAgAB8ADAALABYAFQAYABcAFAATABIAEQAIAAcABAADABwBIQEQAQICHQIhAyEDHAMEBAcEIQUhBRoFBgYbBiEHIQcICBEIIQkhCSAJCgoPCiELIQsWCwwMHwwhDSENHg0ODhkOIQ8hDxAQIREhERISExIhEyETFBQXFCEVIRUYFRYWIRchFxgYIRkhGRoaIRshGxwcIR0hHR4eIR8hHyAgIQAbHAAGGwAFBgAFGgAZGgAOGQANDgANHgAdHgACHQABAgABEAAPEAAKDwAJCgAJIAAfIAAMHwALDAALFgAVFgAVGAAXGAAUFwATFAASEwAREgAIEQAHCAAEBwADBAADHAECIQEQIQIdIQMEIQMcIQQHIQUGIQUaIQYbIQcIIQgRIQkKIQkgIQoPIQsMIQsWIQwfIQ0OIQ0eIQ4ZIQ8QIRESIRITIRMUIRQXIRUWIRUYIRcYIRkaIRscIR0eIR8gIQAAAABU46W9u3STvFTjpb1U46U9u3STPFTjpT2JRUE6Z/WrNSbbMhwzuxApJtsyHH5FITZ1hnenM7sQKXWGd6dn9as1mDtKMfmSlK8bQOWvAACAP0lDRQFTVVBNAAAAAElDRQFHQVVTAAAAABAAAAAABgAAJSUpKSoqNTY2Nzg4Ozs6OiUlKSkqKjU2Njc4ODs7OjolJSkpKio1NjY3ODg7Ozo6JSUpKSoqNTY2Nzg4Ozs6OiUlKSkqKjU2Njc4ODs7OjolJSkpKio1NjY3ODg7Ozo6JSUpKSoqNTY2Nzg4Ozs6OiUlKSkqKjU2Njc4ODs7OjodHRwcGxsaGRkYFxcWFhUVHR0cHBsbGhkZGBcXFhYVFR0dHBwbGxoZGRgXFxYWFRUdHRwcGxsaGRkYFxcWFhUVHR0cHBsbGhkZGBcXFhYVFR0dHBwbGxoZGRgXFxYWFRUdHRwcGxsaGRkYFxcWFhUVHR0cHBsbGhkZGBcXFhYVFTMzMTEyMj4iIiAhITQ0LS0zMzExMjI+IiIgISE0NC0tMzMxMTIyPiIiICEhNDQtLTMzMTEyMj4iIiAhITQ0LS0zMzExMjI+IiIgISE0NC0tMzMxMTIyPiIiICEhNDQtLTMzMTEyMj4iIiAhITQ0LS0zMzExMjI+IiIgISE0NC0tBQUGBgcHCAkJCgsLDAwNDQUFBgYHBwgJCQoLCwwMDQ0FBQYGBwcICQkKCwsMDA0NBQUGBgcHCAkJCgsLDAwNDQUFBgYHBwgJCQoLCwwMDQ0FBQYGBwcICQkKCwsMDA0NBQUGBgcHCAkJCgsLDAwNDQUFBgYHBwgJCQoLCwwMDQ0FBQQEAwMCAQEAHx8eHh0dBQUFBAQDAgEBAB8eHh0dHQYFBQQEAwIBAQAfHh4dHRwGBgYFBAQDAgAfHh4dHBwcBwYGBgUEAwIAHx4dHBwcGwcHBwYGBQQCAB4dHBwbGxsICAgHBwYFAx8dHBsbGhoaCQkJCAgIBwUdGxoaGhkZGQkJCQoKCgsNFRcYGBgZGRkKCgoLCwwNDxMVFhcXGBgYCwsLDAwNDhASFBUWFhcXFwsMDAwNDg8QEhMUFRYWFhcMDAwNDg4PEBITFBQVFhYWDA0NDg4PEBEREhMUFBUVFg0NDQ4ODxARERITFBQVFRUNDQ4ODw8QERESExMUFBUVMzM8PCcnJigoPSQkIyMlJTMzMzw8JyYoKD0kIyMlJSUxMzM8PCcmKCg9JCMjJSUpMTExMzw8JyY9JCMjJSkpKTIxMTEzPCcmPSQjJSkpKSoyMjIxMTM8Jj0jJSkpKioqPj4+MjIxMyckJSkqKjU1NSIiIj4+PjIzJSo1NTU2NjYiIiIgICAhLTo4Nzc3NjY2ICAgISE0LSwvOjs4ODc3NyEhITQ0LSs/Ljk6Ozs4ODghNDQ0LSssPy4vOTo7Ozs4NDQ0LSsrLD8uLzk5Ojs7OzQtLSsrLD8wMC4vOTk6OjstLS0rKyw/MDAuLzk5Ojo6LS0rKywsPzAwLi8vOTk6Oi0tLS0tLS0tDQ0NDQ0NDQ0tLS0tLS0tLQ0NDQ0NDQ0NKysrKysrKysODg4ODg4ODisrKysrKysrDg4ODg4ODg4sLCwsLCwsLA8PDw8PDw8PLCwsLCwsLCwPDw8PDw8PDz8/Pz8/Pz8/EBAQEBAQEBAwMDAwMDAwMBERERERERERMDAwMDAwMDARERERERERES4uLi4uLi4uEhISEhISEhIvLy8vLy8vLxMTExMTExMTLy8vLy8vLy8TExMTExMTEzk5OTk5OTk5FBQUFBQUFBQ5OTk5OTk5ORQUFBQUFBQUOjo6Ojo6OjoVFRUVFRUVFTo6Ojo6Ojo6FRUVFRUVFRUzMzMzMzMzMwUFBQUFBQUFMzMzMzMzMzMFBQUFBQUFBTw8PDw8PDw8BAQEBAQEBAQ8PDw8PDw8PAQEBAQEBAQEJycnJycnJycDAwMDAwMDAycnJycnJycnAwMDAwMDAwMmJiYmJiYmJgICAgICAgICKCgoKCgoKCgBAQEBAQEBASgoKCgoKCgoAQEBAQEBAQE9PT09PT09PQAAAAAAAAAAJCQkJCQkJCQfHx8fHx8fHyQkJCQkJCQkHx8fHx8fHx8jIyMjIyMjIx4eHh4eHh4eIyMjIyMjIyMeHh4eHh4eHiUlJSUlJSUlHR0dHR0dHR0lJSUlJSUlJR0dHR0dHR0dDQ0MDAsLCgkJCAcHBgYFBQ0NDAwLCwoJCQgHBwYGBQUNDQwMCwsKCQkIBwcGBgUFDQ0MDAsLCgkJCAcHBgYFBQ0NDAwLCwoJCQgHBwYGBQUNDQwMCwsKCQkIBwcGBgUFDQ0MDAsLCgkJCAcHBgYFBQ0NDAwLCwoJCQgHBwYGBQUtLTQ0ISEgIiI+MjIxMTMzLS00NCEhICIiPjIyMTEzMy0tNDQhISAiIj4yMjExMzMtLTQ0ISEgIiI+MjIxMTMzLS00NCEhICIiPjIyMTEzMy0tNDQhISAiIj4yMjExMzMtLTQ0ISEgIiI+MjIxMTMzLS00NCEhICIiPjIyMTEzMxUVFhYXFxgZGRobGxwcHR0VFRYWFxcYGRkaGxscHB0dFRUWFhcXGBkZGhsbHBwdHRUVFhYXFxgZGRobGxwcHR0VFRYWFxcYGRkaGxscHB0dFRUWFhcXGBkZGhsbHBwdHRUVFhYXFxgZGRobGxwcHR0VFRYWFxcYGRkaGxscHB0dOjo7Ozg4NzY2NSoqKSklJTo6Ozs4ODc2NjUqKikpJSU6Ojs7ODg3NjY1KiopKSUlOjo7Ozg4NzY2NSoqKSklJTo6Ozs4ODc2NjUqKikpJSU6Ojs7ODg3NjY1KiopKSUlOjo7Ozg4NzY2NSoqKSklJTo6Ozs4ODc2NjUqKikpJSU6Ojk5Ly8uMDA/LCwrKy0tOjo6OTkvLjAwPywrKy0tLTs6Ojk5Ly4wMD8sKystLTQ7Ozs6OTkvLj8sKystNDQ0ODs7Ozo5Ly4/LCstNDQ0ITg4ODs7OjkuPystNDQhISE3Nzc4ODs6LywtNCEhICAgNjY2Nzc3ODotISAgICIiIjY2NjU1NSolMzI+Pj4iIiI1NTUqKiklJCczMTIyPj4+KioqKSklIz0mPDMxMTIyMiopKSklIyQ9Jic8MzExMTIpKSklIyMkPSYnPDwzMTExKSUlIyMkPSgoJic8PDMzMSUlJSMjJD0oKCYnPDwzMzMlJSMjJCQ9KCgmJyc8PDMzFRUUFBMTEhEREA8PDg4NDRUVFRQUExIRERAPDg4NDQ0WFRUUFBMSEREQDw4ODQ0MFhYWFRQUExIQDw4ODQwMDBcWFhYVFBMSEA8ODQwMDAsXFxcWFhUUEhAODQwMCwsLGBgYFxcWFRMPDQwLCwoKChkZGRgYGBcVDQsKCgoJCQkZGRkaGhobHQUHCAgICQkJGhoaGxscHR8DBQYHBwgICBsbGxwcHR4AAgQFBgYHBwcbHBwcHR4fAAIDBAUGBgYHHBwcHR4eHwACAwQEBQYGBhwdHR4eHwABAQIDBAQFBQYdHR0eHh8AAQECAwQEBQUFHR0eHh8fAAEBAgMDBAQFBR0dHR0dHR0dJSUlJSUlJSUdHR0dHR0dHSUlJSUlJSUlHh4eHh4eHh4jIyMjIyMjIx4eHh4eHh4eIyMjIyMjIyMfHx8fHx8fHyQkJCQkJCQkHx8fHx8fHx8kJCQkJCQkJAAAAAAAAAAAPT09PT09PT0BAQEBAQEBASgoKCgoKCgoAQEBAQEBAQEoKCgoKCgoKAICAgICAgICJiYmJiYmJiYDAwMDAwMDAycnJycnJycnAwMDAwMDAwMnJycnJycnJwQEBAQEBAQEPDw8PDw8PDwEBAQEBAQEBDw8PDw8PDw8BQUFBQUFBQUzMzMzMzMzMwUFBQUFBQUFMzMzMzMzMzMVFRUVFRUVFTo6Ojo6Ojo6FRUVFRUVFRU6Ojo6Ojo6OhQUFBQUFBQUOTk5OTk5OTkUFBQUFBQUFDk5OTk5OTk5ExMTExMTExMvLy8vLy8vLxMTExMTExMTLy8vLy8vLy8SEhISEhISEi4uLi4uLi4uEREREREREREwMDAwMDAwMBERERERERERMDAwMDAwMDAQEBAQEBAQED8/Pz8/Pz8/Dw8PDw8PDw8sLCwsLCwsLA8PDw8PDw8PLCwsLCwsLCwODg4ODg4ODisrKysrKysrDg4ODg4ODg4rKysrKysrKw0NDQ0NDQ0NLS0tLS0tLS0NDQ0NDQ0NDS0tLS0tLS0tSUNFAVZBTEUCAAAAQAAAAMAAAAADAAAAAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwE9HwIoAAMmAQQnAgU8AwYzBAcxBQgyBgk+BwoiCAsgCQwhCg00Cw4tDA8rDRAsDhE/DxIwEBMuERQvEhU5ExY6FBc7FRg4Fhk3Fxo2GBs1GRwqGh0pGx4lHB8jHQAkHiEiCgs0ICA+CSQlHh89IyMpHScoAgM8JiY9ASUqHCk1GywtDg8/Kys0DS8wEhM5Li4/ETIzBgc+MTE8BS0hDCo2GjU3GTY4GDc7FzovFBU7OTg6FjMnBCgkACIyCDAsEAAAgL+9dJM8scqjPX1EKjx9RCo8"
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[15642539112992]/Components/Component_[8110923963616165068]/ColliderConfiguration/CollisionLayer/Index",
+                    "value": 1
                 },
                 {
                     "op": "replace",
@@ -178,12 +213,12 @@
                 {
                     "op": "replace",
                     "path": "/Entities/Entity_[15741323360800]/Components/Component_[1828080485137528399]/Transform Data/Translate/0",
-                    "value": 0.5506629943847656
+                    "value": 0.46472644805908203
                 },
                 {
                     "op": "replace",
                     "path": "/Entities/Entity_[15741323360800]/Components/Component_[1828080485137528399]/Transform Data/Translate/2",
-                    "value": 0.07168877124786377
+                    "value": 0.08022470772266388
                 },
                 {
                     "op": "add",
@@ -195,7 +230,7 @@
                             "$type": "ROS2Lidar2DSensorComponent",
                             "Id": 0,
                             "SensorConfiguration": {
-                                "Visualise": true,
+                                "Visualize": true,
                                 "Publishing Enabled": true,
                                 "Frequency (HZ)": 10.0,
                                 "Publishers": {
@@ -210,40 +245,38 @@
                                     }
                                 }
                             },
-                            "lidarModel": 6,
-                            "lidarImplementation": "Scene Queries",
-                            "LidarParameters": {
-                                "Name": "CustomLidar2D",
-                                "Layers": 1,
-                                "Points per layer": 924,
-                                "Min horizontal angle": -90.0,
-                                "Max horizontal angle": 90.0,
-                                "Min vertical angle": 0.0,
-                                "Max vertical angle": 0.0,
-                                "Min range": 0.0,
-                                "Max range": 100.0,
-                                "Enable Noise": true,
-                                "Noise Parameters": {
-                                    "Angular noise standard deviation": 0.0,
-                                    "Distance noise standard deviation base": 0.019999999552965164,
-                                    "Distance noise standard deviation slope": 0.0010000000474974513
-                                }
-                            },
-                            "IgnoreLayer": false,
-                            "IgnoredLayerIndex": 0,
-                            "ExcludedEntities": [],
-                            "PointsAtMax": false
+                            "lidarConfiguration": {
+                                "lidarModel": 6,
+                                "lidarImplementation": "Scene Queries",
+                                "LidarParameters": {
+                                    "Name": "CustomLidar2D",
+                                    "Layers": 1,
+                                    "Points per layer": 924,
+                                    "Min horizontal angle": -180.0,
+                                    "Max horizontal angle": 180.0,
+                                    "Min vertical angle": 0.0,
+                                    "Max vertical angle": 0.0,
+                                    "Min range": 0.0,
+                                    "Max range": 100.0,
+                                    "Enable Noise": true,
+                                    "Noise Parameters": {
+                                        "Angular noise standard deviation": 0.0,
+                                        "Distance noise standard deviation base": 0.019999999552965164,
+                                        "Distance noise standard deviation slope": 0.0010000000474974513
+                                    }
+                                },
+                                "IgnoredLayerIndices": [
+                                    1
+                                ],
+                                "ExcludedEntities": [],
+                                "PointsAtMax": false
+                            }
                         }
                     }
                 },
                 {
                     "op": "remove",
                     "path": "/Entities/Entity_[15741323360800]/Components/Component_[15707946702459327170]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[15659718982176]/Components/Component_[639102350977932618]/m_template/Namespace Configuration/Namespace Strategy",
-                    "value": 1
                 }
             ]
         }

--- a/Templates/Ros2FleetRobotTemplate/Template/Registry/physxsystemconfiguration.setreg
+++ b/Templates/Ros2FleetRobotTemplate/Template/Registry/physxsystemconfiguration.setreg
@@ -7,7 +7,7 @@
                         "Layers": {
                             "LayerNames": [
                                 "Default",
-                                {},
+                                "Robots",
                                 {},
                                 {},
                                 {},


### PR DESCRIPTION
After changes to lidar reflection (LidarCore introduction) Proteus prefab changes did not follow up. Moreover, lidar ignore layer handling was updated. For these two reasons, ROS2 Fleet Template did not work - lidar rays were being reflected from robot internal surfaces, making robots impossible to navigate.

This request updates ProteusLaserScanner prefab and configures lidar ignore layers.

This request solves #557.