### PR TITLE
Fully working SDF material conversions

### DIFF
--- a/Gems/ROS2/Assets/Gazebo/Black.material
+++ b/Gems/ROS2/Assets/Gazebo/Black.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/BlackTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/BlackTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Blue.material
+++ b/Gems/ROS2/Assets/Gazebo/Blue.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/BlueGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/BlueGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/BlueLaser.material
+++ b/Gems/ROS2/Assets/Gazebo/BlueLaser.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.6
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/BlueTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/BlueTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Bricks.material
+++ b/Gems/ROS2/Assets/Gazebo/Bricks.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 1.0,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.6627,
+            0.302,
+            0.1568,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/CeilingTiled.material
+++ b/Gems/ROS2/Assets/Gazebo/CeilingTiled.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.921,
+            0.921,
+            0.921,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/CloudySky.material
+++ b/Gems/ROS2/Assets/Gazebo/CloudySky.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.1,
+        "metallic.factor": 0.6,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/DarkGray.material
+++ b/Gems/ROS2/Assets/Gazebo/DarkGray.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.825,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.175,
+            0.175,
+            0.175,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/DarkGrey.material
+++ b/Gems/ROS2/Assets/Gazebo/DarkGrey.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.825,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.175,
+            0.175,
+            0.175,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/DarkMagentaTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/DarkMagentaTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.6,
+            0.0,
+            0.6,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/DarkYellow.material
+++ b/Gems/ROS2/Assets/Gazebo/DarkYellow.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 1.0,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.7,
+            0.7,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/FlatBlack.material
+++ b/Gems/ROS2/Assets/Gazebo/FlatBlack.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.99,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.1,
+            0.1,
+            0.1,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Footway.material
+++ b/Gems/ROS2/Assets/Gazebo/Footway.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.95,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.607,
+            0.607,
+            0.5607,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Gold.material
+++ b/Gems/ROS2/Assets/Gazebo/Gold.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.1,
+        "metallic.factor": 1.0,
+        "baseColor.color": [
+            0.8,
+            0.64869,
+            0.120759,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Grass.material
+++ b/Gems/ROS2/Assets/Gazebo/Grass.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Gray.material
+++ b/Gems/ROS2/Assets/Gazebo/Gray.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.99,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.7,
+            0.7,
+            0.7,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Green.material
+++ b/Gems/ROS2/Assets/Gazebo/Green.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/GreenGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/GreenGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/GreenTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/GreenTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Grey.material
+++ b/Gems/ROS2/Assets/Gazebo/Grey.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.99,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.7,
+            0.7,
+            0.7,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/GreyGradientSky.material
+++ b/Gems/ROS2/Assets/Gazebo/GreyGradientSky.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.99,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.7,
+            0.7,
+            0.7,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/GreyTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/GreyTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.5,
+            0.5,
+            0.5,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Indigo.material
+++ b/Gems/ROS2/Assets/Gazebo/Indigo.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.33,
+            0.0,
+            0.5,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/LightBlueLaser.material
+++ b/Gems/ROS2/Assets/Gazebo/LightBlueLaser.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.5,
+            0.5,
+            1.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.6
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/LightOff.material
+++ b/Gems/ROS2/Assets/Gazebo/LightOff.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            1.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/LightOn.material
+++ b/Gems/ROS2/Assets/Gazebo/LightOn.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Orange.material
+++ b/Gems/ROS2/Assets/Gazebo/Orange.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.5,
+        "metallic.factor": 0.125,
+        "baseColor.color": [
+            1.0,
+            0.5088,
+            0.0468,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/OrangeTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/OrangeTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.44,
+            0.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.6
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/PaintedWall.material
+++ b/Gems/ROS2/Assets/Gazebo/PaintedWall.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 1.0,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            1.0,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Pedestrian.material
+++ b/Gems/ROS2/Assets/Gazebo/Pedestrian.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.95,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.607,
+            0.607,
+            0.5607,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Purple.material
+++ b/Gems/ROS2/Assets/Gazebo/Purple.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.0,
+            1.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/PurpleGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/PurpleGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.0,
+            1.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            1.0,
+            0.0,
+            1.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Red.material
+++ b/Gems/ROS2/Assets/Gazebo/Red.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.0,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/RedBright.material
+++ b/Gems/ROS2/Assets/Gazebo/RedBright.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.6,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.87,
+            0.26,
+            0.07,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/RedGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/RedGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            1.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/RedTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/RedTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Residential.material
+++ b/Gems/ROS2/Assets/Gazebo/Residential.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.95,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.35,
+            0.35,
+            0.35,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Road.material
+++ b/Gems/ROS2/Assets/Gazebo/Road.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.95,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.35,
+            0.35,
+            0.35,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/SkyBlue.material
+++ b/Gems/ROS2/Assets/Gazebo/SkyBlue.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.1,
+        "metallic.factor": 0.6,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Turquoise.material
+++ b/Gems/ROS2/Assets/Gazebo/Turquoise.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            1.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/TurquoiseGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/TurquoiseGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            1.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            0.0,
+            1.0,
+            1.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/White.material
+++ b/Gems/ROS2/Assets/Gazebo/White.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            1.0,
+            1.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/WhiteGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/WhiteGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            1.0,
+            1.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            1.0,
+            1.0,
+            1.0,
+            1.0
+        ],
+        "emissive.intensity": 8.0
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Wood.material
+++ b/Gems/ROS2/Assets/Gazebo/Wood.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.1,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.698,
+            0.4314,
+            0.1921,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/WoodFloor.material
+++ b/Gems/ROS2/Assets/Gazebo/WoodFloor.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.1,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.557,
+            0.275,
+            0.067,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/WoodPallet.material
+++ b/Gems/ROS2/Assets/Gazebo/WoodPallet.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.6627,
+            0.5,
+            0.2784,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Yellow.material
+++ b/Gems/ROS2/Assets/Gazebo/Yellow.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 1.0,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            1.0,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/YellowGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/YellowGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            1.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/YellowTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/YellowTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/ZincYellow.material
+++ b/Gems/ROS2/Assets/Gazebo/ZincYellow.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.05,
+        "metallic.factor": 1.0,
+        "baseColor.color": [
+            0.9725,
+            0.9529,
+            0.2078,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Sdf/empty.sdf
+++ b/Gems/ROS2/Assets/Sdf/empty.sdf
@@ -1,0 +1,7 @@
+<?xml version='1.0'?>
+<sdf version="1.4">
+  <model name="empty_model">
+    <link name="empty_link">
+    </link>
+  </model>
+</sdf>

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
@@ -48,10 +48,10 @@ namespace ROS2
         m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
         m_table->setSelectionMode(QAbstractItemView::SingleSelection);
         // Set the header items.
-        QTableWidgetItem* headerItem = new QTableWidgetItem(tr("URDF/SDF mesh path"));
+        QTableWidgetItem* headerItem = new QTableWidgetItem(tr("URDF/SDF asset path"));
         headerItem->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
         m_table->setHorizontalHeaderItem(Columns::SdfMeshPath, headerItem);
-        headerItem = new QTableWidgetItem(tr("Resolved mesh from URDF/SDF"));
+        headerItem = new QTableWidgetItem(tr("Resolved asset from URDF/SDF"));
         headerItem->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
         m_table->setHorizontalHeaderItem(Columns::ResolvedMeshPath, headerItem);
         headerItem = new QTableWidgetItem(tr("Type"));
@@ -81,11 +81,11 @@ namespace ROS2
     {
         if (m_missingCount == 0)
         {
-            setTitle(tr("Resolved meshes"));
+            setTitle(tr("Resolved assets"));
         }
         else
         {
-            setTitle(tr("There are ") + QString::number(m_missingCount) + tr(" unresolved meshes"));
+            setTitle(tr("There are ") + QString::number(m_missingCount) + tr(" unresolved assets"));
         }
     }
 
@@ -243,10 +243,12 @@ namespace ROS2
                     {
                         if (!failed)
                         {
-                            const AZStd::string productRelPathVisual = Utils::GetModelProductAsset(assetUuid);
-                            const AZStd::string productRelPathCollider = Utils::GetPhysXMeshProductAsset(assetUuid);
-                            QString text = QString::fromUtf8(productRelPathVisual.data(), productRelPathVisual.size()) + " " +
-                                QString::fromUtf8(productRelPathCollider.data(), productRelPathCollider.size());
+                            const AZStd::vector<AZStd::string> productPaths = Utils::GetProductAssets(assetUuid);
+                            QString text;
+                            for (const auto& productPath : productPaths)
+                            {
+                                text += QString::fromUtf8(productPath.data(), productPath.size()) + " ";
+                            }
                             m_table->setItem(i, Columns::ProductAsset, createCell(true, text));
                             m_table->item(i, Columns::ProductAsset)->setIcon(m_okIcon);
                         }
@@ -265,12 +267,12 @@ namespace ROS2
             m_refreshTimer->stop();
             if (m_failedCount == 0 && m_missingCount == 0)
             {
-                setTitle(tr("All meshes were processed"));
+                setTitle(tr("All assets were processed"));
             }
             else
             {
                 setTitle(
-                    tr("There are ") + QString::number(m_missingCount) + tr(" unresolved meshes.") + tr("There are ") +
+                    tr("There are ") + QString::number(m_missingCount) + tr(" unresolved assets.") + tr("There are ") +
                     QString::number(m_failedCount) + tr(" failed asset processor jobs."));
             }
         }

--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -148,14 +148,12 @@ namespace ROS2
         // Urdf Root has been parsed successfully retrieve it from the Outcome
         const sdf::Root& parsedSdfRoot = parsedSdfOutcome.GetRoot();
 
-        auto collidersNames = Utils::GetMeshesFilenames(parsedSdfRoot, false, true);
-        auto visualNames = Utils::GetMeshesFilenames(parsedSdfRoot, true, false);
-        auto meshNames = Utils::GetMeshesFilenames(parsedSdfRoot, true, true);
+        auto assetNames = Utils::GetReferencedAssetFilenames(parsedSdfRoot);
         AZStd::shared_ptr<Utils::UrdfAssetMap> urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>();
         if (importAssetWithUrdf)
         {
             urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(
-                Utils::CopyAssetForURDFAndCreateAssetMap(meshNames, filePath, collidersNames, visualNames, sdfBuilderSettings));
+                Utils::CopyReferencedAssetsAndCreateAssetMap(assetNames, filePath, sdfBuilderSettings));
         }
         bool allAssetProcessed = false;
         bool assetProcessorFailed = false;

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -217,7 +217,7 @@ namespace ROS2
                 m_parsedSdf = AZStd::move(parsedSdfOutcome.GetRoot());
                 m_prefabMaker.reset();
                 // Report the status of skipping this page
-                m_meshNames = Utils::GetMeshesFilenames(m_parsedSdf, true, true);
+                m_assetNames = Utils::GetReferencedAssetFilenames(m_parsedSdf);
                 m_assetPage->ClearAssetsList();
             }
             else
@@ -265,9 +265,6 @@ namespace ROS2
     {
         if (m_assetPage->IsEmpty())
         {
-            auto collidersNames = Utils::GetMeshesFilenames(m_parsedSdf, false, true);
-            auto visualNames = Utils::GetMeshesFilenames(m_parsedSdf, true, false);
-
             AZ::Uuid::FixedString dirSuffix;
             if (!m_params.empty())
             {
@@ -286,26 +283,29 @@ namespace ROS2
 
             if (m_importAssetWithUrdf)
             {
-                m_urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(Utils::CopyAssetForURDFAndCreateAssetMap(
-                    m_meshNames, m_urdfPath.String(), collidersNames, visualNames, sdfBuilderSettings, dirSuffix));
+                m_urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(Utils::CopyReferencedAssetsAndCreateAssetMap(
+                    m_assetNames, m_urdfPath.String(), sdfBuilderSettings, dirSuffix));
             }
             else
             {
                 m_urdfAssetsMapping =
-                    AZStd::make_shared<Utils::UrdfAssetMap>(Utils::FindAssetsForUrdf(m_meshNames, m_urdfPath.String(), sdfBuilderSettings));
-                for (const AZStd::string& meshPath : m_meshNames)
+                    AZStd::make_shared<Utils::UrdfAssetMap>(Utils::FindReferencedAssets(m_assetNames, m_urdfPath.String(), sdfBuilderSettings));
+                for (const auto& [assetPath, assetReferenceType] : m_assetNames)
                 {
-                    if (m_urdfAssetsMapping->contains(meshPath))
+                    if (m_urdfAssetsMapping->contains(assetPath))
                     {
-                        const auto& asset = m_urdfAssetsMapping->at(meshPath);
-                        bool visual = visualNames.contains(meshPath);
-                        bool collider = collidersNames.contains(meshPath);
-                        Utils::CreateSceneManifest(asset.m_availableAssetInfo.m_sourceAssetGlobalPath, collider, visual);
+                        const auto& asset = m_urdfAssetsMapping->at(assetPath);
+                        bool visual = (assetReferenceType & Utils::ReferencedAssetType::VisualMesh) == Utils::ReferencedAssetType::VisualMesh;
+                        bool collider = (assetReferenceType & Utils::ReferencedAssetType::ColliderMesh) == Utils::ReferencedAssetType::ColliderMesh;
+                        if (visual || collider)
+                        {
+                            Utils::CreateSceneManifest(asset.m_availableAssetInfo.m_sourceAssetGlobalPath, collider, visual);
+                        }
                     }
                 }
             };
 
-            for (const AZStd::string& meshPath : m_meshNames)
+            for (const auto& [assetPath, assetReferenceType] : m_assetNames)
             {
                 AZ::Uuid sourceAssetUuid = AZ::Uuid::CreateNull();
                 QString type = tr("Unknown");
@@ -313,30 +313,35 @@ namespace ROS2
                 AZStd::optional<AZStd::string> sourcePath;
                 AZStd::optional<AZStd::string> resolvedPath;
 
-                if (m_urdfAssetsMapping->contains(meshPath))
+                if (m_urdfAssetsMapping->contains(assetPath))
                 {
-                    bool visual = visualNames.contains(meshPath);
-                    bool collider = collidersNames.contains(meshPath);
+                    bool visual = (assetReferenceType & Utils::ReferencedAssetType::VisualMesh) == Utils::ReferencedAssetType::VisualMesh;
+                    bool collider = (assetReferenceType & Utils::ReferencedAssetType::ColliderMesh) == Utils::ReferencedAssetType::ColliderMesh;
+                    bool texture = (assetReferenceType & Utils::ReferencedAssetType::Texture) == Utils::ReferencedAssetType::Texture;
                     if (visual && collider)
                     {
-                        type = tr("Visual and Collider");
+                        type = tr("Visual and Collider Mesh");
                     }
                     else if (visual)
                     {
-                        type = tr("Visual");
+                        type = tr("Visual Mesh");
                     }
                     else if (collider)
                     {
-                        type = tr("Collider");
+                        type = tr("Collider Mesh");
+                    }
+                    else if (texture)
+                    {
+                        type = tr("Texture");
                     }
 
-                    const auto& asset = m_urdfAssetsMapping->at(meshPath);
+                    const auto& asset = m_urdfAssetsMapping->at(assetPath);
                     sourceAssetUuid = asset.m_availableAssetInfo.m_sourceGuid;
                     sourcePath = asset.m_availableAssetInfo.m_sourceAssetRelativePath.String();
                     resolvedPath = asset.m_resolvedUrdfPath.String();
                     crc = asset.m_urdfFileCRC;
                 }
-                m_assetPage->ReportAsset(sourceAssetUuid, meshPath, type, sourcePath, crc, resolvedPath);
+                m_assetPage->ReportAsset(sourceAssetUuid, assetPath, type, sourcePath, crc, resolvedPath);
             }
             m_assetPage->StartWatchAsset();
         }
@@ -411,9 +416,9 @@ namespace ROS2
             }
             if (m_checkUrdfPage->isComplete())
             {
-                if (m_meshNames.size() == 0)
+                if (m_assetNames.empty())
                 {
-                    // skip two pages when urdf/sdf is parsed without problems, and it has no meshes
+                    // skip two pages when urdf/sdf is parsed without problems, and it has no assets
                     return m_assetPage->nextId();
                 }
                 else

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -78,7 +78,7 @@ namespace ROS2
         /// mapping from urdf path to asset source
         AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;
         AZStd::unique_ptr<URDFPrefabMaker> m_prefabMaker;
-        AZStd::unordered_set<AZStd::string> m_meshNames;
+        Utils::AssetFilenameReferences m_assetNames;
 
         /// Xacro params
         Utils::xacro::Params m_params;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.h
@@ -37,9 +37,6 @@ namespace ROS2
         //! Prevent copying of existing CollidersMaker
         CollidersMaker(const CollidersMaker& other) = delete;
 
-        //! Builds .pxmeshes for every collider in link collider mesh.
-        //! @param link A parsed SDF tree link node which could hold information about colliders.
-        void BuildColliders(const sdf::Link* link);
         //! Add zero, one or many collider elements (depending on link content).
         //! @param model An SDF model object provided by libsdformat from a parsed URDF/SDF
         //! @param link A parsed SDF tree link node which could hold information about colliders.
@@ -51,7 +48,6 @@ namespace ROS2
 
     private:
         void FindWheelMaterial();
-        void BuildCollider(const sdf::Collision* collision);
         void AddCollider(
             const sdf::Collision* collision,
             AZ::EntityId entityId,

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -278,7 +278,7 @@ namespace ROS2
             }
         }
 
-        AZ_Info("AddMaterial", "Added product material %s", materialProductPath.c_str());
+        AZ_Info("AddMaterial", "Added product material %s\n", materialProductPath.c_str());
     }
 
     static void OverrideMaterialPbrSettings(const sdf::Material* material, const AZStd::shared_ptr<Utils::UrdfAssetMap>& assetMapping, AZ::Render::MaterialAssignmentMap& overrides)

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -278,7 +278,7 @@ namespace ROS2
             }
         }
 
-        AZ_Info("AddMaterial", "Added product material %s", materialProductPath.String().c_str());
+        AZ_Info("AddMaterial", "Added product material %s\n", materialProductPath.c_str());
     }
 
     static void OverrideMaterialPbrSettings(const sdf::Material* material, const AZStd::shared_ptr<Utils::UrdfAssetMap>& assetMapping, AZ::Render::MaterialAssignmentMap& overrides)

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -10,6 +10,7 @@
 #include "RobotImporter/URDF/PrefabMakerUtils.h"
 #include "RobotImporter/Utils/TypeConversions.h"
 
+#include <Atom/RPI.Reflect/Material/MaterialAsset.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentConfig.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentConstants.h>
@@ -231,7 +232,54 @@ namespace ROS2
         entity->Deactivate();
     }
 
-    static void OverrideMaterialPbrSettings(const sdf::Material* material, [[maybe_unused]] AZ::Render::MaterialAssignmentMap& overrides)
+    static void OverrideScriptMaterial(const sdf::Material* material, [[maybe_unused]] AZ::Render::MaterialAssignmentMap& overrides)
+    {
+        AZStd::string materialName(material->ScriptName().c_str(), material->ScriptName().size());
+        if (materialName.empty())
+        {
+            return;
+        }
+
+        // If a material has a <script> element we'll treat the name as a path and name to an O3DE material.
+        // For example, "Gazebo/Wood" will look for a product material in "<cache>/gazebo/wood.azmaterial"
+        AZ::IO::Path materialProductPath(materialName);
+        materialProductPath.ReplaceExtension(".azmaterial");
+
+        // Try getting an asset ID for the given name.
+        constexpr bool AutoGenerateId = false;
+        AZ::Data::AssetId assetId;
+        AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+            assetId,
+            &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath,
+            materialProductPath.String().c_str(),
+            azrtti_typeid<AZ::RPI::MaterialAsset>(),
+            AutoGenerateId);
+
+        // No asset was found, we can't convert the material script.
+        if (!assetId.IsValid())
+        {
+            AZ_Warning("AddMaterial", false, "Failed to find product material for %s", materialProductPath.String().c_str());
+            return;
+        }
+
+        // The asset was found, so replace all the material assets in the given material assignment map.
+        AZ::Data::Asset<AZ::RPI::MaterialAsset> materialAsset(assetId, azrtti_typeid<AZ::RPI::MaterialAsset>());
+        for (auto& [id, override] : overrides)
+        {
+            if (id == AZ::Render::DefaultMaterialAssignmentId)
+            {
+                override.m_defaultMaterialAsset = materialAsset;
+            }
+            else
+            {
+                override.m_materialAsset = materialAsset;
+            }
+        }
+
+        AZ_Info("AddMaterial", "Added product material %s", materialProductPath.String().c_str());
+    }
+
+    static void OverrideMaterialPbrSettings(const sdf::Material* material, const AZStd::shared_ptr<Utils::UrdfAssetMap>& assetMapping, AZ::Render::MaterialAssignmentMap& overrides)
     {
         if (auto pbr = material->PbrMaterial(); pbr)
         {
@@ -253,49 +301,52 @@ namespace ROS2
 
             for (auto& [id, materialAssignment] : overrides)
             {
-                // To truly add PBR conversion, all of the texture map references need to get detected and handled.
-                // The code in the following commented-out blocks demonstrate how to detect the texture maps 
-                // and shows the correct property overrides to connect them to. However, the property overrides
-                // currently require an ImageAsset reference, not a string, so the code won't quite work as-is.
-                // Either the Material overrides need to be changed to work with strings, or this code needs to be changed
-                // to provide ImageAsset references, which would mean that the texture references would already need to be resolved
-                // and processed by the Asset Processor.
-                /*
+                auto GetImageAssetFromPath = [&assetMapping](const std::string& uri) -> AZ::Data::Asset<AZ::RPI::ImageAsset>
+                {
+                    AZ::Data::AssetId assetId;
+                    const auto asset = PrefabMakerUtils::GetAssetFromPath(*assetMapping, uri);
+                    AZ_Warning("AddVisual", asset, "There is no source image asset for %s.", uri.c_str());
+
+                    if (asset)
+                    {
+                        assetId = Utils::GetImageProductAssetId(asset->m_sourceGuid);
+                        AZ_Warning("AddVisual", assetId.IsValid(), "There is no product image asset for %s.", asset->m_sourceAssetRelativePath.c_str());
+                    }
+                    return AZ::Data::Asset<AZ::RPI::ImageAsset>(assetId, azrtti_typeid<AZ::RPI::ImageAsset>());
+                };
+
                 if (auto texture = pbrWorkflow->AlbedoMap(); !texture.empty())
                 {
-                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("baseColor.textureMap"), AZStd::any(AZStd::string(texture.data(), texture.size())));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("baseColor.textureMap"), AZStd::any(GetImageAssetFromPath(texture)));
                 }
 
                 if (auto texture = pbrWorkflow->NormalMap(); !texture.empty())
                 {
-                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("normal.textureMap"), AZStd::any(AZStd::string(texture.data(), texture.size())));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("normal.textureMap"), AZStd::any(GetImageAssetFromPath(texture)));
                 }
 
                 if (auto texture = pbrWorkflow->AmbientOcclusionMap(); !texture.empty())
                 {
-                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("occlusion.diffuseTextureMap"), AZStd::any(AZStd::string(texture.data(), texture.size())));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("occlusion.diffuseTextureMap"), AZStd::any(GetImageAssetFromPath(texture)));
                 }
 
                 if (auto texture = pbrWorkflow->EmissiveMap(); !texture.empty())
                 {
                     materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.enable"), AZStd::any(true));
-                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.textureMap"), AZStd::any(AZStd::string(texture.data(), texture.size())));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.textureMap"), AZStd::any(GetImageAssetFromPath(texture)));
                 }
-                */
 
                 if (pbrWorkflow->Type() == sdf::PbrWorkflowType::METAL)
                 {
-                    /*
                     if (auto texture = pbrWorkflow->RoughnessMap(); !texture.empty())
                     {
-                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("roughness.textureMap"), AZStd::any(AZStd::string(texture.data(), texture.size())));
+                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("roughness.textureMap"), AZStd::any(GetImageAssetFromPath(texture)));
                     }
 
                     if (auto texture = pbrWorkflow->MetalnessMap(); !texture.empty())
                     {
-                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("metallic.textureMap"), AZStd::any(AZStd::string(texture.data(), texture.size())));
+                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("metallic.textureMap"), AZStd::any(GetImageAssetFromPath(texture)));
                     }
-                    */
 
                     if (pbrWorkflow->Element()->HasElement("roughness"))
                     {
@@ -478,7 +529,8 @@ namespace ROS2
         config.m_materials = AZ::Render::GetDefaultMaterialMapFromModelAsset(modelAsset);
 
         // Try to override all of the various material settings based on what's contained in the <material> and <visual> elements in the source file.
-        OverrideMaterialPbrSettings(material, config.m_materials);
+        OverrideScriptMaterial(material, config.m_materials);
+        OverrideMaterialPbrSettings(material, m_urdfAssetsMapping, config.m_materials);
         OverrideMaterialBaseColor(material, config.m_materials);
         OverrideMaterialTransparency(visual, config.m_materials);
         OverrideMaterialEmissiveSettings(material, config.m_materials);

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -260,7 +260,7 @@ namespace ROS2
         // No asset was found, we can't convert the material script.
         if (!assetId.IsValid())
         {
-            AZ_Warning("AddMaterial", false, "Failed to find product material for %s", materialProductPath.String().c_str());
+            AZ_Warning("AddMaterial", false, "Failed to find product material for %s", materialProductPath.c_str());
             return;
         }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -301,7 +301,7 @@ namespace ROS2
 
             for (auto& [id, materialAssignment] : overrides)
             {
-                auto GetImageAssetFromPath = [&assetMapping](const std::string& uri) -> AZ::Data::Asset<AZ::RPI::ImageAsset>
+                auto GetImageAssetIdFromPath = [&assetMapping](const std::string& uri) -> AZ::Data::AssetId
                 {
                     AZ::Data::AssetId assetId;
                     const auto asset = PrefabMakerUtils::GetAssetFromPath(*assetMapping, uri);
@@ -312,40 +312,40 @@ namespace ROS2
                         assetId = Utils::GetImageProductAssetId(asset->m_sourceGuid);
                         AZ_Warning("AddVisual", assetId.IsValid(), "There is no product image asset for %s.", asset->m_sourceAssetRelativePath.c_str());
                     }
-                    return AZ::Data::Asset<AZ::RPI::ImageAsset>(assetId, azrtti_typeid<AZ::RPI::ImageAsset>());
+                    return assetId;
                 };
 
                 if (auto texture = pbrWorkflow->AlbedoMap(); !texture.empty())
                 {
-                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("baseColor.textureMap"), AZStd::any(GetImageAssetFromPath(texture)));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("baseColor.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                 }
 
                 if (auto texture = pbrWorkflow->NormalMap(); !texture.empty())
                 {
-                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("normal.textureMap"), AZStd::any(GetImageAssetFromPath(texture)));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("normal.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                 }
 
                 if (auto texture = pbrWorkflow->AmbientOcclusionMap(); !texture.empty())
                 {
-                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("occlusion.diffuseTextureMap"), AZStd::any(GetImageAssetFromPath(texture)));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("occlusion.diffuseTextureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                 }
 
                 if (auto texture = pbrWorkflow->EmissiveMap(); !texture.empty())
                 {
                     materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.enable"), AZStd::any(true));
-                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.textureMap"), AZStd::any(GetImageAssetFromPath(texture)));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                 }
 
                 if (pbrWorkflow->Type() == sdf::PbrWorkflowType::METAL)
                 {
                     if (auto texture = pbrWorkflow->RoughnessMap(); !texture.empty())
                     {
-                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("roughness.textureMap"), AZStd::any(GetImageAssetFromPath(texture)));
+                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("roughness.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                     }
 
                     if (auto texture = pbrWorkflow->MetalnessMap(); !texture.empty())
                     {
-                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("metallic.textureMap"), AZStd::any(GetImageAssetFromPath(texture)));
+                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("metallic.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                     }
 
                     if (pbrWorkflow->Element()->HasElement("roughness"))

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -240,6 +240,8 @@ namespace ROS2
             return;
         }
 
+        // Make sure the material name is lowercased before checking the path in the Asset Cache
+        AZStd::to_lower(materialName);
         // If a material has a <script> element we'll treat the name as a path and name to an O3DE material.
         // For example, "Gazebo/Wood" will look for a product material in "<cache>/gazebo/wood.azmaterial"
         AZ::IO::Path materialProductPath(materialName);

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -278,7 +278,7 @@ namespace ROS2
             }
         }
 
-        AZ_Info("AddMaterial", "Added product material %s\n", materialProductPath.c_str());
+        AZ_Info("AddMaterial", "Added product material %s", materialProductPath.c_str());
     }
 
     static void OverrideMaterialPbrSettings(const sdf::Material* material, const AZStd::shared_ptr<Utils::UrdfAssetMap>& assetMapping, AZ::Render::MaterialAssignmentMap& overrides)

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -232,7 +232,7 @@ namespace ROS2
         entity->Deactivate();
     }
 
-    static void OverrideScriptMaterial(const sdf::Material* material, [[maybe_unused]] AZ::Render::MaterialAssignmentMap& overrides)
+    static void OverrideScriptMaterial(const sdf::Material* material, AZ::Render::MaterialAssignmentMap& overrides)
     {
         AZStd::string materialName(material->ScriptName().c_str(), material->ScriptName().size());
         if (materialName.empty())

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -427,7 +427,7 @@ namespace ROS2::Utils
     AssetFilenameReferences GetReferencedAssetFilenames(const sdf::Root& root)
     {
         AssetFilenameReferences filenames;
-        auto GetMeshesFromModel = [&filenames](const sdf::Model& model, const ModelStack&) -> VisitModelResponse
+        auto GetAssetsFromModel = [&filenames](const sdf::Model& model, const ModelStack&) -> VisitModelResponse
         {
             const auto addFilenameFromGeometry = [&filenames](const sdf::Geometry* geometry, ReferencedAssetType assetType)
             {
@@ -525,7 +525,7 @@ namespace ROS2::Utils
             return VisitModelResponse::VisitNestedAndSiblings;
         };
 
-        VisitModels(root, GetMeshesFromModel);
+        VisitModels(root, GetAssetsFromModel);
 
         return filenames;
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -424,39 +424,96 @@ namespace ROS2::Utils
         VisitModelsForNestedModels(sdfRoot);
     }
 
-    AZStd::unordered_set<AZStd::string> GetMeshesFilenames(const sdf::Root& root, bool visual, bool colliders)
+    AssetFilenameReferences GetReferencedAssetFilenames(const sdf::Root& root)
     {
-        AZStd::unordered_set<AZStd::string> filenames;
-        auto GetMeshesFromModel = [&filenames, visual, colliders](const sdf::Model& model, const ModelStack&) -> VisitModelResponse
+        AssetFilenameReferences filenames;
+        auto GetMeshesFromModel = [&filenames](const sdf::Model& model, const ModelStack&) -> VisitModelResponse
         {
-            const auto addFilenameFromGeometry = [&filenames](const sdf::Geometry* geometry)
+            const auto addFilenameFromGeometry = [&filenames](const sdf::Geometry* geometry, ReferencedAssetType assetType)
             {
                 if (geometry->Type() == sdf::GeometryType::MESH)
                 {
-                    auto pMesh = geometry->MeshShape();
-                    std::string meshUri = pMesh->Uri();
-                    if (pMesh && !meshUri.empty())
+                    if (auto mesh = geometry->MeshShape(); mesh)
                     {
-                        filenames.emplace(meshUri.c_str(), meshUri.size());
+                        AZStd::string uri(mesh->Uri().c_str(), mesh->Uri().size());
+                        if (filenames.contains(uri))
+                        {
+                            filenames[uri] = filenames[uri] | assetType;
+                        }
+                        else
+                        {
+                            filenames.emplace(uri, assetType);
+                        }
                     }
                 }
             };
 
-            const auto processLink = [&addFilenameFromGeometry, visual, colliders](const sdf::Link* link)
+            const auto addFilenamesFromMaterial = [&filenames](const sdf::Material* material)
             {
-                if (visual)
+                // Only PBR entries on a material have filenames that need to be added.
+                if ((!material) || (!material->PbrMaterial()))
                 {
-                    for (uint64_t index = 0; index < link->VisualCount(); index++)
+                    return;
+                }
+
+                if (auto pbr = material->PbrMaterial(); pbr)
+                {
+                    auto pbrWorkflow = pbr->Workflow(sdf::PbrWorkflowType::METAL);
+                    if (!pbrWorkflow)
                     {
-                        addFilenameFromGeometry(link->VisualByIndex(index)->Geom());
+                        pbrWorkflow = pbr->Workflow(sdf::PbrWorkflowType::SPECULAR);
+                        if (!pbrWorkflow)
+                        {
+                            return;
+                        }
+                    }
+
+                    if (auto texture = pbrWorkflow->AlbedoMap(); !texture.empty())
+                    {
+                        filenames.emplace(AZStd::string(texture.c_str(), texture.size()), ReferencedAssetType::Texture);
+                    }
+
+                    if (auto texture = pbrWorkflow->NormalMap(); !texture.empty())
+                    {
+                        filenames.emplace(AZStd::string(texture.c_str(), texture.size()), ReferencedAssetType::Texture);
+                    }
+
+                    if (auto texture = pbrWorkflow->AmbientOcclusionMap(); !texture.empty())
+                    {
+                        filenames.emplace(AZStd::string(texture.c_str(), texture.size()), ReferencedAssetType::Texture);
+                    }
+
+                    if (auto texture = pbrWorkflow->EmissiveMap(); !texture.empty())
+                    {
+                        filenames.emplace(AZStd::string(texture.c_str(), texture.size()), ReferencedAssetType::Texture);
+                    }
+
+                    if (pbrWorkflow->Type() == sdf::PbrWorkflowType::METAL)
+                    {
+                        if (auto texture = pbrWorkflow->RoughnessMap(); !texture.empty())
+                        {
+                            filenames.emplace(AZStd::string(texture.c_str(), texture.size()), ReferencedAssetType::Texture);
+                        }
+
+                        if (auto texture = pbrWorkflow->MetalnessMap(); !texture.empty())
+                        {
+                            filenames.emplace(AZStd::string(texture.c_str(), texture.size()), ReferencedAssetType::Texture);
+                        }
                     }
                 }
-                if (colliders)
+            };
+
+            const auto processLink = [&addFilenameFromGeometry, &addFilenamesFromMaterial](const sdf::Link* link)
+            {
+                for (uint64_t index = 0; index < link->VisualCount(); index++)
                 {
-                    for (uint64_t index = 0; index < link->CollisionCount(); index++)
-                    {
-                        addFilenameFromGeometry(link->CollisionByIndex(index)->Geom());
-                    }
+                    addFilenameFromGeometry(link->VisualByIndex(index)->Geom(), ReferencedAssetType::VisualMesh);
+                    addFilenamesFromMaterial(link->VisualByIndex(index)->Material());
+                }
+
+                for (uint64_t index = 0; index < link->CollisionCount(); index++)
+                {
+                    addFilenameFromGeometry(link->CollisionByIndex(index)->Geom(), ReferencedAssetType::ColliderMesh);
                 }
             };
 

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -16,6 +16,7 @@
 #include <AzCore/std/function/function_template.h>
 #include <AzCore/std/string/string.h>
 #include <RobotImporter/URDF/UrdfParser.h>
+#include <RobotImporter/Utils/SourceAssetsStorage.h>
 #include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
 
 #include <sdf/sdf.hh>
@@ -128,13 +129,11 @@ namespace ROS2::Utils
     //! @returns void
     void VisitModels(const sdf::Root& sdfRoot, const ModelVisitorCallback& modelVisitorCB, bool visitNestedModels = true);
 
-    //! Retrieve all meshes referenced in URDF as unresolved URDF patches.
-    //! Note that returned filenames are unresolved URDF patches.
+    //! Retrieve all assets referenced in SDF/URDF as unresolved URIs.
+    //! The URIs will still need to get resolved via ResolveAssetPath() to point to a valid file location.
     //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param visual search for visual meshes.
-    //! @param colliders search for collider meshes.
     //! @returns set of meshes' filenames.
-    AZStd::unordered_set<AZStd::string> GetMeshesFilenames(const sdf::Root& root, bool visual, bool colliders);
+    AssetFilenameReferences GetReferencedAssetFilenames(const sdf::Root& root);
 
     //! Returns the SDF model object which contains the specified link
     //! @param root reference to SDF Root object representing the root of the parsed SDF xml document

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -8,6 +8,8 @@
 
 #include "SourceAssetsStorage.h"
 #include "RobotImporterUtils.h"
+#include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
+#include <Atom/RPI.Reflect/Model/ModelAsset.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/Serialization/Json/JsonImporter.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
@@ -16,6 +18,7 @@
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzFramework/Asset/AssetSystemBus.h>
 #include <AzToolsFramework/Asset/AssetUtils.h>
+#include <PhysX/MeshAsset.h>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
 #include <SceneAPI/SceneCore/Containers/Utilities/Filters.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IMaterialData.h>
@@ -96,8 +99,16 @@ namespace ROS2::Utils
         return r;
     }
 
-    AZStd::string GetProductAsset(const AZ::Uuid& sourceAssetUUID, const AZ::TypeId typeId)
+    AZStd::vector<AZStd::string> GetProductAssets(const AZ::Uuid& sourceAssetUUID)
     {
+        AZStd::vector<AZStd::string> productPaths;
+        const auto importantTypes = AZStd::to_array<const AZ::TypeId>(
+        {
+            azrtti_typeid<AZ::RPI::StreamingImageAsset>(),
+            azrtti_typeid<AZ::RPI::ModelAsset>(),
+            azrtti_typeid<PhysX::Pipeline::MeshAsset>()
+        });
+
         AZStd::vector<AZ::Data::AssetInfo> productsAssetInfo;
         using AssetSysReqBus = AzToolsFramework::AssetSystemRequestBus;
         bool ok{ false };
@@ -106,26 +117,24 @@ namespace ROS2::Utils
         {
             for (auto& product : productsAssetInfo)
             {
-                if (product.m_assetType == typeId)
+                for (auto& typeId : importantTypes)
                 {
-                    AZStd::string assetPath;
-                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
-                        assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, product.m_assetId);
-                    return assetPath;
+                    if (product.m_assetType == typeId)
+                    {
+                        AZStd::string assetPath;
+                        AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                            assetPath, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetPathById, product.m_assetId);
+                        if (!assetPath.empty())
+                        {
+                            productPaths.emplace_back(AZStd::move(assetPath));
+                            break;
+                        }
+                    }
                 }
             }
         }
-        return "";
-    }
 
-    AZStd::string GetModelProductAsset(const AZ::Uuid& sourceAssetUUID)
-    {
-        return GetProductAsset(sourceAssetUUID, AZ::TypeId("{2C7477B6-69C5-45BE-8163-BCD6A275B6D8}")); // AZ::RPI::ModelAsset;
-    }
-
-    AZStd::string GetPhysXMeshProductAsset(const AZ::Uuid& sourceAssetUUID)
-    {
-        return GetProductAsset(sourceAssetUUID, AZ::TypeId("{7A2871B9-5EAB-4DE0-A901-B0D2C6920DDB}")); // PhysX::Pipeline::MeshAsset
+        return productPaths;
     }
 
     AZ::Data::AssetId GetProductAssetId(const AZ::Uuid& sourceAssetUUID, const AZ::TypeId typeId)
@@ -147,14 +156,19 @@ namespace ROS2::Utils
         return {};
     }
 
+    AZ::Data::AssetId GetImageProductAssetId(const AZ::Uuid& sourceAssetUUID)
+    {
+        return GetProductAssetId(sourceAssetUUID, azrtti_typeid<AZ::RPI::StreamingImageAsset>());
+    }
+
     AZ::Data::AssetId GetModelProductAssetId(const AZ::Uuid& sourceAssetUUID)
     {
-        return GetProductAssetId(sourceAssetUUID, AZ::TypeId("{2C7477B6-69C5-45BE-8163-BCD6A275B6D8}")); // AZ::RPI::ModelAsset;
+        return GetProductAssetId(sourceAssetUUID, azrtti_typeid<AZ::RPI::ModelAsset>());
     }
 
     AZ::Data::AssetId GetPhysXMeshProductAssetId(const AZ::Uuid& sourceAssetUUID)
     {
-        return GetProductAssetId(sourceAssetUUID, AZ::TypeId("{7A2871B9-5EAB-4DE0-A901-B0D2C6920DDB}")); // PhysX::Pipeline::MeshAsset
+        return GetProductAssetId(sourceAssetUUID, azrtti_typeid<PhysX::Pipeline::MeshAsset>());
     }
 
     AvailableAsset GetAvailableAssetInfo(const AZStd::string& globalSourceAssetPath)
@@ -272,17 +286,15 @@ namespace ROS2::Utils
         return availableAssets;
     }
 
-    UrdfAssetMap CopyAssetForURDFAndCreateAssetMap(
-        const AZStd::unordered_set<AZStd::string>& meshesFilenames,
+    UrdfAssetMap CopyReferencedAssetsAndCreateAssetMap(
+        const AssetFilenameReferences& assetFilenames,
         const AZStd::string& urdfFilename,
-        const AZStd::unordered_set<AZStd::string>& colliders,
-        const AZStd::unordered_set<AZStd::string>& visuals,
         const SdfAssetBuilderSettings& sdfBuilderSettings,
         AZStd::string_view outputDirSuffix,
         AZ::IO::FileIOBase* fileIO)
     {
         UrdfAssetMap urdfAssetMap;
-        if (meshesFilenames.empty())
+        if (assetFilenames.empty())
         {
             return urdfAssetMap;
         }
@@ -325,18 +337,15 @@ namespace ROS2::Utils
         auto amentPrefixPath = Utils::GetAmentPrefixPath();
         AZStd::unordered_map<AZStd::string, unsigned int> countFilenames;
 
-        for (const auto& unresolvedUrfFileName : meshesFilenames)
+        for (const auto& [unresolvedFileName, assetReferenceType] : assetFilenames)
         {
             auto resolvedPath =
-                Utils::ResolveAssetPath(unresolvedUrfFileName, AZ::IO::PathView(urdfFilename), amentPrefixPath, sdfBuilderSettings);
+                Utils::ResolveAssetPath(unresolvedFileName, AZ::IO::PathView(urdfFilename), amentPrefixPath, sdfBuilderSettings);
             if (resolvedPath.empty())
             {
-                AZ_Warning("CopyAssetForURDF", false, "There is no resolved path for %s", unresolvedUrfFileName.c_str());
+                AZ_Warning("CopyAssetForURDF", false, "There is no resolved path for %s", unresolvedFileName.c_str());
                 continue;
             }
-
-            const bool needsVisual = visuals.contains(unresolvedUrfFileName);
-            const bool needsCollider = colliders.contains(unresolvedUrfFileName);
 
             AZStd::string filename = resolvedPath.Filename().String();
             auto count = countFilenames[filename]++;
@@ -364,36 +373,45 @@ namespace ROS2::Utils
                     outcomeCopyTmp.GetResultCode());
                 if (outcomeCopyTmp)
                 {
-                    // create asset info at destination location using the temporary mesh file
-                    const bool assetInfoOk = CreateSceneManifest(targetPathAssetTmp, targetPathAssetInfo, needsCollider, needsVisual);
+                    const bool needsVisual = (assetReferenceType & ReferencedAssetType::VisualMesh) == ReferencedAssetType::VisualMesh;
+                    const bool needsCollider = (assetReferenceType & ReferencedAssetType::ColliderMesh) == ReferencedAssetType::ColliderMesh;
+                    const bool isMeshFile = (needsVisual || needsCollider);
+
+                    // if the asset is a mesh, create asset info at destination location using the temporary mesh file
+                    const bool assetInfoOk = isMeshFile
+                        ? CreateSceneManifest(targetPathAssetTmp, targetPathAssetInfo, needsCollider, needsVisual)
+                        : true;
 
                     if (assetInfoOk)
                     {
                         // copy additional assets such as textures directly to destination location
-                        const auto& meshTextureAssets = Utils::GetMeshTextureAssets(targetPathAssetTmp);
-                        for (const auto& unresolvedAssetPath : meshTextureAssets)
+                        if (isMeshFile)
                         {
-                            // Manifest returns local path in Project's directory temp folder
-                            const AZ::IO::Path assetLocalPath(AZ::IO::Path(AZ::IO::Path(AZ::Utils::GetProjectPath()) / unresolvedAssetPath)
-                                                                  .LexicallyRelative(importDirectoryTmp));
-
-                            const AZ::IO::Path assetFullPathSrc(AZ::IO::Path(resolvedPath.ParentPath()) / assetLocalPath);
-                            const AZ::IO::Path assetFullPathDst(importDirectoryDst / assetLocalPath);
-
-                            const auto outcomeMkdir = fileIO->CreatePath(AZ::IO::Path(assetFullPathDst.ParentPath()).c_str());
-                            if (!outcomeMkdir)
+                            const auto& meshTextureAssets = Utils::GetMeshTextureAssets(targetPathAssetTmp);
+                            for (const auto& unresolvedAssetPath : meshTextureAssets)
                             {
-                                break;
-                            }
+                                // Manifest returns local path in Project's directory temp folder
+                                const AZ::IO::Path assetLocalPath(AZ::IO::Path(AZ::IO::Path(AZ::Utils::GetProjectPath()) / unresolvedAssetPath)
+                                                                    .LexicallyRelative(importDirectoryTmp));
 
-                            const auto outcomeCopy = fileIO->Copy(assetFullPathSrc.c_str(), assetFullPathDst.c_str());
-                            if (outcomeCopy)
-                            {
-                                copiedFiles[assetFullPathSrc.String()] = assetFullPathDst.String();
+                                const AZ::IO::Path assetFullPathSrc(AZ::IO::Path(resolvedPath.ParentPath()) / assetLocalPath);
+                                const AZ::IO::Path assetFullPathDst(importDirectoryDst / assetLocalPath);
+
+                                const auto outcomeMkdir = fileIO->CreatePath(AZ::IO::Path(assetFullPathDst.ParentPath()).c_str());
+                                if (!outcomeMkdir)
+                                {
+                                    break;
+                                }
+
+                                const auto outcomeCopy = fileIO->Copy(assetFullPathSrc.c_str(), assetFullPathDst.c_str());
+                                if (outcomeCopy)
+                                {
+                                    copiedFiles[assetFullPathSrc.String()] = assetFullPathDst.String();
+                                }
                             }
                         }
 
-                        // move mesh file from temporary location to destination location
+                        // move asset file from temporary location to destination location
                         const auto outcomeMoveDst = fileIO->Rename(targetPathAssetTmp.c_str(), targetPathAssetDst.c_str());
                         AZ_Printf(
                             "CopyAssetForURDF",
@@ -417,7 +435,7 @@ namespace ROS2::Utils
 
                         if (outcomeMoveDst)
                         {
-                            copiedFiles[unresolvedUrfFileName] = targetPathAssetDst.String();
+                            copiedFiles[unresolvedFileName] = targetPathAssetDst.String();
                         }
                     }
                 }
@@ -425,15 +443,15 @@ namespace ROS2::Utils
             else
             {
                 AZ_Printf("CopyAssetForURDF", "File %s already exists, omitting import", targetPathAssetDst.c_str());
-                copiedFiles[unresolvedUrfFileName] = targetPathAssetDst.String();
+                copiedFiles[unresolvedFileName] = targetPathAssetDst.String();
             }
 
             Utils::UrdfAsset asset;
             asset.m_urdfPath = urdfFilename;
             asset.m_resolvedUrdfPath =
-                Utils::ResolveAssetPath(unresolvedUrfFileName, AZ::IO::PathView(urdfFilename), amentPrefixPath, sdfBuilderSettings);
+                Utils::ResolveAssetPath(unresolvedFileName, AZ::IO::PathView(urdfFilename), amentPrefixPath, sdfBuilderSettings);
             asset.m_urdfFileCRC = AZ::Crc32();
-            urdfAssetMap.emplace(unresolvedUrfFileName, AZStd::move(asset));
+            urdfAssetMap.emplace(unresolvedFileName, AZStd::move(asset));
         }
 
         fileIO->DestroyPath(importDirectoryTmp.c_str());
@@ -453,22 +471,22 @@ namespace ROS2::Utils
         return urdfAssetMap;
     }
 
-    UrdfAssetMap FindAssetsForUrdf(
-        const AZStd::unordered_set<AZStd::string>& meshesFilenames,
+    UrdfAssetMap FindReferencedAssets(
+        const AssetFilenameReferences& assetFilenames,
         const AZStd::string& urdfFilename,
         const SdfAssetBuilderSettings& sdfBuilderSettings)
     {
         auto amentPrefixPath = Utils::GetAmentPrefixPath();
 
         UrdfAssetMap urdfToAsset;
-        for (const auto& t : meshesFilenames)
+        for (const auto& [assetPath, assetReferenceType] : assetFilenames)
         {
             Utils::UrdfAsset asset;
-            asset.m_urdfPath = t;
+            asset.m_urdfPath = assetPath;
             asset.m_resolvedUrdfPath =
                 Utils::ResolveAssetPath(asset.m_urdfPath, AZ::IO::PathView(urdfFilename), amentPrefixPath, sdfBuilderSettings);
             asset.m_urdfFileCRC = Utils::GetFileCRC(asset.m_resolvedUrdfPath);
-            urdfToAsset.emplace(t, AZStd::move(asset));
+            urdfToAsset.emplace(assetPath, AZStd::move(asset));
         }
 
         if (!urdfToAsset.empty())

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -109,17 +109,17 @@ namespace ROS2::Utils
     //! @returns product asset id (invalid id if not found)
     AZ::Data::AssetId GetProductAssetId(const AZ::Uuid& sourceAssetUUID, const AZ::TypeId typeId);
 
-    //! Helper function that gives AZ::RPI::ImageAsset product asset from source asset GUID
+    //! Helper function that gives AZ::RPI::ImageAsset product asset ID from source asset GUID
     //! @param sourceAssetUUID is source asset GUID
     //! @returns product asset id (invalid id if not found)
     AZ::Data::AssetId GetImageProductAssetId(const AZ::Uuid& sourceAssetUUID);
 
-    //! Helper function that gives AZ::RPI::ModelAsset product asset from source asset GUID
+    //! Helper function that gives AZ::RPI::ModelAsset product asset ID from source asset GUID
     //! @param sourceAssetUUID is source asset GUID
     //! @returns product asset id (invalid id if not found)
     AZ::Data::AssetId GetModelProductAssetId(const AZ::Uuid& sourceAssetUUID);
 
-    //! Helper function that gives PhysX::Pipeline::MeshAsset product asset from source asset GUID
+    //! Helper function that gives PhysX::Pipeline::MeshAsset product asset ID from source asset GUID
     //! @param sourceAssetUUID is source asset GUID
     //! @returns product asset id (invalid id if not found)
     AZ::Data::AssetId GetPhysXMeshProductAssetId(const AZ::Uuid& sourceAssetUUID);

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -59,6 +59,19 @@ namespace ROS2::Utils
         AvailableAsset m_availableAssetInfo;
     };
 
+    //! Bitfield containing the types of asset references are associated with a given unresolved URI or path reference.
+    //! These are flags because the same mesh URI can refer to both a Visual and a Collider entry, for example.
+    enum class ReferencedAssetType
+    {
+        VisualMesh =   0b00000001,   //! URI references a mesh for a Visual entry
+        ColliderMesh = 0b00000010,   //! URI references a mesh for a Collider entry
+        Texture =      0b00000100,   //! URI references one of a multitude of texture types (Diffuse, Normal, AO, etc)
+    };
+    AZ_DEFINE_ENUM_BITWISE_OPERATORS(ReferencedAssetType);
+
+    //! Maps unresolved URI asset references to the type of reference(s) - mesh, texture, etc.
+    using AssetFilenameReferences = AZStd::unordered_map<AZStd::string, ReferencedAssetType>;
+
     /// Type that hold result of mapping from URDF path to asset info
     using UrdfAssetMap = AZStd::unordered_map<AZ::IO::Path, Utils::UrdfAsset>;
 
@@ -76,36 +89,30 @@ namespace ROS2::Utils
     //! - Files pointed by resolved URDF patches have their checksum computed `GetFileCRC`.
     //! - Function scans all available O3DE assets by calling `GetInterestingSourceAssetsCRC`.
     //! - Suitable mapping to the O3DE asset is found by comparing the checksum of the file pointed by the URDF path and source asset.
-    //! @param meshesFilenames - list of the unresolved path from the URDF file
+    //! @param assetFilenames - list of the unresolved paths from the SDF/URDF file
     //! @param urdfFilename - filename of URDF file, used for resolvement
     //! @param sdfBuilderSettings - the builder settings that should be used to resolve paths
     //! @returns a URDF Asset map where the key is unresolved URDF path to AvailableAsset
-    UrdfAssetMap FindAssetsForUrdf(
-        const AZStd::unordered_set<AZStd::string>& meshesFilenames,
+    UrdfAssetMap FindReferencedAssets(
+        const AssetFilenameReferences& assetFilenames,
         const AZStd::string& urdfFilename,
         const SdfAssetBuilderSettings& sdfBuilderSettings);
 
-    //! Helper function that gives product's path from source asset GUID
+    //! Helper function that gets all the potential primary product asset paths from the source asset GUID
     //! @param sourceAssetUUID is source asset GUID
-    //! @param typeId type of product asset
-    //! @returns relative path to product, empty string if product is not found
-    AZStd::string GetProductAsset(const AZ::Uuid& sourceAssetUUID, const AZ::TypeId typeId);
-
-    //! Helper function that gives AZ::RPI::ModelAsset product asset from source asset GUID
-    //! @param sourceAssetUUID is source asset GUID
-    //! @returns relative path to product, empty string if product is not found
-    AZStd::string GetModelProductAsset(const AZ::Uuid& sourceAssetUUID);
-
-    //! Helper function that gives PhysX::Pipeline::MeshAsset product asset from source asset GUID
-    //! @param sourceAssetUUID is source asset GUID
-    //! @returns relative path to product, empty string if product is not found
-    AZStd::string GetPhysXMeshProductAsset(const AZ::Uuid& sourceAssetUUID);
+    //! @returns vector of relative paths to products, empty if no products are found
+    AZStd::vector<AZStd::string> GetProductAssets(const AZ::Uuid& sourceAssetUUID);
 
     //! Helper function that gives the desired product asset ID from source asset GUID
     //! @param sourceAssetUUID is source asset GUID
     //! @param typeId type of product asset
     //! @returns product asset id (invalid id if not found)
     AZ::Data::AssetId GetProductAssetId(const AZ::Uuid& sourceAssetUUID, const AZ::TypeId typeId);
+
+    //! Helper function that gives AZ::RPI::ImageAsset product asset from source asset GUID
+    //! @param sourceAssetUUID is source asset GUID
+    //! @returns product asset id (invalid id if not found)
+    AZ::Data::AssetId GetImageProductAssetId(const AZ::Uuid& sourceAssetUUID);
 
     //! Helper function that gives AZ::RPI::ModelAsset product asset from source asset GUID
     //! @param sourceAssetUUID is source asset GUID
@@ -134,22 +141,18 @@ namespace ROS2::Utils
     bool CreateSceneManifest(
         const AZ::IO::Path& sourceAssetPath, const AZ::IO::Path& assetInfoFile, const bool collider, const bool visual);
 
-    //! Copies and prepares meshes that are referenced in URDF.
-    //! It resolves every mesh, creates a directory in Project's Asset directory, copies files, and prepares assets info.
-    //! Finally, it assembles its results into mapping that allows mapping Urdf's mesh name to the source asset.
-    //! @param meshesFilenames - files to copy (as unresolved urdf paths)
-    //! @param urdFilename - path to URDF file (as a global path)
-    //! @param colliders - files to create collider assetinfo (as unresolved urdf paths)
-    //! @param visuals - files to create visual assetinfo (as unresolved urdf paths)
+    //! Copies and prepares assets that are referenced in SDF/URDF.
+    //! It resolves every asset, creates a directory in Project's Asset directory, copies files, and prepares assets info.
+    //! Finally, it assembles its results into mapping that allows mapping the SDF/URDF mesh name to the source asset.
+    //! @param assetFilenames - files to copy (as unresolved urdf paths)
+    //! @param urdfFilename - path to URDF file (as a global path)
     //! @param sdfBuilderSettings - the builder settings to use to convert the SDF/URDF files
     //! @param outputDirSuffix - suffix to make output directory unique, if xacro file was used
     //! @param fileIO - instance to fileIO class
     //! @returns mapping from unresolved urdf paths to source asset info
-    UrdfAssetMap CopyAssetForURDFAndCreateAssetMap(
-        const AZStd::unordered_set<AZStd::string>& meshesFilenames,
+    UrdfAssetMap CopyReferencedAssetsAndCreateAssetMap(
+        const AssetFilenameReferences& assetFilenames,
         const AZStd::string& urdfFilename,
-        const AZStd::unordered_set<AZStd::string>& colliders,
-        const AZStd::unordered_set<AZStd::string>& visual,
         const SdfAssetBuilderSettings& sdfBuilderSettings,
         AZStd::string_view outputDirSuffix = "",
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
@@ -86,7 +86,7 @@ namespace ROS2
     Utils::UrdfAssetMap SdfAssetBuilder::FindAssets(const sdf::Root& root, const AZStd::string& sourceFilename) const
     {
         AZ_Info(SdfAssetBuilderName, "Parsing mesh and collider names");
-        auto assetNames = Utils::GetMeshesFilenames(root, true, true);
+        auto assetNames = Utils::GetReferencedAssetFilenames(root);
 
         Utils::UrdfAssetMap assetMap;
 
@@ -94,7 +94,7 @@ namespace ROS2
 
         auto amentPrefixPath = Utils::GetAmentPrefixPath();
 
-        for (const auto& uri : assetNames)
+        for (const auto& [uri, assetReferenceType] : assetNames)
         {
             Utils::UrdfAsset asset;
             asset.m_urdfPath = uri;


### PR DESCRIPTION
This PR finishes the work of supporting <material> conversions:
* <pbr> subsections in a <material> will now convert correctly.
* <script> subsections in a <material> will look for an asset of the same name (ex: "Gazebo/Wood" will look for "Gazebo/Wood.material") and use the asset reference if found.
* Most of the standard Gazebo materials have been added as material assets. These materials could use further refinement and textures (wood, grass, asphalt, etc), right now they are all solid color materials that are roughly similar to the equivalent standard Gazebo materials, but are neither exactly the same nor enhanced. I'm not an artist though, so hopefully someone else will come along and improve these. I tried to preserve diffuse color, emissive behavior, and transparency as best as possible when converting.

Some additional changes are in here as well:
* Added an "empty.sdf" file. This can be used with the URI prefix mapping system to replace an <include> file with an empty file. Useful for when you're trying to remove an <include> without modifying the source file.
* Removed BuildCollider() / BuildColliders(), they were dead code.
* Extended the asset copying and status tracking code to also handle any textures referenced by materials. These extensions should also make it much easier to add other asset references in the future, like heightmap images, geometry images, etc. The textures referenced by a <pbr> block will get copied over and reported on the asset status page.

(Converted https://github.com/azazdeaz/fields-ignition/tree/noetic/fields_ignition/generated_examples/tomato_field/tomato_0 )

Asset status page showing referenced textures that are copied:
![image](https://github.com/o3de/o3de-extras/assets/82224783/b912f2b3-fcf8-4c25-99a4-fd8b452f169c)

SDF conversion using multiple <pbr> blocks to apply different textures to different parts of the tomato plant:
![image](https://github.com/o3de/o3de-extras/assets/82224783/9d3d3cc1-c3a4-46a6-8217-8aab30837157)
NOTE: This is also demonstrating some limitations in the conversion:
* <submesh> support doesn't exist yet, so multiple materials are trying to get applied to the entire mesh, leaving a somewhat random and chaotic result. 
* The material in the source SDF _ought_ to denote `<doubleSided>` but doesn't, so the leaves are invisible from one side. 
* There isn't a way for the source SDF to specify an opacity mode of Blended/Cutout, so the leaves ended up with visible opaque black fringes from the conversion which requires a manual edit to set the opacity mode to fix.

(Converted https://github.com/Daniella1/urdf_files_dataset/tree/main/urdf_files/ros-industrial/motoman/motoman_sia10d_support/urdf )

SDF conversion using "Gazebo/White" and "Gazebo/Blue" default materials:
![image](https://github.com/o3de/o3de-extras/assets/82224783/7503eed5-496c-4bf6-a947-536957d1c16b)
