### PR TITLE
Merge next changes from development to stabilization2310

### DIFF
--- a/Gems/ROS2/Assets/Gazebo/Black.material
+++ b/Gems/ROS2/Assets/Gazebo/Black.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/BlackTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/BlackTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Blue.material
+++ b/Gems/ROS2/Assets/Gazebo/Blue.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/BlueGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/BlueGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/BlueLaser.material
+++ b/Gems/ROS2/Assets/Gazebo/BlueLaser.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.6
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/BlueTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/BlueTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Bricks.material
+++ b/Gems/ROS2/Assets/Gazebo/Bricks.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 1.0,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.6627,
+            0.302,
+            0.1568,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/CeilingTiled.material
+++ b/Gems/ROS2/Assets/Gazebo/CeilingTiled.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.921,
+            0.921,
+            0.921,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/CloudySky.material
+++ b/Gems/ROS2/Assets/Gazebo/CloudySky.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.1,
+        "metallic.factor": 0.6,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/DarkGray.material
+++ b/Gems/ROS2/Assets/Gazebo/DarkGray.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.825,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.175,
+            0.175,
+            0.175,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/DarkGrey.material
+++ b/Gems/ROS2/Assets/Gazebo/DarkGrey.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.825,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.175,
+            0.175,
+            0.175,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/DarkMagentaTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/DarkMagentaTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.6,
+            0.0,
+            0.6,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/DarkYellow.material
+++ b/Gems/ROS2/Assets/Gazebo/DarkYellow.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 1.0,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.7,
+            0.7,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/FlatBlack.material
+++ b/Gems/ROS2/Assets/Gazebo/FlatBlack.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.99,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.1,
+            0.1,
+            0.1,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Footway.material
+++ b/Gems/ROS2/Assets/Gazebo/Footway.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.95,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.607,
+            0.607,
+            0.5607,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Gold.material
+++ b/Gems/ROS2/Assets/Gazebo/Gold.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.1,
+        "metallic.factor": 1.0,
+        "baseColor.color": [
+            0.8,
+            0.64869,
+            0.120759,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Grass.material
+++ b/Gems/ROS2/Assets/Gazebo/Grass.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Gray.material
+++ b/Gems/ROS2/Assets/Gazebo/Gray.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.99,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.7,
+            0.7,
+            0.7,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Green.material
+++ b/Gems/ROS2/Assets/Gazebo/Green.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/GreenGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/GreenGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/GreenTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/GreenTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Grey.material
+++ b/Gems/ROS2/Assets/Gazebo/Grey.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.99,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.7,
+            0.7,
+            0.7,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/GreyGradientSky.material
+++ b/Gems/ROS2/Assets/Gazebo/GreyGradientSky.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.99,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.7,
+            0.7,
+            0.7,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/GreyTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/GreyTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.5,
+            0.5,
+            0.5,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Indigo.material
+++ b/Gems/ROS2/Assets/Gazebo/Indigo.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.33,
+            0.0,
+            0.5,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/LightBlueLaser.material
+++ b/Gems/ROS2/Assets/Gazebo/LightBlueLaser.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.5,
+            0.5,
+            1.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.6
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/LightOff.material
+++ b/Gems/ROS2/Assets/Gazebo/LightOff.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            1.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/LightOn.material
+++ b/Gems/ROS2/Assets/Gazebo/LightOn.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            0.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Orange.material
+++ b/Gems/ROS2/Assets/Gazebo/Orange.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.5,
+        "metallic.factor": 0.125,
+        "baseColor.color": [
+            1.0,
+            0.5088,
+            0.0468,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/OrangeTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/OrangeTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.44,
+            0.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.6
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/PaintedWall.material
+++ b/Gems/ROS2/Assets/Gazebo/PaintedWall.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 1.0,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            1.0,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Pedestrian.material
+++ b/Gems/ROS2/Assets/Gazebo/Pedestrian.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.95,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.607,
+            0.607,
+            0.5607,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Purple.material
+++ b/Gems/ROS2/Assets/Gazebo/Purple.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.0,
+            1.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/PurpleGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/PurpleGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.0,
+            1.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            1.0,
+            0.0,
+            1.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Red.material
+++ b/Gems/ROS2/Assets/Gazebo/Red.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.0,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/RedBright.material
+++ b/Gems/ROS2/Assets/Gazebo/RedBright.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.6,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.87,
+            0.26,
+            0.07,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/RedGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/RedGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            1.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/RedTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/RedTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Residential.material
+++ b/Gems/ROS2/Assets/Gazebo/Residential.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.95,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.35,
+            0.35,
+            0.35,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Road.material
+++ b/Gems/ROS2/Assets/Gazebo/Road.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.95,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.35,
+            0.35,
+            0.35,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/SkyBlue.material
+++ b/Gems/ROS2/Assets/Gazebo/SkyBlue.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.1,
+        "metallic.factor": 0.6,
+        "baseColor.color": [
+            0.0,
+            0.0,
+            1.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Turquoise.material
+++ b/Gems/ROS2/Assets/Gazebo/Turquoise.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            1.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/TurquoiseGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/TurquoiseGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.0,
+            1.0,
+            1.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            0.0,
+            1.0,
+            1.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/White.material
+++ b/Gems/ROS2/Assets/Gazebo/White.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            1.0,
+            1.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/WhiteGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/WhiteGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            1.0,
+            1.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            1.0,
+            1.0,
+            1.0,
+            1.0
+        ],
+        "emissive.intensity": 8.0
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Wood.material
+++ b/Gems/ROS2/Assets/Gazebo/Wood.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.1,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.698,
+            0.4314,
+            0.1921,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/WoodFloor.material
+++ b/Gems/ROS2/Assets/Gazebo/WoodFloor.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.1,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.557,
+            0.275,
+            0.067,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/WoodPallet.material
+++ b/Gems/ROS2/Assets/Gazebo/WoodPallet.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            0.6627,
+            0.5,
+            0.2784,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/Yellow.material
+++ b/Gems/ROS2/Assets/Gazebo/Yellow.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 1.0,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            1.0,
+            0.0,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/YellowGlow.material
+++ b/Gems/ROS2/Assets/Gazebo/YellowGlow.material
@@ -1,0 +1,28 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "emissive.enable": true,
+        "emissive.color": [
+            1.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "emissive.intensity": 5.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/YellowTransparent.material
+++ b/Gems/ROS2/Assets/Gazebo/YellowTransparent.material
@@ -1,0 +1,23 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.9,
+        "metallic.factor": 0.0,
+        "baseColor.color": [
+            1.0,
+            1.0,
+            0.0,
+            1.0
+        ],
+        "opacity.mode": "Blended",
+        "opacity.alphaSource": "None",
+        "opacity.factor": 0.5
+    }
+}

--- a/Gems/ROS2/Assets/Gazebo/ZincYellow.material
+++ b/Gems/ROS2/Assets/Gazebo/ZincYellow.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 5,
+    "propertyValues": {
+        "metallic.useTexture": false,
+        "normal.useTexture": false,
+        "roughness.useTexture": false,
+        "specularF0.enableMultiScatterCompensation": true,
+        "specularF0.useTexture": false,
+        "baseColor.useTexture": false,
+        "roughness.factor": 0.05,
+        "metallic.factor": 1.0,
+        "baseColor.color": [
+            0.9725,
+            0.9529,
+            0.2078,
+            1.0
+        ]
+    }
+}

--- a/Gems/ROS2/Assets/Sdf/empty.sdf
+++ b/Gems/ROS2/Assets/Sdf/empty.sdf
@@ -1,0 +1,7 @@
+<?xml version='1.0'?>
+<sdf version="1.4">
+  <model name="empty_model">
+    <link name="empty_link">
+    </link>
+  </model>
+</sdf>

--- a/Gems/ROS2/Code/Platform/Linux/PAL_linux.cmake
+++ b/Gems/ROS2/Code/Platform/Linux/PAL_linux.cmake
@@ -9,11 +9,11 @@
 set(PAL_TRAIT_BUILD_ROS2_GEM_SUPPORTED TRUE)
 
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
-    ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev1-linux
+    ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev2-linux
         TARGETS sdformat
-        PACKAGE_HASH 71a86e255cfc7a176f6087e069fb26c9837c98e277becf87f3a4b0e25fe90bd3)
+        PACKAGE_HASH b8e988954c07f41b99ba0950da3f4d3e8489ffabaaff157f79ab0c716e2142e0)
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
-    ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev1-linux-aarch64
+    ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev2-linux-aarch64
         TARGETS sdformat
-        PACKAGE_HASH c8ca2ffad604162cbc8ed852c8ea8695851c4c69c5f39f2a9d8e423511ce78f9)
+        PACKAGE_HASH 7e51cc60c61a058c1f8aba7277574946ab974af3ff4601884e72380e8585c0ea)
 endif()

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
@@ -105,7 +105,9 @@ namespace ROS2
         int i = m_table->rowCount();
         m_table->setRowCount(i + 1);
 
-        bool isOk = assetSourcePath.has_value() && resolvedSdfPath.has_value();
+        // The Asset ID GUID must not be null(all zeros) and the asset source path must not be empty
+        bool isOk = (assetSourcePath.has_value() && !assetSourcePath->empty() && assetSourcePath != "not found")
+            && (resolvedSdfPath.has_value() && !resolvedSdfPath->empty()) && !assetUuid.IsNull();
         if (!isOk)
         {
             m_missingCount++;
@@ -154,8 +156,13 @@ namespace ROS2
             m_table->item(i, Columns::ResolvedMeshPath)->setIcon(m_failureIcon);
             m_table->setItem(i, Columns::ProductAsset, createCell(false, QString()));
         }
-        m_assetsPaths.push_back(assetSourcePath ? *assetSourcePath : AZStd::string());
-        m_assetsUuids.push_back(assetUuid);
+
+        // Don't add an empty asset path to the list of resolved assets
+        if (isOk)
+        {
+            m_assetsPaths.push_back(AZStd::move(*assetSourcePath));
+            m_assetsUuids.push_back(assetUuid);
+        }
     }
 
     void CheckAssetPage::StartWatchAsset()

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
@@ -48,10 +48,10 @@ namespace ROS2
         m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
         m_table->setSelectionMode(QAbstractItemView::SingleSelection);
         // Set the header items.
-        QTableWidgetItem* headerItem = new QTableWidgetItem(tr("URDF/SDF mesh path"));
+        QTableWidgetItem* headerItem = new QTableWidgetItem(tr("URDF/SDF asset path"));
         headerItem->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
         m_table->setHorizontalHeaderItem(Columns::SdfMeshPath, headerItem);
-        headerItem = new QTableWidgetItem(tr("Resolved mesh from URDF/SDF"));
+        headerItem = new QTableWidgetItem(tr("Resolved asset from URDF/SDF"));
         headerItem->setTextAlignment(Qt::AlignVCenter | Qt::AlignLeft);
         m_table->setHorizontalHeaderItem(Columns::ResolvedMeshPath, headerItem);
         headerItem = new QTableWidgetItem(tr("Type"));
@@ -81,11 +81,11 @@ namespace ROS2
     {
         if (m_missingCount == 0)
         {
-            setTitle(tr("Resolved meshes"));
+            setTitle(tr("Resolved assets"));
         }
         else
         {
-            setTitle(tr("There are ") + QString::number(m_missingCount) + tr(" unresolved meshes"));
+            setTitle(tr("There are ") + QString::number(m_missingCount) + tr(" unresolved assets"));
         }
     }
 
@@ -243,10 +243,12 @@ namespace ROS2
                     {
                         if (!failed)
                         {
-                            const AZStd::string productRelPathVisual = Utils::GetModelProductAsset(assetUuid);
-                            const AZStd::string productRelPathCollider = Utils::GetPhysXMeshProductAsset(assetUuid);
-                            QString text = QString::fromUtf8(productRelPathVisual.data(), productRelPathVisual.size()) + " " +
-                                QString::fromUtf8(productRelPathCollider.data(), productRelPathCollider.size());
+                            const AZStd::vector<AZStd::string> productPaths = Utils::GetProductAssets(assetUuid);
+                            QString text;
+                            for (const auto& productPath : productPaths)
+                            {
+                                text += QString::fromUtf8(productPath.data(), productPath.size()) + " ";
+                            }
                             m_table->setItem(i, Columns::ProductAsset, createCell(true, text));
                             m_table->item(i, Columns::ProductAsset)->setIcon(m_okIcon);
                         }
@@ -265,12 +267,12 @@ namespace ROS2
             m_refreshTimer->stop();
             if (m_failedCount == 0 && m_missingCount == 0)
             {
-                setTitle(tr("All meshes were processed"));
+                setTitle(tr("All assets were processed"));
             }
             else
             {
                 setTitle(
-                    tr("There are ") + QString::number(m_missingCount) + tr(" unresolved meshes.") + tr("There are ") +
+                    tr("There are ") + QString::number(m_missingCount) + tr(" unresolved assets.") + tr("There are ") +
                     QString::number(m_failedCount) + tr(" failed asset processor jobs."));
             }
         }

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.h
@@ -53,9 +53,9 @@ namespace ROS2
         unsigned int m_missingCount{ 0 };
         unsigned int m_failedCount{ 0 };
         void SetTitle();
-        AZStd::vector<AZ::Uuid> m_assetsUuids;
-        AZStd::vector<AZStd::string> m_assetsPaths;
-        AZStd::unordered_set<AZ::Uuid> m_assetsUuidsFinished;
+        AZStd::unordered_map<AZ::Uuid, int> m_assetsUuidsToColumnIndex; //!< Map of asset UUIDs to column index in the table.
+        AZStd::unordered_map<AZ::Uuid, AZStd::string> m_assetsPaths; //! Map of asset UUIDs to asset source paths.
+        AZStd::unordered_set<AZ::Uuid> m_assetsUuidsFinished; //!< Set of asset UUIDs that have been processed by asset processor.
         void DoubleClickRow(int row, int col);
         void RefreshTimerElapsed();
         QIcon m_failureIcon;

--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -148,14 +148,12 @@ namespace ROS2
         // Urdf Root has been parsed successfully retrieve it from the Outcome
         const sdf::Root& parsedSdfRoot = parsedSdfOutcome.GetRoot();
 
-        auto collidersNames = Utils::GetMeshesFilenames(parsedSdfRoot, false, true);
-        auto visualNames = Utils::GetMeshesFilenames(parsedSdfRoot, true, false);
-        auto meshNames = Utils::GetMeshesFilenames(parsedSdfRoot, true, true);
+        auto assetNames = Utils::GetReferencedAssetFilenames(parsedSdfRoot);
         AZStd::shared_ptr<Utils::UrdfAssetMap> urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>();
         if (importAssetWithUrdf)
         {
             urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(
-                Utils::CopyAssetForURDFAndCreateAssetMap(meshNames, filePath, collidersNames, visualNames, sdfBuilderSettings));
+                Utils::CopyReferencedAssetsAndCreateAssetMap(assetNames, filePath, sdfBuilderSettings));
         }
         bool allAssetProcessed = false;
         bool assetProcessorFailed = false;

--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -222,7 +222,8 @@ namespace ROS2
         };
 
         // Use the URDF/SDF file name stem the prefab name
-        AZStd::string prefabName = AZStd::string(AZ::IO::PathView(filePath).Stem().Native());
+        auto fileStem = AZ::IO::PathView(filePath).Stem();
+        AZStd::string prefabName = AZStd::string::format("%.*s.prefab", AZ_PATH_ARG(fileStem));
 
         if (prefabName.empty())
         {

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -348,7 +348,7 @@ namespace ROS2
     void RobotImporterWidget::FillPrefabMakerPage()
     {
         // Use the URDF/SDF file name stem the prefab name
-        AZStd::string robotName = AZStd::string(m_urdfPath.Stem().Native()) + ".prefab";
+        AZStd::string robotName = AZStd::string::format("%.*s.prefab", AZ_PATH_ARG(m_urdfPath.Stem()));
         m_prefabMakerPage->setProposedPrefabName(robotName);
         QWizard::button(PrefabCreationButtonId)->setText(tr("Create Prefab"));
         QWizard::setOption(HavePrefabCreationButton, true);
@@ -439,7 +439,6 @@ namespace ROS2
         const AZ::IO::Path prefabPath(AZ::IO::Path(AZ::Utils::GetProjectPath()) / prefabPathRelative);
         bool fileExists = AZ::IO::FileIOBase::GetInstance()->Exists(prefabPath.c_str());
 
-        if (CheckCyclicalDependency(prefabPathRelative))
         {
             m_prefabMakerPage->setSuccess(false);
             return;

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -330,14 +330,11 @@ namespace ROS2
                         type = tr("Collider");
                     }
 
-                    if (m_urdfAssetsMapping->contains(meshPath))
-                    {
-                        const auto& asset = m_urdfAssetsMapping->at(meshPath);
-                        sourceAssetUuid = asset.m_availableAssetInfo.m_sourceGuid;
-                        sourcePath = asset.m_availableAssetInfo.m_sourceAssetRelativePath.String();
-                        resolvedPath = asset.m_resolvedUrdfPath.String();
-                        crc = asset.m_urdfFileCRC;
-                    }
+                    const auto& asset = m_urdfAssetsMapping->at(meshPath);
+                    sourceAssetUuid = asset.m_availableAssetInfo.m_sourceGuid;
+                    sourcePath = asset.m_availableAssetInfo.m_sourceAssetRelativePath.String();
+                    resolvedPath = asset.m_resolvedUrdfPath.String();
+                    crc = asset.m_urdfFileCRC;
                 }
                 m_assetPage->ReportAsset(sourceAssetUuid, meshPath, type, sourcePath, crc, resolvedPath);
             }

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -217,7 +217,7 @@ namespace ROS2
                 m_parsedSdf = AZStd::move(parsedSdfOutcome.GetRoot());
                 m_prefabMaker.reset();
                 // Report the status of skipping this page
-                m_meshNames = Utils::GetMeshesFilenames(m_parsedSdf, true, true);
+                m_assetNames = Utils::GetReferencedAssetFilenames(m_parsedSdf);
                 m_assetPage->ClearAssetsList();
             }
             else
@@ -265,9 +265,6 @@ namespace ROS2
     {
         if (m_assetPage->IsEmpty())
         {
-            auto collidersNames = Utils::GetMeshesFilenames(m_parsedSdf, false, true);
-            auto visualNames = Utils::GetMeshesFilenames(m_parsedSdf, true, false);
-
             AZ::Uuid::FixedString dirSuffix;
             if (!m_params.empty())
             {
@@ -286,26 +283,29 @@ namespace ROS2
 
             if (m_importAssetWithUrdf)
             {
-                m_urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(Utils::CopyAssetForURDFAndCreateAssetMap(
-                    m_meshNames, m_urdfPath.String(), collidersNames, visualNames, sdfBuilderSettings, dirSuffix));
+                m_urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(Utils::CopyReferencedAssetsAndCreateAssetMap(
+                    m_assetNames, m_urdfPath.String(), sdfBuilderSettings, dirSuffix));
             }
             else
             {
                 m_urdfAssetsMapping =
-                    AZStd::make_shared<Utils::UrdfAssetMap>(Utils::FindAssetsForUrdf(m_meshNames, m_urdfPath.String(), sdfBuilderSettings));
-                for (const AZStd::string& meshPath : m_meshNames)
+                    AZStd::make_shared<Utils::UrdfAssetMap>(Utils::FindReferencedAssets(m_assetNames, m_urdfPath.String(), sdfBuilderSettings));
+                for (const auto& [assetPath, assetReferenceType] : m_assetNames)
                 {
-                    if (m_urdfAssetsMapping->contains(meshPath))
+                    if (m_urdfAssetsMapping->contains(assetPath))
                     {
-                        const auto& asset = m_urdfAssetsMapping->at(meshPath);
-                        bool visual = visualNames.contains(meshPath);
-                        bool collider = collidersNames.contains(meshPath);
-                        Utils::CreateSceneManifest(asset.m_availableAssetInfo.m_sourceAssetGlobalPath, collider, visual);
+                        const auto& asset = m_urdfAssetsMapping->at(assetPath);
+                        bool visual = (assetReferenceType & Utils::ReferencedAssetType::VisualMesh) == Utils::ReferencedAssetType::VisualMesh;
+                        bool collider = (assetReferenceType & Utils::ReferencedAssetType::ColliderMesh) == Utils::ReferencedAssetType::ColliderMesh;
+                        if (visual || collider)
+                        {
+                            Utils::CreateSceneManifest(asset.m_availableAssetInfo.m_sourceAssetGlobalPath, collider, visual);
+                        }
                     }
                 }
             };
 
-            for (const AZStd::string& meshPath : m_meshNames)
+            for (const auto& [assetPath, assetReferenceType] : m_assetNames)
             {
                 AZ::Uuid sourceAssetUuid = AZ::Uuid::CreateNull();
                 QString type = tr("Unknown");
@@ -313,30 +313,35 @@ namespace ROS2
                 AZStd::optional<AZStd::string> sourcePath;
                 AZStd::optional<AZStd::string> resolvedPath;
 
-                if (m_urdfAssetsMapping->contains(meshPath))
+                if (m_urdfAssetsMapping->contains(assetPath))
                 {
-                    bool visual = visualNames.contains(meshPath);
-                    bool collider = collidersNames.contains(meshPath);
+                    bool visual = (assetReferenceType & Utils::ReferencedAssetType::VisualMesh) == Utils::ReferencedAssetType::VisualMesh;
+                    bool collider = (assetReferenceType & Utils::ReferencedAssetType::ColliderMesh) == Utils::ReferencedAssetType::ColliderMesh;
+                    bool texture = (assetReferenceType & Utils::ReferencedAssetType::Texture) == Utils::ReferencedAssetType::Texture;
                     if (visual && collider)
                     {
-                        type = tr("Visual and Collider");
+                        type = tr("Visual and Collider Mesh");
                     }
                     else if (visual)
                     {
-                        type = tr("Visual");
+                        type = tr("Visual Mesh");
                     }
                     else if (collider)
                     {
-                        type = tr("Collider");
+                        type = tr("Collider Mesh");
+                    }
+                    else if (texture)
+                    {
+                        type = tr("Texture");
                     }
 
-                    const auto& asset = m_urdfAssetsMapping->at(meshPath);
+                    const auto& asset = m_urdfAssetsMapping->at(assetPath);
                     sourceAssetUuid = asset.m_availableAssetInfo.m_sourceGuid;
                     sourcePath = asset.m_availableAssetInfo.m_sourceAssetRelativePath.String();
                     resolvedPath = asset.m_resolvedUrdfPath.String();
                     crc = asset.m_urdfFileCRC;
                 }
-                m_assetPage->ReportAsset(sourceAssetUuid, meshPath, type, sourcePath, crc, resolvedPath);
+                m_assetPage->ReportAsset(sourceAssetUuid, assetPath, type, sourcePath, crc, resolvedPath);
             }
             m_assetPage->StartWatchAsset();
         }
@@ -411,9 +416,9 @@ namespace ROS2
             }
             if (m_checkUrdfPage->isComplete())
             {
-                if (m_meshNames.size() == 0)
+                if (m_assetNames.empty())
                 {
-                    // skip two pages when urdf/sdf is parsed without problems, and it has no meshes
+                    // skip two pages when urdf/sdf is parsed without problems, and it has no assets
                     return m_assetPage->nextId();
                 }
                 else

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -439,6 +439,7 @@ namespace ROS2
         const AZ::IO::Path prefabPath(AZ::IO::Path(AZ::Utils::GetProjectPath()) / prefabPathRelative);
         bool fileExists = AZ::IO::FileIOBase::GetInstance()->Exists(prefabPath.c_str());
 
+        if (CheckCyclicalDependency(prefabPathRelative))
         {
             m_prefabMakerPage->setSuccess(false);
             return;

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -78,7 +78,7 @@ namespace ROS2
         /// mapping from urdf path to asset source
         AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;
         AZStd::unique_ptr<URDFPrefabMaker> m_prefabMaker;
-        AZStd::unordered_set<AZStd::string> m_meshNames;
+        Utils::AssetFilenameReferences m_assetNames;
 
         /// Xacro params
         Utils::xacro::Params m_params;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/CollidersMaker.h
@@ -37,9 +37,6 @@ namespace ROS2
         //! Prevent copying of existing CollidersMaker
         CollidersMaker(const CollidersMaker& other) = delete;
 
-        //! Builds .pxmeshes for every collider in link collider mesh.
-        //! @param link A parsed SDF tree link node which could hold information about colliders.
-        void BuildColliders(const sdf::Link* link);
         //! Add zero, one or many collider elements (depending on link content).
         //! @param model An SDF model object provided by libsdformat from a parsed URDF/SDF
         //! @param link A parsed SDF tree link node which could hold information about colliders.
@@ -51,7 +48,6 @@ namespace ROS2
 
     private:
         void FindWheelMaterial();
-        void BuildCollider(const sdf::Collision* collision);
         void AddCollider(
             const sdf::Collision* collision,
             AZ::EntityId entityId,

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -25,8 +25,9 @@
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/ROS2GemUtilities.h>
 #include <RobotControl/ROS2RobotControlComponent.h>
+#include <RobotImporter/Utils/ErrorUtils.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
-#include <optional>
+#include <RobotImporter/Utils/TypeConversions.h>
 
 namespace ROS2
 {
@@ -183,10 +184,43 @@ namespace ROS2
         // Build up a list of all entities created as a part of processing the file.
         AZStd::vector<AZ::EntityId> createdEntities;
         AZStd::unordered_map<const sdf::Link*, AzToolsFramework::Prefab::PrefabEntityResult> createdLinks;
+        AZStd::unordered_map<const sdf::Model*, AzToolsFramework::Prefab::PrefabEntityResult> createdModels;
         AZStd::unordered_map<AZStd::string, const sdf::Link*> links;
-        for ([[maybe_unused]] const auto& [fullLinkName, linkPtr, _] : linksMapper.m_links)
+        for ([[maybe_unused]] const auto& [fullLinkName, linkPtr, attachedModel] : linksMapper.m_links)
         {
-            createdLinks[linkPtr] = AddEntitiesForLink(linkPtr, AZ::EntityId{}, createdEntities);
+            // Create entities for the model containing the link
+            AZ::EntityId modelEntityId;
+            if (attachedModel != nullptr)
+            {
+                if (auto modelIt = createdModels.find(attachedModel); modelIt != createdModels.end())
+                {
+                    if (modelIt->second.IsSuccess())
+                    {
+                        modelEntityId = modelIt->second.GetValue();
+                    }
+                }
+                else
+                {
+                    if (AzToolsFramework::Prefab::PrefabEntityResult createModelEntityResult = CreateEntityForModel(*attachedModel);
+                        createModelEntityResult)
+                    {
+                        modelEntityId = createModelEntityResult.GetValue();
+                        // Add the model entity to the created entity list
+                        // so that it gets added to the prefab
+                        createdEntities.emplace_back(modelEntityId);
+
+                        std::string modelName = attachedModel->Name();
+                        AZStd::string azModelName(modelName.c_str(), modelName.size());
+                        AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
+                        m_status.emplace(azModelName, AZStd::string::format("created as: %s", modelEntityId.ToString().c_str()));
+                        createdModels.emplace(attachedModel, createModelEntityResult);
+                    }
+                }
+
+            }
+
+            // Add all link as children of their attached model entity by default
+            createdLinks[linkPtr] = AddEntitiesForLink(*linkPtr, attachedModel, modelEntityId, createdEntities);
         }
 
         for (const auto& [linkPtr, result] : createdLinks)
@@ -345,7 +379,7 @@ namespace ROS2
                     "Joint %s has no parent link %s. Cannot create",
                     azJointName.c_str(),
                     parentLinkName.c_str());
-                return true;
+                continue;
             }
             auto leadEntity = parentEntityIter->second;
 
@@ -361,7 +395,7 @@ namespace ROS2
                     "Joint %s has no child link %s. Cannot create",
                     azJointName.c_str(),
                     childLinkName.c_str());
-                return true;
+                continue;
             }
             auto childEntity = childEntityIter->second;
 
@@ -389,14 +423,13 @@ namespace ROS2
                     AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
                     auto result = m_jointsMaker.AddJointComponent(jointPtr, childEntity.GetValue(), leadEntity.GetValue());
                     m_status.emplace(
-                        azJointName, AZStd::string::format(" %s %llu", result.IsSuccess() ? "created as" : "Failed", result.GetValue()));
+                        azJointName, AZStd::string::format(" %s: %llu", result.IsSuccess() ? "created as" : "failed", result.GetValue()));
                 }
                 else
                 {
                     AZ_Warning("CreatePrefabFromUrdfOrSdf", false, "cannot create joint %s", azJointName.c_str());
                 }
             }
-            return true;
         }
 
         // Use the first entity based on a link that is not parented to any other link
@@ -493,15 +526,91 @@ namespace ROS2
         return result;
     }
 
-    AzToolsFramework::Prefab::PrefabEntityResult URDFPrefabMaker::AddEntitiesForLink(
-        const sdf::Link* link, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities)
+    AzToolsFramework::Prefab::PrefabEntityResult URDFPrefabMaker::CreateEntityForModel(const sdf::Model& model)
     {
-        if (!link)
+        auto createEntityResult = PrefabMakerUtils::CreateEntity(AZ::EntityId{}, model.Name().c_str());
+        if (!createEntityResult.IsSuccess())
         {
-            AZ::Failure(AZStd::string("Failed to create prefab entity - link is null"));
+            return createEntityResult;
         }
 
-        auto createEntityResult = PrefabMakerUtils::CreateEntity(parentEntityId, link->Name().c_str());
+        // Get the model entity and update its transform component with the pose information
+        AZ::EntityId entityId = createEntityResult.GetValue();
+        AZStd::unique_ptr<AZ::Entity> entity(AzToolsFramework::GetEntityById(entityId));
+
+        if (auto* transformComponent = entity->FindComponent<AzToolsFramework::Components::TransformComponent>();
+            transformComponent != nullptr)
+        {
+            gz::math::Pose3d modelPose;
+            if (sdf::Errors poseResolveErrors = model.SemanticPose().Resolve(modelPose); !poseResolveErrors.empty())
+            {
+                AZStd::string poseErrorMessages = Utils::JoinSdfErrorsToString(poseResolveErrors);
+
+                auto poseErrorsForModel = AZStd::string::format(
+                    R"(Unable to resolve semantic pose for model %s. Creation of Model entity has failed. Errors: "%s")",
+                    model.Name().c_str(),
+                    poseErrorMessages.c_str());
+
+                return AZ::Failure(poseErrorsForModel);
+            }
+
+            AZ::Transform modelTransform = URDF::TypeConversions::ConvertPose(modelPose);
+
+            // If the model is nested below another model, check if it has a placement frame
+            if (const sdf::Model* parentModel = Utils::GetModelContainingModel(*m_root, model); parentModel != nullptr)
+            {
+                if (const sdf::Frame* modelPlacementFrame = parentModel->FrameByName(model.PlacementFrameName()); modelPlacementFrame != nullptr)
+                {
+                    gz::math::Pose3d placementFramePose;
+                    if (sdf::Errors poseResolveErrors = modelPlacementFrame->SemanticPose().Resolve(placementFramePose);
+                        !poseResolveErrors.empty())
+                    {
+                        AZStd::string poseErrorMessages = Utils::JoinSdfErrorsToString(poseResolveErrors);
+
+                        auto poseErrorsForModel = AZStd::string::format(
+                            R"(Unable to resolve semantic pose for model %s parent model %s. Creation of Model entity has failed. Errors: "%s")",
+                            model.Name().c_str(),
+                            parentModel->Name().c_str(),
+                            poseErrorMessages.c_str());
+
+                        return AZ::Failure(poseErrorsForModel);
+                    }
+
+                    modelTransform = modelTransform * URDF::TypeConversions::ConvertPose(placementFramePose);
+                }
+            }
+
+            if (const sdf::Frame* implicitFrame = model.FrameByName("__model__"); implicitFrame != nullptr)
+            {
+                gz::math::Pose3d implicitFramePose;
+                if (sdf::Errors poseResolveErrors = implicitFrame->SemanticPose().Resolve(implicitFramePose); !poseResolveErrors.empty())
+                {
+                    AZStd::string poseErrorMessages = Utils::JoinSdfErrorsToString(poseResolveErrors);
+
+                    auto poseErrorsForModel = AZStd::string::format(
+                        R"(Unable to resolve semantic pose for model's implicit frame %s. Creation of Model entity has failed. Errors: "%s")",
+                        implicitFrame->Name().c_str(),
+                        poseErrorMessages.c_str());
+
+                    return AZ::Failure(poseErrorsForModel);
+                }
+
+                modelTransform = modelTransform * URDF::TypeConversions::ConvertPose(implicitFramePose);
+            }
+
+            transformComponent->SetWorldTM(AZStd::move(modelTransform));
+        }
+
+        // Allow the created model entity to persist if there are no errors at ths point
+        entity.release();
+
+        return entityId;
+    }
+
+    AzToolsFramework::Prefab::PrefabEntityResult URDFPrefabMaker::AddEntitiesForLink(
+        const sdf::Link& link, const sdf::Model* attachedModel, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities)
+    {
+        auto createEntityResult = PrefabMakerUtils::CreateEntity(parentEntityId, link.Name().c_str());
         if (!createEntityResult.IsSuccess())
         {
             return createEntityResult;
@@ -516,30 +625,27 @@ namespace ROS2
         {
             auto* component = Utils::GetGameOrEditorComponent<ROS2FrameComponent>(entity);
             AZ_Assert(component, "ROS2 Frame Component does not exist for %s", entityId.ToString().c_str());
-            component->SetFrameID(AZStd::string(link->Name().c_str(), link->Name().size()));
+            component->SetFrameID(AZStd::string(link.Name().c_str(), link.Name().size()));
         }
-        auto createdVisualEntities = m_visualsMaker.AddVisuals(link, entityId);
+        auto createdVisualEntities = m_visualsMaker.AddVisuals(&link, entityId);
         createdEntities.insert(createdEntities.end(), createdVisualEntities.begin(), createdVisualEntities.end());
-
-        // Get the SDF model where this link is a child
-        const sdf::Model* modelContainingLink = Utils::GetModelContainingLink(*m_root, *link);
 
         if (!m_useArticulations)
         {
-            m_inertialsMaker.AddInertial(link->Inertial(), entityId);
+            m_inertialsMaker.AddInertial(link.Inertial(), entityId);
         }
         else
         {
-            if (modelContainingLink != nullptr)
+            if (attachedModel != nullptr)
             {
-                m_articulationsMaker.AddArticulationLink(*modelContainingLink, link, entityId);
+                m_articulationsMaker.AddArticulationLink(*attachedModel, &link, entityId);
             }
         }
 
-        if (modelContainingLink != nullptr)
+        if (attachedModel != nullptr)
         {
-            m_collidersMaker.AddColliders(*modelContainingLink, link, entityId);
-            m_sensorsMaker.AddSensors(*modelContainingLink, link, entityId);
+            m_collidersMaker.AddColliders(*attachedModel, &link, entityId);
+            m_sensorsMaker.AddSensors(*attachedModel, &link, entityId);
         }
         return AZ::Success(entityId);
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -70,7 +70,8 @@ namespace ROS2
         AZStd::string GetStatus();
 
     private:
-        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(const sdf::Link* link, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities);
+        AzToolsFramework::Prefab::PrefabEntityResult CreateEntityForModel(const sdf::Model& model);
+        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(const sdf::Link& link, const sdf::Model* attachedModel, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities);
         void AddRobotControl(AZ::EntityId rootEntityId);
         static void MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId, AZStd::optional<AZ::Transform> spawnPosition);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -70,9 +70,7 @@ namespace ROS2
         AZStd::string GetStatus();
 
     private:
-        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(
-            const sdf::Link* link, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities);
-        void BuildAssetsForLink(const sdf::Link* link);
+        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(const sdf::Link* link, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities);
         void AddRobotControl(AZ::EntityId rootEntityId);
         static void MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId, AZStd::optional<AZ::Transform> spawnPosition);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -11,6 +11,7 @@
 #include "RobotImporter/Utils/TypeConversions.h"
 
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h>
+#include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentConfig.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentConstants.h>
 #include <AtomLyIntegration/CommonFeatures/Mesh/MeshComponentBus.h>
 #include <AtomLyIntegration/CommonFeatures/Mesh/MeshComponentConstants.h>
@@ -19,12 +20,14 @@
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponent.h>
 
+#include <sdf/Material.hh>
+#include <sdf/Pbr.hh>
+
 namespace ROS2
 {
     VisualsMaker::VisualsMaker() = default;
-    VisualsMaker::VisualsMaker(MaterialNameMap materials, const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping)
-        : m_materials(AZStd::move(materials))
-        , m_urdfAssetsMapping(urdfAssetsMapping)
+    VisualsMaker::VisualsMaker(const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping)
+        : m_urdfAssetsMapping(urdfAssetsMapping)
     {
     }
 
@@ -88,13 +91,16 @@ namespace ROS2
             return AZ::EntityId();
         }
         auto visualEntityId = createEntityResult.GetValue();
-        AddVisualToEntity(visual, visualEntityId);
-        AddMaterialForVisual(visual, visualEntityId);
+        auto visualAssetId = AddVisualToEntity(visual, visualEntityId);
+        AddMaterialForVisual(visual, visualEntityId, visualAssetId);
         return visualEntityId;
     }
 
-    void VisualsMaker::AddVisualToEntity(const sdf::Visual* visual, AZ::EntityId entityId) const
+    AZ::Data::AssetId VisualsMaker::AddVisualToEntity(const sdf::Visual* visual, AZ::EntityId entityId) const
     {
+        // Asset ID for the asset added to the visual entity, if any.
+        AZ::Data::AssetId assetId;
+
         // Apply transform as per origin
         PrefabMakerUtils::SetEntityTransformLocal(visual->RawPose(), entityId);
 
@@ -109,7 +115,6 @@ namespace ROS2
                 const AZ::Vector3 sphereDimensions(sphereGeometry->Radius() * 2.0f);
 
                 // The `_sphere_1x1.fbx.azmodel` is created by Asset Processor based on O3DE `PrimitiveAssets` Gem source.
-                AZ::Data::AssetId assetId;
                 const char* sphereAssetRelPath = "objects/_primitives/_sphere_1x1.fbx.azmodel"; // relative path to cache folder.
                 AZ::Data::AssetCatalogRequestBus::BroadcastResult(
                     assetId,
@@ -131,7 +136,6 @@ namespace ROS2
                     cylinderGeometry->Radius() * 2.0f, cylinderGeometry->Radius() * 2.0f, cylinderGeometry->Length());
 
                 // The `_cylinder_1x1.fbx.azmodel` is created by Asset Processor based on O3DE `PrimitiveAssets` Gem source.
-                AZ::Data::AssetId assetId;
                 const char* cylinderAssetRelPath = "objects/_primitives/_cylinder_1x1.fbx.azmodel"; // relative path to cache folder.
                 AZ::Data::AssetCatalogRequestBus::BroadcastResult(
                     assetId,
@@ -151,7 +155,6 @@ namespace ROS2
                 const AZ::Vector3 boxDimensions = URDF::TypeConversions::ConvertVector3(boxGeometry->Size());
 
                 // The `_box_1x1.fbx.azmodel` is created by Asset Processor based on O3DE `PrimitiveAssets` Gem source.
-                AZ::Data::AssetId assetId;
                 const char* boxAssetRelPath = "objects/_primitives/_box_1x1.fbx.azmodel"; // relative path to cache folder.
                 AZ::Data::AssetCatalogRequestBus::BroadcastResult(
                     assetId,
@@ -171,7 +174,8 @@ namespace ROS2
                 const AZ::Vector3 scaleVector = URDF::TypeConversions::ConvertVector3(meshGeometry->Scale());
 
                 const auto asset = PrefabMakerUtils::GetAssetFromPath(*m_urdfAssetsMapping, AZStd::string(meshGeometry->Uri().c_str()));
-                AZ::Data::AssetId assetId;
+                AZ_Warning("AddVisual", asset, "There is no source asset for %s.", meshGeometry->Uri().c_str());
+
                 if (asset)
                 {
                     assetId = Utils::GetModelProductAssetId(asset->m_sourceGuid);
@@ -183,8 +187,10 @@ namespace ROS2
             break;
         default:
             AZ_Warning("AddVisual", false, "Unsupported visual geometry type, %d", (int)geometry->Type());
-            return;
+            break;
         }
+
+        return assetId;
     }
 
     void VisualsMaker::AddVisualAssetToEntity(AZ::EntityId entityId, const AZ::Data::AssetId& assetId, const AZ::Vector3& scale) const
@@ -225,36 +231,264 @@ namespace ROS2
         entity->Deactivate();
     }
 
-    void VisualsMaker::AddMaterialForVisual(const sdf::Visual* visual, AZ::EntityId entityId) const
+    static void OverrideMaterialPbrSettings(const sdf::Material* material, [[maybe_unused]] AZ::Render::MaterialAssignmentMap& overrides)
     {
-        // URDF does not include information from <gazebo> tags with specific materials, diffuse, specular and emissive params
-        if (!visual->Material())
+        if (auto pbr = material->PbrMaterial(); pbr)
         {
-            // Material is optional, and it requires geometry
+            // Start by trying to get the Metal workflow, since this is the workflow that O3DE uses.
+            auto pbrWorkflow = pbr->Workflow(sdf::PbrWorkflowType::METAL);
+
+            if (!pbrWorkflow)
+            {
+                // If the Metal workflow doesn't exist, try to get the Specular workflow.
+                // Even though O3DE uses a Metal workflow, the vast majority of the Specular workflow data can still be used.
+                // It's only the specular/glossiness maps that won't be converted.
+                pbrWorkflow = pbr->Workflow(sdf::PbrWorkflowType::SPECULAR);
+                if (!pbrWorkflow)
+                {
+                    AZ_Error("AddMaterial", false, "Material has a PBR definition, but it is neither a Metal nor a Specular workflow. Cannot convert.");
+                    return;
+                }
+            }
+
+            for (auto& [id, materialAssignment] : overrides)
+            {
+                // To truly add PBR conversion, all of the texture map references need to get detected and handled.
+                // The code in the following commented-out blocks demonstrate how to detect the texture maps 
+                // and shows the correct property overrides to connect them to. However, the property overrides
+                // currently require an ImageAsset reference, not a string, so the code won't quite work as-is.
+                // Either the Material overrides need to be changed to work with strings, or this code needs to be changed
+                // to provide ImageAsset references, which would mean that the texture references would already need to be resolved
+                // and processed by the Asset Processor.
+                /*
+                if (auto texture = pbrWorkflow->AlbedoMap(); !texture.empty())
+                {
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("baseColor.textureMap"), AZStd::any(AZStd::string(texture.data(), texture.size())));
+                }
+
+                if (auto texture = pbrWorkflow->NormalMap(); !texture.empty())
+                {
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("normal.textureMap"), AZStd::any(AZStd::string(texture.data(), texture.size())));
+                }
+
+                if (auto texture = pbrWorkflow->AmbientOcclusionMap(); !texture.empty())
+                {
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("occlusion.diffuseTextureMap"), AZStd::any(AZStd::string(texture.data(), texture.size())));
+                }
+
+                if (auto texture = pbrWorkflow->EmissiveMap(); !texture.empty())
+                {
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.enable"), AZStd::any(true));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.textureMap"), AZStd::any(AZStd::string(texture.data(), texture.size())));
+                }
+                */
+
+                if (pbrWorkflow->Type() == sdf::PbrWorkflowType::METAL)
+                {
+                    /*
+                    if (auto texture = pbrWorkflow->RoughnessMap(); !texture.empty())
+                    {
+                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("roughness.textureMap"), AZStd::any(AZStd::string(texture.data(), texture.size())));
+                    }
+
+                    if (auto texture = pbrWorkflow->MetalnessMap(); !texture.empty())
+                    {
+                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("metallic.textureMap"), AZStd::any(AZStd::string(texture.data(), texture.size())));
+                    }
+                    */
+
+                    if (pbrWorkflow->Element()->HasElement("roughness"))
+                    {
+                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("roughness.factor"), AZStd::any(static_cast<float>(pbrWorkflow->Roughness())));
+                    }
+
+                    if (pbrWorkflow->Element()->HasElement("metalness"))
+                    {
+                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("metallic.factor"), AZStd::any(static_cast<float>(pbrWorkflow->Metalness())));
+                    }
+                }
+                else
+                {
+                    AZ_Warning("AddMaterial", pbrWorkflow->GlossinessMap().empty(), 
+                        "PBR material has a Glossiness map (%s), which is a Specular PBR workflow, not a Metal PBR workflow. It will not be converted.", pbrWorkflow->GlossinessMap().c_str());
+                    AZ_Warning("AddMaterial", pbrWorkflow->SpecularMap().empty(), 
+                        "PBR material has a Specular map (%s), which is a Specular PBR workflow, not a Metal PBR workflow. It will not be converted.", pbrWorkflow->SpecularMap().c_str());
+                }
+            }
+        }
+
+    }
+
+    static void OverrideMaterialBaseColor(const sdf::Material* material, AZ::Render::MaterialAssignmentMap& overrides)
+    {
+        // Base Color: Try to use the diffuse color if the material has one, or fall back to using the ambient color as a backup option.
+        if (material->Element()->HasElement("diffuse") || material->Element()->HasElement("ambient"))
+        {
+            // Get the material's diffuse color as the preferred option for the PBR material base color.
+            // If a diffuse color didn't exist but ambient does, try to use that instead as the base color.
+            // It will likely be too dark, but that's still probably better than not setting the color at all.
+            // Convert from gamma to linear to try and account for the different color spaces between phong and PBR rendering.
+            const auto materialColor = material->Element()->HasElement("diffuse") ? material->Diffuse() : material->Ambient();
+            const AZ::Color baseColor = URDF::TypeConversions::ConvertColor(materialColor).GammaToLinear();
+
+            for (auto& [id, materialAssignment] : overrides)
+            {
+                materialAssignment.m_propertyOverrides.emplace(AZ::Name("baseColor.color"), AZStd::any(baseColor));
+            }
+        }
+    }
+
+    static void OverrideMaterialTransparency(const sdf::Visual* visual, AZ::Render::MaterialAssignmentMap& overrides)
+    {
+        // Opacity: Use visual->transparency to set the material's opacity.
+        if (visual->Element()->HasElement("transparency"))
+        {
+            const auto transparency = visual->Transparency();
+            if (transparency > 0.0f)
+            {
+                // Override the material properties for every material used by the model.
+                for (auto& [id, materialAssignment] : overrides)
+                {
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("opacity.mode"), AZStd::any(AZStd::string("Blended")));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("opacity.alphaSource"), AZStd::any(AZStd::string("None")));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("opacity.factor"), AZStd::any(1.0f - transparency));
+                }
+            }
+        }
+    }
+
+    static void OverrideMaterialEmissiveSettings(const sdf::Material* material, AZ::Render::MaterialAssignmentMap& overrides)
+    {
+        // Emissive: If an emissive color has been specified, enable emissive on the material and set the emissive color to the provided one.
+        if (material->Element()->HasElement("emissive"))
+        {
+            // Get the color and convert from gamma to linear to try and account for the different color spaces between phong and PBR rendering.
+            const auto materialColor = material->Emissive();
+            const AZ::Color emissiveColor = URDF::TypeConversions::ConvertColor(materialColor).GammaToLinear();
+
+            // It seems to be fairly common to have an emissive entry of black, which isn't emissive at all. 
+            // Only enable the emissive color if it's a non-black value.
+            if ((emissiveColor.GetR() > 0.0f) || (emissiveColor.GetG() > 0.0f) || (emissiveColor.GetB() > 0.0f))
+            {
+                for (auto& [id, materialAssignment] : overrides)
+                {
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.enable"), AZStd::any(true));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.color"), AZStd::any(emissiveColor));
+
+                    // The URDF/SDF file doesn't specify an emissive intensity, just a color. 
+                    // We're arbitrarily using a value slightly higher than the default emissive intensity.
+                    // This value was picked based on observations of emissive color behaviors in Gazebo. 
+                    // This intensity mostly preserves the color (though it lightens it a little) and 
+                    // potentially adds a little bit of lighting to the scene if Bloom or Diffuse Probe Grid also exist in the world.
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.intensity"), AZStd::any(5.5f));
+                }
+            }
+        }
+    }
+
+    static void OverrideMaterialRoughness(const sdf::Material* material, AZ::Render::MaterialAssignmentMap& overrides)
+    {
+        // Metallic/Roughness: Try to use the shininess value for roughness if we have one, otherwise fall back to using the specular brightness.
+        if (material->Element()->HasElement("shininess") || material->Element()->HasElement("specular"))
+        {
+            float shininess = 0.0f;
+            float roughness = 0.0f;
+
+            if (material->Element()->HasElement("shininess"))
+            {
+                // If we have a shininess value, we'll use it to set both metallic and roughness. 
+                // The shinier it is, the more metallic and less rough we'll make the result.
+                shininess = material->Shininess();
+                roughness = 1.0f - shininess;
+            }
+            else
+            {
+                // We don't have shininess, so use the specular color to estimate metallic/roughness values.
+
+                // Convert the specular color into a brightness value. To get the brightness, we'll use the average of the three
+                // color values. This isn't the most perceptually accurate choice, but specular brightness isn't the same as roughness
+                // anyways, so it's hard to say what perceptual brightness model would cause any better or worse results here.
+                // Another possibility to consider would be taking the max of the RGB values.
+                const auto materialColor = material->Specular();
+                const AZ::Color specularColor = URDF::TypeConversions::ConvertColor(materialColor);
+                const float specularBrightness = (specularColor.GetR() + specularColor.GetG() + specularColor.GetB()) / 3.0f;
+                roughness = 1.0f - specularBrightness;
+
+                // Since specular color doesn't really speak to shininess, we'll arbitrarily scale down the specular brightness to
+                // 1/4 of the total brightness to modulate the metallic reflectiveness a little, but not too much. Without this scaling,
+                // a white specular color would always become fully metallic, perfectly smooth, and therefore fully reflective.
+                // With the scaling, a white specular color will be perfectly smooth but only 25% metallic, so it will have some reflectivity
+                // but not a lot.
+                shininess = specularBrightness * 0.25f;
+
+            }
+                
+            for (auto& [id, materialAssignment] : overrides)
+            {
+                materialAssignment.m_propertyOverrides.emplace(AZ::Name("metallic.factor"), AZStd::any(shininess));
+                materialAssignment.m_propertyOverrides.emplace(AZ::Name("roughness.factor"), AZStd::any(roughness));
+            }
+        }
+    }
+
+    static void OverrideMaterialDoubleSided(const sdf::Material* material, AZ::Render::MaterialAssignmentMap& overrides)
+    {
+        // DoubleSided: The double_sided element converts directly over to the O3DE doubleSided material attribute.
+        if (material->Element()->HasElement("double_sided"))
+        {
+            // The default material property value is one-sided, so only override the value if it should be double-sided.
+            if (material->DoubleSided())
+            {
+                for (auto& [id, materialAssignment] : overrides)
+                {
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("general.doubleSided"), AZStd::any(true));
+                }
+            }
+        }
+    }
+
+    void VisualsMaker::AddMaterialForVisual(const sdf::Visual* visual, AZ::EntityId entityId, const AZ::Data::AssetId& assetId) const
+    {
+        auto material = visual->Material();
+
+        if (!material)
+        {
+            // Material is optional, it might not appear on all visuals.
             return;
         }
 
+        AZ_Assert(material->Element(), "Material has data but no Element pointer. Something unexpected has happened with the SDF parsing.");
+
+        // Conversions from <material> in the file to O3DE are extremely imprecise because the data is going from a Phong model to PBR,
+        // and there are no direct translations from one type of lighting model to the other. All of the conversions will create some
+        // rough approximations of the source lighting data, but should hopefully provide a reasonable starting point for tuning the look.
+
+        // Also, URDF/SDF files don't have a concept of overriding specific materials, so every material override generated
+        // below will get applied to *all* materials for a mesh file.
+
+        // First, force the model asset to get loaded into memory before adding the material component.
+        // This is required so that we can get the default material map that will be used to override properties for each material.
+        auto modelAsset = AZ::Data::AssetManager::Instance().GetAsset<AZ::RPI::ModelAsset>(assetId, AZ::Data::AssetLoadBehavior::Default);
+        modelAsset.BlockUntilLoadComplete();
+
+        AZ_Error("AddMaterial", modelAsset.IsReady(), "Trying to create materials for a model that couldn't load. The generated material overrides may not work correctly.");
+
+        // Initialize the material component configuration to contain all of the material mappings from the model.
+        AZ::Render::MaterialComponentConfig config;
+        config.m_materials = AZ::Render::GetDefaultMaterialMapFromModelAsset(modelAsset);
+
+        // Try to override all of the various material settings based on what's contained in the <material> and <visual> elements in the source file.
+        OverrideMaterialPbrSettings(material, config.m_materials);
+        OverrideMaterialBaseColor(material, config.m_materials);
+        OverrideMaterialTransparency(visual, config.m_materials);
+        OverrideMaterialEmissiveSettings(material, config.m_materials);
+        OverrideMaterialRoughness(material, config.m_materials);
+        OverrideMaterialDoubleSided(material, config.m_materials);
+
+        // All the material overrides are in place, so get the entity, add the material component, and set its configuration to use the material overrides.
         AZ::Entity* entity = AzToolsFramework::GetEntityById(entityId);
-
-        // As a Material doesn't have a name and there can only be 1 material per <visual> tag,
-        // the Visual Name is used for the material
-        const std::string materialName{ visual->Name() };
-        const AZStd::string azMaterialName{ materialName.c_str(), materialName.size() };
-
-        // If present in map, take map color definition as priority, otherwise apply local node definition
-        const auto materialColorUrdf =
-            m_materials.contains(azMaterialName) ? m_materials.at(azMaterialName)->Diffuse() : visual->Material()->Diffuse();
-        const AZ::Color materialColor = URDF::TypeConversions::ConvertColor(materialColorUrdf);
-
-        entity->CreateComponent(AZ::Render::EditorMaterialComponentTypeId);
-        AZ_Trace("AddVisual", "Setting color for material %s\n", azMaterialName.c_str());
-        entity->Activate();
-        AZ::Render::MaterialComponentRequestBus::Event(
-            entityId,
-            &AZ::Render::MaterialComponentRequestBus::Events::SetPropertyValue,
-            AZ::Render::DefaultMaterialAssignmentId,
-            "settings.color",
-            AZStd::any(materialColor));
-        entity->Deactivate();
+        AZ_Assert(entity, "Entity ID for visual %s couldn't be found.", visual->Name().c_str());
+        auto component = entity->CreateComponent(AZ::Render::EditorMaterialComponentTypeId);
+        component->SetConfiguration(config);
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.h
@@ -22,10 +22,8 @@ namespace ROS2
     class VisualsMaker
     {
     public:
-        using MaterialNameMap = AZStd::unordered_map<AZStd::string, const sdf::Material*>;
-
         VisualsMaker();
-        VisualsMaker(MaterialNameMap materials, const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping);
+        VisualsMaker(const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping);
 
         //! Add zero, one or many visual elements to a given entity (depending on link content).
         //! Note that a sub-entity will be added to hold each visual (since they can have different transforms).
@@ -36,11 +34,10 @@ namespace ROS2
 
     private:
         AZ::EntityId AddVisual(const sdf::Visual* visual, AZ::EntityId entityId, const AZStd::string& generatedName) const;
-        void AddVisualToEntity(const sdf::Visual* visual, AZ::EntityId entityId) const;
+        AZ::Data::AssetId AddVisualToEntity(const sdf::Visual* visual, AZ::EntityId entityId) const;
         void AddVisualAssetToEntity(AZ::EntityId entityId, const AZ::Data::AssetId& assetId, const AZ::Vector3& scale) const;
-        void AddMaterialForVisual(const sdf::Visual* visual, AZ::EntityId entityId) const;
+        void AddMaterialForVisual(const sdf::Visual* visual, AZ::EntityId entityId, const AZ::Data::AssetId& assetId) const;
 
-        MaterialNameMap m_materials;
         AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -144,7 +144,7 @@ namespace ROS2::Utils
     const sdf::Model* GetModelContainingLink(const sdf::Root& root, AZStd::string_view linkName);
 
     //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param link SDF link object to lookup in the SDF document
+    //! @param link SDF link reference to lookup in the SDF document
     const sdf::Model* GetModelContainingLink(const sdf::Root& root, const sdf::Link& link);
 
     //! Returns the SDF model object which contains the specified joint
@@ -155,8 +155,14 @@ namespace ROS2::Utils
     const sdf::Model* GetModelContainingJoint(const sdf::Root& root, AZStd::string_view jointName);
 
     //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param joint SDF joint pointer to lookup in the SDF document
+    //! @param joint SDF joint reference to lookup in the SDF document
     const sdf::Model* GetModelContainingJoint(const sdf::Root& root, const sdf::Joint& joint);
+
+    //! Returns the SDF model object which contains the specified model
+    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param model SDF model reference to lookup in the SDF document
+    //! @return pointer to parent model containing this model if the model is nested, otherwise nullptr
+    const sdf::Model* GetModelContainingModel(const sdf::Root& root, const sdf::Model& model);
 
     //! Callback used to check for file exist of a path referenced within a URDF/SDF file
     //! @param path Candidate local filesystem path to check for existence

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -43,9 +43,15 @@ namespace ROS2::Utils
     //! @returns root to entity transform
     AZ::Transform GetWorldTransformURDF(const sdf::Link* link, AZ::Transform t = AZ::Transform::Identity());
 
+    //! Type Alias representing a "stack" of Model object that were visited on the way to the current Link/Joint Visitor Callback
+    using ModelStack = AZStd::deque<AZStd::reference_wrapper<const sdf::Model>>;
+
     //! Callback which is invoke for each link within a model
+    //! @param link reference to link being visited
+    //! @param modelStack stack of references to the models and nested models that were visited to get to the current link. The stack will
+    //! always contain at least one element. The back() element of the stack returns the direct model the link is attached to
     //! @return Return true to continue visiting links or false to halt
-    using LinkVisitorCallback = AZStd::function<bool(const sdf::Link&)>;
+    using LinkVisitorCallback = AZStd::function<bool(const sdf::Link& link, const ModelStack& modelStack)>;
     //! Visit links from URDF/SDF
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query link
     //! @param visitNestedModelLinks When true recurses to any nested <model> tags of the Model object and invoke visitor on their links as
@@ -53,35 +59,36 @@ namespace ROS2::Utils
     //! @returns void
     void VisitLinks(const sdf::Model& sdfModel, const LinkVisitorCallback& linkVisitorCB, bool visitNestedModelLinks = false);
 
-    //! Retrieve all links in URDF/SDF as a map, where a key is link's name and a value is a pointer to link.
+    //! Retrieve all links in URDF/SDF as a map, where a key is link's fully qualified name and a value is a pointer to link.
     //! Allows to retrieve a pointer to a link given it name.
     //! @param sdfModel object of SDF document corresponding to the <model> tag. It used to query links
     //! @param gatherNestedModelLinks When true recurses to any nested <model> tags of the Model object and also gathers their links as well
-    //! @returns mapping from link name to link pointer
+    //! @returns mapping from fully qualified link name(such as "model_name::link_name") to link pointer
     AZStd::unordered_map<AZStd::string, const sdf::Link*> GetAllLinks(const sdf::Model& sdfModel, bool gatherNestedModelLinks = false);
 
     //! Callback which is invoke for each valid joint for a given model
+    //! @param joint reference to joint being visited
+    //! @param modelStack stack of references to the models and nested models that were visited to get to the current joint. The stack will
+    //! always contain at least one element. The back() element of the stack returns the direct model the joint is attached to
     //! @return Return true to continue visiting joint or false to halt
-    using JointVisitorCallback = AZStd::function<bool(const sdf::Joint&)>;
+    using JointVisitorCallback = AZStd::function<bool(const sdf::Joint& joint, const ModelStack& modelStack)>;
     //! Visit joints from URDF/SDF
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
-    //! @param visitNestedModelJoints When true recurses to any nested <model> tags of the Model object and invoke visitor on their joints
-    //! as well
+    //! @param visitNestedModelJoints When true recurses to any nested <model> tags of the Model object and invoke visitor on their joint as well
     //! @returns void
     void VisitJoints(const sdf::Model& sdfModel, const JointVisitorCallback& jointVisitorCB, bool visitNestedModelJoints = false);
 
-    //! Retrieve all joints in URDF/SDF.
+    //! Retrieve all joints in URDF/SDF where the key is the full composed path following the name scoping proposal in SDF 1.8
+    //! http://sdformat.org/tutorials?tut=composition_proposal#1-nesting-and-encapsulation
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
-    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
-    //! well
-    //! @returns mapping from joint name to joint pointer
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
+    //! @returns mapping from fully qualified joint name(such as "model_name::joint_name") to joint pointer
     AZStd::unordered_map<AZStd::string, const sdf::Joint*> GetAllJoints(const sdf::Model& sdfModel, bool gatherNestedModelJoints = false);
 
     //! Retrieve all joints from URDF/SDF in which the specified link is a child in a sdf::Joint.
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
     //! @param linkName Name of link which to query in joint objects ChildName()
-    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
-    //! well
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
     //! @returns vector of joints where link is a child
     AZStd::vector<const sdf::Joint*> GetJointsForChildLink(
         const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints = false);
@@ -89,8 +96,7 @@ namespace ROS2::Utils
     //! Retrieve all joints from URDF/SDF in which the specified link is a parent in a sdf::Joint.
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
     //! @param linkName Name of link which to query in joint objects ParentName()
-    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
-    //! well
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
     //! @returns vector of joints where link is a parent
     AZStd::vector<const sdf::Joint*> GetJointsForParentLink(
         const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints = false);
@@ -111,8 +117,11 @@ namespace ROS2::Utils
     //! Callback which is invoke for each model in the SDF
     //! This function visits any <model> tags in the root of the SDF XML content
     //! as well as any <model> tags in any <world> tags that are in the root of the SDF XML content
+    //! @param model reference to SDF model object being visited
+    //! @param modelStack stack of references to the models were visited to get to the current model
+    //! NOTE: Unlike the Link/Joint visitor the modelStack can be empty (i.e for the root model or a model that is a child of a <world>)
     //! @return Return true to continue visiting models or false to halt
-    using ModelVisitorCallback = AZStd::function<VisitModelResponse(const sdf::Model&)>;
+    using ModelVisitorCallback = AZStd::function<VisitModelResponse(const sdf::Model& model, const ModelStack& modelStack)>;
     //! Visit Models from URDF/SDF
     //! @param sdfRoot Root object of SDF document
     //! @param visitNestedModels When true recurses to any nested <model> tags of the Model objects and invoke the visitor on them
@@ -121,26 +130,32 @@ namespace ROS2::Utils
 
     //! Retrieve all meshes referenced in URDF as unresolved URDF patches.
     //! Note that returned filenames are unresolved URDF patches.
-    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param visual - search for visual meshes.
-    //! @param colliders - search for collider meshes.
+    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param visual search for visual meshes.
+    //! @param colliders search for collider meshes.
     //! @returns set of meshes' filenames.
     AZStd::unordered_set<AZStd::string> GetMeshesFilenames(const sdf::Root& root, bool visual, bool colliders);
 
     //! Returns the SDF model object which contains the specified link
-    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param linkName - Name of SDF link to lookup in the SDF document
+    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param linkName Fully qualified name of SDF link to lookup in the SDF document
+    //! A fully qualified name has the form "modelname1::nested_modelname1::linkname"
+    //! This is detailed in the SDF format composition proposal: http://sdformat.org/tutorials?tut=composition_proposal#motivation
     const sdf::Model* GetModelContainingLink(const sdf::Root& root, AZStd::string_view linkName);
-    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param link - SDF link object to lookup in the SDF document
+
+    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param link SDF link object to lookup in the SDF document
     const sdf::Model* GetModelContainingLink(const sdf::Root& root, const sdf::Link& link);
 
     //! Returns the SDF model object which contains the specified joint
-    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param jointName - Name of SDF joint to lookup in the SDF document
+    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param jointName Name of SDF joint to lookup in the SDF document
+    //! A fully qualified name has the form "modelname1::nested_modelname1::jointname"
+    //! This is detailed in the SDF format composition proposal: http://sdformat.org/tutorials?tut=composition_proposal#motivation
     const sdf::Model* GetModelContainingJoint(const sdf::Root& root, AZStd::string_view jointName);
-    //! @param root - reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param jointName - Name of SDF joint to lookup in the SDF document
+
+    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @param joint SDF joint pointer to lookup in the SDF document
     const sdf::Model* GetModelContainingJoint(const sdf::Root& root, const sdf::Joint& joint);
 
     //! Callback used to check for file exist of a path referenced within a URDF/SDF file
@@ -149,11 +164,11 @@ namespace ROS2::Utils
     using FileExistsCB = AZStd::function<bool(const AZ::IO::PathView&)>;
 
     //! Resolves path for an asset referenced in a URDF/SDF file.
-    //! @param unresolvedPath - unresolved URDF/SDF path, example : `model://meshes/foo.dae`.
-    //! @param baseFilePath - the absolute path of URDF/SDF file which contains the path that is to be resolved.
-    //! @param amentPrefixPath - the string that contains available packages' path, separated by ':' signs.
-    //! @param settings - the asset path resolution settings to use for attempting to locate the correct files
-    //! @param fileExists - functor to check if the given file exists. Exposed for unit test, default one should be used.
+    //! @param unresolvedPath unresolved URDF/SDF path, example : `model://meshes/foo.dae`.
+    //! @param baseFilePath the absolute path of URDF/SDF file which contains the path that is to be resolved.
+    //! @param amentPrefixPath the string that contains available packages' path, separated by ':' signs.
+    //! @param settings the asset path resolution settings to use for attempting to locate the correct files
+    //! @param fileExists functor to check if the given file exists. Exposed for unit test, default one should be used.
     //! @returns resolved path to the referenced file within the URDF/SDF, or the passed-in path if no resolution was possible.
     AZ::IO::Path ResolveAssetPath(
         AZ::IO::Path unresolvedPath,

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -16,6 +16,7 @@
 #include <AzCore/std/function/function_template.h>
 #include <AzCore/std/string/string.h>
 #include <RobotImporter/URDF/UrdfParser.h>
+#include <RobotImporter/Utils/SourceAssetsStorage.h>
 #include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
 
 #include <sdf/sdf.hh>
@@ -128,13 +129,11 @@ namespace ROS2::Utils
     //! @returns void
     void VisitModels(const sdf::Root& sdfRoot, const ModelVisitorCallback& modelVisitorCB, bool visitNestedModels = true);
 
-    //! Retrieve all meshes referenced in URDF as unresolved URDF patches.
-    //! Note that returned filenames are unresolved URDF patches.
+    //! Retrieve all assets referenced in SDF/URDF as unresolved URIs.
+    //! The URIs will still need to get resolved via ResolveAssetPath() to point to a valid file location.
     //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @param visual search for visual meshes.
-    //! @param colliders search for collider meshes.
     //! @returns set of meshes' filenames.
-    AZStd::unordered_set<AZStd::string> GetMeshesFilenames(const sdf::Root& root, bool visual, bool colliders);
+    AssetFilenameReferences GetReferencedAssetFilenames(const sdf::Root& root);
 
     //! Returns the SDF model object which contains the specified link
     //! @param root reference to SDF Root object representing the root of the parsed SDF xml document

--- a/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
+++ b/Gems/ROS2/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
@@ -86,7 +86,7 @@ namespace ROS2
     Utils::UrdfAssetMap SdfAssetBuilder::FindAssets(const sdf::Root& root, const AZStd::string& sourceFilename) const
     {
         AZ_Info(SdfAssetBuilderName, "Parsing mesh and collider names");
-        auto assetNames = Utils::GetMeshesFilenames(root, true, true);
+        auto assetNames = Utils::GetReferencedAssetFilenames(root);
 
         Utils::UrdfAssetMap assetMap;
 
@@ -94,7 +94,7 @@ namespace ROS2
 
         auto amentPrefixPath = Utils::GetAmentPrefixPath();
 
-        for (const auto& uri : assetNames)
+        for (const auto& [uri, assetReferenceType] : assetNames)
         {
             Utils::UrdfAsset asset;
             asset.m_urdfPath = uri;


### PR DESCRIPTION
This PR includes following changes:
 - #523 
 - #550
 - #547
 - #561
 - #555
 - #566
 - #569
 current state imported zoo of urdfs:

![image](https://github.com/o3de/o3de-extras/assets/3209244/2611d824-9088-40c3-a5b3-3aa72a92057f)

Tests:
```
142: Note: Google Test filter = -*SUITE_smoke*:*SUITE_periodic*:*SUITE_benchmark*:*SUITE_sandbox*:*SUITE_awsi*
142: [==========] Running 4 tests from 1 test case.
142: [----------] Global test environment set-up.
142: [----------] 4 tests from GNSSTest
142: [ RUN      ] GNSSTest.WGS84ToECEF
142: [       OK ] GNSSTest.WGS84ToECEF (0 ms)
142: [ RUN      ] GNSSTest.ECEFToENU
142: [       OK ] GNSSTest.ECEFToENU (0 ms)
142: [ RUN      ] GNSSTest.ENUToECEF
142: [       OK ] GNSSTest.ENUToECEF (0 ms)
142: [ RUN      ] GNSSTest.ECEFToWSG84
142: [       OK ] GNSSTest.ECEFToWSG84 (0 ms)
142: [----------] 4 tests from GNSSTest (0 ms total)
142: 
142: [----------] Global test environment tear-down
142: [==========] 4 tests from 1 test case ran. (0 ms total)
142: [  PASSED  ] 4 tests.
142: OKAY AzRunUnitTests() returned 0
142: Returning code: 0

100% tests passed, 0 tests failed out of 1

Label Time Summary:
FRAMEWORK_googletest    =   0.05 sec*proc (1 test)
SUITE_main              =   0.05 sec*proc (1 test)

Total Test time (real) =   0.06 sec
Process finished with exit code 0
```

```
143: [==========] Running 36 tests from 2 test cases.
143: [----------] Global test environment set-up.
143: [----------] 6 tests from SdfParserTest
143: [ RUN      ] SdfParserTest.SdfWithDuplicateModelNames_ResultsInError
143: SDF with duplicate model names failed to parse with errors: ErrorCode=2, Message=model with name[my_model] already exists.
143: ErrorCode=9, Message=Failed to load a world.
143: 
143: [       OK ] SdfParserTest.SdfWithDuplicateModelNames_ResultsInError (38 ms)
143: [ RUN      ] SdfParserTest.SdfWithModelsOnRootAndWorld_ParsesSuccessfully
143: [       OK ] SdfParserTest.SdfWithModelsOnRootAndWorld_ParsesSuccessfully (39 ms)
143: [ RUN      ] SdfParserTest.VisitingSdfWithMultipleModelsWithSameLinkName_VisitsAllLinks
143: [       OK ] SdfParserTest.VisitingSdfWithMultipleModelsWithSameLinkName_VisitsAllLinks (33 ms)
143: [ RUN      ] SdfParserTest.CheckModelCorrectness
143: [       OK ] SdfParserTest.CheckModelCorrectness (47 ms)
143: [ RUN      ] SdfParserTest.RobotImporterUtils
143: [       OK ] SdfParserTest.RobotImporterUtils (26 ms)
143: [ RUN      ] SdfParserTest.SensorPluginImporterHookCheck
143: [       OK ] SdfParserTest.SensorPluginImporterHookCheck (46 ms)
143: [----------] 6 tests from SdfParserTest (230 ms total)
143: 
143: [----------] 30 tests from UrdfParserTest
143: [ RUN      ] UrdfParserTest.ParseUrdfWithOneLink
143: [       OK ] UrdfParserTest.ParseUrdfWithOneLink (22 ms)
143: [ RUN      ] UrdfParserTest.ParseUrdfWithTwoLinksAndFixedJoint_WithPreserveFixedJoint_False
143: [       OK ] UrdfParserTest.ParseUrdfWithTwoLinksAndFixedJoint_WithPreserveFixedJoint_False (22 ms)
143: [ RUN      ] UrdfParserTest.ParseUrdfWithTwoLinksAndFixedJoint_WithPreserveFixedJoint_True
143: [       OK ] UrdfParserTest.ParseUrdfWithTwoLinksAndFixedJoint_WithPreserveFixedJoint_True (23 ms)
143: [ RUN      ] UrdfParserTest.ParseUrdfWithTwoLinksAndNonFixedJoint
143: [       OK ] UrdfParserTest.ParseUrdfWithTwoLinksAndNonFixedJoint (24 ms)
143: [ RUN      ] UrdfParserTest.ParseURDF_WithTwoLinks_AndBaseLinkWithNoInertia_WithUrdfFixedJointPreservationOn_Fails
143: URDF with single link and no inertia: ErrorCode=17, Message=A model must have at least one link.
143: ErrorCode=17, Message=A model must have at least one link.
143: ErrorCode=25, Message=FrameAttachedToGraph error: scope context name[] does not match __model__ or world.
143: 
143: [       OK ] UrdfParserTest.ParseURDF_WithTwoLinks_AndBaseLinkWithNoInertia_WithUrdfFixedJointPreservationOn_Fails (23 ms)
143: [ RUN      ] UrdfParserTest.ParseURDF_WithTwoLinks_AndBaseLinkWithNoInertia_WithUrdfFixedJointPreservationOff_Succeeds
143: [       OK ] UrdfParserTest.ParseURDF_WithTwoLinks_AndBaseLinkWithNoInertia_WithUrdfFixedJointPreservationOff_Succeeds (23 ms)
143: [ RUN      ] UrdfParserTest.ParseUrdf_WithRootLink_WithName_world_DoesNotContain_world_Link
143: [       OK ] UrdfParserTest.ParseUrdf_WithRootLink_WithName_world_DoesNotContain_world_Link (25 ms)
143: [ RUN      ] UrdfParserTest.ParseUrdf_WithRootLink_WithoutName_world_DoesContainThatLink
143: [       OK ] UrdfParserTest.ParseUrdf_WithRootLink_WithoutName_world_DoesContainThatLink (25 ms)
143: [ RUN      ] UrdfParserTest.WheelHeuristicNameValid
143: [       OK ] UrdfParserTest.WheelHeuristicNameValid (50 ms)
143: [ RUN      ] UrdfParserTest.WheelHeuristicNameNotValid1
143: [       OK ] UrdfParserTest.WheelHeuristicNameNotValid1 (24 ms)
143: [ RUN      ] UrdfParserTest.WheelHeuristicJointNotValid
143: [       OK ] UrdfParserTest.WheelHeuristicJointNotValid (23 ms)
143: [ RUN      ] UrdfParserTest.WheelHeuristicJointVisualNotValid
143: [       OK ] UrdfParserTest.WheelHeuristicJointVisualNotValid (24 ms)
143: [ RUN      ] UrdfParserTest.WheelHeuristicJointColliderNotValid
143: [       OK ] UrdfParserTest.WheelHeuristicJointColliderNotValid (25 ms)
143: [ RUN      ] UrdfParserTest.TestLinkListing
143: [       OK ] UrdfParserTest.TestLinkListing (25 ms)
143: [ RUN      ] UrdfParserTest.TestJointLink
143: [       OK ] UrdfParserTest.TestJointLink (26 ms)
143: [ RUN      ] UrdfParserTest.TestTransforms
143: [       OK ] UrdfParserTest.TestTransforms (28 ms)
143: [ RUN      ] UrdfParserTest.TestQueryJointsForParentLink_Succeeds
143: [       OK ] UrdfParserTest.TestQueryJointsForParentLink_Succeeds (27 ms)
143: [ RUN      ] UrdfParserTest.TestQueryJointsForChildLink_Succeeds
143: [       OK ] UrdfParserTest.TestQueryJointsForChildLink_Succeeds (28 ms)
143: [ RUN      ] UrdfParserTest.TestPathResolve_ValidAbsolutePath_ResolvesCorrectly
143: [       OK ] UrdfParserTest.TestPathResolve_ValidAbsolutePath_ResolvesCorrectly (0 ms)
143: [ RUN      ] UrdfParserTest.TestPathResolve_InvalidAbsolutePath_ReturnsEmptyPath
143: [       OK ] UrdfParserTest.TestPathResolve_InvalidAbsolutePath_ReturnsEmptyPath (0 ms)
143: [ RUN      ] UrdfParserTest.TestPathResolve_ValidRelativePath_ResolvesCorrectly
143: [       OK ] UrdfParserTest.TestPathResolve_ValidRelativePath_ResolvesCorrectly (0 ms)
143: [ RUN      ] UrdfParserTest.TestPathResolve_InvalidRelativePath_ReturnsEmptyPath
143: [       OK ] UrdfParserTest.TestPathResolve_InvalidRelativePath_ReturnsEmptyPath (0 ms)
143: [ RUN      ] UrdfParserTest.TestPathResolve_ValidAmentRelativePathButNoPrefix_ReturnsEmptyPath
143: [       OK ] UrdfParserTest.TestPathResolve_ValidAmentRelativePathButNoPrefix_ReturnsEmptyPath (0 ms)
143: [ RUN      ] UrdfParserTest.TestPathResolve_ValidAmentRelativePathAndPrefix_ResolvesCorrectly
143: [       OK ] UrdfParserTest.TestPathResolve_ValidAmentRelativePathAndPrefix_ResolvesCorrectly (0 ms)
143: [ RUN      ] UrdfParserTest.TestPathResolve_ValidPathRelativeToAncestorPath_ResolvesCorrectly
143: [       OK ] UrdfParserTest.TestPathResolve_ValidPathRelativeToAncestorPath_ResolvesCorrectly (0 ms)
143: [ RUN      ] UrdfParserTest.TestPathResolve_ValidPathRelativeToAncestorPath_FailsToResolveWhenAncestorPathsDisabled
143: [       OK ] UrdfParserTest.TestPathResolve_ValidPathRelativeToAncestorPath_FailsToResolveWhenAncestorPathsDisabled (0 ms)
143: [ RUN      ] UrdfParserTest.TestPathResolvementExplicitPackageName
143: [       OK ] UrdfParserTest.TestPathResolvementExplicitPackageName (0 ms)
143: [ RUN      ] UrdfParserTest.ResolvePath_UsingModelUriScheme_Succeeds
143: [       OK ] UrdfParserTest.ResolvePath_UsingModelUriScheme_Succeeds (0 ms)
143: [ RUN      ] UrdfParserTest.XacroParseArgsInvalid
143: [       OK ] UrdfParserTest.XacroParseArgsInvalid (0 ms)
143: [ RUN      ] UrdfParserTest.XacroParseArgs
143: [       OK ] UrdfParserTest.XacroParseArgs (0 ms)
143: [----------] 30 tests from UrdfParserTest (467 ms total)
143: 
143: [----------] Global test environment tear-down
143: [==========] 36 tests from 2 test cases ran. (697 ms total)
143: [  PASSED  ] 36 tests.
143: OKAY AzRunUnitTests() returned 0
143: Returning code: 0

100% tests passed, 0 tests failed out of 1

Label Time Summary:
FRAMEWORK_googletest    =   0.77 sec*proc (1 test)
SUITE_main              =   0.77 sec*proc (1 test)

Total Test time (real) =   0.78 sec
Process finished with exit code 0
```


