### PR TITLE
Adding UnitTest for verifying import of nested SDF import via the `<include>` tag

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -569,8 +569,9 @@ namespace ROS2
         {
             gz::math::Pose3d modelPose = model.RawPose();
             AZ::Transform modelTransform = URDF::TypeConversions::ConvertPose(modelPose);
-
-            transformComponent->SetWorldTM(AZStd::move(modelTransform));
+            // Set the local transform for each model to have it be translated in relation
+            // to its parent
+            transformComponent->SetLocalTM(AZStd::move(modelTransform));
         }
 
         // Allow the created model entity to persist if there are no errors at ths point

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -73,8 +73,8 @@ namespace ROS2
             struct JointToAttachedModel
             {
                 AZStd::string m_fullyQualifiedName;
-                const sdf::Joint* m_joint;
-                const sdf::Model* m_attachedModel;
+                const sdf::Joint* m_joint{};
+                const sdf::Model* m_attachedModel{};
             };
             // this is a unique ordered vector
             AZStd::vector<JointToAttachedModel> m_joints;
@@ -121,8 +121,8 @@ namespace ROS2
             struct LinkToAttachedModel
             {
                 AZStd::string m_fullyQualifiedName;
-                const sdf::Link* m_link;
-                const sdf::Model* m_attachedModel;
+                const sdf::Link* m_link{};
+                const sdf::Model* m_attachedModel{};
             };
             // this is a unique ordered vector
             AZStd::vector<LinkToAttachedModel> m_links;
@@ -134,8 +134,8 @@ namespace ROS2
             struct NestedModelToAttachedModel
             {
                 AZStd::string m_fullyQualifiedName;
-                const sdf::Model* m_nestedModel;
-                const sdf::Model* m_attachedModel;
+                const sdf::Model* m_nestedModel{};
+                const sdf::Model* m_attachedModel{};
             };
             // this is a unique ordered vector
             AZStd::vector<NestedModelToAttachedModel> m_models;
@@ -156,7 +156,8 @@ namespace ROS2
             }
 
             // Use the model stack to create a mapping from the current model
-            // to the any model it is attached or nullptr if the model is at the top level SDF Root
+            // to the parent model it is attached to.
+            // If the current model has no parent model the attached model is set to nullptr
             std::string stdFullModelName;
             for (const sdf::Model& ancestorModel : modelStack)
             {
@@ -173,7 +174,7 @@ namespace ROS2
             return Utils::VisitModelResponse::VisitNestedAndSiblings;
         };
 
-        // Gather all links and direct nested from all the models in the SDF
+        // Gather all links and add a mapping of nested model -> parent model for each model in the SDF
         Utils::VisitModels(*m_root, GetAllLinksAndSetModelHierarchy, visitNestedModels);
 
         // Build up a list of all entities created as a part of processing the file.

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -129,7 +129,20 @@ namespace ROS2
         };
         LinksMapper linksMapper;
 
-        auto GetAllLinksFromModel = [&linksMapper](const sdf::Model& model, const Utils::ModelStack&) -> Utils::VisitModelResponse
+        struct ModelMapper
+        {
+            struct NestedModelToAttachedModel
+            {
+                AZStd::string m_fullyQualifiedName;
+                const sdf::Model* m_nestedModel;
+                const sdf::Model* m_attachedModel;
+            };
+            // this is a unique ordered vector
+            AZStd::vector<NestedModelToAttachedModel> m_models;
+        };
+        ModelMapper modelMapper;
+
+        auto GetAllLinksAndSetModelHierarchy = [&linksMapper, &modelMapper](const sdf::Model& model, const Utils::ModelStack& modelStack) -> Utils::VisitModelResponse
         {
             // As the VisitModels function visits nested models by default, gatherNestedModelLinks is set to false
             constexpr bool gatherNestedModelLinks = false;
@@ -137,25 +150,90 @@ namespace ROS2
             for (const auto& [fullyQualifiedName, link] : linksForModel)
             {
                 // Push back the mapping of link to attached model into the ordered vector
-                LinksMapper::LinkToAttachedModel linkToAttachedModel{ AZStd::string(fullyQualifiedName.c_str(), fullyQualifiedName.size()),
-                                                                      link,
-                                                                      &model };
+                AZStd::string fullLinkName(fullyQualifiedName.c_str(), fullyQualifiedName.size());
+                LinksMapper::LinkToAttachedModel linkToAttachedModel{ AZStd::move(fullLinkName), link, &model };
                 linksMapper.m_links.push_back(AZStd::move(linkToAttachedModel));
             }
+
+            // Use the model stack to create a mapping from the current model
+            // to the any model it is attached or nullptr if the model is at the top level SDF Root
+            std::string stdFullModelName;
+            for (const sdf::Model& ancestorModel : modelStack)
+            {
+                stdFullModelName = sdf::JoinName(stdFullModelName, ancestorModel.Name());
+            }
+            stdFullModelName = sdf::JoinName(stdFullModelName, model.Name());
+            AZStd::string fullModelName(stdFullModelName.c_str(), stdFullModelName.size());
+            ModelMapper::NestedModelToAttachedModel nestedModelToAttachedModel;
+            nestedModelToAttachedModel.m_fullyQualifiedName = AZStd::move(fullModelName);
+            nestedModelToAttachedModel.m_nestedModel = &model;
+            nestedModelToAttachedModel.m_attachedModel = !modelStack.empty() ? &modelStack.back().get() : nullptr;
+            modelMapper.m_models.push_back(AZStd::move(nestedModelToAttachedModel));
+
             return Utils::VisitModelResponse::VisitNestedAndSiblings;
         };
 
-        // Gather all links from all the models in the SDF
-        Utils::VisitModels(*m_root, GetAllLinksFromModel, visitNestedModels);
+        // Gather all links and direct nested from all the models in the SDF
+        Utils::VisitModels(*m_root, GetAllLinksAndSetModelHierarchy, visitNestedModels);
 
         // Build up a list of all entities created as a part of processing the file.
         AZStd::vector<AZ::EntityId> createdEntities;
-        AZStd::unordered_map<const sdf::Link*, AzToolsFramework::Prefab::PrefabEntityResult> createdLinks;
         AZStd::unordered_map<const sdf::Model*, AzToolsFramework::Prefab::PrefabEntityResult> createdModels;
+
+        AZStd::unordered_map<const sdf::Link*, AzToolsFramework::Prefab::PrefabEntityResult> createdLinks;
         AZStd::unordered_map<AZStd::string, const sdf::Link*> links;
-        for ([[maybe_unused]] const auto& [fullLinkName, linkPtr, attachedModel] : linksMapper.m_links)
+
+        // Create an entity for each model
+        for ([[maybe_unused]] const auto& [fullModelName, modelPtr, _] : modelMapper.m_models)
         {
-            // Create entities for the model containing the link
+            // Create entities for each model in the SDF
+            if (AzToolsFramework::Prefab::PrefabEntityResult createModelEntityResult = CreateEntityForModel(*modelPtr);
+                createModelEntityResult)
+            {
+                AZ::EntityId createdModelEntityId = createModelEntityResult.GetValue();
+                // Add the model entity to the created entity list so that it gets added to the prefab
+                createdEntities.emplace_back(createdModelEntityId);
+
+                std::string modelName = modelPtr->Name();
+                AZStd::string azModelName(modelName.c_str(), modelName.size());
+                AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
+                m_status.emplace(azModelName, AZStd::string::format("[model] created as: %s", createdModelEntityId.ToString().c_str()));
+                createdModels.emplace(modelPtr, createModelEntityResult);
+            }
+        }
+
+        //! Setup the parent hierarchy for the nested models
+        for ([[maybe_unused]] const auto& [_, modelPtr, parentModelPtr] : modelMapper.m_models)
+        {
+            // If there is no parent model, then the model would be at the top level of the hiearachy
+            if (parentModelPtr == nullptr || modelPtr == nullptr)
+            {
+                continue;
+            }
+            // Create entities for each model in the SDF
+            AZ::EntityId modelEntityId;
+            if (auto modelIt = createdModels.find(modelPtr); modelIt != createdModels.end() && modelIt->second)
+            {
+                modelEntityId = modelIt->second.GetValue();
+            }
+
+            AZ::EntityId parentModelEntityId;
+            if (auto parentModelIt = createdModels.find(parentModelPtr); parentModelIt != createdModels.end() && parentModelIt->second)
+            {
+                parentModelEntityId = parentModelIt->second.GetValue();
+            }
+
+            // If the both the parent model and current model entity exist
+            // set the current model transform component parent to the parent model
+            if (parentModelEntityId.IsValid() && modelEntityId.IsValid())
+            {
+                PrefabMakerUtils::SetEntityParent(modelEntityId, parentModelEntityId);
+            }
+        }
+
+        // Create an entity for each link and set the parent to be the model entity where the link is attached
+        for ([[maybe_unused]] const auto& [_, linkPtr, attachedModel] : linksMapper.m_links)
+        {
             AZ::EntityId modelEntityId;
             if (attachedModel != nullptr)
             {
@@ -166,26 +244,7 @@ namespace ROS2
                         modelEntityId = modelIt->second.GetValue();
                     }
                 }
-                else
-                {
-                    if (AzToolsFramework::Prefab::PrefabEntityResult createModelEntityResult = CreateEntityForModel(*attachedModel);
-                        createModelEntityResult)
-                    {
-                        modelEntityId = createModelEntityResult.GetValue();
-                        // Add the model entity to the created entity list
-                        // so that it gets added to the prefab
-                        createdEntities.emplace_back(modelEntityId);
-
-                        std::string modelName = attachedModel->Name();
-                        AZStd::string azModelName(modelName.c_str(), modelName.size());
-                        AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
-                        m_status.emplace(azModelName, AZStd::string::format("created as: %s", modelEntityId.ToString().c_str()));
-                        createdModels.emplace(attachedModel, createModelEntityResult);
-                    }
-                }
-
             }
-
             // Add all link as children of their attached model entity by default
             createdLinks[linkPtr] = AddEntitiesForLink(*linkPtr, attachedModel, modelEntityId, createdEntities);
         }
@@ -202,11 +261,11 @@ namespace ROS2
             AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
             if (result.IsSuccess())
             {
-                m_status.emplace(azLinkName, AZStd::string::format("created as: %s", result.GetValue().ToString().c_str()));
+                m_status.emplace(azLinkName, AZStd::string::format("[link] created as: %s", result.GetValue().ToString().c_str()));
             }
             else
             {
-                m_status.emplace(azLinkName, AZStd::string::format("failed : %s", result.GetError().c_str()));
+                m_status.emplace(azLinkName, AZStd::string::format("[link] failed : %s", result.GetError().c_str()));
             }
         }
 
@@ -390,7 +449,7 @@ namespace ROS2
                     AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
                     auto result = m_jointsMaker.AddJointComponent(jointPtr, childEntity.GetValue(), leadEntity.GetValue());
                     m_status.emplace(
-                        azJointName, AZStd::string::format(" %s: %llu", result.IsSuccess() ? "created as" : "failed", result.GetValue()));
+                        azJointName, AZStd::string::format("[joint] %s: %llu", result.IsSuccess() ? "created as" : "failed", result.GetValue()));
                 }
                 else
                 {
@@ -508,62 +567,8 @@ namespace ROS2
         if (auto* transformComponent = entity->FindComponent<AzToolsFramework::Components::TransformComponent>();
             transformComponent != nullptr)
         {
-            gz::math::Pose3d modelPose;
-            if (sdf::Errors poseResolveErrors = model.SemanticPose().Resolve(modelPose); !poseResolveErrors.empty())
-            {
-                AZStd::string poseErrorMessages = Utils::JoinSdfErrorsToString(poseResolveErrors);
-
-                auto poseErrorsForModel = AZStd::string::format(
-                    R"(Unable to resolve semantic pose for model %s. Creation of Model entity has failed. Errors: "%s")",
-                    model.Name().c_str(),
-                    poseErrorMessages.c_str());
-
-                return AZ::Failure(poseErrorsForModel);
-            }
-
+            gz::math::Pose3d modelPose = model.RawPose();
             AZ::Transform modelTransform = URDF::TypeConversions::ConvertPose(modelPose);
-
-            // If the model is nested below another model, check if it has a placement frame
-            if (const sdf::Model* parentModel = Utils::GetModelContainingModel(*m_root, model); parentModel != nullptr)
-            {
-                if (const sdf::Frame* modelPlacementFrame = parentModel->FrameByName(model.PlacementFrameName()); modelPlacementFrame != nullptr)
-                {
-                    gz::math::Pose3d placementFramePose;
-                    if (sdf::Errors poseResolveErrors = modelPlacementFrame->SemanticPose().Resolve(placementFramePose);
-                        !poseResolveErrors.empty())
-                    {
-                        AZStd::string poseErrorMessages = Utils::JoinSdfErrorsToString(poseResolveErrors);
-
-                        auto poseErrorsForModel = AZStd::string::format(
-                            R"(Unable to resolve semantic pose for model %s parent model %s. Creation of Model entity has failed. Errors: "%s")",
-                            model.Name().c_str(),
-                            parentModel->Name().c_str(),
-                            poseErrorMessages.c_str());
-
-                        return AZ::Failure(poseErrorsForModel);
-                    }
-
-                    modelTransform = modelTransform * URDF::TypeConversions::ConvertPose(placementFramePose);
-                }
-            }
-
-            if (const sdf::Frame* implicitFrame = model.FrameByName("__model__"); implicitFrame != nullptr)
-            {
-                gz::math::Pose3d implicitFramePose;
-                if (sdf::Errors poseResolveErrors = implicitFrame->SemanticPose().Resolve(implicitFramePose); !poseResolveErrors.empty())
-                {
-                    AZStd::string poseErrorMessages = Utils::JoinSdfErrorsToString(poseResolveErrors);
-
-                    auto poseErrorsForModel = AZStd::string::format(
-                        R"(Unable to resolve semantic pose for model's implicit frame %s. Creation of Model entity has failed. Errors: "%s")",
-                        implicitFrame->Name().c_str(),
-                        poseErrorMessages.c_str());
-
-                    return AZ::Failure(poseErrorsForModel);
-                }
-
-                modelTransform = modelTransform * URDF::TypeConversions::ConvertPose(implicitFramePose);
-            }
 
             transformComponent->SetWorldTM(AZStd::move(modelTransform));
         }

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -368,7 +368,7 @@ namespace ROS2::Utils
                 if (const sdf::Model* model = world.ModelByIndex(modelIndex); model != nullptr)
                 {
                     // Delegate to the sdf::Model call operator overload to visit nested models
-                    // Stop visited the world's <model> children if any children return Stop
+                    // Stop visiting the world's <model> children if any children return Stop
                     if (VisitModelResponse visitResponse = operator()(*model); visitResponse >= VisitModelResponse::Stop)
                     {
                         return visitResponse;
@@ -382,7 +382,7 @@ namespace ROS2::Utils
 
         void operator()(const sdf::Root& root)
         {
-            // Visit the root <model> tag if one exist
+            // Visit all <model> tags at the root of the SDF
             VisitModelResponse modelVisitResponse = VisitModelResponse::VisitNestedAndSiblings;
             if (const sdf::Model* model = root.Model(); model != nullptr)
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -128,12 +128,31 @@ namespace ROS2::Utils
     //! @param visitNestedModels When true recurses to any nested <model> tags of the Model objects and invoke the visitor on them
     //! @returns void
     void VisitModels(const sdf::Root& sdfRoot, const ModelVisitorCallback& modelVisitorCB, bool visitNestedModels = true);
+    //! @param sdfWorld World object of SDF document corresponding to the <world> tag.
+    //! @param visitNestedModels When true recurses to any nested <model> tags of the Model objects and invoke the visitor on them
+    //! @returns void
+    void VisitModels(const sdf::World& sdfWorld, const ModelVisitorCallback& modelVisitorCB, bool visitNestedModels = true);
+    //! @param sdfModel Model object corresponding to a <model> tag in the SDF.
+    //! @param visitNestedModels When true recurses to any nested <model> tags of the Model objects and invoke the visitor on them
+    //! @returns void
+    void VisitModels(const sdf::Model& sdfModel, const ModelVisitorCallback& modelVisitorCB, bool visitNestedModels = true);
 
-    //! Retrieve all assets referenced in SDF/URDF as unresolved URIs.
-    //! The URIs will still need to get resolved via ResolveAssetPath() to point to a valid file location.
-    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
-    //! @returns set of meshes' filenames.
-    AssetFilenameReferences GetReferencedAssetFilenames(const sdf::Root& root);
+    using ModelMap = AZStd::unordered_map<AZStd::string, const sdf::Model*>;
+    //! Retrieve all models in URDF/SDF where the key is the fully composed path following the name scoping proposal in SDF 1.8
+    //! http://sdformat.org/tutorials?tut=composition_proposal#1-nesting-and-encapsulation
+    //! @param sdfRoot Root object of SDF document. The SDF <world> and <model> tags are recursed to locate SDF models
+    //! @param gatherNestedModelsForModel When true recurses to any nested <model> tags of the Model object and also gathers their models as well
+    //! @returns mapping from fully qualified model name(such as "model_name::nested_model_name") to model pointer
+    //! NOTE: For the SDF world object if gatherNestedModelsForModel=false, then only the direct models of the world are gathered
+    ModelMap GetAllModels(const sdf::Root& sdfRoot, bool gatherNestedModelsForModel = false);
+    //! @param sdfWorld World object of SDF document corresponding to the <world> tag. It used to query models
+    //! @param gatherNestedModelsForModel When true recurses to any nested <model> tags of the Model object and also gathers their models as well
+    //! @returns mapping from fully qualified model name(such as "model_name::nested_model_name") to model pointer
+    ModelMap GetAllModels(const sdf::World& sdfWorld, bool gatherNestedModelsForModel = false);
+    //! @param sdfModel Model object corresponding to a <model> tag in the SDF. It used to query nested models
+    //! @param gatherNestedModelsForModel When true recurses to any nested <model> tags of the Model object and also gathers their models as well
+    //! @returns mapping from fully qualified model name(such as "model_name::nested_model_name") to model pointer
+    ModelMap GetAllModels(const sdf::Model& sdfModel, bool gatherNestedModelsForModel = false);
 
     //! Returns the SDF model object which contains the specified link
     //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
@@ -162,6 +181,12 @@ namespace ROS2::Utils
     //! @param model SDF model reference to lookup in the SDF document
     //! @return pointer to parent model containing this model if the model is nested, otherwise nullptr
     const sdf::Model* GetModelContainingModel(const sdf::Root& root, const sdf::Model& model);
+
+    //! Retrieve all assets referenced in SDF/URDF as unresolved URIs.
+    //! The URIs will still need to get resolved via ResolveAssetPath() to point to a valid file location.
+    //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
+    //! @returns set of meshes' filenames.
+    AssetFilenameReferences GetReferencedAssetFilenames(const sdf::Root& root);
 
     //! Callback used to check for file exist of a path referenced within a URDF/SDF file
     //! @param path Candidate local filesystem path to check for existence

--- a/Gems/ROS2/Code/Tests/SdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/SdfParserTest.cpp
@@ -374,7 +374,7 @@ namespace UnitTest
         // Verify the nested test SDF file has been created
         ASSERT_TRUE(nestedModelFullPath.has_value());
 
-        // Now grab the world sdf content and use the Parse command to parse the contens
+        // Now grab the world sdf content and use the Parse command to parse the contents
         const auto xmlStr = sdfStack.m_stack.front();
 
         sdf::ParserConfig sdfConfig;
@@ -397,10 +397,10 @@ namespace UnitTest
         const auto* sdfWorld = sdfRoot.WorldByIndex(0);
         ASSERT_NE(nullptr, sdfWorld);
 
-        // There should be model on the world that is the "top_model"
+        // There should be only one model on the world that is the "top_model"
         EXPECT_EQ(1, sdfWorld->ModelCount());
 
-        // The nested model contain the name from within
+        // The nested model contains the name from within
         const auto* topModel = sdfWorld->ModelByName("top_model");
         ASSERT_NE(nullptr, topModel);
 

--- a/Gems/ROS2/Code/Tests/SdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/SdfParserTest.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzTest/AzTest.h>
+#include <AzTest/Utils.h>
 #include <RobotImporter/SDFormat/ROS2SensorHooks.h>
 #include <RobotImporter/Utils/ErrorUtils.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
@@ -137,7 +138,7 @@ namespace UnitTest
 
         static std::string GetSdfWithDuplicateModelName()
         {
-          return R"(<?xml version="1.0"?>
+            return R"(<?xml version="1.0"?>
             <sdf version="1.7">
             <model name="root_model">
               <link name="root_link"/>
@@ -158,7 +159,7 @@ namespace UnitTest
 
         static std::string GetSdfWithWorldThatHasMultipleModels()
         {
-          return R"(<?xml version="1.0"?>
+            return R"(<?xml version="1.0"?>
             <sdf version="1.8">
             <model name="root_model">
               <link name="root_link"/>
@@ -181,7 +182,7 @@ namespace UnitTest
 
         static std::string GetSdfWithMultipleModelsThatHaveLinksWithTheSameName()
         {
-          return R"(<?xml version="1.0"?>
+            return R"(<?xml version="1.0"?>
             <sdf version="1.10">
             <world name="default">
               <model name="my_model">
@@ -192,6 +193,39 @@ namespace UnitTest
               </model>
             </world>
           </sdf>)";
+        }
+
+        struct SdfXmlStack
+        {
+            AZStd::deque<std::string> m_stack;
+        };
+        static SdfXmlStack GetSdfWorldWithNestedModelWithPose()
+        {
+            SdfXmlStack sdfXmlStack;
+            sdfXmlStack.m_stack.emplace_back(R"(<?xml version="1.0"?>
+            <sdf version="1.10">
+                <world name="default">
+                    <model name="top_model">
+                        <include>
+                            <uri>model://nested_test.sdf</uri>
+                        </include>
+                        <pose>8 2 4 0 -0 -1.564217</pose>
+                    </model>
+                </world>
+            </sdf>)");
+
+            sdfXmlStack.m_stack.emplace_back(R"(<?xml version="1.0"?>
+            <sdf version="1.10">
+                <model name="nested_model">
+                    <link name="link">
+                        <inertial>
+                            <mass>50</mass>
+                        </inertial>
+                    </link>
+                </model>
+            </sdf>)");
+
+            return sdfXmlStack;
         }
     };
 
@@ -321,6 +355,69 @@ namespace UnitTest
         ASSERT_EQ(2, links.size());
         EXPECT_TRUE(links.contains("my_model::same_link_name"));
         EXPECT_TRUE(links.contains("your_model::same_link_name"));
+    }
+
+    TEST_F(SdfParserTest, NestedModel_CanBeIncludedFromURI_Succeeds)
+    {
+        const SdfXmlStack sdfStack = GetSdfWorldWithNestedModelWithPose();
+        ASSERT_EQ(2, sdfStack.m_stack.size());
+
+        // First create the model file in a temporary directory and setup
+        // the model URI prefixes
+        const std::string& nestedModelXml = sdfStack.m_stack.back();
+
+        constexpr AZ::IO::PathView nestedModelFilePath = "nested_test.sdf";
+        AZ::Test::ScopedAutoTempDirectory tempDirectory;
+        AZStd::optional<AZ::IO::FixedMaxPath> nestedModelFullPath =
+            AZ::Test::CreateTestFile(tempDirectory, nestedModelFilePath, AZStd::string_view(nestedModelXml.data(), nestedModelXml.size()));
+
+        // Verify the nested test SDF file has been created
+        ASSERT_TRUE(nestedModelFullPath.has_value());
+
+        // Now grab the world sdf content and use the Parse command to parse the contens
+        const auto xmlStr = sdfStack.m_stack.front();
+
+        sdf::ParserConfig sdfConfig;
+        // Add the temporary directory as a URI prefix
+        sdfConfig.AddURIPath("model://", tempDirectory.GetDirectory());
+
+        auto SdfFindCallback = [](const std::string& fileName) -> std::string
+        {
+            ADD_FAILURE() << "File " << fileName << " was not found in UnitTest.\n";
+            return std::string{};
+        };
+
+        sdfConfig.SetFindCallback(AZStd::move(SdfFindCallback));
+
+        const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, sdfConfig);
+        ASSERT_TRUE(sdfRootOutcome);
+        const auto& sdfRoot = sdfRootOutcome.GetRoot();
+        // The SDF should also have a single world
+        ASSERT_EQ(1, sdfRoot.WorldCount());
+        const auto* sdfWorld = sdfRoot.WorldByIndex(0);
+        ASSERT_NE(nullptr, sdfWorld);
+
+        // There should be model on the world that is the "top_model"
+        EXPECT_EQ(1, sdfWorld->ModelCount());
+
+        // The nested model contain the name from within
+        const auto* topModel = sdfWorld->ModelByName("top_model");
+        ASSERT_NE(nullptr, topModel);
+
+        gz::math::Pose3d modelPose = topModel->RawPose();
+        EXPECT_DOUBLE_EQ(8.0, modelPose.X());
+        EXPECT_DOUBLE_EQ(2.0, modelPose.Y());
+        EXPECT_DOUBLE_EQ(4.0, modelPose.Z());
+        EXPECT_DOUBLE_EQ(-1.564217, modelPose.Yaw());
+
+        ASSERT_EQ(1, topModel->ModelCount());
+        const auto* nestedModel = topModel->ModelByName("nested_model");
+        ASSERT_NE(nullptr, nestedModel);
+
+        // The nested model should have a link on it
+        EXPECT_TRUE(nestedModel->LinkNameExists("link"));
+        // The link name can also be looked up using the relative scoped name as well from the parent top model
+        EXPECT_TRUE(topModel->LinkNameExists("nested_model::link"));
     }
 
     TEST_F(SdfParserTest, CheckModelCorrectness)


### PR DESCRIPTION
The UnitTest also verifies the URI Prefixes are resolved by libsdformat real files.

depends on o3de/o3de#16859

### Nested Model Fixes

Updated URDFPrefabMaker to also add the parent model entities for the nested model entities.
The parent model entities of the nested models actually contains the pose information needed to translate and rotate the nested model into the correct location.