### PR TITLE
fix lidars in ROSBot prefabs

### DIFF
--- a/Gems/RosRobotSample/Assets/ROSBot_slamtec.prefab
+++ b/Gems/RosRobotSample/Assets/ROSBot_slamtec.prefab
@@ -801,24 +801,13 @@
                                     },
                                     "lidarCore": {
                                         "lidarConfiguration": {
-                                            "lidarModelName": "CustomLidar2D",
+                                            "lidarModelName": "Slamtec RPLIDAR S1",
                                             "lidarImplementation": "Scene Queries",
                                             "LidarParameters": {
-                                                "Name": "CustomLidar2D",
-                                                "Layers": 1,
-                                                "Points per layer": 924,
-                                                "Min horizontal angle": -180.0,
-                                                "Max horizontal angle": 180.0,
-                                                "Min vertical angle": 0.0,
-                                                "Max vertical angle": 0.0,
-                                                "Min range": 0.0,
-                                                "Max range": 100.0,
-                                                "Enable Noise": true,
-                                                "Noise Parameters": {
-                                                    "Angular noise standard deviation": 0.0,
-                                                    "Distance noise standard deviation base": 0.019999999552965164,
-                                                    "Distance noise standard deviation slope": 0.0010000000474974513
-                                                }
+                                                "Name": "Slamtec RPLIDAR S1",
+                                                "Points per layer": 921,
+                                                "Min range": 0.10000000149011612,
+                                                "Max range": 40.0
                                             },
                                             "IgnoredLayerIndices": [
                                                 1

--- a/Gems/RosRobotSample/Assets/ROSbot_velodyne.prefab
+++ b/Gems/RosRobotSample/Assets/ROSbot_velodyne.prefab
@@ -668,23 +668,17 @@
                                     },
                                     "lidarCore": {
                                         "lidarConfiguration": {
-                                            "lidarModelName": "CustomLidar",
+                                            "lidarModelName": "Velodyne Puck (VLP-16)",
                                             "lidarImplementation": "Scene Queries",
                                             "LidarParameters": {
-                                                "Name": "CustomLidar",
-                                                "Layers": 24,
-                                                "Points per layer": 924,
-                                                "Min horizontal angle": -180.0,
-                                                "Max horizontal angle": 180.0,
-                                                "Min vertical angle": -35.0,
-                                                "Max vertical angle": 35.0,
-                                                "Min range": 0.0,
-                                                "Max range": 100.0,
+                                                "Name": "Velodyne Puck (VLP-16)",
+                                                "Layers": 16,
+                                                "Points per layer": 1800,
+                                                "Min vertical angle": 15.0,
+                                                "Max vertical angle": -15.0,
                                                 "Enable Noise": true,
                                                 "Noise Parameters": {
-                                                    "Angular noise standard deviation": 0.0,
-                                                    "Distance noise standard deviation base": 0.009999999776482582,
-                                                    "Distance noise standard deviation slope": 0.0010000000474974513
+                                                    "Distance noise standard deviation base": 0.029999999329447746
                                                 }
                                             },
                                             "IgnoredLayerIndices": [


### PR DESCRIPTION
Lidars in `RosRobotSample` gem were set to custom instead of the defined ones. Some parameters were incorrect.

Before:
![image](https://github.com/o3de/o3de-extras/assets/134940295/57479842-6202-4612-9027-2f194c9201c7)

After:
![image](https://github.com/o3de/o3de-extras/assets/134940295/f6481750-60d5-4957-9a60-201be67c2dd7)
