### PR TITLE
RobotImporter: add Lidar2D and sdf::GPU_LIDAR support

### DIFF
--- a/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
@@ -26,9 +26,9 @@ namespace ROS2
         void Activate();
         void Deactivate();
 
-    private:
         static constexpr const char* SystemName = "Scene Queries";
 
+    private:
         // LidarSystemRequestBus overrides
         LidarId CreateLidar(AZ::EntityId lidarEntityId) override;
         void DestroyLidar(LidarId lidarId) override;

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -82,10 +82,13 @@ namespace ROS2::SDFormat
                 }
             }
 
-            AZ_Warning("ROS2LidarSensorHook", !lidarConfiguration.m_lidarSystem.empty(), "Lidar System not set.");
-            if (sdfSensor.Type() == sdf::SensorType::GPU_LIDAR)
+            if (lidarConfiguration.m_lidarSystem.empty())
             {
-                AZ_Info("ROS2LidarSensorHook", "Enable RGL Gem to import GPU Lidar.");
+                AZ_Warning("ROS2LidarSensorHook", false, "Lidar System in imported robot not set.");
+                AZ_Warning(
+                    "ROS2LidarSensorHook",
+                    sdfSensor.Type() != sdf::SensorType::GPU_LIDAR,
+                    "GPU Lidar requires RGL Gem, see https://github.com/RobotecAI/o3de-rgl-gem for more details.\n");
             }
 
             // Create required components


### PR DESCRIPTION
Previously lidar hook in robot importer was adding `ROS2LidarSensorComponent` for all lidar sensors. Now it can also add `ROS2Lidar2DSensorComponent` based on the configuration in URDF input file (number of vertical scan samples). 

It also solves the issue that was quickfixed in #587. 

This PR was tested by importing Husarion Robot with Slamtec and Velodyne Puck lidars.
