### PR TITLE
change duplicated guid in WarehouseAutomation

### DIFF
--- a/Gems/WarehouseAutomation/Code/Source/WarehouseAutomationModule.cpp
+++ b/Gems/WarehouseAutomation/Code/Source/WarehouseAutomationModule.cpp
@@ -12,7 +12,7 @@ namespace WarehouseAutomation
     class WarehouseAutomationModule : public WarehouseAutomationModuleInterface
     {
     public:
-        AZ_RTTI(WarehouseAutomationModule, "{906B71F8-374D-4F8E-B8F2-EAFEFF863F7F}", WarehouseAutomationModuleInterface);
+        AZ_RTTI(WarehouseAutomationModule, "{E7816766-0AE9-4B3E-A9EA-F80CCE35A6D5}", WarehouseAutomationModuleInterface);
         AZ_CLASS_ALLOCATOR(WarehouseAutomationModule, AZ::SystemAllocator);
     };
 } // namespace WarehouseAutomation

--- a/Gems/WarehouseAutomation/gem.json
+++ b/Gems/WarehouseAutomation/gem.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
     "origin": "RobotecAI",
-    "origin_url": "https://github.com/o3de/o3de-extras/development/Gems/WarehouseAutomation",
+    "origin_url": "https://robotec.ai",
     "type": "Code",
     "summary": "Gem for simulating an automated warehouse or factory",
     "canonical_tags": [
@@ -22,6 +22,7 @@
         "Linux"
     ],
     "icon_path": "preview.png",
+    "requirements": "This gem requires ROS 2 gem and PhysX gem.",
     "dependencies": [
         "ROS2",
         "PhysX"

--- a/Gems/WarehouseAutomation/gem.json
+++ b/Gems/WarehouseAutomation/gem.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
     "origin": "RobotecAI",
-    "origin_url": "https://robotec.ai",
+    "origin_url": "https://github.com/o3de/o3de-extras/development/Gems/WarehouseAutomation",
     "type": "Code",
     "summary": "Gem for simulating an automated warehouse or factory",
     "canonical_tags": [


### PR DESCRIPTION
There was a duplicated _guid_ in two different modules - probably a copy-paste error in the creation:

https://github.com/o3de/o3de-extras/blob/5e2a13b0f3c8b4ce07a82c409b4a70e18e4f47f8/Gems/WarehouseAutomation/Code/Source/WarehouseAutomationEditorModule.cpp#L15
https://github.com/o3de/o3de-extras/blob/5e2a13b0f3c8b4ce07a82c409b4a70e18e4f47f8/Gems/WarehouseAutomation/Code/Source/WarehouseAutomationModule.cpp#L15



 