### PR TITLE
Change spawnning of robots during import

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
@@ -34,9 +34,11 @@ namespace ROS2
         m_spawnPointsComboBox = new QComboBox(this);
         m_spawnPointsInfos = allActiveSpawnPoints.values;
 
-        for (int i = 0; i < allActiveSpawnPoints.values.size(); i++)
+        m_spawnPointsComboBox->addItem("default", QVariant(0));
+
+        for (int i = 1; i <= allActiveSpawnPoints.values.size(); i++)
         {
-            for (const auto& element : allActiveSpawnPoints.values[i])
+            for (const auto& element : allActiveSpawnPoints.values[i - 1])
             {
                 m_spawnPointsComboBox->addItem(element.first.c_str(), QVariant(i));
             }
@@ -96,8 +98,12 @@ namespace ROS2
         if (!m_spawnPointsInfos.empty())
         {
             int vectorIndex = m_spawnPointsComboBox->currentData().toInt();
+            if (vectorIndex == 0)
+            {
+                return AZStd::nullopt;
+            }
             AZStd::string mapKey(m_spawnPointsComboBox->currentText().toStdString().c_str());
-            auto& map = m_spawnPointsInfos[vectorIndex];
+            auto& map = m_spawnPointsInfos[vectorIndex - 1];
             if (auto spawnInfo = map.find(mapKey);
                 spawnInfo != map.end())
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
@@ -32,16 +32,15 @@ namespace ROS2
         SpawnerRequestsBus::BroadcastResult(allActiveSpawnPoints, &SpawnerRequestsBus::Events::GetAllSpawnPointInfos);
 
         m_spawnPointsComboBox = new QComboBox(this);
-        m_spawnPointsInfos = allActiveSpawnPoints.values;
 
-        m_spawnPointsComboBox->addItem(zeroPoint.data(), QVariant(0));
+        m_spawnPointsComboBox->addItem(tr(zeroPoint.data()));
 
-        for (int i = 0; i < allActiveSpawnPoints.values.size(); i++)
+        for (const auto& spawnPointMap : allActiveSpawnPoints.values)
         {
-            for (const auto& element : allActiveSpawnPoints.values[i])
+            for (const auto& spawnPoint : spawnPointMap)
             {
-                // The index of the element is increased by one due to the zero point having the index 0.
-                m_spawnPointsComboBox->addItem(element.first.c_str(), QVariant(i + 1));
+                m_spawnPointsComboBox->addItem(spawnPoint.first.c_str());
+                m_spawnPointsInfos.insert({ spawnPoint.first.c_str(), spawnPoint.second });
             }
         }
 
@@ -58,11 +57,11 @@ namespace ROS2
         QLabel* spawnPointListLabel;
         if (allActiveSpawnPoints.values.size() == 0)
         {
-            spawnPointListLabel = new QLabel("Select spawn position (No spawn positions were detected)", this);
+            spawnPointListLabel = new QLabel(tr("Select spawn position (No spawn positions were detected)"), this);
         }
         else
         {
-            spawnPointListLabel = new QLabel("Select spawn position", this);
+            spawnPointListLabel = new QLabel(tr("Select spawn position"), this);
         }
         layout->addWidget(spawnPointListLabel);
         layout->addWidget(m_spawnPointsComboBox);
@@ -98,14 +97,12 @@ namespace ROS2
     {
         if (!m_spawnPointsInfos.empty())
         {
-            int vectorIndex = m_spawnPointsComboBox->currentData().toInt();
             AZStd::string spawnPointName(m_spawnPointsComboBox->currentText().toStdString().c_str());
-            if (IsZeroPoint(spawnPointName, vectorIndex))
+            if (IsZeroPoint(spawnPointName))
             {
                 return AZStd::nullopt;
             }
-            auto& map = m_spawnPointsInfos[vectorIndex - 1];
-            if (auto spawnInfo = map.find(spawnPointName); spawnInfo != map.end())
+            if (auto spawnInfo = m_spawnPointsInfos.find(spawnPointName); spawnInfo != m_spawnPointsInfos.end())
             {
                 return spawnInfo->second.pose;
             }
@@ -113,8 +110,8 @@ namespace ROS2
         return AZStd::nullopt;
     }
 
-    bool PrefabMakerPage::IsZeroPoint(AZStd::string spawnPointName, int data)
+    bool PrefabMakerPage::IsZeroPoint(AZStd::string spawnPointName)
     {
-        return data == 0 && spawnPointName == PrefabMakerPage::zeroPoint;
+        return spawnPointName == PrefabMakerPage::zeroPoint;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
@@ -34,13 +34,14 @@ namespace ROS2
         m_spawnPointsComboBox = new QComboBox(this);
         m_spawnPointsInfos = allActiveSpawnPoints.values;
 
-        m_spawnPointsComboBox->addItem("default", QVariant(0));
+        m_spawnPointsComboBox->addItem(zeroPoint.data(), QVariant(0));
 
-        for (int i = 1; i <= allActiveSpawnPoints.values.size(); i++)
+        for (int i = 0; i < allActiveSpawnPoints.values.size(); i++)
         {
-            for (const auto& element : allActiveSpawnPoints.values[i - 1])
+            for (const auto& element : allActiveSpawnPoints.values[i])
             {
-                m_spawnPointsComboBox->addItem(element.first.c_str(), QVariant(i));
+                // The index of the element is increased by one due to the zero point having the index 0.
+                m_spawnPointsComboBox->addItem(element.first.c_str(), QVariant(i + 1));
             }
         }
 
@@ -98,18 +99,22 @@ namespace ROS2
         if (!m_spawnPointsInfos.empty())
         {
             int vectorIndex = m_spawnPointsComboBox->currentData().toInt();
-            if (vectorIndex == 0)
+            AZStd::string spawnPointName(m_spawnPointsComboBox->currentText().toStdString().c_str());
+            if (IsZeroPoint(spawnPointName, vectorIndex))
             {
                 return AZStd::nullopt;
             }
-            AZStd::string mapKey(m_spawnPointsComboBox->currentText().toStdString().c_str());
             auto& map = m_spawnPointsInfos[vectorIndex - 1];
-            if (auto spawnInfo = map.find(mapKey);
-                spawnInfo != map.end())
+            if (auto spawnInfo = map.find(spawnPointName); spawnInfo != map.end())
             {
                 return spawnInfo->second.pose;
             }
         }
         return AZStd::nullopt;
+    }
+
+    bool PrefabMakerPage::IsZeroPoint(AZStd::string spawnPointName, int data)
+    {
+        return data == 0 && spawnPointName == PrefabMakerPage::zeroPoint;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.h
@@ -41,6 +41,10 @@ namespace ROS2
         void onCreateButtonPressed();
 
     private:
+        static bool IsZeroPoint(AZStd::string spawnPointName, int data);
+
+        static constexpr AZStd::string_view zeroPoint = "Simulation origin";
+
         bool m_success;
         QLineEdit* m_prefabName;
         QPushButton* m_createButton;

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.h
@@ -41,7 +41,7 @@ namespace ROS2
         void onCreateButtonPressed();
 
     private:
-        static bool IsZeroPoint(AZStd::string spawnPointName, int data);
+        static bool IsZeroPoint(AZStd::string spawnPointName);
 
         static constexpr AZStd::string_view zeroPoint = "Simulation origin";
 
@@ -50,7 +50,7 @@ namespace ROS2
         QPushButton* m_createButton;
         QTextEdit* m_log;
         QComboBox* m_spawnPointsComboBox;
-        AZStd::vector<SpawnPointInfoMap> m_spawnPointsInfos;
+        SpawnPointInfoMap m_spawnPointsInfos;
         RobotImporterWidget* m_parentImporterWidget;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -354,7 +354,6 @@ namespace ROS2
         if (!linkEntityIdsWithoutParent.empty() && linkEntityIdsWithoutParent.front().IsValid())
         {
             AZ::EntityId contentEntityId = linkEntityIdsWithoutParent.front();
-            MoveEntityToDefaultSpawnPoint(contentEntityId, m_spawnPosition);
             AddRobotControl(contentEntityId);
         }
 
@@ -429,6 +428,10 @@ namespace ROS2
             auto prefabInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabPublicInterface>::Get();
             [[maybe_unused]] auto createPrefabOutcome =
                 prefabInterface->InstantiatePrefab(relativePath.String(), AZ::EntityId(), AZ::Vector3::CreateZero());
+            if (createPrefabOutcome.IsSuccess())
+            {
+                MoveEntityToDefaultSpawnPoint(createPrefabOutcome.GetValue(), m_spawnPosition);
+            }
         }
         else
         {

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerEditorComponent.cpp
@@ -62,7 +62,7 @@ namespace ROS2
 
             if (editorSpawnPoint != nullptr)
             {
-                result.insert(editorSpawnPoint->GetInfo());
+                result.insert({ GetEntity()->GetName() + " - " + editorSpawnPoint->GetInfo().first, editorSpawnPoint->GetInfo().second });
             }
         }
 

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerEditorComponent.cpp
@@ -46,7 +46,7 @@ namespace ROS2
     AZStd::unordered_map<AZStd::string, SpawnPointInfo> ROS2SpawnerEditorComponent::GetSpawnPoints() const
     {
         AZStd::unordered_map<AZStd::string, SpawnPointInfo> result;
-        result[GetEntity()->GetName() + "-default"] =
+        result[GetEntity()->GetName() + " - default"] =
             SpawnPointInfo{ "Default spawn pose defined in the Editor", m_controller.GetDefaultSpawnPose() };
 
         AZStd::vector<AZ::EntityId> children;

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerEditorComponent.cpp
@@ -45,10 +45,12 @@ namespace ROS2
 
     AZStd::unordered_map<AZStd::string, SpawnPointInfo> ROS2SpawnerEditorComponent::GetSpawnPoints() const
     {
+        AZStd::unordered_map<AZStd::string, SpawnPointInfo> result;
+        result[GetEntity()->GetName() + "-default"] =
+            SpawnPointInfo{ "Default spawn pose defined in the Editor", m_controller.GetDefaultSpawnPose() };
+
         AZStd::vector<AZ::EntityId> children;
         AZ::TransformBus::EventResult(children, m_controller.GetEditorEntityId(), &AZ::TransformBus::Events::GetChildren);
-
-        AZStd::unordered_map<AZStd::string, SpawnPointInfo> result;
 
         for (const AZ::EntityId& child : children)
         {
@@ -64,9 +66,6 @@ namespace ROS2
             }
         }
 
-        // setting name of spawn point component "default" in a child entity will have no effect since it is overwritten here with the
-        // default spawn pose of spawner
-        result["default"] = SpawnPointInfo{ "Default spawn pose defined in the Editor", m_controller.GetDefaultSpawnPose() };
         return result;
     }
 


### PR DESCRIPTION
I've modified the spawning behavior of the Robot Importer to always display the default spawn position as the first one. I've also changed the importer such that robot prefabs are moved and not the first entity during the move.

Resolves #597 