### PR TITLE
Simple API to listen for ros2 system component state change

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/ROS2Bus.h
+++ b/Gems/ROS2/Code/Include/ROS2/ROS2Bus.h
@@ -8,10 +8,11 @@
 #pragma once
 
 #include <AzCore/EBus/EBus.h>
+#include <AzCore/EBus/Event.h>
 #include <AzCore/Interface/Interface.h>
+#include <ROS2/Clock/SimulationClock.h>
 #include <builtin_interfaces/msg/time.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
-#include <ROS2/Clock/SimulationClock.h>
 #include <rclcpp/node.hpp>
 
 namespace ROS2
@@ -24,6 +25,8 @@ namespace ROS2
     class ROS2Requests
     {
     public:
+        using NodeChangedEvent = AZ::Event<std::shared_ptr<rclcpp::Node>>;
+
         AZ_RTTI(ROS2Requests, "{a9bdbff6-e644-430d-8096-cdb53c88e8fc}");
         virtual ~ROS2Requests() = default;
 
@@ -32,6 +35,12 @@ namespace ROS2
         //! @return The central ROS2 node which holds default publishers for core topics such as /clock and /tf.
         //! @note Alternatively, you can use your own node along with an executor.
         virtual std::shared_ptr<rclcpp::Node> GetNode() const = 0;
+
+        //! Attach handler to ROS2 node change events.
+        //! You can use this method to correctly initialize SystemComponents that depend on ROS2Node.
+        //! @param handler which will be connected to NodeChangedEvent.
+        //! @note callback is active as long as handler is not destroyed.
+        virtual void ConnectOnNodeChanged(NodeChangedEvent::Handler& handler) = 0;
 
         //! Acquire current time as ROS2 timestamp.
         //! Timestamps provide temporal context for messages such as sensor data.
@@ -55,7 +64,6 @@ namespace ROS2
         //! Obtains a simulation clock that is used across simulation.
         //! @returns constant reference to currently running clock.
         virtual const SimulationClock& GetSimulationClock() const = 0;
-
     };
 
     class ROS2BusTraits : public AZ::EBusTraits

--- a/Gems/ROS2/Code/Source/ROS2SystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/ROS2SystemComponent.cpp
@@ -151,6 +151,7 @@ namespace ROS2
 
         ROS2RequestBus::Handler::BusConnect();
         AZ::TickBus::Handler::BusConnect();
+        m_nodeChangedEvent.Signal(m_ros2Node);
     }
 
     void ROS2SystemComponent::Deactivate()
@@ -165,6 +166,7 @@ namespace ROS2
         m_executor.reset();
         m_simulationClock.reset();
         m_ros2Node.reset();
+        m_nodeChangedEvent.Signal(m_ros2Node);
     }
 
     builtin_interfaces::msg::Time ROS2SystemComponent::GetROSTimestamp() const
@@ -175,6 +177,11 @@ namespace ROS2
     std::shared_ptr<rclcpp::Node> ROS2SystemComponent::GetNode() const
     {
         return m_ros2Node;
+    }
+
+    void ROS2SystemComponent::ConnectOnNodeChanged(NodeChangedEvent::Handler& handler)
+    {
+        handler.Connect(m_nodeChangedEvent);
     }
 
     const SimulationClock& ROS2SystemComponent::GetSimulationClock() const

--- a/Gems/ROS2/Code/Source/ROS2SystemComponent.h
+++ b/Gems/ROS2/Code/Source/ROS2SystemComponent.h
@@ -61,6 +61,7 @@ namespace ROS2
         //////////////////////////////////////////////////////////////////////////
         // ROS2RequestBus::Handler overrides
         std::shared_ptr<rclcpp::Node> GetNode() const override;
+        void ConnectOnNodeChanged(NodeChangedEvent::Handler& handler) override;
         builtin_interfaces::msg::Time GetROSTimestamp() const override;
         void BroadcastTransform(const geometry_msgs::msg::TransformStamped& t, bool isDynamic) override;
         const SimulationClock& GetSimulationClock() const override;
@@ -90,6 +91,7 @@ namespace ROS2
         AZStd::unique_ptr<tf2_ros::TransformBroadcaster> m_dynamicTFBroadcaster;
         AZStd::unique_ptr<tf2_ros::StaticTransformBroadcaster> m_staticTFBroadcaster;
         AZStd::unique_ptr<SimulationClock> m_simulationClock;
+        NodeChangedEvent m_nodeChangedEvent;
         //! Load the pass templates of the ROS2 gem.
         void LoadPassTemplateMappings();
         AZ::RPI::PassSystemInterface::OnReadyLoadTemplatesEvent::Handler m_loadTemplatesHandler;


### PR DESCRIPTION
This PR allows SystemComponents in Editor to get ros2Node without actively querying ROS2SystemComponent for its state.

Decouples ROS2 SystemComponent state from assumptions based on external events. 
Useful when creating components that publish data originating from other system components.