### PR TITLE
OpenXR Fixes

### DIFF
--- a/Gems/OpenXRVk/Code/Include/OpenXRVk/OpenXRVkDevice.h
+++ b/Gems/OpenXRVk/Code/Include/OpenXRVk/OpenXRVkDevice.h
@@ -79,6 +79,5 @@ namespace OpenXRVk
         XrCompositionLayerProjection m_xrLayer{ XR_TYPE_COMPOSITION_LAYER_PROJECTION };
         AZStd::vector<XrCompositionLayerProjectionView> m_projectionLayerViews;
         AZStd::vector<XrView> m_views;
-        uint32_t m_viewCountOutput = 0;
     };
 }

--- a/Gems/OpenXRVk/Code/Include/OpenXRVk/OpenXRVkUtils.h
+++ b/Gems/OpenXRVk/Code/Include/OpenXRVk/OpenXRVkUtils.h
@@ -8,8 +8,10 @@
 
 #pragma once
 
+#include <AzCore/Math/Transform.h>
 #include <OpenXRVk_Platform.h>
 #include <XR/XRBase.h>
+
 
 // Macro to generate stringify functions for OpenXR enumerations based data provided in openxr_reflection.h
 #define ENUM_CASE_STR(name, val) case name: return #name;
@@ -63,4 +65,10 @@ namespace OpenXRVk
     //! Iterate through the characters while caching the starting pointer to a string
     //! and every time ' ' is encountered replace it with '\0' to indicate the end of a string.
     AZStd::vector<const char*> ParseExtensionString(char* names);
+
+    AZ::Quaternion AzQuaternionFromXrPose(const XrPosef& pose, bool convertCoordinates = true);
+    AZ::Vector3 AzPositionFromXrPose(const XrPosef& pose, bool convertCoordinates = true);
+    AZ::Transform AzTransformFromXrPose(const XrPosef& pose, bool convertCoordinates = true);
+    XrPosef XrPoseFromAzTransform(const AZ::Transform& tm, bool convertCoordinates = true);
+
 }

--- a/Gems/OpenXRVk/Code/Source/OpenXRVkInput.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkInput.cpp
@@ -402,6 +402,8 @@ namespace OpenXRVk
 
             AZ::RPI::XRSpaceNotificationBus::Broadcast(&AZ::RPI::XRSpaceNotifications::OnXRSpaceLocationsChanged,
                 baseToHeadTm, headToLeftEyeTm, headToRightEyeTm);
+
+            return true;
         }
 
         return false;

--- a/Gems/OpenXRVk/Code/Source/OpenXRVkUtils.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkUtils.cpp
@@ -74,4 +74,48 @@ namespace OpenXRVk
         }
         return list;
     }
+
+    AZ::Quaternion AzQuaternionFromXrPose(const XrPosef& pose, bool convertCoordinates)
+    {
+        if (convertCoordinates)
+        {
+            return AZ::Quaternion(pose.orientation.x, -pose.orientation.z, pose.orientation.y, pose.orientation.w);
+        }
+        return AZ::Quaternion(pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w);
+    }
+
+    AZ::Vector3 AzPositionFromXrPose(const XrPosef& pose, bool convertCoordinates)
+    {
+        return AZ::Vector3(pose.position.x,
+                           convertCoordinates ? -pose.position.z : pose.position.y,
+                           convertCoordinates ? pose.position.y : pose.position.z);
+    }
+
+    AZ::Transform AzTransformFromXrPose(const XrPosef& pose, bool convertCoordinates)
+    {
+        const auto azQuat = AzQuaternionFromXrPose(pose, convertCoordinates);
+        const auto azVec = AzPositionFromXrPose(pose, convertCoordinates);
+        AZ::Transform tm = AZ::Transform::CreateFromQuaternionAndTranslation(azQuat, azVec);
+        return tm;
+    }
+
+    XrPosef XrPoseFromAzTransform(const AZ::Transform& tm, bool convertCoordinates)
+    {
+        const auto &azQuat = tm.GetRotation();
+        const auto &azPos = tm.GetTranslation();
+        
+        XrPosef pose;
+        
+        pose.orientation.x = azQuat.GetX();
+        pose.orientation.y = convertCoordinates ? -azQuat.GetZ() : azQuat.GetY();
+        pose.orientation.z = convertCoordinates ? azQuat.GetY() : azQuat.GetZ();
+        pose.orientation.w = azQuat.GetW();
+
+        pose.position.x = azPos.GetX();
+        pose.position.y = convertCoordinates ? -azPos.GetZ() : azPos.GetY();
+        pose.position.z = convertCoordinates ?  azPos.GetY() : azPos.GetZ();
+
+        return pose; 
+    }
+
 }

--- a/Gems/OpenXRVk/Code/Source/XRCameraMovementComponent.h
+++ b/Gems/OpenXRVk/Code/Source/XRCameraMovementComponent.h
@@ -11,6 +11,7 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzFramework/Input/Events/InputChannelEventListener.h>
+#include <AzFramework/Components/CameraBus.h>
 
 
 namespace OpenXRVk
@@ -22,6 +23,7 @@ namespace OpenXRVk
         : public AZ::Component
         , public AZ::TickBus::Handler
         , public AzFramework::InputChannelEventListener
+        , public Camera::CameraNotificationBus::Handler
     {
     public:
         AZ_COMPONENT(OpenXRVk::XRCameraMovementComponent, "{7FEC0A04-D994-445C-B8DE-190D03BC3820}");
@@ -44,6 +46,9 @@ namespace OpenXRVk
         // AzFramework::InputChannelEventListener
         bool OnInputChannelEventFiltered(const AzFramework::InputChannel& inputChannel) override;
 
+        // Camera::CameraNotificationBus::Handler overrides
+        void OnActiveViewChanged(const AZ::EntityId&) override;
+
     private:
         void OnXRControllerEvent(const AzFramework::InputChannel& inputChannel);
 
@@ -54,6 +59,9 @@ namespace OpenXRVk
         // Serialized data...
         float m_moveSpeed = 20.f;
         float m_movementSensitivity = 0.025f;
+
+        // We will process XR Actions only if the entity that owns this component is the active camera. 
+        bool m_isActive = false;
     };
 
 } // namespace OpenXRVk

--- a/Gems/OpenXRVk/gem.json
+++ b/Gems/OpenXRVk/gem.json
@@ -16,5 +16,5 @@
     "dependencies": [],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/openxrvk-1.0.0-gem.zip",
-    "version": "1.0.0"
+    "version": "1.0.1"
 }

--- a/Gems/OpenXRVk/gem.json
+++ b/Gems/OpenXRVk/gem.json
@@ -6,7 +6,7 @@
     "origin": "Open 3D Engine - o3de.org",
     "origin_url": "https://github.com/o3de/o3de",
     "type": "Code",
-    "summary": "OpenXR Vulcan for Atom",
+    "summary": "OpenXR Vulkan for Atom",
     "canonical_tags": [
         "Gem"
     ],

--- a/Gems/XR/Code/Include/XR/XRSession.h
+++ b/Gems/XR/Code/Include/XR/XRSession.h
@@ -76,6 +76,9 @@ namespace XR
         //! Api to retrieve the controller space data
         virtual AZ::RHI::ResultCode GetControllerPose(AZ::u32 handIndex, AZ::RPI::PoseData& outPoseData) const = 0;
 
+        //! Same as above, but conveniently returns a transform
+        virtual AZ::RHI::ResultCode GetControllerTransform(AZ::u32 handIndex, AZ::Transform& outTransform) const = 0;
+
         //! Api to retrieve the controller space data associated with local view translated and rotated by 60 deg left or right based on handIndex
         virtual AZ::RHI::ResultCode GetControllerStagePose(AZ::u32 handIndex, AZ::RPI::PoseData& outPoseData) const = 0;
 

--- a/Gems/XR/Code/Include/XR/XRSystem.h
+++ b/Gems/XR/Code/Include/XR/XRSystem.h
@@ -71,6 +71,8 @@ namespace XR
         AZ::RHI::ResultCode GetViewLocalPose(AZ::RPI::PoseData& outPoseData) const override;
         AZ::RHI::ResultCode GetControllerStagePose(AZ::u32 handIndex, AZ::RPI::PoseData& outPoseData) const override;
         AZ::RHI::ResultCode GetControllerPose(AZ::u32 handIndex, AZ::RPI::PoseData& outPoseData) const override;
+        AZ::RHI::ResultCode GetControllerTransform(const AZ::u32 handIndex, AZ::Transform& outTransform) const override;
+
         float GetControllerScale(AZ::u32 handIndex) const override;
         bool ShouldRender() const override;
         AZ::Matrix4x4 CreateStereoscopicProjection(float angleLeft, float angleRight,

--- a/Gems/XR/Code/Source/XRSystem.cpp
+++ b/Gems/XR/Code/Source/XRSystem.cpp
@@ -254,6 +254,15 @@ namespace XR
         return AZ::RHI::ResultCode::NotReady;
     }
 
+    AZ::RHI::ResultCode System::GetControllerTransform(const AZ::u32 handIndex, AZ::Transform& outTransform) const
+    {
+        if (m_session->IsSessionRunning())
+        {
+            return m_session->GetControllerTransform(handIndex, outTransform);
+        }
+        return AZ::RHI::ResultCode::NotReady;
+    }
+
     AZ::RHI::ResultCode System::GetControllerStagePose(AZ::u32 handIndex, AZ::RPI::PoseData& outPoseData) const
     {
         if (m_session->IsSessionRunning())

--- a/Gems/XR/gem.json
+++ b/Gems/XR/gem.json
@@ -16,5 +16,5 @@
     "dependencies": [],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/xr-1.0.0-gem.zip",
-    "version": "1.0.0"
+    "version": "1.0.1"
 }

--- a/Projects/OpenXRTest/project.json
+++ b/Projects/OpenXRTest/project.json
@@ -21,7 +21,7 @@
     ],
     "restricted": "OpenXRTest",
     "gem_names": [
-        "XR",
-        "OpenXRVk"
+        "XR>=1.0.1",
+        "OpenXRVk>=1.0.1"
     ]
 }


### PR DESCRIPTION
    This PR improves XrSpaces location calculation.

    Previously, XrSpaces were being located each frame
    during OpenXRVkInput::PollActions() which was called
    before OpenXRVk::Device::BeginInternal(). The problem
    with that approach is that xrLocateSpace needs
     a "predicted display time" for the CURRENT frame.
    But the "predicted display time" is calculated during
      OpenXRVk::Device::BeginInternal(), this means that all XrPoses
      for the CURRENT frame were calculated with the "predicted
    display time" of the PREVIOUS frame. This was causing the rendered
    frames to look jittery.

    In this PR, the XrSpaces are now located during
     OpenXRVk::Device::BeginInternal() this guarantees that
     when xrLocateSpace is called it is using the correct
     "predicted display time" for the CURRENT frame. This improves
     the jitter because the camera View Srg transforms now feed the correct
     transform value for each frame improving the stability of the rendered
     views.

    Another improvement is that the Base Space used in xrLocateSpace
    is the LOCAL space instead of the hard coded VIEW space. Also APIS were
    added to change the Base Space for both Visualized spaces and Controller (Joysticks)
    spaces.

    Also the engine is now notified via AZ::RPI::XRSpaceNotificationBus::OnXRSpaceLocationsChanged
    at the right time so the engine can update the ViewSrg for each eye
    at the correct time.

    Another improvement is that the AZ::RPI::PoseData reported to the engine
    is now given according to the O3DE convention: X+ Right, Y+ forward, Z+ Up.
    Also added equivalent APIs that report the data as AZ::Transform.

    Fixed bug when the Xr Poses would be corrupted
    if the Proximity Sensor was enabled.

    Now the XrSpaces are reset each time a XR_SESSION_STATE_READY
    event is received (typically because the Proximity Sensor is disabled)