### PR TITLE
Spawnable validation

### DIFF
--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -136,8 +136,7 @@ namespace ROS2
 
         if (spawnable->second->IsLoading())
         {
-            // This check is done during the simulation. All assets in the build of the simulation are loaded and processed.
-            // This will only run when the simulation is started before all assets are processed.
+            // This is an Editor only situation. All assets during game mode are fully loaded.
             response.success = false;
             response.status_message = "Asset for spawnable " + request->name + " has not yet loaded.";
             service_handle->send_response(*header, response);
@@ -147,7 +146,7 @@ namespace ROS2
         if (spawnable->second->IsError())
         {
             response.success = false;
-            response.status_message = "Spawnable " + request->name + " loaded with an error";
+            response.status_message = "Spawnable " + request->name + " loaded with an error.";
             service_handle->send_response(*header, response);
             return;
         }

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -147,7 +147,7 @@ namespace ROS2
         if (spawnable->second->IsError())
         {
             response.success = false;
-            response.status_message = "Spawnable loaded with an error";
+            response.status_message = "Spawnable " + request->name + " loaded with an error";
             service_handle->send_response(*header, response);
             return;
         }


### PR DESCRIPTION
Depends on #611.
Resolves #136.

I've added a check before the spawning of the Entity. This checks if the asset was loaded without error and returns a negative response when the error is detected.

Additionally in the o3de/development branch, the new DPE feature shows when a spawnable is improperly loaded.
![Screenshot from 2023-11-17 11-49-55](https://github.com/o3de/o3de-extras/assets/130671280/a5f24a2a-0844-40b7-a889-6e77efe7cce7)
![Screenshot from 2023-11-17 11-50-04](https://github.com/o3de/o3de-extras/assets/130671280/261ec43b-79f5-4717-8f5a-77127b34ec24)
There is no possibility to input a non spawnable in the above menu as the field is `AZ::Data::Asset<AzFramework::Spawnable>`.