### PR TITLE
FlushIO after copying files in Robot Importer

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -431,7 +431,7 @@ namespace ROS2::Utils
                             targetPathAssetDst.c_str(),
                             outcomeMoveDst.GetResultCode());
 
-                        // call FlushIOOfAsset to ensure the asset processor is aware of the new file
+                        // call FlushIOOfAsset to ensure the asset processor is aware of the move operation.
                         FlushIOOfAsset(targetPathAssetDst);
 
                         if (outcomeMoveDst)

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -374,6 +374,14 @@ namespace ROS2::Utils
 
                 if (outcomeCopyTmp)
                 {
+                    // An I/O flush is required here because we need to load the Scene file into memory from the temporary directory
+                    // to generate a proper manifest for it in the final directory before the Scene file itself is moved into the final
+                    // directory and processed. This ensures that when the Scene file is detected by the Asset Processor in the final
+                    // location, it will already have the desired export settings in the manifest to cause it to be exported correctly.
+                    // If we didn't flush the I/O here, the Scene file load can fail because the load contains a call to 
+                    // AssetSystemComponent::GetSourceInfoBySourcePath that will fail if the Asset Processor hasn't detected the
+                    // existence of the file yet. With the flush, everything works correctly.
+
                     FlushIOOfAsset(targetPathAssetTmp);
 
                     const bool needsVisual = (assetReferenceType & ReferencedAssetType::VisualMesh) == ReferencedAssetType::VisualMesh;

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -371,8 +371,11 @@ namespace ROS2::Utils
                     resolvedPath.c_str(),
                     targetPathAssetTmp.c_str(),
                     outcomeCopyTmp.GetResultCode());
+
                 if (outcomeCopyTmp)
                 {
+                    FlushIOOfAsset(targetPathAssetTmp);
+
                     const bool needsVisual = (assetReferenceType & ReferencedAssetType::VisualMesh) == ReferencedAssetType::VisualMesh;
                     const bool needsCollider = (assetReferenceType & ReferencedAssetType::ColliderMesh) == ReferencedAssetType::ColliderMesh;
                     const bool isMeshFile = (needsVisual || needsCollider);
@@ -420,18 +423,8 @@ namespace ROS2::Utils
                             targetPathAssetDst.c_str(),
                             outcomeMoveDst.GetResultCode());
 
-                        // call GetAssetStatus_FlushIO to ensure the asset processor is aware of the new file
-                        AzFramework::AssetSystem::AssetStatus copiedAssetStatus =
-                            AzFramework::AssetSystem::AssetStatus::AssetStatus_Unknown;
-                        AzFramework::AssetSystemRequestBus::BroadcastResult(
-                            copiedAssetStatus,
-                            &AzFramework::AssetSystem::AssetSystemRequests::GetAssetStatus_FlushIO,
-                            targetPathAssetDst.c_str());
-                        AZ_Warning(
-                            "CopyAssetForURDF",
-                            copiedAssetStatus != AzFramework::AssetSystem::AssetStatus::AssetStatus_Unknown,
-                            "Asset processor did not recognize the new file %s.",
-                            targetPathAssetDst.c_str());
+                        // call FlushIOOfAsset to ensure the asset processor is aware of the new file
+                        FlushIOOfAsset(targetPathAssetDst);
 
                         if (outcomeMoveDst)
                         {
@@ -660,5 +653,19 @@ namespace ROS2::Utils
             }
         }
         return assetsFilepaths;
+    }
+
+    AzFramework::AssetSystem::AssetStatus FlushIOOfAsset(const AZ::IO::Path& path)
+    {
+        AzFramework::AssetSystem::AssetStatus assetStatus = AzFramework::AssetSystem::AssetStatus::AssetStatus_Unknown;
+        AzFramework::AssetSystemRequestBus::BroadcastResult(
+            assetStatus, &AzFramework::AssetSystem::AssetSystemRequests::GetAssetStatus_FlushIO, path.c_str());
+        AZ_Warning(
+            "CopyAssetForURDF",
+            assetStatus != AzFramework::AssetSystem::AssetStatus::AssetStatus_Unknown,
+            "Asset processor did not recognize the new file %s.",
+            path.c_str());
+
+        return assetStatus;
     }
 } // namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -17,6 +17,7 @@
 #include <AzCore/Math/Crc.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/containers/unordered_set.h>
+#include <AzFramework/Asset/AssetSystemBus.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 
 namespace ROS2
@@ -161,5 +162,10 @@ namespace ROS2::Utils
     //! @param sourceMeshAssetPath - global path to source asset used to find scene
     //! @returns list of file paths referenced in the scene
     AZStd::unordered_set<AZ::IO::Path> GetMeshTextureAssets(const AZ::IO::Path& sourceMeshAssetPath);
+
+    //! Flushes the IO of an asset to disk
+    //! @param path - path to asset to flush
+    //! @returns status of the asset after flushing
+    AzFramework::AssetSystem::AssetStatus FlushIOOfAsset(const AZ::IO::Path& path);
 
 } // namespace ROS2::Utils


### PR DESCRIPTION
Resolves #607.

I've added a flushIOOfAsset function that flushes the assets to make the copied files available to the Asset Processor before further processing. 

This addition slows down the importing process. After clicking next in the page before CheckAssetsPage the user needs to wait and the window does not reflect that anything is being done in the background (the files are being copied). I've proposed a UX change in #617.