### PR TITLE
improve ux for robot importer check assets

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
@@ -103,9 +103,7 @@ namespace ROS2
         m_table->setRowCount(rowId + 1);
 
         SetTitle();
-        AZStd::string crcStr;
-
-        crcStr = AZStd::to_string(urdfAsset.m_urdfFileCRC);
+        const AZStd::string crcStr = AZStd::to_string(urdfAsset.m_urdfFileCRC);
 
         QTableWidgetItem* p =
             createCell(true, QString::fromUtf8(urdfAsset.m_urdfPath.String().data(), urdfAsset.m_urdfPath.String().size()));

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.h
@@ -41,6 +41,12 @@ namespace ROS2
         bool isComplete() const override;
         void StartWatchAsset(AZStd::shared_ptr<Utils::UrdfAssetMap> urdfAssetMap, AZStd::shared_ptr<AZStd::mutex> urdfAssetMapMutex);
 
+    public:
+        void OnAssetCopyStatusChanged(
+            const Utils::CopyStatus& status, const AZStd::string& unresolvedFileName, const AZStd::string assetPath);
+
+        void OnAssetProcessStatusChanged(const AZStd::string& unresolvedFileName, const Utils::UrdfAsset& urdfAsset, bool isError);
+
     private:
         bool m_success;
         QTimer* m_refreshTimer{};
@@ -61,5 +67,7 @@ namespace ROS2
         QIcon m_failureIcon;
         QIcon m_okIcon;
         QIcon m_processingIcon;
+
+        int GetRowIndex(const AZStd::string& unresolvedFileName);
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/CheckAssetPage.h
@@ -14,7 +14,6 @@
 #include <AzCore/Math/Crc.h>
 #include <AzCore/std/containers/map.h>
 #include <AzCore/std/containers/vector.h>
-#include <AzCore/std/parallel/mutex.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzCore/std/string/string.h>
 #include <QLabel>
@@ -39,9 +38,7 @@ namespace ROS2
         void ClearAssetsList();
         bool IsEmpty() const;
         bool isComplete() const override;
-        void StartWatchAsset(AZStd::shared_ptr<Utils::UrdfAssetMap> urdfAssetMap, AZStd::shared_ptr<AZStd::mutex> urdfAssetMapMutex);
 
-    public:
         void OnAssetCopyStatusChanged(
             const Utils::CopyStatus& status, const AZStd::string& unresolvedFileName, const AZStd::string assetPath);
 
@@ -49,7 +46,6 @@ namespace ROS2
 
     private:
         bool m_success;
-        QTimer* m_refreshTimer{};
         QTableWidget* m_table{};
         QTableWidgetItem* createCell(bool isOk, const QString& text);
         QLabel* m_numberOfAssetLabel{};
@@ -58,12 +54,9 @@ namespace ROS2
         void SetTitle();
         AZStd::unordered_map<AZStd::string, int> m_assetsToColumnIndex; //!< Map of unresolved asset to column index in the table.
         AZStd::unordered_map<AZ::Uuid, AZStd::string> m_assetsPaths; //! Map of asset UUIDs to asset source paths.
-        AZStd::unordered_set<AZStd::string>
-            m_assetsFinished; //!< Set of asset unresolved paths that have been processed by asset processor.
         AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetMap;
-        AZStd::shared_ptr<AZStd::mutex> m_urdfAssetMapMutex;
+
         void DoubleClickRow(int row, int col);
-        void RefreshTimerElapsed();
         QIcon m_failureIcon;
         QIcon m_okIcon;
         QIcon m_processingIcon;

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -417,7 +417,7 @@ namespace ROS2
                             // Check all assets that are ready to be processed
                             CheckToProcessAssets();
                         }
-                        Utils::Remove$tmpDir(destStatus.GetValue().importDirectoryTmp);
+                        Utils::RemoveTmpDir(destStatus.GetValue().importDirectoryTmp);
 
                         if (!m_toProcessAssets.empty())
                         {

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <atomic>
 #if !defined(Q_MOC_RUN)
 #include "Pages/CheckAssetPage.h"
 #include "Pages/CheckUrdfPage.h"
@@ -59,11 +58,6 @@ namespace ROS2
         explicit RobotImporterWidget(QWidget* parent = nullptr);
         void CreatePrefab(AZStd::string prefabName);
 
-    signals:
-        void CopyStatusChanged(const Utils::CopyStatus& status, const AZStd::string& unresolvedFileName, const AZStd::string& assetPath);
-
-        void AssetProcessStatusChanged(const AZStd::string& unresolvedFileName, const Utils::UrdfAsset& urdfAsset, bool isError);
-
     private:
         int nextId() const override;
         bool validateCurrentPage() override;
@@ -108,8 +102,11 @@ namespace ROS2
 
         //! Checks all assets that are in the m_toProcessAssets set and emits signals based on results.
         void CheckToProcessAssets();
+
+        //! Checks if the asset is finished processing by asset processor. Timer callback.
         void RefreshTimerElapsed();
         QTimer* m_refreshTimerCheckAssets{};
+        //! Variable used to start the timer as the timer start function cannot be called from a different thread.
         AZStd::atomic_bool m_shouldCheckAssets{ false };
 
         //! Checks if the importedPrefabFilename is the same as focused prefab name.

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -20,6 +20,8 @@
 #include "URDF/UrdfParser.h"
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/parallel/thread.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <RobotImporter/FixURDF/URDFModifications.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
 #include <RobotImporter/xacro/XacroUtils.h>
@@ -77,6 +79,9 @@ namespace ROS2
 
         /// mapping from urdf path to asset source
         AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;
+        AZStd::shared_ptr<AZStd::mutex> m_urdfAssetsMappingMutex;
+        AZStd::shared_ptr<AZStd::thread> m_copyReferencedAssetsThread;
+
         AZStd::unique_ptr<URDFPrefabMaker> m_prefabMaker;
         Utils::AssetFilenameReferences m_assetNames;
 

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -320,7 +320,7 @@ namespace ROS2::Utils
             }
             CopyReferencedAsset(unresolvedFileName, destDirectory.GetValue(), urdfAsset, duplicatedFilenames[unresolvedFileName]);
         }
-        Utils::Remove$tmpDir(destDirectory.GetValue().importDirectoryTmp);
+        Utils::RemoveTmpDir(destDirectory.GetValue().importDirectoryTmp);
 
         return urdfAssetMap;
     }
@@ -542,7 +542,7 @@ namespace ROS2::Utils
         return AZ::Success(importedAssetsDest);
     }
 
-    AZ::Outcome<bool> Remove$tmpDir(const AZ::IO::Path $tmpDir, AZ::IO::FileIOBase* fileIO)
+    AZ::Outcome<bool> RemoveTmpDir(const AZ::IO::Path $tmpDir, AZ::IO::FileIOBase* fileIO)
     {
         AZ_Assert(fileIO, "No FileIO instance");
         const auto outcomeRemoveTmpDir = fileIO->DestroyPath($tmpDir.c_str());

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/Serialization/Json/JsonImporter.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/Utils/Utils.h>
+#include <AzCore/std/parallel/lock.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzFramework/Asset/AssetSystemBus.h>
@@ -293,181 +294,13 @@ namespace ROS2::Utils
         AZStd::string_view outputDirSuffix,
         AZ::IO::FileIOBase* fileIO)
     {
-        UrdfAssetMap urdfAssetMap;
-        if (assetFilenames.empty())
+        auto urdfAssetMap = CreateAssetMap(assetFilenames, urdfFilename, sdfBuilderSettings);
+        AZStd::mutex urdfAssetMapMutex;
+        if (urdfAssetMap.empty())
         {
             return urdfAssetMap;
         }
-
-        //! Maps the unresolved urdf path to global path
-        AZStd::unordered_map<AZStd::string, AZ::IO::Path> copiedFiles;
-
-        AZ_Assert(fileIO, "No FileIO instance");
-        AZ::Crc32 urdfFileCrc;
-        urdfFileCrc.Add(urdfFilename);
-        const AZ::IO::Path urdfPath(urdfFilename);
-
-        // By naming the temp directory '$tmp_*', the default configuration in AssetProcessorPlatformConfig.setreg will
-        // exclude these files from processing.
-        const AZStd::string directoryNameTmp = AZStd::string::format("$tmp_%u.tmp", AZ::u32(urdfFileCrc));
-        const auto directoryNameDst = AZ::IO::FixedMaxPathString::format(
-            "%u_%.*s%.*s", AZ::u32(urdfFileCrc), AZ_PATH_ARG(urdfPath.Stem()), AZ_STRING_ARG(outputDirSuffix));
-
-        const AZ::IO::Path importDirectoryTmp = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "UrdfImporter" / directoryNameTmp;
-        const AZ::IO::Path importDirectoryDst = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "UrdfImporter" / directoryNameDst;
-
-        fileIO->DestroyPath(importDirectoryTmp.c_str());
-        const auto outcomeCreateDstDir = fileIO->CreatePath(importDirectoryDst.c_str());
-        const auto outcomeCreateTmpDir = fileIO->CreatePath(importDirectoryTmp.c_str());
-        AZ_Error("CopyAssetForURDF", outcomeCreateDstDir, "Cannot create destination directory : %s", importDirectoryDst.c_str());
-        AZ_Error("CopyAssetForURDF", outcomeCreateTmpDir, "Cannot create temporary directory : %s", importDirectoryTmp.c_str());
-
-        if (!outcomeCreateDstDir || !outcomeCreateTmpDir)
-        {
-            if (outcomeCreateDstDir)
-            {
-                fileIO->DestroyPath(importDirectoryDst.c_str());
-            }
-            if (outcomeCreateTmpDir)
-            {
-                fileIO->DestroyPath(importDirectoryTmp.c_str());
-            }
-            return urdfAssetMap;
-        }
-        auto amentPrefixPath = Utils::GetAmentPrefixPath();
-        AZStd::unordered_map<AZStd::string, unsigned int> countFilenames;
-
-        for (const auto& [unresolvedFileName, assetReferenceType] : assetFilenames)
-        {
-            auto resolvedPath =
-                Utils::ResolveAssetPath(unresolvedFileName, AZ::IO::PathView(urdfFilename), amentPrefixPath, sdfBuilderSettings);
-            if (resolvedPath.empty())
-            {
-                AZ_Warning("CopyAssetForURDF", false, "There is no resolved path for %s", unresolvedFileName.c_str());
-                continue;
-            }
-
-            AZStd::string filename = resolvedPath.Filename().String();
-            auto count = countFilenames[filename]++;
-            if (count > 0)
-            {
-                AZStd::string stem = resolvedPath.Stem().String();
-                AZStd::string extension = resolvedPath.Extension().String();
-                filename = AZStd::string::format("%s_dup_%u%s", stem.c_str(), count, extension.c_str());
-            }
-
-            AZ::IO::Path targetPathAssetDst(importDirectoryDst / filename);
-            AZ::IO::Path targetPathAssetTmp(importDirectoryTmp / filename);
-
-            AZ::IO::Path targetPathAssetInfo(targetPathAssetDst.Native() + ".assetinfo");
-
-            if (!fileIO->Exists(targetPathAssetDst.c_str()))
-            {
-                // copy mesh file to temporary location ignored by AP
-                const auto outcomeCopyTmp = fileIO->Copy(resolvedPath.c_str(), targetPathAssetTmp.c_str());
-                AZ_Printf(
-                    "CopyAssetForURDF",
-                    "Copy %s to %s, result: %d",
-                    resolvedPath.c_str(),
-                    targetPathAssetTmp.c_str(),
-                    outcomeCopyTmp.GetResultCode());
-
-                if (outcomeCopyTmp)
-                {
-                    // An I/O flush is required here because we need to load the Scene file into memory from the temporary directory
-                    // to generate a proper manifest for it in the final directory before the Scene file itself is moved into the final
-                    // directory and processed. This ensures that when the Scene file is detected by the Asset Processor in the final
-                    // location, it will already have the desired export settings in the manifest to cause it to be exported correctly.
-                    // If we didn't flush the I/O here, the Scene file load can fail because the load contains a call to 
-                    // AssetSystemComponent::GetSourceInfoBySourcePath that will fail if the Asset Processor hasn't detected the
-                    // existence of the file yet. With the flush, everything works correctly.
-
-                    FlushIOOfAsset(targetPathAssetTmp);
-
-                    const bool needsVisual = (assetReferenceType & ReferencedAssetType::VisualMesh) == ReferencedAssetType::VisualMesh;
-                    const bool needsCollider = (assetReferenceType & ReferencedAssetType::ColliderMesh) == ReferencedAssetType::ColliderMesh;
-                    const bool isMeshFile = (needsVisual || needsCollider);
-
-                    // if the asset is a mesh, create asset info at destination location using the temporary mesh file
-                    const bool assetInfoOk = isMeshFile
-                        ? CreateSceneManifest(targetPathAssetTmp, targetPathAssetInfo, needsCollider, needsVisual)
-                        : true;
-
-                    if (assetInfoOk)
-                    {
-                        // copy additional assets such as textures directly to destination location
-                        if (isMeshFile)
-                        {
-                            const auto& meshTextureAssets = Utils::GetMeshTextureAssets(targetPathAssetTmp);
-                            for (const auto& unresolvedAssetPath : meshTextureAssets)
-                            {
-                                // Manifest returns local path in Project's directory temp folder
-                                const AZ::IO::Path assetLocalPath(AZ::IO::Path(AZ::IO::Path(AZ::Utils::GetProjectPath()) / unresolvedAssetPath)
-                                                                    .LexicallyRelative(importDirectoryTmp));
-
-                                const AZ::IO::Path assetFullPathSrc(AZ::IO::Path(resolvedPath.ParentPath()) / assetLocalPath);
-                                const AZ::IO::Path assetFullPathDst(importDirectoryDst / assetLocalPath);
-
-                                const auto outcomeMkdir = fileIO->CreatePath(AZ::IO::Path(assetFullPathDst.ParentPath()).c_str());
-                                if (!outcomeMkdir)
-                                {
-                                    break;
-                                }
-
-                                const auto outcomeCopy = fileIO->Copy(assetFullPathSrc.c_str(), assetFullPathDst.c_str());
-                                if (outcomeCopy)
-                                {
-                                    copiedFiles[assetFullPathSrc.String()] = assetFullPathDst.String();
-                                }
-                            }
-                        }
-
-                        // move asset file from temporary location to destination location
-                        const auto outcomeMoveDst = fileIO->Rename(targetPathAssetTmp.c_str(), targetPathAssetDst.c_str());
-                        AZ_Printf(
-                            "CopyAssetForURDF",
-                            "Rename file %s to %s, result: %d",
-                            targetPathAssetTmp.c_str(),
-                            targetPathAssetDst.c_str(),
-                            outcomeMoveDst.GetResultCode());
-
-                        // call FlushIOOfAsset to ensure the asset processor is aware of the move operation.
-                        FlushIOOfAsset(targetPathAssetDst);
-
-                        if (outcomeMoveDst)
-                        {
-                            copiedFiles[unresolvedFileName] = targetPathAssetDst.String();
-                        }
-                    }
-                }
-            }
-            else
-            {
-                AZ_Printf("CopyAssetForURDF", "File %s already exists, omitting import", targetPathAssetDst.c_str());
-                copiedFiles[unresolvedFileName] = targetPathAssetDst.String();
-            }
-
-            Utils::UrdfAsset asset;
-            asset.m_urdfPath = urdfFilename;
-            asset.m_resolvedUrdfPath =
-                Utils::ResolveAssetPath(unresolvedFileName, AZ::IO::PathView(urdfFilename), amentPrefixPath, sdfBuilderSettings);
-            asset.m_urdfFileCRC = AZ::Crc32();
-            urdfAssetMap.emplace(unresolvedFileName, AZStd::move(asset));
-        }
-
-        fileIO->DestroyPath(importDirectoryTmp.c_str());
-        for (const auto& copied : copiedFiles)
-        {
-            AZ_Printf("CopyAssetForURDF", " %s is copied to %s", copied.first.c_str(), copied.second.c_str());
-        }
-
-        // add available asset info
-        for (const auto& [unresolvedUrfFileName, sourceAssetGlobalPath] : copiedFiles)
-        {
-            AZ_Assert(
-                urdfAssetMap.contains(unresolvedUrfFileName), "urdfAssetMap should contain urdf path %s", unresolvedUrfFileName.c_str());
-            urdfAssetMap[unresolvedUrfFileName].m_availableAssetInfo = Utils::GetAvailableAssetInfo(sourceAssetGlobalPath.String());
-        }
+        CopyReferencedAssets(urdfAssetMap, urdfAssetMapMutex, urdfFilename, outputDirSuffix, fileIO);
 
         return urdfAssetMap;
     }
@@ -621,6 +454,218 @@ namespace ROS2::Utils
     bool CreateSceneManifest(const AZ::IO::Path& sourceAssetPath, const bool collider, const bool visual)
     {
         return CreateSceneManifest(sourceAssetPath, sourceAssetPath.Native() + ".assetinfo", collider, visual);
+    }
+
+    UrdfAssetMap CreateAssetMap(
+        const AssetFilenameReferences& assetFilenames, const AZStd::string& urdfFilename, const SdfAssetBuilderSettings& sdfBuilderSettings)
+    {
+        UrdfAssetMap urdfAssetMap;
+        if (assetFilenames.empty())
+        {
+            return urdfAssetMap;
+        }
+
+        auto amentPrefixPath = Utils::GetAmentPrefixPath();
+        for (const auto& [unresolvedFileName, assetReferenceType] : assetFilenames)
+        {
+            Utils::UrdfAsset asset;
+            asset.m_urdfPath = unresolvedFileName;
+            asset.m_resolvedUrdfPath =
+                Utils::ResolveAssetPath(unresolvedFileName, AZ::IO::PathView(urdfFilename), amentPrefixPath, sdfBuilderSettings);
+            asset.m_urdfFileCRC = AZ::Crc32();
+            asset.m_assetReferenceType = assetReferenceType;
+            asset.m_unresolvedFileName = unresolvedFileName;
+            urdfAssetMap.emplace(unresolvedFileName, AZStd::move(asset));
+        }
+
+        return urdfAssetMap;
+    }
+
+    bool CopyReferencedAssets(
+        UrdfAssetMap& urdfAssetMap,
+        AZStd::mutex& urdfAssetMapMutex,
+        const AZStd::string& urdfFilename,
+        AZStd::string_view outputDirSuffix,
+        AZ::IO::FileIOBase* fileIO)
+    {
+        AZ_Assert(fileIO, "No FileIO instance");
+        AZ::Crc32 urdfFileCrc;
+        urdfFileCrc.Add(urdfFilename);
+        const AZ::IO::Path urdfPath(urdfFilename);
+
+        // By naming the temp directory '$tmp_*', the default configuration in AssetProcessorPlatformConfig.setreg will
+        // exclude these files from processing.
+        const AZStd::string directoryNameTmp = AZStd::string::format("$tmp_%u.tmp", AZ::u32(urdfFileCrc));
+        const auto directoryNameDst = AZ::IO::FixedMaxPathString::format(
+            "%u_%.*s%.*s", AZ::u32(urdfFileCrc), AZ_PATH_ARG(urdfPath.Stem()), AZ_STRING_ARG(outputDirSuffix));
+
+        const AZ::IO::Path importDirectoryTmp = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "UrdfImporter" / directoryNameTmp;
+        const AZ::IO::Path importDirectoryDst = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "UrdfImporter" / directoryNameDst;
+
+        fileIO->DestroyPath(importDirectoryTmp.c_str());
+        const auto outcomeCreateDstDir = fileIO->CreatePath(importDirectoryDst.c_str());
+        const auto outcomeCreateTmpDir = fileIO->CreatePath(importDirectoryTmp.c_str());
+        AZ_Error("CopyAssetForURDF", outcomeCreateDstDir, "Cannot create destination directory : %s", importDirectoryDst.c_str());
+        AZ_Error("CopyAssetForURDF", outcomeCreateTmpDir, "Cannot create temporary directory : %s", importDirectoryTmp.c_str());
+
+        if (!outcomeCreateDstDir || !outcomeCreateTmpDir)
+        {
+            if (outcomeCreateDstDir)
+            {
+                fileIO->DestroyPath(importDirectoryDst.c_str());
+            }
+            if (outcomeCreateTmpDir)
+            {
+                fileIO->DestroyPath(importDirectoryTmp.c_str());
+            }
+            return false;
+        }
+
+        AZStd::unordered_map<AZStd::string, unsigned int> countFilenames;
+        for (auto& [unresolvedFileName, urdfAsset] : urdfAssetMap)
+        {
+            if (urdfAsset.m_resolvedUrdfPath.empty())
+            {
+                AZ_Warning("CopyAssetForURDF", false, "There is no resolved path for %s", unresolvedFileName.c_str());
+                {
+                    AZStd::lock_guard<AZStd::mutex> lock(urdfAssetMapMutex);
+                    urdfAsset.m_copyStatus = CopyStatus::Unresolvable;
+                }
+                continue;
+            }
+
+            AZStd::string filename = urdfAsset.m_resolvedUrdfPath.Filename().String();
+            auto count = countFilenames[filename]++;
+            if (count > 0)
+            {
+                AZStd::string stem = urdfAsset.m_resolvedUrdfPath.Stem().String();
+                AZStd::string extension = urdfAsset.m_resolvedUrdfPath.Extension().String();
+                filename = AZStd::string::format("%s_dup_%u%s", stem.c_str(), count, extension.c_str());
+            }
+
+            AZ::IO::Path targetPathAssetDst(importDirectoryDst / filename);
+            AZ::IO::Path targetPathAssetTmp(importDirectoryTmp / filename);
+
+            AZ::IO::Path targetPathAssetInfo(targetPathAssetDst.Native() + ".assetinfo");
+
+            bool targetAssetExists = fileIO->Exists(targetPathAssetDst.c_str());
+            if (!targetAssetExists)
+            {
+                {
+                    AZStd::lock_guard<AZStd::mutex> lock(urdfAssetMapMutex);
+                    urdfAsset.m_copyStatus = CopyStatus::Copying;
+                }
+                // copy mesh file to temporary location ignored by AP
+                const auto outcomeCopyTmp = fileIO->Copy(urdfAsset.m_resolvedUrdfPath.c_str(), targetPathAssetTmp.c_str());
+                AZ_Printf(
+                    "CopyAssetForURDF",
+                    "Copy %s to %s, result: %d",
+                    urdfAsset.m_resolvedUrdfPath.c_str(),
+                    targetPathAssetTmp.c_str(),
+                    outcomeCopyTmp.GetResultCode());
+
+                if (outcomeCopyTmp)
+                {
+                    // call FlushIOOfAsset to ensure the asset processor is aware of the new file
+                    FlushIOOfAsset(targetPathAssetTmp);
+
+                    const bool needsVisual =
+                        (urdfAsset.m_assetReferenceType & ReferencedAssetType::VisualMesh) == ReferencedAssetType::VisualMesh;
+                    const bool needsCollider =
+                        (urdfAsset.m_assetReferenceType & ReferencedAssetType::ColliderMesh) == ReferencedAssetType::ColliderMesh;
+                    const bool isMeshFile = (needsVisual || needsCollider);
+
+                    // if the asset is a mesh, create asset info at destination location using the temporary mesh file
+                    const bool assetInfoOk =
+                        isMeshFile ? CreateSceneManifest(targetPathAssetTmp, targetPathAssetInfo, needsCollider, needsVisual) : true;
+
+                    if (assetInfoOk)
+                    {
+                        // copy additional assets such as textures directly to destination location
+                        if (isMeshFile)
+                        {
+                            const auto& meshTextureAssets = Utils::GetMeshTextureAssets(targetPathAssetTmp);
+                            for (const auto& unresolvedAssetPath : meshTextureAssets)
+                            {
+                                // Manifest returns local path in Project's directory temp folder
+                                const AZ::IO::Path assetLocalPath(
+                                    AZ::IO::Path(AZ::IO::Path(AZ::Utils::GetProjectPath()) / unresolvedAssetPath)
+                                        .LexicallyRelative(importDirectoryTmp));
+
+                                const AZ::IO::Path assetFullPathSrc(
+                                    AZ::IO::Path(urdfAsset.m_resolvedUrdfPath.ParentPath()) / assetLocalPath);
+                                const AZ::IO::Path assetFullPathDst(importDirectoryDst / assetLocalPath);
+
+                                const auto outcomeMkdir = fileIO->CreatePath(AZ::IO::Path(assetFullPathDst.ParentPath()).c_str());
+                                if (!outcomeMkdir)
+                                {
+                                    break;
+                                }
+
+                                const auto outcomeCopy = fileIO->Copy(assetFullPathSrc.c_str(), assetFullPathDst.c_str());
+                                if (!outcomeCopy)
+                                {
+                                    AZStd::lock_guard<AZStd::mutex> lock(urdfAssetMapMutex);
+                                    urdfAsset.m_copyStatus = CopyStatus::Failed;
+                                }
+                            }
+                        }
+
+                        // move asset file from temporary location to destination location
+                        const auto outcomeMoveDst = fileIO->Rename(targetPathAssetTmp.c_str(), targetPathAssetDst.c_str());
+                        AZ_Printf(
+                            "CopyAssetForURDF",
+                            "Rename file %s to %s, result: %d",
+                            targetPathAssetTmp.c_str(),
+                            targetPathAssetDst.c_str(),
+                            outcomeMoveDst.GetResultCode());
+
+                        // call FlushIOOfAsset to ensure the asset processor is aware of the new file
+                        FlushIOOfAsset(targetPathAssetDst);
+
+                        if (!outcomeMoveDst)
+                        {
+                            AZStd::lock_guard<AZStd::mutex> lock(urdfAssetMapMutex);
+                            urdfAsset.m_copyStatus = CopyStatus::Failed;
+                        }
+                        else
+                        {
+                            AZStd::lock_guard<AZStd::mutex> lock(urdfAssetMapMutex);
+                            urdfAsset.m_copyStatus = CopyStatus::Copied;
+                        }
+                    }
+                }
+                else
+                {
+                    {
+                        AZStd::lock_guard<AZStd::mutex> lock(urdfAssetMapMutex);
+                        urdfAsset.m_copyStatus = CopyStatus::Failed;
+                    }
+                }
+            }
+            else
+            {
+                AZ_Printf("CopyAssetForURDF", "File %s already exists, omitting import", targetPathAssetDst.c_str());
+                {
+                    AZStd::lock_guard<AZStd::mutex> lock(urdfAssetMapMutex);
+                    urdfAsset.m_copyStatus = CopyStatus::Exists;
+                }
+            }
+            {
+                AZStd::lock_guard<AZStd::mutex> lock(urdfAssetMapMutex);
+                if (urdfAsset.m_copyStatus == CopyStatus::Exists || urdfAsset.m_copyStatus == CopyStatus::Copied)
+                {
+                    urdfAsset.m_copyStatus = targetAssetExists ? CopyStatus::Exists : CopyStatus::Copied;
+                    urdfAsset.m_availableAssetInfo = Utils::GetAvailableAssetInfo(targetPathAssetDst.String());
+                }
+                urdfAsset.m_urdfPath = urdfFilename;
+                urdfAsset.m_urdfFileCRC = AZ::Crc32();
+            }
+        }
+
+        fileIO->DestroyPath(importDirectoryTmp.c_str());
+
+        return true;
     }
 
     AZStd::unordered_set<AZ::IO::Path> GetMeshTextureAssets(const AZ::IO::Path& sourceMeshAssetPath)

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -46,6 +46,16 @@ namespace ROS2::Utils
         AZ::Uuid m_sourceGuid = AZ::Uuid::CreateNull();
     };
 
+    //! Bitfield containing the types of asset references are associated with a given unresolved URI or path reference.
+    //! These are flags because the same mesh URI can refer to both a Visual and a Collider entry, for example.
+    enum class ReferencedAssetType
+    {
+        VisualMesh = 0b00000001, //! URI references a mesh for a Visual entry
+        ColliderMesh = 0b00000010, //! URI references a mesh for a Collider entry
+        Texture = 0b00000100, //! URI references one of a multitude of texture types (Diffuse, Normal, AO, etc)
+    };
+    AZ_DEFINE_ENUM_BITWISE_OPERATORS(ReferencedAssetType);
+
     //! Status of the copy process.
     enum CopyStatus
     {
@@ -56,16 +66,6 @@ namespace ROS2::Utils
         Exists, //! Already exists
         Failed, //! Failed
     };
-
-    //! Bitfield containing the types of asset references are associated with a given unresolved URI or path reference.
-    //! These are flags because the same mesh URI can refer to both a Visual and a Collider entry, for example.
-    enum class ReferencedAssetType
-    {
-        VisualMesh = 0b00000001, //! URI references a mesh for a Visual entry
-        ColliderMesh = 0b00000010, //! URI references a mesh for a Collider entry
-        Texture = 0b00000100, //! URI references one of a multitude of texture types (Diffuse, Normal, AO, etc)
-    };
-    AZ_DEFINE_ENUM_BITWISE_OPERATORS(ReferencedAssetType);
 
     //! The structure contains a mapping between URDF's path to O3DE asset information.
     struct UrdfAsset

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -14,7 +14,6 @@
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/Path/Path.h>
-#include <AzCore/IO/Path/Path_fwd.h>
 #include <AzCore/Math/Crc.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/containers/unordered_set.h>
@@ -228,7 +227,7 @@ namespace ROS2::Utils
     //! @param tmpDir - path to temporary directory
     //! @param fileIO - instance to fileIO class
     //! @returns true if succeed
-    AZ::Outcome<bool> Remove$tmpDir(const AZ::IO::Path $tmpDir, AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
+    AZ::Outcome<bool> RemoveTmpDir(const AZ::IO::Path $tmpDir, AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 
     //! Creates a list of files referenced in an asset (e.g. materials)
     //! @param sourceMeshAssetPath - global path to source asset used to find scene

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -18,7 +18,6 @@
 #include <AzCore/Math/Crc.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/containers/unordered_set.h>
-#include <AzCore/std/parallel/mutex.h>
 #include <AzFramework/Asset/AssetSystemBus.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 
@@ -200,14 +199,14 @@ namespace ROS2::Utils
         const AZStd::string& urdfFilename,
         const SdfAssetBuilderSettings& sdfBuilderSettings);
 
-    //! Copies and prepares assets that are referenced in SDF/URDF.
-    //! Modifies urdfAssetMap in place.
-    //! @param urdfAssetMap - mapping from unresolved urdf paths to source asset info
-    //! @param urdfAssetMapMutex - mutex to protect changes done to urdfAssetMap from other threads
-    //! @param urdfFilename - path to URDF file (as a global path)
-    //! @param outputDirSuffix - suffix to make output directory unique, if xacro file was used
+    //! Copies and prepares asset that is referenced in SDF/URDF.
+    //! Modifies urdfAsset in place.
+    //! @param unresolvedFileName - unresolved urdf path to asset
+    //! @param importedAssetsDest - destination ImportedAssetsDest for imported assets.
+    //! @param urdfAsset - asset info. Will be modified.
+    //! @param duplicationCounter - number indication the number of times the asset has been duplicated
     //! @param fileIO - instance to fileIO class
-    //! @returns true if succeed
+    //! @returns status of the copy process
     CopyStatus CopyReferencedAsset(
         const AZ::IO::Path& unresolvedFileName,
         const ImportedAssetsDest& importedAssetsDest,
@@ -215,11 +214,20 @@ namespace ROS2::Utils
         unsigned int duplicationCounter,
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 
+    //! Prepares temporary and final directory for imported assets.
+    //! @param urdfFilename - path to URDF file (as a global path)
+    //! @param outputDirSuffix - name of the output directory
+    //! @param fileIO - instance to fileIO class
+    //! @returns structure containing paths to temporary and final directory for imported assets, or failure if failed to create.
     AZ::Outcome<ImportedAssetsDest> PrepareImportedAssetsDest(
         const AZStd::string& urdfFilename,
         AZStd::string_view outputDirSuffix = "",
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 
+    //! Remove temporary directory for imported assets.
+    //! @param tmpDir - path to temporary directory
+    //! @param fileIO - instance to fileIO class
+    //! @returns true if succeed
     AZ::Outcome<bool> Remove$tmpDir(const AZ::IO::Path $tmpDir, AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 
     //! Creates a list of files referenced in an asset (e.g. materials)

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -92,6 +92,16 @@ namespace ROS2::Utils
         AvailableAsset m_availableAssetInfo;
     };
 
+    //! Structure contains paths to the temporary and destination directories for imported assets.
+    struct ImportedAssetsDest
+    {
+        //! Temporary directory for imported assets.
+        AZ::IO::Path importDirectoryTmp;
+
+        //! Destination directory for imported assets.
+        AZ::IO::Path importDirectoryDst;
+    };
+
     //! Maps unresolved URI asset references to the type of reference(s) - mesh, texture, etc.
     using AssetFilenameReferences = AZStd::unordered_map<AZStd::string, ReferencedAssetType>;
 
@@ -198,12 +208,19 @@ namespace ROS2::Utils
     //! @param outputDirSuffix - suffix to make output directory unique, if xacro file was used
     //! @param fileIO - instance to fileIO class
     //! @returns true if succeed
-    bool CopyReferencedAssets(
-        UrdfAssetMap& urdfAssetMap,
-        AZStd::mutex& urdfAssetMapMutex,
+    CopyStatus CopyReferencedAsset(
+        const AZ::IO::Path& unresolvedFileName,
+        const ImportedAssetsDest& importedAssetsDest,
+        Utils::UrdfAsset& urdfAsset,
+        unsigned int duplicationCounter,
+        AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
+
+    AZ::Outcome<ImportedAssetsDest> PrepareImportedAssetsDest(
         const AZStd::string& urdfFilename,
         AZStd::string_view outputDirSuffix = "",
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
+
+    AZ::Outcome<bool> Remove$tmpDir(const AZ::IO::Path $tmpDir, AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 
     //! Creates a list of files referenced in an asset (e.g. materials)
     //! @param sourceMeshAssetPath - global path to source asset used to find scene


### PR DESCRIPTION
This PR depends on #616.
Resolves #617.

This PR improves the UX of the robot importer, by creating a separate thread for copying files. 
Usage example:

https://github.com/o3de/o3de-extras/assets/130671280/a53e20f8-ea45-43ef-b721-226621960d84
