### PR TITLE
Add delete entity service

### DIFF
--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.h
@@ -16,6 +16,7 @@
 #include <AzFramework/Components/ComponentAdapter.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+#include <gazebo_msgs/srv/delete_entity.hpp>
 #include <gazebo_msgs/srv/get_model_state.hpp>
 #include <gazebo_msgs/srv/get_world_properties.hpp>
 #include <gazebo_msgs/srv/spawn_entity.hpp>
@@ -28,6 +29,9 @@ namespace ROS2
     using SpawnEntityRequest = std::shared_ptr<gazebo_msgs::srv::SpawnEntity::Request>;
     using SpawnEntityResponse = gazebo_msgs::srv::SpawnEntity::Response;
     using SpawnEntityServiceHandle = std::shared_ptr<rclcpp::Service<gazebo_msgs::srv::SpawnEntity>>;
+    using DeleteEntityRequest = std::shared_ptr<gazebo_msgs::srv::DeleteEntity::Request>;
+    using DeleteEntityServiceHandle = std::shared_ptr<rclcpp::Service<gazebo_msgs::srv::DeleteEntity>>;
+    using DeleteEntityResponse = gazebo_msgs::srv::DeleteEntity::Response;
     using GetSpawnPointInfoRequest = std::shared_ptr<gazebo_msgs::srv::GetModelState::Request>;
     using GetSpawnPointInfoResponse = std::shared_ptr<gazebo_msgs::srv::GetModelState::Response>;
     using GetSpawnPointsNamesRequest = std::shared_ptr<gazebo_msgs::srv::GetWorldProperties::Request>;
@@ -59,6 +63,7 @@ namespace ROS2
         rclcpp::Service<gazebo_msgs::srv::GetWorldProperties>::SharedPtr m_getSpawnablesNamesService;
         rclcpp::Service<gazebo_msgs::srv::GetWorldProperties>::SharedPtr m_getSpawnPointsNamesService;
         rclcpp::Service<gazebo_msgs::srv::SpawnEntity>::SharedPtr m_spawnService;
+        rclcpp::Service<gazebo_msgs::srv::DeleteEntity>::SharedPtr m_deleteService;
         rclcpp::Service<gazebo_msgs::srv::GetModelState>::SharedPtr m_getSpawnPointInfoService;
 
         void GetAvailableSpawnableNames(const GetAvailableSpawnableNamesRequest request, GetAvailableSpawnableNamesResponse response);
@@ -73,6 +78,9 @@ namespace ROS2
             const AZ::Transform&,
             const AZStd::string& spawnableName,
             const AZStd::string& spawnableNamespace);
+
+        void DeleteEntity(
+            const DeleteEntityServiceHandle service_handle, const std::shared_ptr<rmw_request_id_t> header, DeleteEntityRequest request);
 
         void GetSpawnPointsNames(const GetSpawnPointsNamesRequest request, GetSpawnPointsNamesResponse response);
         void GetSpawnPointInfo(const GetSpawnPointInfoRequest request, GetSpawnPointInfoResponse response);


### PR DESCRIPTION
I've added a service that allows to despawn a spawned entity.

I've modified the `spawn_entity` service to include the name of the ticket (this will become the name of the robot used to remove it later) in the `status_message`.

By calling the `gazebo_msgs/srv/DeleteEntity` service with the `name` parameter set to the response of the spawn service the entity will be deleted.

Resolves #618 