### PR TITLE
Fix GNSSTest after changes in #604

### DIFF
--- a/Gems/ROS2/Code/Source/Georeference/GNSSFormatConversions.h
+++ b/Gems/ROS2/Code/Source/Georeference/GNSSFormatConversions.h
@@ -7,8 +7,8 @@
  */
 
 #pragma once
-#include <ROS2/Georeference/GeoreferenceStructures.h>
 #include <AzCore/Math/Matrix4x4.h>
+#include <ROS2/Georeference/GeoreferenceStructures.h>
 
 namespace ROS2::Utils::GeodeticConversions
 {
@@ -32,7 +32,7 @@ namespace ROS2::Utils::GeodeticConversions
     //! @param referenceLatitudeLongitudeAltitude - reference point's latitude, longitude and altitude as WGS::WGS84Coordinate.
     //! @param ENUPoint - ENU point to bo converted.
     //! @return 3d vector of ECEF coordinates.
-    WGS::Vector3d ENUToECEF(const WGS::WGS84Coordinate& referenceLatitudeLongitudeAltitude, const  WGS::Vector3d& ENUPoint);
+    WGS::Vector3d ENUToECEF(const WGS::WGS84Coordinate& referenceLatitudeLongitudeAltitude, const WGS::Vector3d& ENUPoint);
 
     //! Converts point in Earth Centred Earth Fixed (ECEF) to  984 World Geodetic System (GS84)
     //! @param ECEFPoint - ECEF point to bo converted.
@@ -40,4 +40,4 @@ namespace ROS2::Utils::GeodeticConversions
     //!     latitude and longitude are in decimal degrees
     //!     altitude is in meters
     WGS::WGS84Coordinate ECEFToWGS84(const WGS::Vector3d& ECFEPoint);
-} // namespace ROS2::GNSS
+} // namespace ROS2::Utils::GeodeticConversions

--- a/Gems/ROS2/Code/Tests/GNSSTest.cpp
+++ b/Gems/ROS2/Code/Tests/GNSSTest.cpp
@@ -31,7 +31,7 @@ namespace UnitTest
         };
         for (const auto& [input, goldResult] : inputGoldSet)
         {
-            const auto result = ROS2::GNSS::WGS84ToECEF(input);
+            const auto result = ROS2::Utils::GeodeticConversions::WGS84ToECEF(input);
             EXPECT_NEAR(result.m_x, goldResult.m_x, OneMillimiter);
             EXPECT_NEAR(result.m_y, goldResult.m_y, OneMillimiter);
             EXPECT_NEAR(result.m_z, goldResult.m_z, OneMillimiter);
@@ -52,7 +52,7 @@ namespace UnitTest
         };
         for (const auto& [input, refWGS84, goldResult] : inputGoldSet)
         {
-            const auto result = ROS2::GNSS::ECEFToENU(refWGS84, input);
+            const auto result = ROS2::Utils::GeodeticConversions::ECEFToENU(refWGS84, input);
             EXPECT_NEAR(result.m_x, goldResult.m_x, OneMillimiter);
             EXPECT_NEAR(result.m_y, goldResult.m_y, OneMillimiter);
             EXPECT_NEAR(result.m_z, goldResult.m_z, OneMillimiter);
@@ -73,7 +73,7 @@ namespace UnitTest
         };
         for (const auto& [input, refWGS84, goldResult] : inputGoldSet)
         {
-            const auto result = ROS2::GNSS::ENUToECEF(refWGS84, input);
+            const auto result = ROS2::Utils::GeodeticConversions::ENUToECEF(refWGS84, input);
             EXPECT_NEAR(result.m_x, goldResult.m_x, OneMillimiter);
             EXPECT_NEAR(result.m_y, goldResult.m_y, OneMillimiter);
             EXPECT_NEAR(result.m_z, goldResult.m_z, OneMillimiter);
@@ -90,7 +90,7 @@ namespace UnitTest
         };
         for (const auto& [input, goldResult] : inputGoldSet)
         {
-            const auto result = ROS2::GNSS::ECEFToWGS84(input);
+            const auto result = ROS2::Utils::GeodeticConversions::ECEFToWGS84(input);
             EXPECT_NEAR(result.m_longitude, goldResult.m_longitude, OneMillimeterInDegreesOnEquator);
             EXPECT_NEAR(result.m_latitude, goldResult.m_latitude, OneMillimeterInDegreesOnEquator);
             EXPECT_NEAR(result.m_altitude, goldResult.m_altitude, OneMillimiter);


### PR DESCRIPTION
Changes in namespaces `GNSS` -> `Utils::GeodeticConversions` in #604 caused some errors while building tests, this PR fixes it.