### PR TITLE
Fix for serialization of PID parameters

### DIFF
--- a/Gems/ROS2/Code/Source/Utilities/Controllers/PidConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Utilities/Controllers/PidConfiguration.cpp
@@ -30,7 +30,7 @@ namespace ROS2::Controllers
             if (AZ::EditContext* ec = serializeContext->GetEditContext())
             {
                 ec->Class<PidConfiguration>("PID configuration", "Configures a PID controller")
-                    ->DataElement(1, &PidConfiguration::m_p, "P", "Proportional gain")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &PidConfiguration::m_p, "P", "Proportional gain")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &PidConfiguration::m_i, "I", "Integral gain")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0)


### PR DESCRIPTION
`P` was not enabled in the editor component

![Screenshot from 2023-12-18 09-28-21](https://github.com/o3de/o3de-extras/assets/31925544/722da121-213a-4c05-b065-4b6a45d67c0f)
