### PR TITLE
Fix rclcpp SIGINT & SIGTERM handling

### DIFF
--- a/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
@@ -105,7 +105,7 @@ namespace ROS2
         // handle signals, e.g. via `Ctrl+C` hotkey or `kill` command 
         auto handler = [](int sig){
             rclcpp::shutdown(); // shutdown rclcpp
-            std::raise(SIGINT); // shutdown o3de
+            std::raise(sig); // shutdown o3de
             };
         signal(SIGINT, handler);
         signal(SIGTERM, handler);

--- a/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
@@ -102,11 +102,13 @@ namespace ROS2
     {
         rclcpp::init(0, 0);
         
-        // handle sigint, e.g. via Ctrl+C
-        signal(SIGINT, [](int sig){
+        // handle signals, e.g. via `Ctrl+C` hotkey or `kill` command 
+        auto handler = [](int sig){
             rclcpp::shutdown(); // shutdown rclcpp
             std::raise(SIGINT); // shutdown o3de
-            });
+            };
+        signal(SIGINT, handler);
+        signal(SIGTERM, handler);
     }
 
     void ROS2SystemComponent::InitClock()

--- a/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <signal.h>
+
 #include "ROS2SystemComponent.h"
 #include <Lidar/LidarCore.h>
 #include <ROS2/Clock/PhysicallyStableClock.h>
@@ -99,6 +101,12 @@ namespace ROS2
     void ROS2SystemComponent::Init()
     {
         rclcpp::init(0, 0);
+        
+        // handle sigint, e.g. via Ctrl+C
+        signal(SIGINT, [](int sig){
+            rclcpp::shutdown(); // shutdown rclcpp
+            std::raise(SIGINT); // shutdown o3de
+            });
     }
 
     void ROS2SystemComponent::InitClock()


### PR DESCRIPTION
Fixes SIGINT & SIGTERM handling to adequately shut down o3de processes that host an rclcpp instance, especially to fix process termination via `CTRL+C` keyboard command

Cf. https://github.com/ros2/rclcpp/issues/317#issuecomment-380318892