### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## What does this PR do?
+
+_Please describe your PR. For a bug fix, what was the old behavior, what is the new behavior?_
+
+_Please add links to any issues, RFCs or other items that are relevant to this PR._
+
+## How was this PR tested?
+
+_Please describe any testing performed._


### PR DESCRIPTION
This pull request adds a Github `pull request template` that will suggest the provision of some minimal description of the changes to the users. The template is copied from [main o3de repository](https://github.com/o3de/o3de/blob/development/.github/pull_request_template.md)

The `issue template` was added (fixed) earlier in https://github.com/o3de/o3de-extras/pull/579