### PR TITLE
Update RobotImporter wizard

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedURDFWindow.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedURDFWindow.cpp
@@ -6,14 +6,14 @@
  *
  */
 
-#include "ModifiedUrdfWindow.h"
+#include "ModifiedURDFWindow.h"
 #include <AzCore/Utils/Utils.h>
 #include <QCloseEvent>
 #include <QVBoxLayout>
 
 namespace ROS2
 {
-    ModifiedUrdfWindow::ModifiedUrdfWindow()
+    ModifiedURDFWindow::ModifiedURDFWindow()
     {
         m_log = new QTextEdit();
         m_log->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
@@ -25,19 +25,19 @@ namespace ROS2
         this->setLayout(layout);
     }
 
-    void ModifiedUrdfWindow::closeEvent([[maybe_unused]] QCloseEvent* event)
+    void ModifiedURDFWindow::closeEvent([[maybe_unused]] QCloseEvent* event)
     {
         event->ignore();
         this->hide();
     }
 
-    void ModifiedUrdfWindow::SetUrdfData(const std::string& urdf)
+    void ModifiedURDFWindow::SetUrdfData(const std::string& urdf)
     {
         m_urdf = AZStd::move(urdf);
         m_log->setText(QString::fromStdString(m_urdf));
     }
 
-    const std::string& ModifiedUrdfWindow::GetUrdfData() const
+    const std::string& ModifiedURDFWindow::GetUrdfData() const
     {
         return m_urdf;
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedURDFWindow.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedURDFWindow.cpp
@@ -31,8 +31,14 @@ namespace ROS2
         this->hide();
     }
 
-    void ModifiedURDFWindow::SetUrdfData(const QString& urdf)
+    void ModifiedURDFWindow::SetUrdfData(const std::string& urdf)
     {
-        m_log->setText(urdf);
+        m_urdf = AZStd::move(urdf);
+        m_log->setText(QString::fromStdString(m_urdf));
+    }
+
+    const std::string& ModifiedURDFWindow::GetUrdfData() const
+    {
+        return m_urdf;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedURDFWindow.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedURDFWindow.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ModifiedURDFWindow.h"
+#include <AzCore/Utils/Utils.h>
+#include <QCloseEvent>
+#include <QVBoxLayout>
+
+namespace ROS2
+{
+    ModifiedURDFWindow::ModifiedURDFWindow()
+    {
+        m_log = new QTextEdit();
+        m_log->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+        setWindowTitle(tr("Modified URDF data"));
+        QVBoxLayout* layout = new QVBoxLayout;
+        layout->addWidget(m_log);
+        m_log->acceptRichText();
+        m_log->setReadOnly(true);
+        this->setLayout(layout);
+    }
+
+    void ModifiedURDFWindow::closeEvent([[maybe_unused]] QCloseEvent* event)
+    {
+        event->ignore();
+        this->hide();
+    }
+
+    void ModifiedURDFWindow::SetUrdfData(const QString& urdf)
+    {
+        m_log->setText(urdf);
+    }
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedURDFWindow.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedURDFWindow.h
@@ -20,11 +20,11 @@
 
 namespace ROS2
 {
-    class ModifiedUrdfWindow : public QWidget
+    class ModifiedURDFWindow : public QWidget
     {
         Q_OBJECT
     public:
-        ModifiedUrdfWindow();
+        ModifiedURDFWindow();
         const std::string& GetUrdfData() const;
         void SetUrdfData(const std::string& urdf);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedURDFWindow.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedURDFWindow.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <QLabel>
+#include <QPushButton>
+#include <QString>
+#include <QTextEdit>
+#include <QWindow>
+#endif
+
+namespace ROS2
+{
+    class ModifiedURDFWindow : public QWidget
+    {
+        Q_OBJECT
+    public:
+        ModifiedURDFWindow();
+        void SetUrdfData(const QString& urdf);
+
+    protected:
+        void closeEvent(QCloseEvent* event) override;
+
+    private:
+        QTextEdit* m_log;
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedURDFWindow.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedURDFWindow.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <string>
+
 #if !defined(Q_MOC_RUN)
 #include <QLabel>
 #include <QPushButton>
@@ -23,12 +25,14 @@ namespace ROS2
         Q_OBJECT
     public:
         ModifiedURDFWindow();
-        void SetUrdfData(const QString& urdf);
+        const std::string& GetUrdfData() const;
+        void SetUrdfData(const std::string& urdf);
 
     protected:
         void closeEvent(QCloseEvent* event) override;
 
     private:
         QTextEdit* m_log;
+        std::string m_urdf;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedUrdfWindow.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedUrdfWindow.cpp
@@ -6,14 +6,14 @@
  *
  */
 
-#include "ModifiedURDFWindow.h"
+#include "ModifiedUrdfWindow.h"
 #include <AzCore/Utils/Utils.h>
 #include <QCloseEvent>
 #include <QVBoxLayout>
 
 namespace ROS2
 {
-    ModifiedURDFWindow::ModifiedURDFWindow()
+    ModifiedUrdfWindow::ModifiedUrdfWindow()
     {
         m_log = new QTextEdit();
         m_log->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
@@ -25,19 +25,19 @@ namespace ROS2
         this->setLayout(layout);
     }
 
-    void ModifiedURDFWindow::closeEvent([[maybe_unused]] QCloseEvent* event)
+    void ModifiedUrdfWindow::closeEvent([[maybe_unused]] QCloseEvent* event)
     {
         event->ignore();
         this->hide();
     }
 
-    void ModifiedURDFWindow::SetUrdfData(const std::string& urdf)
+    void ModifiedUrdfWindow::SetUrdfData(const std::string& urdf)
     {
         m_urdf = AZStd::move(urdf);
         m_log->setText(QString::fromStdString(m_urdf));
     }
 
-    const std::string& ModifiedURDFWindow::GetUrdfData() const
+    const std::string& ModifiedUrdfWindow::GetUrdfData() const
     {
         return m_urdf;
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedUrdfWindow.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/ModifiedUrdfWindow.h
@@ -20,11 +20,11 @@
 
 namespace ROS2
 {
-    class ModifiedURDFWindow : public QWidget
+    class ModifiedUrdfWindow : public QWidget
     {
         Q_OBJECT
     public:
-        ModifiedURDFWindow();
+        ModifiedUrdfWindow();
         const std::string& GetUrdfData() const;
         void SetUrdfData(const std::string& urdf);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
@@ -70,29 +70,32 @@ namespace ROS2
         connect(m_createButton, &QPushButton::pressed, this, &PrefabMakerPage::onCreateButtonPressed);
     }
 
-    void PrefabMakerPage::setProposedPrefabName(const AZStd::string prefabName)
+    void PrefabMakerPage::SetProposedPrefabName(const AZStd::string prefabName)
     {
         m_prefabName->setText(QString::fromUtf8(prefabName.data(), int(prefabName.size())));
     }
 
-    AZStd::string PrefabMakerPage::getPrefabName() const
+    AZStd::string PrefabMakerPage::GetPrefabName() const
     {
         return AZStd::string(m_prefabName->text().toUtf8().constData());
     }
 
-    void PrefabMakerPage::reportProgress(const AZStd::string& progressForUser)
+    void PrefabMakerPage::ReportProgress(const AZStd::string& progressForUser)
     {
         m_log->setText(QString::fromUtf8(progressForUser.data(), int(progressForUser.size())));
     }
-    void PrefabMakerPage::setSuccess(bool success)
+
+    void PrefabMakerPage::SetSuccess(bool success)
     {
         m_success = success;
         emit completeChanged();
     }
+
     bool PrefabMakerPage::isComplete() const
     {
         return m_success;
     }
+
     AZStd::optional<AZ::Transform> PrefabMakerPage::getSelectedSpawnPoint() const
     {
         if (!m_spawnPointsInfos.empty())

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
@@ -84,7 +84,7 @@ namespace ROS2
 
     void PrefabMakerPage::ReportProgress(const AZStd::string& progressForUser)
     {
-        m_log->setText(QString::fromUtf8(progressForUser.data(), int(progressForUser.size())));
+        m_log->setMarkdown(QString::fromUtf8(progressForUser.data(), int(progressForUser.size())));
     }
 
     void PrefabMakerPage::SetSuccess(bool success)

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.cpp
@@ -47,6 +47,8 @@ namespace ROS2
         m_prefabName = new QLineEdit(this);
         m_createButton = new QPushButton(tr("Create Prefab"), this);
         m_log = new QTextEdit(this);
+        m_log->acceptRichText();
+        m_log->setReadOnly(true);
 
         setTitle(tr("Prefab creation"));
         QVBoxLayout* layout = new QVBoxLayout;

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/PrefabMakerPage.h
@@ -31,10 +31,10 @@ namespace ROS2
         Q_OBJECT
     public:
         explicit PrefabMakerPage(RobotImporterWidget* parent);
-        void setProposedPrefabName(const AZStd::string prefabName);
-        AZStd::string getPrefabName() const;
-        void reportProgress(const AZStd::string& progressForUser);
-        void setSuccess(bool success);
+        void SetProposedPrefabName(const AZStd::string prefabName);
+        AZStd::string GetPrefabName() const;
+        void ReportProgress(const AZStd::string& progressForUser);
+        void SetSuccess(bool success);
         bool isComplete() const override;
         AZStd::optional<AZ::Transform> getSelectedSpawnPoint() const;
     Q_SIGNALS:

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.cpp
@@ -16,13 +16,26 @@ namespace ROS2
         , m_success(false)
         , m_warning(false)
     {
+        m_urdfName = new QLineEdit(this);
+        m_saveButton = new QPushButton(tr("Save URDF"), this);
+        m_showButton = new QPushButton(tr("Show URDF"), this);
         m_log = new QTextEdit(this);
-        setTitle(tr("URDF/SDF opening results:"));
-        QVBoxLayout* layout = new QVBoxLayout;
-        layout->addWidget(m_log);
         m_log->acceptRichText();
         m_log->setReadOnly(true);
+
+        QVBoxLayout* layout = new QVBoxLayout;
+        QHBoxLayout* layoutInner = new QHBoxLayout;
+        layoutInner->addWidget(m_urdfName);
+        layoutInner->addWidget(m_saveButton);
+        layoutInner->addWidget(m_showButton);
+
+        layout->addWidget(m_log);
+        layout->addLayout(layoutInner);
+
+        setTitle(tr("URDF/SDF opening results:"));
         setLayout(layout);
+        connect(m_saveButton, &QPushButton::pressed, this, &RobotDescriptionPage::onSaveModifiedURDFPressed);
+        connect(m_showButton, &QPushButton::pressed, this, &RobotDescriptionPage::onShowModifiedURDFPressed);
     }
 
     void RobotDescriptionPage::ReportParsingResult(const QString& status, bool isSuccess, bool isWarning)

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.cpp
@@ -46,6 +46,16 @@ namespace ROS2
         emit completeChanged();
     }
 
+    void RobotDescriptionPage::SetModifiedURDFName(const AZStd::string prefabName)
+    {
+        m_urdfName->setText(QString::fromUtf8(prefabName.data(), int(prefabName.size())));
+    }
+
+    AZStd::string RobotDescriptionPage::GetModifiedURDFName() const
+    {
+        return AZStd::string(m_urdfName->text().toUtf8().constData());
+    }
+
     bool RobotDescriptionPage::isComplete() const
     {
         return m_success;

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.cpp
@@ -34,8 +34,8 @@ namespace ROS2
 
         setTitle(tr("URDF/SDF opening results:"));
         setLayout(layout);
-        connect(m_saveButton, &QPushButton::pressed, this, &RobotDescriptionPage::onSaveModifiedURDFPressed);
-        connect(m_showButton, &QPushButton::pressed, this, &RobotDescriptionPage::onShowModifiedURDFPressed);
+        connect(m_saveButton, &QPushButton::pressed, this, &RobotDescriptionPage::onSaveModifiedUrdfPressed);
+        connect(m_showButton, &QPushButton::pressed, this, &RobotDescriptionPage::onShowModifiedUrdfPressed);
     }
 
     void RobotDescriptionPage::ReportParsingResult(const QString& status, bool isSuccess, bool isWarning)
@@ -46,12 +46,12 @@ namespace ROS2
         emit completeChanged();
     }
 
-    void RobotDescriptionPage::SetModifiedURDFName(const AZStd::string prefabName)
+    void RobotDescriptionPage::SetModifiedUrdfName(const AZStd::string prefabName)
     {
         m_urdfName->setText(QString::fromUtf8(prefabName.data(), int(prefabName.size())));
     }
 
-    AZStd::string RobotDescriptionPage::GetModifiedURDFName() const
+    AZStd::string RobotDescriptionPage::GetModifiedUrdfName() const
     {
         return AZStd::string(m_urdfName->text().toUtf8().constData());
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.cpp
@@ -6,12 +6,12 @@
  *
  */
 
-#include "CheckUrdfPage.h"
+#include "RobotDescriptionPage.h"
 #include <QVBoxLayout>
 
 namespace ROS2
 {
-    CheckUrdfPage::CheckUrdfPage(QWizard* parent)
+    RobotDescriptionPage::RobotDescriptionPage(QWizard* parent)
         : QWizardPage(parent)
         , m_success(false)
         , m_warning(false)
@@ -25,7 +25,7 @@ namespace ROS2
         setLayout(layout);
     }
 
-    void CheckUrdfPage::ReportURDFResult(const QString& status, bool isSuccess, bool isWarning)
+    void RobotDescriptionPage::ReportParsingResult(const QString& status, bool isSuccess, bool isWarning)
     {
         m_log->setMarkdown(status);
         m_success = isSuccess;
@@ -33,12 +33,12 @@ namespace ROS2
         emit completeChanged();
     }
 
-    bool CheckUrdfPage::isComplete() const
+    bool RobotDescriptionPage::isComplete() const
     {
         return m_success;
     }
 
-    bool CheckUrdfPage::isWarning() const
+    bool RobotDescriptionPage::isWarning() const
     {
         return m_warning;
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <AzCore/std/string/string.h>
+
 #if !defined(Q_MOC_RUN)
 #include <QLabel>
 #include <QLineEdit>
@@ -25,6 +27,8 @@ namespace ROS2
     public:
         explicit RobotDescriptionPage(QWizard* parent);
         void ReportParsingResult(const QString& status, bool isSuccess, bool isWarning = false);
+        void SetModifiedURDFName(const AZStd::string prefabName);
+        AZStd::string GetModifiedURDFName() const;
         bool isComplete() const override;
         bool isWarning() const;
     Q_SIGNALS:

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.h
@@ -27,13 +27,13 @@ namespace ROS2
     public:
         explicit RobotDescriptionPage(QWizard* parent);
         void ReportParsingResult(const QString& status, bool isSuccess, bool isWarning = false);
-        void SetModifiedURDFName(const AZStd::string prefabName);
-        AZStd::string GetModifiedURDFName() const;
+        void SetModifiedUrdfName(const AZStd::string prefabName);
+        AZStd::string GetModifiedUrdfName() const;
         bool isComplete() const override;
         bool isWarning() const;
     Q_SIGNALS:
-        void onSaveModifiedURDFPressed();
-        void onShowModifiedURDFPressed();
+        void onSaveModifiedUrdfPressed();
+        void onShowModifiedUrdfPressed();
 
     private:
         QTextEdit* m_log;

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.h
@@ -17,12 +17,12 @@
 
 namespace ROS2
 {
-    class CheckUrdfPage : public QWizardPage
+    class RobotDescriptionPage : public QWizardPage
     {
         Q_OBJECT
     public:
-        explicit CheckUrdfPage(QWizard* parent);
-        void ReportURDFResult(const QString& result, bool isSuccess, bool isWarning = false);
+        explicit RobotDescriptionPage(QWizard* parent);
+        void ReportParsingResult(const QString& result, bool isSuccess, bool isWarning = false);
         bool isComplete() const override;
         bool isWarning() const;
 

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.h
@@ -10,6 +10,8 @@
 
 #if !defined(Q_MOC_RUN)
 #include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
 #include <QString>
 #include <QTextEdit>
 #include <QWizardPage>
@@ -25,10 +27,16 @@ namespace ROS2
         void ReportParsingResult(const QString& status, bool isSuccess, bool isWarning = false);
         bool isComplete() const override;
         bool isWarning() const;
+    Q_SIGNALS:
+        void onSaveModifiedURDFPressed();
+        void onShowModifiedURDFPressed();
 
     private:
         QTextEdit* m_log;
         QString m_fileName;
+        QLineEdit* m_urdfName;
+        QPushButton* m_saveButton;
+        QPushButton* m_showButton;
         bool m_success;
         bool m_warning;
     };

--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.h
@@ -22,7 +22,7 @@ namespace ROS2
         Q_OBJECT
     public:
         explicit RobotDescriptionPage(QWizard* parent);
-        void ReportParsingResult(const QString& result, bool isSuccess, bool isWarning = false);
+        void ReportParsingResult(const QString& status, bool isSuccess, bool isWarning = false);
         bool isComplete() const override;
         bool isWarning() const;
 

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -35,6 +35,7 @@ namespace ROS2
         m_assetPage = new CheckAssetPage(this);
         m_prefabMakerPage = new PrefabMakerPage(this);
         m_xacroParamsPage = new XacroParamsPage(this);
+        m_modifiedUrdfWindow = new ModifiedURDFWindow();
 
         addPage(m_introPage);
         addPage(m_fileSelectPage);
@@ -46,6 +47,16 @@ namespace ROS2
         connect(this, &QWizard::currentIdChanged, this, &RobotImporterWidget::onCurrentIdChanged);
         connect(m_prefabMakerPage, &QWizardPage::completeChanged, this, &RobotImporterWidget::OnUrdfCreated);
         connect(m_prefabMakerPage, &PrefabMakerPage::onCreateButtonPressed, this, &RobotImporterWidget::onCreateButtonPressed);
+        connect(
+            m_robotDescriptionPage,
+            &RobotDescriptionPage::onSaveModifiedURDFPressed,
+            this,
+            &RobotImporterWidget::onSaveModifiedURDFPressed);
+        connect(
+            m_robotDescriptionPage,
+            &RobotDescriptionPage::onShowModifiedURDFPressed,
+            this,
+            &RobotImporterWidget::onShowModifiedURDFPressed);
         connect(
             this,
             &QWizard::customButtonClicked,
@@ -91,6 +102,7 @@ namespace ROS2
     {
         // This is a URDF only path, and therefore the report text does not mention SDF
         report += "# " + tr("The URDF was parsed, though results were modified to be compatible with SDFormat") + "\n";
+        report += tr("Please check the modified code and/or save it using the button below.") + "\n";
 
         if (!parsedSdfOutcome.m_urdfModifications.missingInertias.empty())
         {
@@ -130,8 +142,7 @@ namespace ROS2
             }
         }
 
-        report += "\n# " + tr("The modified URDF code:") + "\n";
-        report += "```\n" + QString::fromStdString(parsedSdfOutcome.m_modifiedURDFContent) + "```\n";
+        m_modifiedUrdfWindow->SetUrdfData(QString::fromStdString(parsedSdfOutcome.m_modifiedURDFContent));
     }
 
     void RobotImporterWidget::OpenUrdf()
@@ -627,6 +638,17 @@ namespace ROS2
     void RobotImporterWidget::onCreateButtonPressed()
     {
         CreatePrefab(m_prefabMakerPage->GetPrefabName());
+    }
+
+    void RobotImporterWidget::onSaveModifiedURDFPressed()
+    {
+        AZ_Warning("JHTODO", false, "Save pressed");
+    }
+
+    void RobotImporterWidget::onShowModifiedURDFPressed()
+    {
+        m_modifiedUrdfWindow->resize(this->size());
+        m_modifiedUrdfWindow->show();
     }
 
     bool RobotImporterWidget::CheckCyclicalDependency(AZ::IO::Path importedPrefabPath)

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -238,7 +238,6 @@ namespace ROS2
                 report += QString::fromUtf8(log.data(), int(log.size()));
                 report += "`";
             }
-            m_robotDescriptionPage->ReportParsingResult(report, urdfParsedSuccess, urdfParsedWithWarnings);
             const auto& messages = parsedSdfOutcome.GetParseMessages();
             if (!messages.empty())
             {
@@ -249,7 +248,7 @@ namespace ROS2
                 report += "\n```\n";
                 AZ_Printf("RobotImporterWidget", "SDF Stream: %s\n", messages.c_str());
             }
-            m_robotDescriptionPage->ReportParsingResult(report, urdfParsedSuccess);
+            m_robotDescriptionPage->ReportParsingResult(report, urdfParsedSuccess, urdfParsedWithWarnings);
         }
     }
 
@@ -479,7 +478,7 @@ namespace ROS2
     {
         // Use the URDF/SDF file name stem the prefab name
         AZStd::string robotName = AZStd::string::format("%.*s.prefab", AZ_PATH_ARG(m_urdfPath.Stem()));
-        m_prefabMakerPage->setProposedPrefabName(robotName);
+        m_prefabMakerPage->SetProposedPrefabName(robotName);
         QWizard::button(PrefabCreationButtonId)->setText(tr("Create Prefab"));
         QWizard::setOption(HavePrefabCreationButton, true);
     }
@@ -578,7 +577,7 @@ namespace ROS2
 
         if (CheckCyclicalDependency(prefabPathRelative))
         {
-            m_prefabMakerPage->setSuccess(false);
+            m_prefabMakerPage->SetSuccess(false);
             return;
         }
         if (fileExists)
@@ -591,7 +590,7 @@ namespace ROS2
             int ret = msgBox.exec();
             if (ret == QMessageBox::Cancel)
             {
-                m_prefabMakerPage->setSuccess(false);
+                m_prefabMakerPage->SetSuccess(false);
                 return;
             }
         }
@@ -610,22 +609,22 @@ namespace ROS2
         if (prefabOutcome.IsSuccess())
         {
             AZStd::string status = m_prefabMaker->GetStatus();
-            m_prefabMakerPage->reportProgress(status);
-            m_prefabMakerPage->setSuccess(true);
+            m_prefabMakerPage->ReportProgress(status);
+            m_prefabMakerPage->SetSuccess(true);
         }
         else
         {
             AZStd::string status = "Failed to create prefab\n";
             status += prefabOutcome.GetError() + "\n";
             status += m_prefabMaker->GetStatus();
-            m_prefabMakerPage->reportProgress(status);
-            m_prefabMakerPage->setSuccess(false);
+            m_prefabMakerPage->ReportProgress(status);
+            m_prefabMakerPage->SetSuccess(false);
         }
     }
 
     void RobotImporterWidget::onCreateButtonPressed()
     {
-        CreatePrefab(m_prefabMakerPage->getPrefabName());
+        CreatePrefab(m_prefabMakerPage->GetPrefabName());
     }
 
     bool RobotImporterWidget::CheckCyclicalDependency(AZ::IO::Path importedPrefabPath)

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -256,6 +256,7 @@ namespace ROS2
     void RobotImporterWidget::onCurrentIdChanged(int id)
     {
         AZ_Printf("Wizard", "Wizard at page %d", id);
+        QWizard::setOption(HavePrefabCreationButton, false);
 
         if (currentPage() == m_assetPage)
         {

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -31,7 +31,7 @@ namespace ROS2
     {
         m_introPage = new IntroPage(this);
         m_fileSelectPage = new FileSelectionPage(this);
-        m_checkUrdfPage = new CheckUrdfPage(this);
+        m_robotDescriptionPage = new RobotDescriptionPage(this);
         m_assetPage = new CheckAssetPage(this);
         m_prefabMakerPage = new PrefabMakerPage(this);
         m_xacroParamsPage = new XacroParamsPage(this);
@@ -39,7 +39,7 @@ namespace ROS2
         addPage(m_introPage);
         addPage(m_fileSelectPage);
         addPage(m_xacroParamsPage);
-        addPage(m_checkUrdfPage);
+        addPage(m_robotDescriptionPage);
         addPage(m_assetPage);
         addPage(m_prefabMakerPage);
 
@@ -191,7 +191,7 @@ namespace ROS2
                             report += tr("(EMPTY)");
                         }
                         report += "\n```";
-                        m_checkUrdfPage->ReportURDFResult(report, false);
+                        m_robotDescriptionPage->ReportParsingResult(report, false);
                         return;
                     }
                 }
@@ -218,7 +218,7 @@ namespace ROS2
                 else
                 {
                     report += "# " + tr("The URDF/SDF was parsed and opened successfully") + "\n";
-                    AZ_Printf("Wizard", "Wizard skips m_checkUrdfPage since there is no errors in URDF\n");
+                    AZ_Printf("Wizard", "Wizard skips m_robotDescriptionPage since there is no errors in URDF\n");
                 }
                 m_parsedSdf = AZStd::move(parsedSdfOutcome.GetRoot());
                 m_prefabMaker.reset();
@@ -238,7 +238,7 @@ namespace ROS2
                 report += QString::fromUtf8(log.data(), int(log.size()));
                 report += "`";
             }
-            m_checkUrdfPage->ReportURDFResult(report, urdfParsedSuccess, urdfParsedWithWarnings);
+            m_robotDescriptionPage->ReportParsingResult(report, urdfParsedSuccess, urdfParsedWithWarnings);
             const auto& messages = parsedSdfOutcome.GetParseMessages();
             if (!messages.empty())
             {
@@ -249,7 +249,7 @@ namespace ROS2
                 report += "\n```\n";
                 AZ_Printf("RobotImporterWidget", "SDF Stream: %s\n", messages.c_str());
             }
-            m_checkUrdfPage->ReportURDFResult(report, urdfParsedSuccess);
+            m_robotDescriptionPage->ReportParsingResult(report, urdfParsedSuccess);
         }
     }
 
@@ -545,11 +545,11 @@ namespace ROS2
         }
         if ((currentPage() == m_fileSelectPage && m_params.empty()) || currentPage() == m_xacroParamsPage)
         {
-            if (!m_checkUrdfPage->isWarning())
+            if (!m_robotDescriptionPage->isWarning())
             {
                 return m_xacroParamsPage->nextId();
             }
-            if (m_checkUrdfPage->isComplete())
+            if (m_robotDescriptionPage->isComplete())
             {
                 if (m_assetNames.empty())
                 {
@@ -559,7 +559,7 @@ namespace ROS2
                 else
                 {
                     // skip one page when urdf/sdf is parsed without problems
-                    return m_checkUrdfPage->nextId();
+                    return m_robotDescriptionPage->nextId();
                 }
             }
             if (m_params.empty())

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -102,7 +102,6 @@ namespace ROS2
     {
         // This is a URDF only path, and therefore the report text does not mention SDF
         report += "# " + tr("The URDF was parsed, though results were modified to be compatible with SDFormat") + "\n";
-        report += tr("Please check the modified code and/or save it using the button below.") + "\n";
 
         if (!parsedSdfOutcome.m_urdfModifications.missingInertias.empty())
         {
@@ -142,6 +141,7 @@ namespace ROS2
             }
         }
 
+        report += "\n\n# " + tr("💡Please check the modified code and/or save it using the interface below.") + "\n";
         m_modifiedUrdfWindow->SetUrdfData(AZStd::move(parsedSdfOutcome.m_modifiedURDFContent));
     }
 
@@ -633,7 +633,7 @@ namespace ROS2
         }
         else
         {
-            AZStd::string status = "Failed to create prefab\n";
+            AZStd::string status = "# Failed to create prefab\n";
             status += prefabOutcome.GetError() + "\n";
             status += m_prefabMaker->GetStatus();
             m_prefabMakerPage->ReportProgress(status);

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -238,6 +238,7 @@ namespace ROS2
                 report += QString::fromUtf8(log.data(), int(log.size()));
                 report += "`";
             }
+            m_robotDescriptionPage->ReportParsingResult(report, urdfParsedSuccess, urdfParsedWithWarnings);
             const auto& messages = parsedSdfOutcome.GetParseMessages();
             if (!messages.empty())
             {
@@ -248,7 +249,7 @@ namespace ROS2
                 report += "\n```\n";
                 AZ_Printf("RobotImporterWidget", "SDF Stream: %s\n", messages.c_str());
             }
-            m_robotDescriptionPage->ReportParsingResult(report, urdfParsedSuccess, urdfParsedWithWarnings);
+            m_robotDescriptionPage->ReportParsingResult(report, urdfParsedSuccess);
         }
     }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -35,7 +35,7 @@ namespace ROS2
         m_assetPage = new CheckAssetPage(this);
         m_prefabMakerPage = new PrefabMakerPage(this);
         m_xacroParamsPage = new XacroParamsPage(this);
-        m_modifiedUrdfWindow = new ModifiedUrdfWindow();
+        m_modifiedUrdfWindow = new ModifiedURDFWindow();
 
         addPage(m_introPage);
         addPage(m_fileSelectPage);

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -35,7 +35,7 @@ namespace ROS2
         m_assetPage = new CheckAssetPage(this);
         m_prefabMakerPage = new PrefabMakerPage(this);
         m_xacroParamsPage = new XacroParamsPage(this);
-        m_modifiedUrdfWindow = new ModifiedURDFWindow();
+        m_modifiedUrdfWindow = new ModifiedUrdfWindow();
 
         addPage(m_introPage);
         addPage(m_fileSelectPage);
@@ -49,14 +49,14 @@ namespace ROS2
         connect(m_prefabMakerPage, &PrefabMakerPage::onCreateButtonPressed, this, &RobotImporterWidget::onCreateButtonPressed);
         connect(
             m_robotDescriptionPage,
-            &RobotDescriptionPage::onSaveModifiedURDFPressed,
+            &RobotDescriptionPage::onSaveModifiedUrdfPressed,
             this,
-            &RobotImporterWidget::onSaveModifiedURDFPressed);
+            &RobotImporterWidget::onSaveModifiedUrdfPressed);
         connect(
             m_robotDescriptionPage,
-            &RobotDescriptionPage::onShowModifiedURDFPressed,
+            &RobotDescriptionPage::onShowModifiedUrdfPressed,
             this,
-            &RobotImporterWidget::onShowModifiedURDFPressed);
+            &RobotImporterWidget::onShowModifiedUrdfPressed);
         connect(
             this,
             &QWizard::customButtonClicked,
@@ -281,7 +281,7 @@ namespace ROS2
         {
             AZStd::string urdfName = m_urdfPath.ReplaceExtension("").String();
             urdfName.append("_modified.urdf");
-            m_robotDescriptionPage->SetModifiedURDFName(urdfName);
+            m_robotDescriptionPage->SetModifiedUrdfName(urdfName);
         }
     }
 
@@ -646,9 +646,9 @@ namespace ROS2
         CreatePrefab(m_prefabMakerPage->GetPrefabName());
     }
 
-    void RobotImporterWidget::onSaveModifiedURDFPressed()
+    void RobotImporterWidget::onSaveModifiedUrdfPressed()
     {
-        const auto filePath = m_robotDescriptionPage->GetModifiedURDFName();
+        const auto filePath = m_robotDescriptionPage->GetModifiedUrdfName();
         const auto& streamData = m_modifiedUrdfWindow->GetUrdfData();
         bool success = false;
         AZ::IO::FileIOBase* fileIo = AZ::IO::FileIOBase::GetInstance();
@@ -665,10 +665,10 @@ namespace ROS2
             success = (bytesWritten == streamData.size());
         }
 
-        AZ_Warning("onSaveModifiedURDFPressed", success, "Cannot save the output file %s", filePath.c_str());
+        AZ_Warning("onSaveModifiedUrdfPressed", success, "Cannot save the output file %s", filePath.c_str());
     }
 
-    void RobotImporterWidget::onShowModifiedURDFPressed()
+    void RobotImporterWidget::onShowModifiedUrdfPressed()
     {
         m_modifiedUrdfWindow->resize(this->size());
         m_modifiedUrdfWindow->show();

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -12,7 +12,7 @@
 #include "Pages/CheckAssetPage.h"
 #include "Pages/FileSelectionPage.h"
 #include "Pages/IntroPage.h"
-#include "Pages/ModifiedUrdfWindow.h"
+#include "Pages/ModifiedURDFWindow.h"
 #include "Pages/PrefabMakerPage.h"
 #include "Pages/RobotDescriptionPage.h"
 #include "Pages/XacroParamsPage.h"
@@ -74,7 +74,7 @@ namespace ROS2
         CheckAssetPage* m_assetPage;
         PrefabMakerPage* m_prefabMakerPage;
         XacroParamsPage* m_xacroParamsPage;
-        ModifiedUrdfWindow* m_modifiedUrdfWindow;
+        ModifiedURDFWindow* m_modifiedUrdfWindow;
         AZ::IO::Path m_urdfPath;
         sdf::Root m_parsedSdf{};
 

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -10,10 +10,10 @@
 
 #if !defined(Q_MOC_RUN)
 #include "Pages/CheckAssetPage.h"
-#include "Pages/CheckUrdfPage.h"
 #include "Pages/FileSelectionPage.h"
 #include "Pages/IntroPage.h"
 #include "Pages/PrefabMakerPage.h"
+#include "Pages/RobotDescriptionPage.h"
 #include "Pages/XacroParamsPage.h"
 
 #include "URDF/URDFPrefabMaker.h"
@@ -67,7 +67,7 @@ namespace ROS2
 
         IntroPage* m_introPage;
         FileSelectionPage* m_fileSelectPage;
-        CheckUrdfPage* m_checkUrdfPage;
+        RobotDescriptionPage* m_robotDescriptionPage;
         CheckAssetPage* m_assetPage;
         PrefabMakerPage* m_prefabMakerPage;
         XacroParamsPage* m_xacroParamsPage;

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -12,7 +12,7 @@
 #include "Pages/CheckAssetPage.h"
 #include "Pages/FileSelectionPage.h"
 #include "Pages/IntroPage.h"
-#include "Pages/ModifiedURDFWindow.h"
+#include "Pages/ModifiedUrdfWindow.h"
 #include "Pages/PrefabMakerPage.h"
 #include "Pages/RobotDescriptionPage.h"
 #include "Pages/XacroParamsPage.h"
@@ -65,8 +65,8 @@ namespace ROS2
         void OpenUrdf();
         void OnUrdfCreated();
         void onCreateButtonPressed();
-        void onSaveModifiedURDFPressed();
-        void onShowModifiedURDFPressed();
+        void onSaveModifiedUrdfPressed();
+        void onShowModifiedUrdfPressed();
 
         IntroPage* m_introPage;
         FileSelectionPage* m_fileSelectPage;
@@ -74,7 +74,7 @@ namespace ROS2
         CheckAssetPage* m_assetPage;
         PrefabMakerPage* m_prefabMakerPage;
         XacroParamsPage* m_xacroParamsPage;
-        ModifiedURDFWindow* m_modifiedUrdfWindow;
+        ModifiedUrdfWindow* m_modifiedUrdfWindow;
         AZ::IO::Path m_urdfPath;
         sdf::Root m_parsedSdf{};
 

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -12,6 +12,7 @@
 #include "Pages/CheckAssetPage.h"
 #include "Pages/FileSelectionPage.h"
 #include "Pages/IntroPage.h"
+#include "Pages/ModifiedURDFWindow.h"
 #include "Pages/PrefabMakerPage.h"
 #include "Pages/RobotDescriptionPage.h"
 #include "Pages/XacroParamsPage.h"
@@ -64,6 +65,8 @@ namespace ROS2
         void OpenUrdf();
         void OnUrdfCreated();
         void onCreateButtonPressed();
+        void onSaveModifiedURDFPressed();
+        void onShowModifiedURDFPressed();
 
         IntroPage* m_introPage;
         FileSelectionPage* m_fileSelectPage;
@@ -71,6 +74,7 @@ namespace ROS2
         CheckAssetPage* m_assetPage;
         PrefabMakerPage* m_prefabMakerPage;
         XacroParamsPage* m_xacroParamsPage;
+        ModifiedURDFWindow* m_modifiedUrdfWindow;
         AZ::IO::Path m_urdfPath;
         sdf::Root m_parsedSdf{};
 

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/ArticulationsMaker.h
@@ -19,11 +19,14 @@ namespace ROS2
     class ArticulationsMaker
     {
     public:
+        using ArticulationsMakerResult = AZ::Outcome<AZ::ComponentId, AZStd::string>;
+
         //! Add zero or one inertial and joints elements to a given entity (depending on link content).
         //! @param model SDF model object which can be queried to locate the joints needed to determine if the supplied
         //!              link is a child link within a joint
         //! @param link A pointer to a parsed SDF link.
         //! @param entityId A non-active entity which will be populated according to inertial content.
-        void AddArticulationLink(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId) const;
+        //! @returns created components Id or string with fail
+        ArticulationsMakerResult AddArticulationLink(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId) const;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -642,7 +642,23 @@ namespace ROS2
         {
             if (attachedModel != nullptr)
             {
-                m_articulationsMaker.AddArticulationLink(*attachedModel, &link, entityId);
+                const auto linkResult = m_articulationsMaker.AddArticulationLink(*attachedModel, &link, entityId);
+                std::string linkName = link.Name();
+                AZStd::string azLinkName(linkName.c_str(), linkName.size());
+                if (linkResult.IsSuccess())
+                {
+                    AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
+                    m_status.emplace(
+                        StatusMessageType::Joint,
+                        AZStd::string::format("%s created as articulation link: %llu", azLinkName.c_str(), linkResult.GetValue()));
+                }
+                else
+                {
+                    AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
+                    m_status.emplace(
+                        StatusMessageType::Joint,
+                        AZStd::string::format("%s as articulation link failed: %s", azLinkName.c_str(), linkResult.GetError().c_str()));
+                }
             }
         }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -142,7 +142,8 @@ namespace ROS2
         };
         ModelMapper modelMapper;
 
-        auto GetAllLinksAndSetModelHierarchy = [&linksMapper, &modelMapper](const sdf::Model& model, const Utils::ModelStack& modelStack) -> Utils::VisitModelResponse
+        auto GetAllLinksAndSetModelHierarchy =
+            [&linksMapper, &modelMapper](const sdf::Model& model, const Utils::ModelStack& modelStack) -> Utils::VisitModelResponse
         {
             // As the VisitModels function visits nested models by default, gatherNestedModelLinks is set to false
             constexpr bool gatherNestedModelLinks = false;
@@ -188,25 +189,34 @@ namespace ROS2
         for ([[maybe_unused]] const auto& [fullModelName, modelPtr, _] : modelMapper.m_models)
         {
             // Create entities for each model in the SDF
+            const std::string modelName = modelPtr->Name();
+            const AZStd::string azModelName(modelName.c_str(), modelName.size());
             if (AzToolsFramework::Prefab::PrefabEntityResult createModelEntityResult = CreateEntityForModel(*modelPtr);
                 createModelEntityResult)
             {
                 AZ::EntityId createdModelEntityId = createModelEntityResult.GetValue();
                 // Add the model entity to the created entity list so that it gets added to the prefab
                 createdEntities.emplace_back(createdModelEntityId);
-
-                std::string modelName = modelPtr->Name();
-                AZStd::string azModelName(modelName.c_str(), modelName.size());
-                AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
-                m_status.emplace(azModelName, AZStd::string::format("[model] created as: %s", createdModelEntityId.ToString().c_str()));
                 createdModels.emplace(modelPtr, createModelEntityResult);
+
+                AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
+                m_status.emplace(
+                    StatusMessageType::Model,
+                    AZStd::string::format("%s created as: %s", azModelName.c_str(), createdModelEntityId.ToString().c_str()));
+            }
+            else
+            {
+                AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
+                m_status.emplace(
+                    StatusMessageType::Model,
+                    AZStd::string::format("%s failed: %s", azModelName.c_str(), createModelEntityResult.GetError().c_str()));
             }
         }
 
         //! Setup the parent hierarchy for the nested models
         for ([[maybe_unused]] const auto& [_, modelPtr, parentModelPtr] : modelMapper.m_models)
         {
-            // If there is no parent model, then the model would be at the top level of the hiearachy
+            // If there is no parent model, then the model would be at the top level of the hierarchy
             if (parentModelPtr == nullptr || modelPtr == nullptr)
             {
                 continue;
@@ -264,11 +274,14 @@ namespace ROS2
             AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
             if (result.IsSuccess())
             {
-                m_status.emplace(azLinkName, AZStd::string::format("[link] created as: %s", result.GetValue().ToString().c_str()));
+                m_status.emplace(
+                    StatusMessageType::Link,
+                    AZStd::string::format("%s created as: %s", azLinkName.c_str(), result.GetValue().ToString().c_str()));
             }
             else
             {
-                m_status.emplace(azLinkName, AZStd::string::format("[link] failed : %s", result.GetError().c_str()));
+                m_status.emplace(
+                    StatusMessageType::Link, AZStd::string::format("%s failed : %s", azLinkName.c_str(), result.GetError().c_str()));
             }
         }
 
@@ -454,8 +467,17 @@ namespace ROS2
                 {
                     AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
                     auto result = m_jointsMaker.AddJointComponent(jointPtr, childEntity.GetValue(), leadEntity.GetValue());
-                    m_status.emplace(
-                        azJointName, AZStd::string::format("[joint] %s: %llu", result.IsSuccess() ? "created as" : "failed", result.GetValue()));
+                    if (result.IsSuccess())
+                    {
+                        m_status.emplace(
+                            StatusMessageType::Joint, AZStd::string::format("%s created as: %llu", azJointName.c_str(), result.GetValue()));
+                    }
+                    else
+                    {
+                        m_status.emplace(
+                            StatusMessageType::Joint,
+                            AZStd::string::format("%s failed : %s", azJointName.c_str(), result.GetError().c_str()));
+                    }
                 }
                 else
                 {
@@ -677,13 +699,34 @@ namespace ROS2
 
     AZStd::string URDFPrefabMaker::GetStatus()
     {
-        AZStd::string str;
+        AZStd::string report;
         AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
-        for (const auto& [entry, entryStatus] : m_status)
+
+        report += "# The following components were found and parsed:\n";
+
+        const AZStd::unordered_map<StatusMessageType, AZStd::string> names = { { StatusMessageType::Model, "Models" },
+                                                                               { StatusMessageType::Link, "Links" },
+                                                                               { StatusMessageType::Joint, "Joints" },
+                                                                               { StatusMessageType::Sensor, "Sensors" },
+                                                                               { StatusMessageType::SensorPlugin, "Sensor plugins" },
+                                                                               { StatusMessageType::ModelPlugin, "Model plugins" } };
+        auto it = m_status.begin();
+        auto end = m_status.end();
+        while (it != end)
         {
-            str += entry + " " + entryStatus + "\n";
+            const auto key = it->first;
+            report += "\n## " + names.at(key) + ":\n";
+
+            do
+            {
+                report += "- " + it->second + "\n";
+                if (++it == end)
+                {
+                    break;
+                }
+            } while (it->first == key);
         }
-        return str;
+        return report;
     }
 
     bool URDFPrefabMaker::ContainsModel() const

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -66,12 +66,16 @@ namespace ROS2
         const AZStd::string& GetPrefabPath() const;
 
         //! Get descriptive status of import.
-        //! A string with the status, which can be understood by the user.
+        //! A string with the status in Markdown format.
         AZStd::string GetStatus();
 
     private:
         AzToolsFramework::Prefab::PrefabEntityResult CreateEntityForModel(const sdf::Model& model);
-        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(const sdf::Link& link, const sdf::Model* attachedModel, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities);
+        AzToolsFramework::Prefab::PrefabEntityResult AddEntitiesForLink(
+            const sdf::Link& link,
+            const sdf::Model* attachedModel,
+            AZ::EntityId parentEntityId,
+            AZStd::vector<AZ::EntityId>& createdEntities);
         void AddRobotControl(AZ::EntityId rootEntityId);
         static void MoveEntityToDefaultSpawnPoint(const AZ::EntityId& rootEntityId, AZStd::optional<AZ::Transform> spawnPosition);
 
@@ -87,8 +91,18 @@ namespace ROS2
         JointsMaker m_jointsMaker;
         ArticulationsMaker m_articulationsMaker;
 
+        //! Type of a status message.
+        enum class StatusMessageType
+        {
+            Model = 0,
+            Link,
+            Joint,
+            Sensor,
+            SensorPlugin,
+            ModelPlugin
+        };
         AZStd::mutex m_statusLock;
-        AZStd::multimap<AZStd::string, AZStd::string> m_status;
+        AZStd::multimap<StatusMessageType, AZStd::string> m_status;
 
         AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;
         bool m_useArticulations{ false };

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/UrdfParser.cpp
@@ -110,7 +110,7 @@ namespace ROS2::UrdfParser
         // regular expression to escape console's color codes
         const AZStd::regex escapeColor("\x1B\\[[0-9;]*[A-Za-z]");
 
-        parseResult.m_parseMessages =  AZStd::regex_replace(AZStd::string(parseMessages.c_str(), parseMessages.size()),escapeColor, "");
+        parseResult.m_parseMessages = AZStd::regex_replace(AZStd::string(parseMessages.c_str(), parseMessages.size()), escapeColor, "");
 
         // if there are no parse errors return the sdf Root object otherwise return the errors
         return parseResult;

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -18,6 +18,8 @@ set(FILES
     Source/Manipulation/JointsManipulationEditorComponent.h
     Source/RobotImporter/FixURDF/FixURDF.cpp
     Source/RobotImporter/FixURDF/FixURDF.h
+    Source/RobotImporter/Pages/ModifiedURDFWindow.cpp
+    Source/RobotImporter/Pages/ModifiedURDFWindow.h
     Source/RobotImporter/Pages/CheckAssetPage.cpp
     Source/RobotImporter/Pages/CheckAssetPage.h
     Source/RobotImporter/Pages/RobotDescriptionPage.cpp

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -18,8 +18,8 @@ set(FILES
     Source/Manipulation/JointsManipulationEditorComponent.h
     Source/RobotImporter/FixURDF/FixURDF.cpp
     Source/RobotImporter/FixURDF/FixURDF.h
-    Source/RobotImporter/Pages/ModifiedURDFWindow.cpp
-    Source/RobotImporter/Pages/ModifiedURDFWindow.h
+    Source/RobotImporter/Pages/ModifiedUrdfWindow.cpp
+    Source/RobotImporter/Pages/ModifiedUrdfWindow.h
     Source/RobotImporter/Pages/CheckAssetPage.cpp
     Source/RobotImporter/Pages/CheckAssetPage.h
     Source/RobotImporter/Pages/RobotDescriptionPage.cpp

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -20,8 +20,8 @@ set(FILES
     Source/RobotImporter/FixURDF/FixURDF.h
     Source/RobotImporter/Pages/CheckAssetPage.cpp
     Source/RobotImporter/Pages/CheckAssetPage.h
-    Source/RobotImporter/Pages/CheckUrdfPage.cpp
-    Source/RobotImporter/Pages/CheckUrdfPage.h
+    Source/RobotImporter/Pages/RobotDescriptionPage.cpp
+    Source/RobotImporter/Pages/RobotDescriptionPage.h
     Source/RobotImporter/Pages/FileSelectionPage.cpp
     Source/RobotImporter/Pages/FileSelectionPage.h
     Source/RobotImporter/Pages/PrefabMakerPage.cpp

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -18,8 +18,8 @@ set(FILES
     Source/Manipulation/JointsManipulationEditorComponent.h
     Source/RobotImporter/FixURDF/FixURDF.cpp
     Source/RobotImporter/FixURDF/FixURDF.h
-    Source/RobotImporter/Pages/ModifiedUrdfWindow.cpp
-    Source/RobotImporter/Pages/ModifiedUrdfWindow.h
+    Source/RobotImporter/Pages/ModifiedURDFWindow.cpp
+    Source/RobotImporter/Pages/ModifiedURDFWindow.h
     Source/RobotImporter/Pages/CheckAssetPage.cpp
     Source/RobotImporter/Pages/CheckAssetPage.h
     Source/RobotImporter/Pages/RobotDescriptionPage.cpp


### PR DESCRIPTION
This PR adds multiple changes to _RobotImporter_ wizard:
1. A bugfix for `Create prefab` button from the last wizard page - the button was never gone when the _back_ button was pressed
2. The page notifying about URDF parsing was redesigned not to include the modified source code anymore - this code can be either displayed in a separate window or saved to the file to use later. This change is caused by the fact that the source code can be long. Moreover, it might happen some other warnings are printed after to code. I believe it is hard to read for the most.
3. The page displaying prefab creating logs was redesigned to print _Markdown_ and the logs were split into categories. This part will be later used to display logs from SDFormat sensor and plugin importer.

I also renamed one file as it is used by URDF/SDFormat/Xacro, but the name suggests URDF only.

I am open for comments on the UI in 2.

Ad 2.
Before on the left, after on the right
![image](https://github.com/o3de/o3de-extras/assets/134940295/4473e3c7-4ac4-40f9-914f-88a3ac16b406)


Ad 3.
Before on the left, after on the right
![image](https://github.com/o3de/o3de-extras/assets/134940295/a179e0f2-a08f-44fd-9b62-e6dcd1400fe8)
