### PR TITLE
Fix SkidSteeringDriveModel

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2SkidSteeringModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2SkidSteeringModelHook.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Math/MathUtils.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <RobotControl/Controllers/SkidSteeringController/SkidSteeringControlComponent.h>
 #include <RobotControl/ROS2RobotControlComponent.h>
@@ -48,10 +49,16 @@ namespace ROS2::SDFormat
                 {
                     AZ_Warning(
                         "CreateVehicleConfiguration",
-                        false,
-                        "Cannot find entity ID for one of the joints: %s or %s",
+                        entityIdLeft.IsValid(),
+                        "Cannot find left joint entity %s while creating the axle %s.",
                         jointNameLeft.c_str(),
-                        jointNameRight.c_str());
+                        tag.c_str());
+                    AZ_Warning(
+                        "CreateVehicleConfiguration",
+                        entityIdRight.IsValid(),
+                        "Cannot find right joint entity %s while creating the axle %s.",
+                        jointNameRight.c_str(),
+                        tag.c_str());
                 }
             };
 
@@ -114,7 +121,7 @@ namespace ROS2::SDFormat
                         constexpr float epsilon = 0.001f;
                         AZ_Warning(
                             "CreateVehicleConfiguration",
-                            fabsf(configuration.m_wheelbase - wheelSeparation->Get<float>()) < epsilon,
+                            AZ::IsClose(configuration.m_wheelbase, wheelSeparation->Get<float>(), epsilon),
                             "Different wheel separation distances in one model are not supported.");
                     }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2SkidSteeringModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2SkidSteeringModelHook.cpp
@@ -38,8 +38,8 @@ namespace ROS2::SDFormat
                 const auto entityIdRight = HooksUtils::GetJointEntityId(jointNameRight, sdfModel, createdEntities);
                 if (entityIdLeft.IsValid() && entityIdRight.IsValid())
                 {
-                    HooksUtils::EnableMotor(entityIdLeft);
-                    HooksUtils::EnableMotor(entityIdRight);
+                    HooksUtils::SetWheelEntity(entityIdLeft);
+                    HooksUtils::SetWheelEntity(entityIdRight);
                     constexpr bool steering = false; // Skid steering model does not have any steering wheels.
                     constexpr bool drive = true;
                     configuration.m_axles.emplace_back(VehicleDynamics::Utilities::Create2WheelAxle(

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -44,10 +44,9 @@ namespace ROS2::SDFormat
         //! @return entity id (invalid id if not found)
         AZ::EntityId GetJointEntityId(const std::string& jointName, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities);
 
-        //! Enable motor in EditorHingeJointComponent if possible or create WheelControllerComponent otherwise (when articulations are
-        //! used); this method shows a warning message if neither was possible
+        //! Enable motor in EditorHingeJointComponent if possible and create WheelControllerComponent
         //! @param entityId entity id of the modified entity
-        void EnableMotor(const AZ::EntityId& entityId);
+        void SetWheelEntity(const AZ::EntityId& entityId);
 
         //! Create a component and attach the component to the entity.
         //! This method ensures that game components are wrapped into GenericComponentWrapper.

--- a/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/SkidSteeringDriveModel.cpp
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/SkidSteeringDriveModel.cpp
@@ -43,72 +43,95 @@ namespace ROS2::VehicleDynamics
     void SkidSteeringDriveModel::Activate(const VehicleConfiguration& vehicleConfig)
     {
         m_config = vehicleConfig;
-        m_wheelsData.clear();
-        m_wheelColumns.clear();
+        m_wheelsCache.clear();
+        m_initialized = false;
     }
 
-    AZStd::tuple<VehicleDynamics::WheelControllerComponent*, AZ::Vector2, AZ::Vector3> SkidSteeringDriveModel::ProduceWheelColumn(
-        int wheelNumber, const AxleConfiguration& axle, const int axisCount) const
+    void SkidSteeringDriveModel::InitializeCache()
     {
-        const auto wheelCount = axle.m_axleWheels.size();
-        const auto wheelEntityId = axle.m_axleWheels[wheelNumber];
-        AZ::Entity* wheelEntityPtr = nullptr;
-        AZ::ComponentApplicationBus::BroadcastResult(wheelEntityPtr, &AZ::ComponentApplicationRequests::FindEntity, wheelEntityId);
-        AZ_Assert(wheelEntityPtr, "The wheelEntity should not be null here");
-        auto* wheelControllerComponentPtr = Utils::GetGameOrEditorComponent<WheelControllerComponent>(wheelEntityPtr);
-        auto wheelData = VehicleDynamics::Utilities::GetWheelData(wheelEntityId, axle.m_wheelRadius);
-        AZ::Transform hingeTransform = Utilities::GetJointTransform(wheelData);
-        if (wheelControllerComponentPtr)
+        // Compute number of drive axles to scale the contribution of each wheel to vehicle's velocity
+        int driveAxlesCount = 0;
+        for (const auto& axle : m_config.m_axles)
         {
-            const float normalizedWheelId = -1.f + 2.f * wheelNumber / (wheelCount - 1);
-            AZ::Vector3 axis = hingeTransform.TransformVector({ 0.f, 1.f, 0.f });
-            float wheelBase = normalizedWheelId * m_config.m_wheelbase;
-            AZ_Assert(axle.m_wheelRadius != 0, "axle.m_wheelRadius must be non-zero");
-            float dX = axle.m_wheelRadius / (wheelCount * axisCount);
-            float dPhi = axle.m_wheelRadius / (wheelBase * axisCount);
-            return { wheelControllerComponentPtr, AZ::Vector2{ dX, dPhi }, axis };
-        }
-        return { nullptr, AZ::Vector2::CreateZero(), AZ::Vector3::CreateZero() };
-    }
-
-    AZStd::pair<AZ::Vector3, AZ::Vector3> SkidSteeringDriveModel::GetVelocityFromModel()
-    {
-        // compute every wheel contribution to vehicle velocity
-        if (m_wheelColumns.empty())
-        {
-            for (const auto& axle : m_config.m_axles)
+            if (axle.m_isDrive && axle.m_axleWheels.size() > 1)
             {
-                const auto wheelCount = axle.m_axleWheels.size();
-                if (!axle.m_isDrive || wheelCount < 1)
+                driveAxlesCount++;
+            }
+            AZ_Warning(
+                "SkidSteeringDriveModel",
+                axle.m_axleWheels.size() > 1,
+                "Axle %s has not enough wheels (%d)",
+                axle.m_axleTag.c_str(),
+                axle.m_axleWheels.size());
+        }
+        AZ_Warning("SkidSteeringDriveModel", driveAxlesCount != 0, "Skid steering model does not have any drive wheels.");
+
+        // Find the contribution of each wheel to vehicle's velocity
+        for (const auto& axle : m_config.m_axles)
+        {
+            const auto wheelCount = axle.m_axleWheels.size();
+            if (!axle.m_isDrive || wheelCount <= 1)
+            {
+                continue;
+            }
+            for (size_t wheelId = 0; wheelId < wheelCount; wheelId++)
+            {
+                const auto column = ProduceWheelColumn(wheelId, axle, driveAxlesCount);
+                if (column.wheelControllerComponentPtr != nullptr)
                 {
-                    continue;
-                }
-                for (size_t wheelId = 0; wheelId < wheelCount; wheelId++)
-                {
-                    const auto column = ProduceWheelColumn(wheelId, axle, m_config.m_axles.size());
-                    if (AZStd::get<0>(column))
-                    {
-                        m_wheelColumns.emplace_back(column);
-                    }
+                    m_wheelsCache.emplace_back(AZStd::move(column));
                 }
             }
         }
 
-        //! accumulated contribution to vehicle's linear movements of every wheel
-        float d_x = 0;
+        m_initialized = true;
+    }
 
-        //! accumulated contribution to vehicle's rotational movements of every wheel
-        float d_fi = 0;
+    SkidSteeringDriveModel::SkidSteeringWheelData SkidSteeringDriveModel::ProduceWheelColumn(
+        const int wheelId, const AxleConfiguration& axle, const int axlesCount) const
+    {
+        SkidSteeringDriveModel::SkidSteeringWheelData out;
 
-        // It is basically multiplication of matrix by a vector.
-        for (auto& [wheel, column, axis] : m_wheelColumns)
+        AZ_Assert(axle.m_wheelRadius != 0, "axle.m_wheelRadius must be non-zero");
+        const auto wheelEntityId = axle.m_axleWheels[wheelId];
+        AZ::Entity* wheelEntityPtr = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(wheelEntityPtr, &AZ::ComponentApplicationRequests::FindEntity, wheelEntityId);
+        AZ_Assert(wheelEntityPtr, "The wheelEntity should not be null here");
+        out.wheelControllerComponentPtr = Utils::GetGameOrEditorComponent<WheelControllerComponent>(wheelEntityPtr);
+        out.wheelData = VehicleDynamics::Utilities::GetWheelData(wheelEntityId, axle.m_wheelRadius);
+        if (out.wheelControllerComponentPtr)
         {
-            const float omega = axis.Dot(wheel->GetRotationVelocity());
-            d_x += omega * column.GetX();
-            d_fi += omega * column.GetY();
+            const auto wheelsCount = axle.m_axleWheels.size();
+            const float normalizedWheelId = -1.f + 2.f * wheelId / (wheelsCount - 1);
+            out.wheelPosition = normalizedWheelId * (m_config.m_track / 2.f);
+            out.dX = axle.m_wheelRadius / (wheelsCount * axlesCount);
+            out.dPhi = axle.m_wheelRadius / (out.wheelPosition * axlesCount * axle.m_axleWheels.size());
+
+            AZ::Transform hingeTransform = Utilities::GetJointTransform(out.wheelData);
+            out.axis = hingeTransform.TransformVector({ 0.f, 1.f, 0.f });
         }
 
-        return AZStd::pair<AZ::Vector3, AZ::Vector3>{ { d_x, 0, 0 }, { 0, 0, d_fi } };
+        return out;
+    }
+
+    AZStd::pair<AZ::Vector3, AZ::Vector3> SkidSteeringDriveModel::GetVelocityFromModel()
+    {
+        if (!m_initialized)
+        {
+            InitializeCache();
+        }
+
+        float dX = 0; // accumulated contribution to vehicle's linear movements of every wheel
+        float dPhi = 0; // accumulated contribution to vehicle's rotational movements of every wheel
+
+        for (const auto& wheel : m_wheelsCache)
+        {
+            const float omega = wheel.axis.Dot(wheel.wheelControllerComponentPtr->GetRotationVelocity());
+            dX += omega * wheel.dX;
+            dPhi += omega * wheel.dPhi;
+        }
+
+        return AZStd::pair<AZ::Vector3, AZ::Vector3>{ { dX, 0, 0 }, { 0, 0, dPhi } };
     }
 
     void SkidSteeringDriveModel::ApplyState(const VehicleInputs& inputs, AZ::u64 deltaTimeNs)
@@ -117,6 +140,12 @@ namespace ROS2::VehicleDynamics
         {
             return;
         }
+
+        if (!m_initialized)
+        {
+            InitializeCache();
+        }
+
         const float angularTargetSpeed = inputs.m_angularRates.GetZ();
         const float linearTargetSpeed = inputs.m_speed.GetX();
         const float angularAcceleration = m_limits.GetAngularAcceleration();
@@ -128,48 +157,12 @@ namespace ROS2::VehicleDynamics
             angularTargetSpeed, m_currentAngularVelocity, deltaTimeNs, angularAcceleration, maxAngularVelocity);
         m_currentLinearVelocity =
             Utilities::ComputeRampVelocity(linearTargetSpeed, m_currentLinearVelocity, deltaTimeNs, linearAcceleration, maxLinearVelocity);
-        // cache PhysX Hinge component IDs
-        if (m_wheelsData.empty())
-        {
-            int driveAxesCount = 0;
-            for (const auto& axle : m_config.m_axles)
-            {
-                if (axle.m_isDrive)
-                {
-                    driveAxesCount++;
-                }
-                for (const auto& wheel : axle.m_axleWheels)
-                {
-                    auto wheelData = VehicleDynamics::Utilities::GetWheelData(wheel, axle.m_wheelRadius);
-                    m_wheelsData[wheel] = wheelData;
-                }
-                AZ_Warning(
-                    "SkidSteeringDriveModel",
-                    axle.m_axleWheels.size() > 1,
-                    "Axle %s has not enough wheels (%d)",
-                    axle.m_axleTag.c_str(),
-                    axle.m_axleWheels.size());
-            }
-            AZ_Warning("SkidSteeringDriveModel", driveAxesCount != 0, "Skid steering model does not have any drive wheels.");
-        }
 
-        for (const auto& axle : m_config.m_axles)
+        for (const auto& wheel : m_wheelsCache)
         {
-            const auto wheelCount = axle.m_axleWheels.size();
-            if (!axle.m_isDrive || wheelCount < 1)
-            {
-                continue;
-            }
-            for (size_t wheelId = 0; wheelId < wheelCount; wheelId++)
-            {
-                const auto& wheelEntityId = axle.m_axleWheels[wheelId];
-                float normalizedWheelId = -1.f + 2.f * wheelId / (wheelCount - 1);
-                float wheelBase = normalizedWheelId * m_config.m_wheelbase / 2.f;
-                AZ_Assert(axle.m_wheelRadius != 0, "axle.m_wheelRadius must be non-zero");
-                float wheelRate = (m_currentLinearVelocity + m_currentAngularVelocity * wheelBase) / axle.m_wheelRadius;
-                const auto& wheelData = m_wheelsData[wheelEntityId];
-                VehicleDynamics::Utilities::SetWheelRotationSpeed(wheelData, wheelRate);
-            }
+            const float wheelRate =
+                (m_currentLinearVelocity + m_currentAngularVelocity * wheel.wheelPosition) / wheel.wheelData.m_wheelRadius;
+            VehicleDynamics::Utilities::SetWheelRotationSpeed(wheel.wheelData, wheelRate);
         }
     }
 

--- a/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/SkidSteeringDriveModel.h
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/SkidSteeringDriveModel.h
@@ -19,7 +19,7 @@
 
 namespace ROS2::VehicleDynamics
 {
-    //! A simple skid steering system implementation converting speed and steering inputs into wheel impulse and steering element torque
+    //! A simple skid steering system implementation converting speed and steering inputs into wheel rotation
     class SkidSteeringDriveModel : public DriveModel
     {
     public:
@@ -39,25 +39,43 @@ namespace ROS2::VehicleDynamics
         AZStd::pair<AZ::Vector3, AZ::Vector3> GetVelocityFromModel() override;
 
     private:
+        // Data collected once and cached for the reuse
+        struct SkidSteeringWheelData
+        {
+            WheelControllerComponent* wheelControllerComponentPtr{ nullptr };
+            WheelDynamicsData wheelData;
+            float wheelPosition{ 0.0f }; // normalized distance between the wheel and the axle's center
+            float dX{ 0.0f }; // wheel's contribution to vehicle's linear movement
+            float dPhi{ 0.0f }; // wheel's contribution to vehicle's rotational movement
+            AZ::Vector3 axis{ AZ::Vector3::CreateZero() }; // rotation axis of the wheel
+        };
+        AZStd::vector<SkidSteeringWheelData> m_wheelsCache;
+        bool m_initialized = false;
+
+        //! Collect all necessary data to compute the impact of wheels on the vehicle's velocity.
+        //! The data is stored in cache and reused.
+        void InitializeCache();
+
         //! Collect all necessary data to compute the impact of the wheel on the vehicle's velocity.
-        //! It can be thought of as a column of the Jacobian matrix of the mechanical system. Jacobian matrix for this model is a matrix of
-        //! size 2 x number of wheels. This function returns elements of column that corresponds to the given wheel and cache necessary data
-        //! to find the wheel's rotation as a scalar.
-        //! @param wheelNumber - number of wheels in axis
+        //! It can be thought of as a column of the Jacobian matrix of the mechanical system. Jacobian matrix for this model is a matrix
+        //! of size 2 x number of wheels. This function returns elements of column that corresponds to the given wheel and cache
+        //! necessary data to find the wheel's rotation as a scalar.
+        //! @param wheelId - id of the currently processed wheel in the axle vector
         //! @param axle - the wheel's axle configuration
-        //! @param axisCount - number of axles in the vehicle
-        //! @returns A tuple containing of :
-        //!  - pointer to WheelControllerComponent (API to query for wheel's ration speed),
+        //! @param axlesCount - number of axles in the vehicle
+        //! @returns A structure containing of:
+        //!  - a pointer to WheelControllerComponent (API to query for wheel's ration speed),
+        //!  - a structure with wheel dynamics data
+        //!  - a signed distance from the wheel to the center of the axle
         //!  - a contribution to vehicle linear and angular velocity (elements of Jacobian matrix)
-        //!  - the axis of wheel (to convert 3D rotation speed to given scalar
-        AZStd::tuple<VehicleDynamics::WheelControllerComponent*, AZ::Vector2, AZ::Vector3> ProduceWheelColumn(
-            int wheelNumber, const AxleConfiguration& axle, const int axisCount) const;
+        //!  - an axis of wheel (to convert 3D rotation speed to given scalar)
+        SkidSteeringWheelData ProduceWheelColumn(const int wheelId, const AxleConfiguration& axle, const int axlesCount) const;
 
         SkidSteeringModelLimits m_limits;
         AZStd::unordered_map<AZ::EntityId, VehicleDynamics::WheelDynamicsData> m_wheelsData;
         AZStd::vector<AZStd::tuple<VehicleDynamics::WheelControllerComponent*, AZ::Vector2, AZ::Vector3>> m_wheelColumns;
         VehicleConfiguration m_config;
-        float m_currentLinearVelocity = 0.0f;
-        float m_currentAngularVelocity = 0.0f;
+        float m_currentLinearVelocity{ 0.0f };
+        float m_currentAngularVelocity{ 0.0f };
     };
 } // namespace ROS2::VehicleDynamics

--- a/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/SkidSteeringDriveModel.h
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/SkidSteeringDriveModel.h
@@ -29,7 +29,6 @@ namespace ROS2::VehicleDynamics
 
         // DriveModel overrides
         void Activate(const VehicleConfiguration& vehicleConfig) override;
-
         static void Reflect(AZ::ReflectContext* context);
 
     protected:
@@ -39,41 +38,32 @@ namespace ROS2::VehicleDynamics
         AZStd::pair<AZ::Vector3, AZ::Vector3> GetVelocityFromModel() override;
 
     private:
-        // Data collected once and cached for the reuse
+        //! Data to compute the impact of a single wheel on the vehicle's velocity and to access the wheel to get/set target values.
         struct SkidSteeringWheelData
         {
-            WheelControllerComponent* wheelControllerComponentPtr{ nullptr };
-            WheelDynamicsData wheelData;
-            float wheelPosition{ 0.0f }; // normalized distance between the wheel and the axle's center
-            float dX{ 0.0f }; // wheel's contribution to vehicle's linear movement
-            float dPhi{ 0.0f }; // wheel's contribution to vehicle's rotational movement
-            AZ::Vector3 axis{ AZ::Vector3::CreateZero() }; // rotation axis of the wheel
+            WheelControllerComponent* wheelControllerComponentPtr{ nullptr }; //!< Pointer to wheel controller to set/get rotation speed.
+            WheelDynamicsData wheelData; //!< Wheel parameters.
+            float wheelPosition{ 0.0f }; //!< Normalized distance between the wheel and the axle's center.
+            float dX{ 0.0f }; //!< Wheel's contribution to vehicle's linear movement.
+            float dPhi{ 0.0f }; //!< Wheel's contribution to vehicle's rotational movement.
+            AZ::Vector3 axis{ AZ::Vector3::CreateZero() }; //!< Rotation axis of the wheel.
         };
-        AZStd::vector<SkidSteeringWheelData> m_wheelsCache;
-        bool m_initialized = false;
+        AZStd::vector<SkidSteeringWheelData> m_wheelsData; //!< Buffer with pre-calculated wheels' data.
+        bool m_initialized = false; //!< Information if m_wheelsData was pre-calculated.
 
-        //! Collect all necessary data to compute the impact of wheels on the vehicle's velocity.
-        //! The data is stored in cache and reused.
-        void InitializeCache();
+        //! Compute all necessary data for wheels' contribution to the vehicle's velocity and store it in the buffer.
+        void ComputeWheelsData();
 
-        //! Collect all necessary data to compute the impact of the wheel on the vehicle's velocity.
-        //! It can be thought of as a column of the Jacobian matrix of the mechanical system. Jacobian matrix for this model is a matrix
-        //! of size 2 x number of wheels. This function returns elements of column that corresponds to the given wheel and cache
-        //! necessary data to find the wheel's rotation as a scalar.
+        //! Compute all necessary data for a single wheel's contribution to the vehicle's velocity. It can be thought of as a column of the
+        //! Jacobian matrix of the mechanical system. This function returns elements of column that corresponds to the given wheel, stores
+        //! necessary data to find the wheel's rotation as a scalar, and stores necessary data to set this rotation.
         //! @param wheelId - id of the currently processed wheel in the axle vector
         //! @param axle - the wheel's axle configuration
         //! @param axlesCount - number of axles in the vehicle
-        //! @returns A structure containing of:
-        //!  - a pointer to WheelControllerComponent (API to query for wheel's ration speed),
-        //!  - a structure with wheel dynamics data
-        //!  - a signed distance from the wheel to the center of the axle
-        //!  - a contribution to vehicle linear and angular velocity (elements of Jacobian matrix)
-        //!  - an axis of wheel (to convert 3D rotation speed to given scalar)
-        SkidSteeringWheelData ProduceWheelColumn(const int wheelId, const AxleConfiguration& axle, const int axlesCount) const;
+        //! @returns SkidSteeringWheelData structure for a single wheel
+        SkidSteeringWheelData ComputeSingleWheelData(const int wheelId, const AxleConfiguration& axle, const int axlesCount) const;
 
         SkidSteeringModelLimits m_limits;
-        AZStd::unordered_map<AZ::EntityId, VehicleDynamics::WheelDynamicsData> m_wheelsData;
-        AZStd::vector<AZStd::tuple<VehicleDynamics::WheelControllerComponent*, AZ::Vector2, AZ::Vector3>> m_wheelColumns;
         VehicleConfiguration m_config;
         float m_currentLinearVelocity{ 0.0f };
         float m_currentAngularVelocity{ 0.0f };

--- a/Gems/ROS2/Code/Source/VehicleDynamics/Utilities.cpp
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/Utilities.cpp
@@ -217,34 +217,33 @@ namespace ROS2::VehicleDynamics::Utilities
             Utils::TryGetFreeArticulationAxis(wheelEntityId, wheelData.m_axis);
             wheelData.m_wheelJoint = articulationComponent->GetId();
             return wheelData;
-
         }
 
         AZ_Warning("GetWheelDynamicData", false, "Entity %s has no PhysX::HingeJointComponent", wheelEntityId.ToString().c_str());
         return wheelData;
     }
 
-    float ComputeRampVelocity(float targetVelocty, float lastVelocity, AZ::u64 deltaTimeNs, float acceleration, float maxVelocity)
+    float ComputeRampVelocity(float targetVelocity, float lastVelocity, AZ::u64 deltaTimeNs, float acceleration, float maxVelocity)
     {
         const float deltaTimeSec = 1e-9f * static_cast<float>(deltaTimeNs);
         const float deltaAcceleration = deltaTimeSec * acceleration;
         float commandVelocity = 0;
-        if (AZStd::abs(lastVelocity - targetVelocty) < deltaAcceleration)
+        if (AZStd::abs(lastVelocity - targetVelocity) < deltaAcceleration)
         {
-            commandVelocity = targetVelocty;
+            commandVelocity = targetVelocity;
         }
-        else if (targetVelocty > lastVelocity)
+        else if (targetVelocity > lastVelocity)
         {
             commandVelocity = lastVelocity + deltaAcceleration;
         }
-        else if (targetVelocty < lastVelocity)
+        else if (targetVelocity < lastVelocity)
         {
             commandVelocity = lastVelocity - deltaAcceleration;
         }
         return AZStd::clamp(commandVelocity, -maxVelocity, maxVelocity);
     }
 
-    void SetWheelRotationSpeed(const  VehicleDynamics::WheelDynamicsData& data, float wheelRotationSpeed)
+    void SetWheelRotationSpeed(const VehicleDynamics::WheelDynamicsData& data, float wheelRotationSpeed)
     {
         if (data.m_isArticulation)
         {
@@ -253,7 +252,8 @@ namespace ROS2::VehicleDynamics::Utilities
         }
         else
         {
-            PhysX::JointRequestBus::Event( AZ::EntityComponentIdPair(data.m_wheelEntity,data.m_wheelJoint), &PhysX::JointRequests::SetVelocity, wheelRotationSpeed);
+            PhysX::JointRequestBus::Event(
+                AZ::EntityComponentIdPair(data.m_wheelEntity, data.m_wheelJoint), &PhysX::JointRequests::SetVelocity, wheelRotationSpeed);
         }
     }
 
@@ -262,7 +262,8 @@ namespace ROS2::VehicleDynamics::Utilities
         AZ::Transform hingeTransform{ AZ::Transform::Identity() };
         if (!data.m_isArticulation)
         {
-            PhysX::JointRequestBus::EventResult(hingeTransform, AZ::EntityComponentIdPair(data.m_wheelEntity,data.m_wheelJoint), &PhysX::JointRequests::GetTransform);
+            PhysX::JointRequestBus::EventResult(
+                hingeTransform, AZ::EntityComponentIdPair(data.m_wheelEntity, data.m_wheelJoint), &PhysX::JointRequests::GetTransform);
         }
         return hingeTransform;
     }


### PR DESCRIPTION
## What does this PR do?

This PR fixes some issues in _SkidSteeringDriveModel_ implementation. Both the method for applying the rotation to wheels based on the requested model movement and the method for calculating the model's movement based on the wheels' rotation were refactored.
- The track parameter is used instead of the wheelbase parameter for calculation (Closes #615), the naming is also unified and fixed.
- The same distance between wheels is used in the codebase (it was two times bigger while [getting the speed](https://github.com/o3de/o3de-extras/blob/d9fc445a72a30ed683cf6cb18dfa8b3a3e762f6a/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/SkidSteeringDriveModel.cpp#L60) than while [applying the speed](https://github.com/o3de/o3de-extras/blob/d9fc445a72a30ed683cf6cb18dfa8b3a3e762f6a/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/SkidSteeringDriveModel.cpp#L162). This part was working correctly only for robots with two wheels per axle, now the code is more readable and works for any number of wheels.
- One buffer instead of [two separate ones](https://github.com/o3de/o3de-extras/blob/d9fc445a72a30ed683cf6cb18dfa8b3a3e762f6a/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/SkidSteeringDriveModel.h#L55) is used to cache data; there is no recalculation of some of it in [every step](https://github.com/o3de/o3de-extras/blob/d9fc445a72a30ed683cf6cb18dfa8b3a3e762f6a/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/SkidSteeringDriveModel.cpp#L160).
- The correct number of axles is used in the calculation (non-drivable axles were taken into consideration [previously](https://github.com/o3de/o3de-extras/blob/d9fc445a72a30ed683cf6cb18dfa8b3a3e762f6a/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/SkidSteeringDriveModel.cpp#L83) ).
- Segfault triggered when the [number of wheels == 1](https://github.com/o3de/o3de-extras/blob/153d83cbf09695c2e141e5016ba7a3ba35ef5709/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/SkidSteeringDriveModel.cpp#L161) is removed.
- The names such as `axis` and `axle` are unified along the codebase and used correctly.

## How was this PR tested?

- create an empty level
- import robot with SkidSteering (ROSbot in my case)
- add `ROS2 Wheel Odometry Sensor`
- send commands to move the robot via ROS2 and echo the odometry in another terminal - the values should be approximately the same
```bash
ros2 topic pub -r 10 /cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.5, y: 0.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 1.0}}" 
ros2 topic echo /odom
```
