### PR TITLE
RobotImporter: Support <pose> within <sensor>

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -23,9 +23,10 @@ namespace ROS2::SDFormat
         SensorImporterHook importerHook;
         importerHook.m_sensorTypes =
             AZStd::unordered_set<sdf::SensorType>{ sdf::SensorType::CAMERA, sdf::SensorType::DEPTH_CAMERA, sdf::SensorType::RGBD_CAMERA };
-        importerHook.m_supportedSensorParams =
-            AZStd::unordered_set<AZStd::string>{ ">update_rate",         ">camera>horizontal_fov", ">camera>image>width",
-                                                 ">camera>image>height", ">camera>clip>near",      ">camera>clip>far" };
+        importerHook.m_supportedSensorParams = AZStd::unordered_set<AZStd::string>{
+            ">pose",           ">update_rate", ">camera>horizontal_fov", ">camera>image>width", ">camera>image>height", ">camera>clip>near",
+            ">camera>clip>far"
+        };
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_camera.so",
                                                                           "libgazebo_ros_depth_camera.so",
                                                                           "libgazebo_ros_openni_kinect.so" };

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -19,7 +19,7 @@ namespace ROS2::SDFormat
     {
         SensorImporterHook importerHook;
         importerHook.m_sensorTypes = AZStd::unordered_set<sdf::SensorType>{ sdf::SensorType::NAVSAT };
-        importerHook.m_supportedSensorParams = AZStd::unordered_set<AZStd::string>{ ">update_rate" };
+        importerHook.m_supportedSensorParams = AZStd::unordered_set<AZStd::string>{ ">pose", ">update_rate" };
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_gps_sensor.so" };
         importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{};
         importerHook.m_sdfSensorToComponentCallback = [](AZ::Entity& entity,

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -21,7 +21,8 @@ namespace ROS2::SDFormat
     {
         SensorImporterHook importerHook;
         importerHook.m_sensorTypes = AZStd::unordered_set<sdf::SensorType>{ sdf::SensorType::IMU };
-        importerHook.m_supportedSensorParams = AZStd::unordered_set<AZStd::string>{ ">update_rate",
+        importerHook.m_supportedSensorParams = AZStd::unordered_set<AZStd::string>{ ">pose",
+                                                                                    ">update_rate",
                                                                                     ">imu>angular_velocity>x>noise>mean",
                                                                                     ">imu>angular_velocity>x>noise>stddev",
                                                                                     ">imu>angular_velocity>y>noise>mean",

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -23,6 +23,7 @@ namespace ROS2::SDFormat
         SensorImporterHook importerHook;
         importerHook.m_sensorTypes = AZStd::unordered_set<sdf::SensorType>{ sdf::SensorType::LIDAR, sdf::SensorType::GPU_LIDAR };
         importerHook.m_supportedSensorParams = AZStd::unordered_set<AZStd::string>{
+            ">pose",
             ">update_rate",
             ">lidar>scan>horizontal>samples",
             ">lidar>scan>horizontal>min_angle",

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -7,7 +7,10 @@
  */
 
 #include "ROS2SDFormatHooksUtils.h"
+#include <AzToolsFramework/ToolsComponents/TransformComponent.h>
 #include <ROS2/Communication/TopicConfiguration.h>
+#include <RobotImporter/Utils/RobotImporterUtils.h>
+#include <RobotImporter/Utils/TypeConversions.h>
 #include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
 #include <VehicleDynamics/WheelControllerComponent.h>
 
@@ -66,6 +69,33 @@ namespace ROS2::SDFormat
                     true);
                 entity->Deactivate();
             }
+        }
+    }
+
+    void HooksUtils::SetSensorEntityTransform(AZ::Entity& entity, const sdf::Sensor& sdfSensor)
+    {
+        const auto sensorSemanticPose = sdfSensor.SemanticPose();
+        AZ::Transform tf = Utils::GetLocalTransformURDF(sensorSemanticPose);
+        auto* transformInterface = entity.FindComponent<AzToolsFramework::Components::TransformComponent>();
+        if (transformInterface)
+        {
+            AZ_Trace(
+                "CreatePrefabFromUrdfOrSdf",
+                "Setting transform %s to [%f %f %f] [%f %f %f %f]\n",
+                sdfSensor.Name().c_str(),
+                tf.GetTranslation().GetX(),
+                tf.GetTranslation().GetY(),
+                tf.GetTranslation().GetZ(),
+                tf.GetRotation().GetX(),
+                tf.GetRotation().GetY(),
+                tf.GetRotation().GetZ(),
+                tf.GetRotation().GetW());
+            transformInterface->SetLocalTM(tf);
+        }
+        else
+        {
+            AZ_Trace(
+                "CreatePrefabFromUrdfOrSdf", "Setting transform failed: %s does not have transform interface\n", sdfSensor.Name().c_str());
         }
     }
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -21,6 +21,7 @@
 #include <Source/EditorHingeJointComponent.h>
 
 #include <sdf/Model.hh>
+#include <sdf/Sensor.hh>
 
 namespace ROS2::SDFormat
 {
@@ -47,6 +48,11 @@ namespace ROS2::SDFormat
         //! Enable motor in EditorHingeJointComponent if possible
         //! @param entityId entity id of the modified entity
         void EnableMotor(const AZ::EntityId& entityId);
+
+        //! Set transform to entity containing sensor based on <pose> tag in sdformat data (if available).
+        //! @param entity entity to which the transform is set
+        //! @param sdfSensor reference to SDFormat sensor possibly containing <pose> tag
+        void SetSensorEntityTransform(AZ::Entity& entity, const sdf::Sensor& sdfSensor);
 
         //! Create a component and attach the component to the entity.
         //! This method ensures that game components are wrapped into GenericComponentWrapper.

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
@@ -12,6 +12,7 @@
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <ROS2/RobotImporter/RobotImporterBus.h>
 #include <ROS2/RobotImporter/SDFormatSensorImporterHook.h>
+#include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
 #include <RobotImporter/URDF/PrefabMakerUtils.h>
 
 #include <sdf/Link.hh>
@@ -27,6 +28,7 @@ namespace ROS2
     {
         // Since O3DE does not allow origin for sensors, we need to create a sub-entity and store sensor there
         AZStd::string subEntityName = sensor->Name().empty() ? sensor->TypeStr().c_str() : sensor->Name().c_str();
+        subEntityName.append("_sensor");
         auto createEntityResult = PrefabMakerUtils::CreateEntity(entityId, subEntityName);
         if (!createEntityResult.IsSuccess())
         {
@@ -44,6 +46,7 @@ namespace ROS2
         createdEntities.emplace_back(sensorEntityId);
         AZ::Entity* sensorEntity = AzToolsFramework::GetEntityById(sensorEntityId);
         hook->m_sdfSensorToComponentCallback(*sensorEntity, *sensor);
+        SDFormat::HooksUtils::SetSensorEntityTransform(*sensorEntity, *sensor);
     }
 
     void AddSensor(AZ::EntityId entityId, const sdf::Sensor* sensor, AZStd::vector<AZ::EntityId>& createdEntities)

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.h
@@ -25,6 +25,7 @@ namespace ROS2
         //! @param model A parsed SDF model which could hold information about sensor to be made.
         //! @param link A parsed SDF tree link node used to identify link being currently processed.
         //! @param entityId A non-active entity which will be affected.
-        void AddSensors(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId) const;
+        //! @return List containing any entities with sensors that were created.
+        AZStd::vector<AZ::EntityId> AddSensors(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId) const;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -674,7 +674,8 @@ namespace ROS2
         if (attachedModel != nullptr)
         {
             m_collidersMaker.AddColliders(*attachedModel, &link, entityId);
-            m_sensorsMaker.AddSensors(*attachedModel, &link, entityId);
+            auto createdSensorEntities = m_sensorsMaker.AddSensors(*attachedModel, &link, entityId);
+            createdEntities.insert(createdEntities.end(), createdSensorEntities.begin(), createdSensorEntities.end());
         }
         return AZ::Success(entityId);
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -292,7 +292,8 @@ namespace ROS2
             {
                 AZ::EntityId createdEntityId = createLinkEntityResult.GetValue();
                 std::string linkName = linkPtr->Name();
-                AZ::Transform tf = Utils::GetLocalTransformURDF(linkPtr);
+                const auto linkSemanticPose = linkPtr->SemanticPose();
+                AZ::Transform tf = Utils::GetLocalTransformURDF(linkSemanticPose);
                 auto* entity = AzToolsFramework::GetEntityById(createdEntityId);
                 if (entity)
                 {

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -180,8 +180,7 @@ namespace ROS2
                 if (asset)
                 {
                     assetId = Utils::GetModelProductAssetId(asset->m_sourceGuid);
-                    AZ_Warning(
-                        "AddVisual", assetId.IsValid(), "There is no product asset for %s.", asset->m_sourceAssetRelativePath.c_str());
+                    AZ_Warning("AddVisual", assetId.IsValid(), "There is no product asset for %s.", asset->m_sourceAssetRelativePath.c_str());
                 }
 
                 AddVisualAssetToEntity(entityId, assetId, scaleVector);
@@ -296,10 +295,7 @@ namespace ROS2
                 pbrWorkflow = pbr->Workflow(sdf::PbrWorkflowType::SPECULAR);
                 if (!pbrWorkflow)
                 {
-                    AZ_Error(
-                        "AddMaterial",
-                        false,
-                        "Material has a PBR definition, but it is neither a Metal nor a Specular workflow. Cannot convert.");
+                    AZ_Error("AddMaterial", false, "Material has a PBR definition, but it is neither a Metal nor a Specular workflow. Cannot convert.");
                     return;
                 }
             }
@@ -315,80 +311,60 @@ namespace ROS2
                     if (asset)
                     {
                         assetId = Utils::GetImageProductAssetId(asset->m_sourceGuid);
-                        AZ_Warning(
-                            "AddVisual",
-                            assetId.IsValid(),
-                            "There is no product image asset for %s.",
-                            asset->m_sourceAssetRelativePath.c_str());
+                        AZ_Warning("AddVisual", assetId.IsValid(), "There is no product image asset for %s.", asset->m_sourceAssetRelativePath.c_str());
                     }
                     return assetId;
                 };
 
                 if (auto texture = pbrWorkflow->AlbedoMap(); !texture.empty())
                 {
-                    materialAssignment.m_propertyOverrides.emplace(
-                        AZ::Name("baseColor.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("baseColor.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                 }
 
                 if (auto texture = pbrWorkflow->NormalMap(); !texture.empty())
                 {
-                    materialAssignment.m_propertyOverrides.emplace(
-                        AZ::Name("normal.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("normal.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                 }
 
                 if (auto texture = pbrWorkflow->AmbientOcclusionMap(); !texture.empty())
                 {
-                    materialAssignment.m_propertyOverrides.emplace(
-                        AZ::Name("occlusion.diffuseTextureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("occlusion.diffuseTextureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                 }
 
                 if (auto texture = pbrWorkflow->EmissiveMap(); !texture.empty())
                 {
                     materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.enable"), AZStd::any(true));
-                    materialAssignment.m_propertyOverrides.emplace(
-                        AZ::Name("emissive.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
+                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                 }
 
                 if (pbrWorkflow->Type() == sdf::PbrWorkflowType::METAL)
                 {
                     if (auto texture = pbrWorkflow->RoughnessMap(); !texture.empty())
                     {
-                        materialAssignment.m_propertyOverrides.emplace(
-                            AZ::Name("roughness.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
+                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("roughness.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                     }
 
                     if (auto texture = pbrWorkflow->MetalnessMap(); !texture.empty())
                     {
-                        materialAssignment.m_propertyOverrides.emplace(
-                            AZ::Name("metallic.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
+                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("metallic.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                     }
 
                     if (pbrWorkflow->Element()->HasElement("roughness"))
                     {
-                        materialAssignment.m_propertyOverrides.emplace(
-                            AZ::Name("roughness.factor"), AZStd::any(static_cast<float>(pbrWorkflow->Roughness())));
+                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("roughness.factor"), AZStd::any(static_cast<float>(pbrWorkflow->Roughness())));
                     }
 
                     if (pbrWorkflow->Element()->HasElement("metalness"))
                     {
-                        materialAssignment.m_propertyOverrides.emplace(
-                            AZ::Name("metallic.factor"), AZStd::any(static_cast<float>(pbrWorkflow->Metalness())));
+                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("metallic.factor"), AZStd::any(static_cast<float>(pbrWorkflow->Metalness())));
                     }
                 }
                 else
                 {
-                    AZ_Warning(
-                        "AddMaterial",
-                        pbrWorkflow->GlossinessMap().empty(),
-                        "PBR material has a Glossiness map (%s), which is a Specular PBR workflow, not a Metal PBR workflow. It will not "
-                        "be converted.",
-                        pbrWorkflow->GlossinessMap().c_str());
-                    AZ_Warning(
-                        "AddMaterial",
-                        pbrWorkflow->SpecularMap().empty(),
-                        "PBR material has a Specular map (%s), which is a Specular PBR workflow, not a Metal PBR workflow. It will not be "
-                        "converted.",
-                        pbrWorkflow->SpecularMap().c_str());
+                    AZ_Warning("AddMaterial", pbrWorkflow->GlossinessMap().empty(), 
+                        "PBR material has a Glossiness map (%s), which is a Specular PBR workflow, not a Metal PBR workflow. It will not be converted.", pbrWorkflow->GlossinessMap().c_str());
+                    AZ_Warning("AddMaterial", pbrWorkflow->SpecularMap().empty(), 
+                        "PBR material has a Specular map (%s), which is a Specular PBR workflow, not a Metal PBR workflow. It will not be converted.", pbrWorkflow->SpecularMap().c_str());
                 }
             }
         }
@@ -434,16 +410,14 @@ namespace ROS2
 
     static void OverrideMaterialEmissiveSettings(const sdf::Material* material, AZ::Render::MaterialAssignmentMap& overrides)
     {
-        // Emissive: If an emissive color has been specified, enable emissive on the material and set the emissive color to the provided
-        // one.
+        // Emissive: If an emissive color has been specified, enable emissive on the material and set the emissive color to the provided one.
         if (material->Element()->HasElement("emissive"))
         {
-            // Get the color and convert from gamma to linear to try and account for the different color spaces between phong and PBR
-            // rendering.
+            // Get the color and convert from gamma to linear to try and account for the different color spaces between phong and PBR rendering.
             const auto materialColor = material->Emissive();
             const AZ::Color emissiveColor = URDF::TypeConversions::ConvertColor(materialColor).GammaToLinear();
 
-            // It seems to be fairly common to have an emissive entry of black, which isn't emissive at all.
+            // It seems to be fairly common to have an emissive entry of black, which isn't emissive at all. 
             // Only enable the emissive color if it's a non-black value.
             if ((emissiveColor.GetR() > 0.0f) || (emissiveColor.GetG() > 0.0f) || (emissiveColor.GetB() > 0.0f))
             {
@@ -465,8 +439,7 @@ namespace ROS2
 
     static void OverrideMaterialRoughness(const sdf::Material* material, AZ::Render::MaterialAssignmentMap& overrides)
     {
-        // Metallic/Roughness: Try to use the shininess value for roughness if we have one, otherwise fall back to using the specular
-        // brightness.
+        // Metallic/Roughness: Try to use the shininess value for roughness if we have one, otherwise fall back to using the specular brightness.
         if (material->Element()->HasElement("shininess") || material->Element()->HasElement("specular"))
         {
             float shininess = 0.0f;
@@ -548,17 +521,13 @@ namespace ROS2
         auto modelAsset = AZ::Data::AssetManager::Instance().GetAsset<AZ::RPI::ModelAsset>(assetId, AZ::Data::AssetLoadBehavior::Default);
         modelAsset.BlockUntilLoadComplete();
 
-        AZ_Error(
-            "AddMaterial",
-            modelAsset.IsReady(),
-            "Trying to create materials for a model that couldn't load. The generated material overrides may not work correctly.");
+        AZ_Error("AddMaterial", modelAsset.IsReady(), "Trying to create materials for a model that couldn't load. The generated material overrides may not work correctly.");
 
         // Initialize the material component configuration to contain all of the material mappings from the model.
         AZ::Render::MaterialComponentConfig config;
         config.m_materials = AZ::Render::GetDefaultMaterialMapFromModelAsset(modelAsset);
 
-        // Try to override all of the various material settings based on what's contained in the <material> and <visual> elements in the
-        // source file.
+        // Try to override all of the various material settings based on what's contained in the <material> and <visual> elements in the source file.
         OverrideScriptMaterial(material, config.m_materials);
         OverrideMaterialPbrSettings(material, m_urdfAssetsMapping, config.m_materials);
         OverrideMaterialBaseColor(material, config.m_materials);
@@ -567,8 +536,7 @@ namespace ROS2
         OverrideMaterialRoughness(material, config.m_materials);
         OverrideMaterialDoubleSided(material, config.m_materials);
 
-        // All the material overrides are in place, so get the entity, add the material component, and set its configuration to use the
-        // material overrides.
+        // All the material overrides are in place, so get the entity, add the material component, and set its configuration to use the material overrides.
         AZ::Entity* entity = AzToolsFramework::GetEntityById(entityId);
         AZ_Assert(entity, "Entity ID for visual %s couldn't be found.", visual->Name().c_str());
         auto component = entity->CreateComponent(AZ::Render::EditorMaterialComponentTypeId);

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -85,7 +85,7 @@ namespace ROS2
         // Use a name generated from the link unless specific name is defined for this visual
         AZStd::string subEntityName = visual->Name().empty() ? generatedName.c_str() : visual->Name().c_str();
         // Since O3DE does not allow origin for visuals, we need to create a sub-entity and store visual there
-        auto createEntityResult = PrefabMakerUtils::CreateEntity(entityId, subEntityName.c_str());
+        auto createEntityResult = PrefabMakerUtils::CreateEntity(entityId, subEntityName);
         if (!createEntityResult.IsSuccess())
         {
             AZ_Error("AddVisual", false, "Unable to create a sub-entity for visual element %s\n", subEntityName.c_str());
@@ -180,7 +180,8 @@ namespace ROS2
                 if (asset)
                 {
                     assetId = Utils::GetModelProductAssetId(asset->m_sourceGuid);
-                    AZ_Warning("AddVisual", assetId.IsValid(), "There is no product asset for %s.", asset->m_sourceAssetRelativePath.c_str());
+                    AZ_Warning(
+                        "AddVisual", assetId.IsValid(), "There is no product asset for %s.", asset->m_sourceAssetRelativePath.c_str());
                 }
 
                 AddVisualAssetToEntity(entityId, assetId, scaleVector);
@@ -277,7 +278,10 @@ namespace ROS2
         AZ_Info("AddMaterial", "Added product material %s\n", materialProductPath.c_str());
     }
 
-    static void OverrideMaterialPbrSettings(const sdf::Material* material, const AZStd::shared_ptr<Utils::UrdfAssetMap>& assetMapping, AZ::Render::MaterialAssignmentMap& overrides)
+    static void OverrideMaterialPbrSettings(
+        const sdf::Material* material,
+        const AZStd::shared_ptr<Utils::UrdfAssetMap>& assetMapping,
+        AZ::Render::MaterialAssignmentMap& overrides)
     {
         if (auto pbr = material->PbrMaterial(); pbr)
         {
@@ -292,7 +296,10 @@ namespace ROS2
                 pbrWorkflow = pbr->Workflow(sdf::PbrWorkflowType::SPECULAR);
                 if (!pbrWorkflow)
                 {
-                    AZ_Error("AddMaterial", false, "Material has a PBR definition, but it is neither a Metal nor a Specular workflow. Cannot convert.");
+                    AZ_Error(
+                        "AddMaterial",
+                        false,
+                        "Material has a PBR definition, but it is neither a Metal nor a Specular workflow. Cannot convert.");
                     return;
                 }
             }
@@ -308,64 +315,83 @@ namespace ROS2
                     if (asset)
                     {
                         assetId = Utils::GetImageProductAssetId(asset->m_sourceGuid);
-                        AZ_Warning("AddVisual", assetId.IsValid(), "There is no product image asset for %s.", asset->m_sourceAssetRelativePath.c_str());
+                        AZ_Warning(
+                            "AddVisual",
+                            assetId.IsValid(),
+                            "There is no product image asset for %s.",
+                            asset->m_sourceAssetRelativePath.c_str());
                     }
                     return assetId;
                 };
 
                 if (auto texture = pbrWorkflow->AlbedoMap(); !texture.empty())
                 {
-                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("baseColor.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
+                    materialAssignment.m_propertyOverrides.emplace(
+                        AZ::Name("baseColor.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                 }
 
                 if (auto texture = pbrWorkflow->NormalMap(); !texture.empty())
                 {
-                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("normal.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
+                    materialAssignment.m_propertyOverrides.emplace(
+                        AZ::Name("normal.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                 }
 
                 if (auto texture = pbrWorkflow->AmbientOcclusionMap(); !texture.empty())
                 {
-                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("occlusion.diffuseTextureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
+                    materialAssignment.m_propertyOverrides.emplace(
+                        AZ::Name("occlusion.diffuseTextureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                 }
 
                 if (auto texture = pbrWorkflow->EmissiveMap(); !texture.empty())
                 {
                     materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.enable"), AZStd::any(true));
-                    materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
+                    materialAssignment.m_propertyOverrides.emplace(
+                        AZ::Name("emissive.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                 }
 
                 if (pbrWorkflow->Type() == sdf::PbrWorkflowType::METAL)
                 {
                     if (auto texture = pbrWorkflow->RoughnessMap(); !texture.empty())
                     {
-                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("roughness.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
+                        materialAssignment.m_propertyOverrides.emplace(
+                            AZ::Name("roughness.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                     }
 
                     if (auto texture = pbrWorkflow->MetalnessMap(); !texture.empty())
                     {
-                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("metallic.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
+                        materialAssignment.m_propertyOverrides.emplace(
+                            AZ::Name("metallic.textureMap"), AZStd::any(GetImageAssetIdFromPath(texture)));
                     }
 
                     if (pbrWorkflow->Element()->HasElement("roughness"))
                     {
-                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("roughness.factor"), AZStd::any(static_cast<float>(pbrWorkflow->Roughness())));
+                        materialAssignment.m_propertyOverrides.emplace(
+                            AZ::Name("roughness.factor"), AZStd::any(static_cast<float>(pbrWorkflow->Roughness())));
                     }
 
                     if (pbrWorkflow->Element()->HasElement("metalness"))
                     {
-                        materialAssignment.m_propertyOverrides.emplace(AZ::Name("metallic.factor"), AZStd::any(static_cast<float>(pbrWorkflow->Metalness())));
+                        materialAssignment.m_propertyOverrides.emplace(
+                            AZ::Name("metallic.factor"), AZStd::any(static_cast<float>(pbrWorkflow->Metalness())));
                     }
                 }
                 else
                 {
-                    AZ_Warning("AddMaterial", pbrWorkflow->GlossinessMap().empty(), 
-                        "PBR material has a Glossiness map (%s), which is a Specular PBR workflow, not a Metal PBR workflow. It will not be converted.", pbrWorkflow->GlossinessMap().c_str());
-                    AZ_Warning("AddMaterial", pbrWorkflow->SpecularMap().empty(), 
-                        "PBR material has a Specular map (%s), which is a Specular PBR workflow, not a Metal PBR workflow. It will not be converted.", pbrWorkflow->SpecularMap().c_str());
+                    AZ_Warning(
+                        "AddMaterial",
+                        pbrWorkflow->GlossinessMap().empty(),
+                        "PBR material has a Glossiness map (%s), which is a Specular PBR workflow, not a Metal PBR workflow. It will not "
+                        "be converted.",
+                        pbrWorkflow->GlossinessMap().c_str());
+                    AZ_Warning(
+                        "AddMaterial",
+                        pbrWorkflow->SpecularMap().empty(),
+                        "PBR material has a Specular map (%s), which is a Specular PBR workflow, not a Metal PBR workflow. It will not be "
+                        "converted.",
+                        pbrWorkflow->SpecularMap().c_str());
                 }
             }
         }
-
     }
 
     static void OverrideMaterialBaseColor(const sdf::Material* material, AZ::Render::MaterialAssignmentMap& overrides)
@@ -408,14 +434,16 @@ namespace ROS2
 
     static void OverrideMaterialEmissiveSettings(const sdf::Material* material, AZ::Render::MaterialAssignmentMap& overrides)
     {
-        // Emissive: If an emissive color has been specified, enable emissive on the material and set the emissive color to the provided one.
+        // Emissive: If an emissive color has been specified, enable emissive on the material and set the emissive color to the provided
+        // one.
         if (material->Element()->HasElement("emissive"))
         {
-            // Get the color and convert from gamma to linear to try and account for the different color spaces between phong and PBR rendering.
+            // Get the color and convert from gamma to linear to try and account for the different color spaces between phong and PBR
+            // rendering.
             const auto materialColor = material->Emissive();
             const AZ::Color emissiveColor = URDF::TypeConversions::ConvertColor(materialColor).GammaToLinear();
 
-            // It seems to be fairly common to have an emissive entry of black, which isn't emissive at all. 
+            // It seems to be fairly common to have an emissive entry of black, which isn't emissive at all.
             // Only enable the emissive color if it's a non-black value.
             if ((emissiveColor.GetR() > 0.0f) || (emissiveColor.GetG() > 0.0f) || (emissiveColor.GetB() > 0.0f))
             {
@@ -424,10 +452,10 @@ namespace ROS2
                     materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.enable"), AZStd::any(true));
                     materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.color"), AZStd::any(emissiveColor));
 
-                    // The URDF/SDF file doesn't specify an emissive intensity, just a color. 
+                    // The URDF/SDF file doesn't specify an emissive intensity, just a color.
                     // We're arbitrarily using a value slightly higher than the default emissive intensity.
-                    // This value was picked based on observations of emissive color behaviors in Gazebo. 
-                    // This intensity mostly preserves the color (though it lightens it a little) and 
+                    // This value was picked based on observations of emissive color behaviors in Gazebo.
+                    // This intensity mostly preserves the color (though it lightens it a little) and
                     // potentially adds a little bit of lighting to the scene if Bloom or Diffuse Probe Grid also exist in the world.
                     materialAssignment.m_propertyOverrides.emplace(AZ::Name("emissive.intensity"), AZStd::any(5.5f));
                 }
@@ -437,7 +465,8 @@ namespace ROS2
 
     static void OverrideMaterialRoughness(const sdf::Material* material, AZ::Render::MaterialAssignmentMap& overrides)
     {
-        // Metallic/Roughness: Try to use the shininess value for roughness if we have one, otherwise fall back to using the specular brightness.
+        // Metallic/Roughness: Try to use the shininess value for roughness if we have one, otherwise fall back to using the specular
+        // brightness.
         if (material->Element()->HasElement("shininess") || material->Element()->HasElement("specular"))
         {
             float shininess = 0.0f;
@@ -445,7 +474,7 @@ namespace ROS2
 
             if (material->Element()->HasElement("shininess"))
             {
-                // If we have a shininess value, we'll use it to set both metallic and roughness. 
+                // If we have a shininess value, we'll use it to set both metallic and roughness.
                 // The shinier it is, the more metallic and less rough we'll make the result.
                 shininess = material->Shininess();
                 roughness = 1.0f - shininess;
@@ -466,12 +495,11 @@ namespace ROS2
                 // Since specular color doesn't really speak to shininess, we'll arbitrarily scale down the specular brightness to
                 // 1/4 of the total brightness to modulate the metallic reflectiveness a little, but not too much. Without this scaling,
                 // a white specular color would always become fully metallic, perfectly smooth, and therefore fully reflective.
-                // With the scaling, a white specular color will be perfectly smooth but only 25% metallic, so it will have some reflectivity
-                // but not a lot.
+                // With the scaling, a white specular color will be perfectly smooth but only 25% metallic, so it will have some
+                // reflectivity but not a lot.
                 shininess = specularBrightness * 0.25f;
-
             }
-                
+
             for (auto& [id, materialAssignment] : overrides)
             {
                 materialAssignment.m_propertyOverrides.emplace(AZ::Name("metallic.factor"), AZStd::any(shininess));
@@ -520,13 +548,17 @@ namespace ROS2
         auto modelAsset = AZ::Data::AssetManager::Instance().GetAsset<AZ::RPI::ModelAsset>(assetId, AZ::Data::AssetLoadBehavior::Default);
         modelAsset.BlockUntilLoadComplete();
 
-        AZ_Error("AddMaterial", modelAsset.IsReady(), "Trying to create materials for a model that couldn't load. The generated material overrides may not work correctly.");
+        AZ_Error(
+            "AddMaterial",
+            modelAsset.IsReady(),
+            "Trying to create materials for a model that couldn't load. The generated material overrides may not work correctly.");
 
         // Initialize the material component configuration to contain all of the material mappings from the model.
         AZ::Render::MaterialComponentConfig config;
         config.m_materials = AZ::Render::GetDefaultMaterialMapFromModelAsset(modelAsset);
 
-        // Try to override all of the various material settings based on what's contained in the <material> and <visual> elements in the source file.
+        // Try to override all of the various material settings based on what's contained in the <material> and <visual> elements in the
+        // source file.
         OverrideScriptMaterial(material, config.m_materials);
         OverrideMaterialPbrSettings(material, m_urdfAssetsMapping, config.m_materials);
         OverrideMaterialBaseColor(material, config.m_materials);
@@ -535,7 +567,8 @@ namespace ROS2
         OverrideMaterialRoughness(material, config.m_materials);
         OverrideMaterialDoubleSided(material, config.m_materials);
 
-        // All the material overrides are in place, so get the entity, add the material component, and set its configuration to use the material overrides.
+        // All the material overrides are in place, so get the entity, add the material component, and set its configuration to use the
+        // material overrides.
         AZ::Entity* entity = AzToolsFramework::GetEntityById(entityId);
         AZ_Assert(entity, "Entity ID for visual %s couldn't be found.", visual->Name().c_str());
         auto component = entity->CreateComponent(AZ::Render::EditorMaterialComponentTypeId);

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -508,7 +508,8 @@ namespace ROS2::Utils
     const sdf::Model* GetModelContainingLink(const sdf::Root& root, AZStd::string_view fullyQualifiedLinkName)
     {
         const sdf::Model* resultModel{};
-        auto IsLinkInModel = [&fullyQualifiedLinkName, &resultModel](const sdf::Model& model, const ModelStack&) -> VisitModelResponse
+        auto IsLinkInModel = [&fullyQualifiedLinkName,
+                              &resultModel](const sdf::Model& model, const ModelStack&) -> VisitModelResponse
         {
             const std::string stdLinkName(fullyQualifiedLinkName.data(), fullyQualifiedLinkName.size());
             if (const sdf::Link* searchLink = model.LinkByName(stdLinkName); searchLink != nullptr)
@@ -704,12 +705,16 @@ namespace ROS2::Utils
         return filenames;
     }
 
-    AZ::IO::Path ResolveAmentPrefixPath(AZ::IO::Path unresolvedPath, AZStd::string_view amentPrefixPath, const FileExistsCB& fileExistsCB)
+    AZ::IO::Path ResolveAmentPrefixPath(
+        AZ::IO::Path unresolvedPath,
+        AZStd::string_view amentPrefixPath,
+        const FileExistsCB& fileExistsCB)
     {
         AZStd::vector<AZ::IO::Path> amentPrefixPaths;
 
         // Parse the AMENT_PREFIX_PATH environment variable into a set of distinct paths.
-        auto AmentPrefixPathVisitor = [&amentPrefixPaths](AZStd::string_view prefixPath)
+        auto AmentPrefixPathVisitor = [&amentPrefixPaths](
+            AZStd::string_view prefixPath)
         {
             amentPrefixPaths.push_back(prefixPath);
         };
@@ -720,7 +725,7 @@ namespace ROS2::Utils
         AZ::IO::PathView strippedPath;
 
         // The AMENT_PREFIX_PATH is only used for lookups if the URI starts with "model://" or "package://"
-        constexpr AZStd::string_view ValidAmentPrefixes[] = { "model://", "package://" };
+        constexpr AZStd::string_view ValidAmentPrefixes[] = {"model://", "package://"};
         for (const auto& prefix : ValidAmentPrefixes)
         {
             // Perform a case-sensitive check to look for the prefix.
@@ -759,12 +764,8 @@ namespace ROS2::Utils
             if (const AZ::IO::Path candidateResolvedPath = amentSharePath / strippedPath;
                 fileExistsCB(packageManifestPath) && fileExistsCB(candidateResolvedPath))
             {
-                AZ_Trace(
-                    "ResolveAssetPath",
-                    R"(Resolved using AMENT_PREFIX_PATH: "%.*s" -> "%.*s")"
-                    "\n",
-                    AZ_PATH_ARG(unresolvedPath),
-                    AZ_PATH_ARG(candidateResolvedPath));
+                AZ_Trace("ResolveAssetPath", R"(Resolved using AMENT_PREFIX_PATH: "%.*s" -> "%.*s")" "\n",
+                    AZ_PATH_ARG(unresolvedPath), AZ_PATH_ARG(candidateResolvedPath));
                 return candidateResolvedPath;
             }
         }
@@ -788,8 +789,7 @@ namespace ROS2::Utils
         // If the settings tell us to try the AMENT_PREFIX_PATH, use that first to try and resolve path.
         if (pathResolverSettings.m_useAmentPrefixPath)
         {
-            if (AZ::IO::Path amentResolvedPath = ResolveAmentPrefixPath(unresolvedPath, amentPrefixPath, fileExistsCB);
-                !amentResolvedPath.empty())
+            if (AZ::IO::Path amentResolvedPath = ResolveAmentPrefixPath(unresolvedPath, amentPrefixPath, fileExistsCB); !amentResolvedPath.empty())
             {
                 return amentResolvedPath;
             }
@@ -839,11 +839,7 @@ namespace ROS2::Utils
                 // There's no match.
                 if (replacedUriPath.empty())
                 {
-                    AZ_Trace(
-                        "ResolveAssetPath",
-                        R"(Resolved Path is empty: "%.*s" -> "")"
-                        "\n",
-                        AZ_PATH_ARG(unresolvedPath));
+                    AZ_Trace("ResolveAssetPath", R"(Resolved Path is empty: "%.*s" -> "")" "\n", AZ_PATH_ARG(unresolvedPath));
                     return {};
                 }
 
@@ -853,12 +849,8 @@ namespace ROS2::Utils
                 {
                     if (fileExistsCB(replacedUriPath))
                     {
-                        AZ_Trace(
-                            "ResolveAssetPath",
-                            R"(Resolved Absolute Path: "%.*s" -> "%.*s")"
-                            "\n",
-                            AZ_PATH_ARG(unresolvedPath),
-                            AZ_PATH_ARG(replacedUriPath));
+                        AZ_Trace("ResolveAssetPath", R"(Resolved Absolute Path: "%.*s" -> "%.*s")" "\n",
+                            AZ_PATH_ARG(unresolvedPath), AZ_PATH_ARG(replacedUriPath));
                         return replacedUriPath;
                     }
                     else
@@ -871,14 +863,11 @@ namespace ROS2::Utils
                 // The URI path is not absolute, so attempt to append it to the ancestor directories of the URDF/SDF file
                 for (const AZ::IO::Path& ancestorPath : ancestorPaths)
                 {
-                    if (const AZ::IO::Path candidateResolvedPath = ancestorPath / replacedUriPath; fileExistsCB(candidateResolvedPath))
+                    if (const AZ::IO::Path candidateResolvedPath = ancestorPath / replacedUriPath;
+                        fileExistsCB(candidateResolvedPath))
                     {
-                        AZ_Trace(
-                            "ResolveAssetPath",
-                            R"(Resolved using ancestor paths: "%.*s" -> "%.*s")"
-                            "\n",
-                            AZ_PATH_ARG(unresolvedPath),
-                            AZ_PATH_ARG(candidateResolvedPath));
+                        AZ_Trace("ResolveAssetPath", R"(Resolved using ancestor paths: "%.*s" -> "%.*s")" "\n",
+                            AZ_PATH_ARG(unresolvedPath), AZ_PATH_ARG(candidateResolvedPath));
                         return candidateResolvedPath;
                     }
                 }
@@ -891,19 +880,13 @@ namespace ROS2::Utils
         {
             if (fileExistsCB(unresolvedPath))
             {
-                AZ_Trace(
-                    "ResolveAssetPath",
-                    R"(Resolved Absolute Path: "%.*s")"
-                    "\n",
+                AZ_Trace("ResolveAssetPath", R"(Resolved Absolute Path: "%.*s")" "\n",
                     AZ_PATH_ARG(unresolvedPath));
                 return unresolvedPath;
             }
             else
             {
-                AZ_Trace(
-                    "ResolveAssetPath",
-                    R"(Failed to resolve Absolute Path: "%.*s")"
-                    "\n",
+                AZ_Trace("ResolveAssetPath", R"(Failed to resolve Absolute Path: "%.*s")" "\n",
                     AZ_PATH_ARG(unresolvedPath));
                 return {};
             }
@@ -915,21 +898,13 @@ namespace ROS2::Utils
 
         if (fileExistsCB(relativePath))
         {
-            AZ_Trace(
-                "ResolveAssetPath",
-                R"(Resolved Relative Path: "%.*s" -> "%.*s")"
-                "\n",
-                AZ_PATH_ARG(unresolvedPath),
-                AZ_PATH_ARG(relativePath));
+            AZ_Trace("ResolveAssetPath", R"(Resolved Relative Path: "%.*s" -> "%.*s")" "\n",
+                AZ_PATH_ARG(unresolvedPath), AZ_PATH_ARG(relativePath));
             return relativePath;
         }
 
-        AZ_Trace(
-            "ResolveAssetPath",
-            R"(Failed to resolve Relative Path: "%.*s" -> "%.*s")"
-            "\n",
-            AZ_PATH_ARG(unresolvedPath),
-            AZ_PATH_ARG(relativePath));
+        AZ_Trace("ResolveAssetPath", R"(Failed to resolve Relative Path: "%.*s" -> "%.*s")" "\n",
+            AZ_PATH_ARG(unresolvedPath), AZ_PATH_ARG(relativePath));
         return {};
     }
     AmentPrefixString GetAmentPrefixPath()
@@ -1049,21 +1024,20 @@ namespace ROS2::Utils::SDFormat
 
         // If any files couldn't be found using our supplied prefix mappings, this callback will get called.
         // Attempt to use our full path resolution, and print a warning if it still couldn't be resolved.
-        sdfConfig.SetFindCallback(
-            [settings, baseFilePath](const std::string& fileName) -> std::string
+        sdfConfig.SetFindCallback([settings, baseFilePath](const std::string &fileName) -> std::string
+        {
+            auto amentPrefixPath = Utils::GetAmentPrefixPath();
+
+            auto resolved = Utils::ResolveAssetPath(AZ::IO::Path(fileName.c_str()), baseFilePath, amentPrefixPath, settings);
+            if (!resolved.empty())
             {
-                auto amentPrefixPath = Utils::GetAmentPrefixPath();
+                AZ_Trace("SdfParserConfig", "SDF SetFindCallback resolved '%s' -> '%s'", fileName.c_str(), resolved.c_str());
+                return resolved.c_str();
+            }
 
-                auto resolved = Utils::ResolveAssetPath(AZ::IO::Path(fileName.c_str()), baseFilePath, amentPrefixPath, settings);
-                if (!resolved.empty())
-                {
-                    AZ_Trace("SdfParserConfig", "SDF SetFindCallback resolved '%s' -> '%s'", fileName.c_str(), resolved.c_str());
-                    return resolved.c_str();
-                }
-
-                AZ_Warning("SdfParserConfig", false, "SDF SetFindCallback failed to resolve '%s'", fileName.c_str());
-                return fileName;
-            });
+            AZ_Warning("SdfParserConfig", false, "SDF SetFindCallback failed to resolve '%s'", fileName.c_str());
+            return fileName;
+        });
 
         return sdfConfig;
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -39,10 +39,10 @@ namespace ROS2::Utils
     bool IsWheelURDFHeuristics(const sdf::Model& model, const sdf::Link* link);
 
     //! Returns an AZ::Transform converted from the link pose defined relative to another frame.
-    //! @param link pointer to URDF/SDF link
+    //! @param semanticPose pointer to URDF/SDF link
     //! @param t initial transform, multiplied against link transform
     //! @returns Transform of link
-    AZ::Transform GetLocalTransformURDF(const sdf::Link* link, AZ::Transform t = AZ::Transform::Identity());
+    AZ::Transform GetLocalTransformURDF(const sdf::SemanticPose& semanticPose, AZ::Transform t = AZ::Transform::Identity());
 
     //! Type Alias representing a "stack" of Model object that were visited on the way to the current Link/Joint Visitor Callback
     using ModelStack = AZStd::deque<AZStd::reference_wrapper<const sdf::Model>>;
@@ -75,21 +75,24 @@ namespace ROS2::Utils
     using JointVisitorCallback = AZStd::function<bool(const sdf::Joint& joint, const ModelStack& modelStack)>;
     //! Visit joints from URDF/SDF
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
-    //! @param visitNestedModelJoints When true recurses to any nested <model> tags of the Model object and invoke visitor on their joint as well
+    //! @param visitNestedModelJoints When true recurses to any nested <model> tags of the Model object and invoke visitor on their joint as
+    //! well
     //! @returns void
     void VisitJoints(const sdf::Model& sdfModel, const JointVisitorCallback& jointVisitorCB, bool visitNestedModelJoints = false);
 
     //! Retrieve all joints in URDF/SDF where the key is the full composed path following the name scoping proposal in SDF 1.8
     //! http://sdformat.org/tutorials?tut=composition_proposal#1-nesting-and-encapsulation
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
-    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
+    //! well
     //! @returns mapping from fully qualified joint name(such as "model_name::joint_name") to joint pointer
     AZStd::unordered_map<AZStd::string, const sdf::Joint*> GetAllJoints(const sdf::Model& sdfModel, bool gatherNestedModelJoints = false);
 
     //! Retrieve all joints from URDF/SDF in which the specified link is a child in a sdf::Joint.
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
     //! @param linkName Name of link which to query in joint objects ChildName()
-    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
+    //! well
     //! @returns vector of joints where link is a child
     AZStd::vector<const sdf::Joint*> GetJointsForChildLink(
         const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints = false);
@@ -97,7 +100,8 @@ namespace ROS2::Utils
     //! Retrieve all joints from URDF/SDF in which the specified link is a parent in a sdf::Joint.
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
     //! @param linkName Name of link which to query in joint objects ParentName()
-    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as well
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
+    //! well
     //! @returns vector of joints where link is a parent
     AZStd::vector<const sdf::Joint*> GetJointsForParentLink(
         const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints = false);
@@ -141,16 +145,19 @@ namespace ROS2::Utils
     //! Retrieve all models in URDF/SDF where the key is the fully composed path following the name scoping proposal in SDF 1.8
     //! http://sdformat.org/tutorials?tut=composition_proposal#1-nesting-and-encapsulation
     //! @param sdfRoot Root object of SDF document. The SDF <world> and <model> tags are recursed to locate SDF models
-    //! @param gatherNestedModelsForModel When true recurses to any nested <model> tags of the Model object and also gathers their models as well
+    //! @param gatherNestedModelsForModel When true recurses to any nested <model> tags of the Model object and also gathers their models as
+    //! well
     //! @returns mapping from fully qualified model name(such as "model_name::nested_model_name") to model pointer
     //! NOTE: For the SDF world object if gatherNestedModelsForModel=false, then only the direct models of the world are gathered
     ModelMap GetAllModels(const sdf::Root& sdfRoot, bool gatherNestedModelsForModel = false);
     //! @param sdfWorld World object of SDF document corresponding to the <world> tag. It used to query models
-    //! @param gatherNestedModelsForModel When true recurses to any nested <model> tags of the Model object and also gathers their models as well
+    //! @param gatherNestedModelsForModel When true recurses to any nested <model> tags of the Model object and also gathers their models as
+    //! well
     //! @returns mapping from fully qualified model name(such as "model_name::nested_model_name") to model pointer
     ModelMap GetAllModels(const sdf::World& sdfWorld, bool gatherNestedModelsForModel = false);
     //! @param sdfModel Model object corresponding to a <model> tag in the SDF. It used to query nested models
-    //! @param gatherNestedModelsForModel When true recurses to any nested <model> tags of the Model object and also gathers their models as well
+    //! @param gatherNestedModelsForModel When true recurses to any nested <model> tags of the Model object and also gathers their models as
+    //! well
     //! @returns mapping from fully qualified model name(such as "model_name::nested_model_name") to model pointer
     ModelMap GetAllModels(const sdf::Model& sdfModel, bool gatherNestedModelsForModel = false);
 

--- a/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
@@ -312,9 +312,9 @@ namespace UnitTest
             ROS2::SdfAssetBuilderSettings settings;
             settings.m_resolverSettings.m_useAmentPrefixPath = true;
             settings.m_resolverSettings.m_useAncestorPaths = true;
-            settings.m_resolverSettings.m_uriPrefixMap.emplace("model://", AZStd::vector<AZStd::string>({ "." }));
-            settings.m_resolverSettings.m_uriPrefixMap.emplace("package://", AZStd::vector<AZStd::string>({ "." }));
-            settings.m_resolverSettings.m_uriPrefixMap.emplace("file://", AZStd::vector<AZStd::string>({ "." }));
+            settings.m_resolverSettings.m_uriPrefixMap.emplace("model://", AZStd::vector<AZStd::string>({"."}));
+            settings.m_resolverSettings.m_uriPrefixMap.emplace("package://", AZStd::vector<AZStd::string>({"."}));
+            settings.m_resolverSettings.m_uriPrefixMap.emplace("file://", AZStd::vector<AZStd::string>({"."}));
 
             return settings;
         }
@@ -536,9 +536,9 @@ namespace UnitTest
         ASSERT_NE(nullptr, link1);
     }
 
-    MATCHER(UnorderedMapKeyMatcher, "")
-    {
-        *result_listener << "Expected Key" << AZStd::get<1>(arg) << "Actual Key" << AZStd::get<0>(arg).first.c_str();
+    MATCHER(UnorderedMapKeyMatcher, "") {
+        *result_listener << "Expected Key" << AZStd::get<1>(arg)
+            << "Actual Key" << AZStd::get<0>(arg).first.c_str();
         return AZStd::get<0>(arg).first == AZStd::get<1>(arg);
     }
 
@@ -875,9 +875,7 @@ namespace UnitTest
         constexpr AZ::IO::PathView expectedResult = "/usr/ros/humble/meshes/bar.dae";
         auto result = ROS2::Utils::ResolveAssetPath(
             dae,
-            urdf,
-            "",
-            GetTestSettings(),
+            urdf, "", GetTestSettings(),
             [expectedResult](const AZ::IO::PathView& p) -> bool
             {
                 // Only a file name that matches the expected result will return that it exists.
@@ -895,9 +893,7 @@ namespace UnitTest
         constexpr AZ::IO::PathView expectedResult = "";
         auto result = ROS2::Utils::ResolveAssetPath(
             dae,
-            urdf,
-            "",
-            GetTestSettings(),
+            urdf, "", GetTestSettings(),
             [](const AZ::IO::PathView& p) -> bool
             {
                 // Always return "not found" for all file names.
@@ -914,9 +910,7 @@ namespace UnitTest
         constexpr AZ::IO::PathView expectedResult = "/home/foo/ros_ws/install/foo_robot/meshes/bar.dae";
         auto result = ROS2::Utils::ResolveAssetPath(
             dae,
-            urdf,
-            "",
-            GetTestSettings(),
+            urdf, "", GetTestSettings(),
             [expectedResult](const AZ::IO::PathView& p) -> bool
             {
                 // Only a file name that matches the expected result will return that it exists.
@@ -933,9 +927,7 @@ namespace UnitTest
         constexpr AZ::IO::PathView expectedResult = "";
         auto result = ROS2::Utils::ResolveAssetPath(
             dae,
-            urdf,
-            "",
-            GetTestSettings(),
+            urdf, "", GetTestSettings(),
             [](const AZ::IO::PathView& p) -> bool
             {
                 // Always return "not found"
@@ -954,9 +946,7 @@ namespace UnitTest
         constexpr AZ::IO::PathView expectedResult = "";
         auto result = ROS2::Utils::ResolveAssetPath(
             dae,
-            urdf,
-            amentPrefixPath,
-            GetTestSettings(),
+            urdf, amentPrefixPath, GetTestSettings(),
             [](const AZ::IO::PathView& p) -> bool
             {
                 // For an AMENT_PREFIX_PATH to be a valid match, the share/<package>/package.xml and share/<relative path>
@@ -977,9 +967,7 @@ namespace UnitTest
         constexpr AZ::IO::PathView expectedResult = "/ament/path2/share/robot/meshes/bar.dae";
         auto result = ROS2::Utils::ResolveAssetPath(
             dae,
-            urdf,
-            amentPrefixPath,
-            GetTestSettings(),
+            urdf, amentPrefixPath, GetTestSettings(),
             [expectedResult](const AZ::IO::PathView& p) -> bool
             {
                 // For an AMENT_PREFIX_PATH to be a valid match, the share/<package>/package.xml and share/<relative path>

--- a/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
@@ -56,42 +56,44 @@ namespace UnitTest
 
         AZStd::string GetUrdfWithTwoLinksAndJoint(AZStd::string_view jointType = "fixed")
         {
-            return AZStd::string::format("<robot name=\"test_two_links_one_joint\">  "
-                   "  <material name=\"some_material\">\n"
-                   "    <color rgba=\"0 0 0 1\"/>\n"
-                   "  </material>"
-                   "  <link name=\"link1\">"
-                   "    <inertial>"
-                   "      <mass value=\"1.0\"/>"
-                   "      <inertia ixx=\"1.0\" iyy=\"1.0\" izz=\"1.0\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
-                   "    </inertial>"
-                   "    <visual>"
-                   "      <geometry>"
-                   "        <box size=\"1.0 2.0 1.0\"/>"
-                   "      </geometry>"
-                   "      <material name=\"some_material\"/>"
-                   "    </visual>"
-                   "  </link>"
-                   "  <link name=\"link2\">"
-                   "    <inertial>"
-                   "      <mass value=\"1.0\"/>"
-                   "      <inertia ixx=\"1.0\" iyy=\"1.0\" izz=\"1.0\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
-                   "    </inertial>"
-                   "    <visual>"
-                   "      <geometry>"
-                   "        <box size=\"1.0 1.0 1.0\"/>"
-                   "      </geometry>"
-                   "      <material name=\"some_material\"/>"
-                   "    </visual>"
-                   "  </link>"
-                   R"(  <joint name="joint12" type="%.*s">)"
-                   "    <parent link=\"link1\"/>"
-                   "    <child link=\"link2\"/>"
-                   "    <origin rpy=\"0 0 0\" xyz=\"1.0 0.5 0.0\"/>"
-                   "    <dynamics damping=\"10.0\" friction=\"5.0\"/>"
-                   "    <limit lower=\"10.0\" upper=\"20.0\" effort=\"90.0\" velocity=\"10.0\"/>"
-                   "  </joint>"
-                   "</robot>", AZ_STRING_ARG(jointType));
+            return AZStd::string::format(
+                "<robot name=\"test_two_links_one_joint\">  "
+                "  <material name=\"some_material\">\n"
+                "    <color rgba=\"0 0 0 1\"/>\n"
+                "  </material>"
+                "  <link name=\"link1\">"
+                "    <inertial>"
+                "      <mass value=\"1.0\"/>"
+                "      <inertia ixx=\"1.0\" iyy=\"1.0\" izz=\"1.0\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
+                "    </inertial>"
+                "    <visual>"
+                "      <geometry>"
+                "        <box size=\"1.0 2.0 1.0\"/>"
+                "      </geometry>"
+                "      <material name=\"some_material\"/>"
+                "    </visual>"
+                "  </link>"
+                "  <link name=\"link2\">"
+                "    <inertial>"
+                "      <mass value=\"1.0\"/>"
+                "      <inertia ixx=\"1.0\" iyy=\"1.0\" izz=\"1.0\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
+                "    </inertial>"
+                "    <visual>"
+                "      <geometry>"
+                "        <box size=\"1.0 1.0 1.0\"/>"
+                "      </geometry>"
+                "      <material name=\"some_material\"/>"
+                "    </visual>"
+                "  </link>"
+                R"(  <joint name="joint12" type="%.*s">)"
+                "    <parent link=\"link1\"/>"
+                "    <child link=\"link2\"/>"
+                "    <origin rpy=\"0 0 0\" xyz=\"1.0 0.5 0.0\"/>"
+                "    <dynamics damping=\"10.0\" friction=\"5.0\"/>"
+                "    <limit lower=\"10.0\" upper=\"20.0\" effort=\"90.0\" velocity=\"10.0\"/>"
+                "  </joint>"
+                "</robot>",
+                AZ_STRING_ARG(jointType));
         }
 
         AZStd::string GetURDFWithTwoLinksAndBaseLinkNoInertia()
@@ -125,7 +127,8 @@ namespace UnitTest
 
         AZStd::string GetURDFWithFourLinksAndRootLinkNoInertia(AZStd::string_view rootLinkName)
         {
-            return AZStd::string::format(R"(<?xml version="1.0" ?>
+            return AZStd::string::format(
+                R"(<?xml version="1.0" ?>
                 <robot name="FooRobot">
                   <link name="%.*s"/>
                   <link name="base_link"/>
@@ -167,14 +170,16 @@ namespace UnitTest
                     <dynamics damping="10.0" friction="5.0"/>
                     <limit lower="10.0" upper="20.0" effort="90.0" velocity="10.0"/>
                   </joint>
-                </robot>)", AZ_STRING_ARG(rootLinkName), AZ_STRING_ARG(rootLinkName));
+                </robot>)",
+                AZ_STRING_ARG(rootLinkName),
+                AZ_STRING_ARG(rootLinkName));
         }
 
         // A URDF <model> can only represent structure which is configurable though the <joint> tags
         // Therefore link can only appear as a child of a single joint.
         // It cannot be a child of multiple joints
         // https://wiki.ros.org/urdf/XML/model
-        AZStd::string GetURDFWithTranforms()
+        AZStd::string GetURDFWithTransforms()
         {
             return "<?xml version=\"1.0\"?>\n"
                    "<robot name=\"complicated\">\n"
@@ -307,9 +312,9 @@ namespace UnitTest
             ROS2::SdfAssetBuilderSettings settings;
             settings.m_resolverSettings.m_useAmentPrefixPath = true;
             settings.m_resolverSettings.m_useAncestorPaths = true;
-            settings.m_resolverSettings.m_uriPrefixMap.emplace("model://", AZStd::vector<AZStd::string>({"."}));
-            settings.m_resolverSettings.m_uriPrefixMap.emplace("package://", AZStd::vector<AZStd::string>({"."}));
-            settings.m_resolverSettings.m_uriPrefixMap.emplace("file://", AZStd::vector<AZStd::string>({"."}));
+            settings.m_resolverSettings.m_uriPrefixMap.emplace("model://", AZStd::vector<AZStd::string>({ "." }));
+            settings.m_resolverSettings.m_uriPrefixMap.emplace("package://", AZStd::vector<AZStd::string>({ "." }));
+            settings.m_resolverSettings.m_uriPrefixMap.emplace("file://", AZStd::vector<AZStd::string>({ "." }));
 
             return settings;
         }
@@ -531,9 +536,9 @@ namespace UnitTest
         ASSERT_NE(nullptr, link1);
     }
 
-    MATCHER(UnorderedMapKeyMatcher, "") {
-        *result_listener << "Expected Key" << AZStd::get<1>(arg)
-            << "Actual Key" << AZStd::get<0>(arg).first.c_str();
+    MATCHER(UnorderedMapKeyMatcher, "")
+    {
+        *result_listener << "Expected Key" << AZStd::get<1>(arg) << "Actual Key" << AZStd::get<0>(arg).first.c_str();
         return AZStd::get<0>(arg).first == AZStd::get<1>(arg);
     }
 
@@ -726,7 +731,7 @@ namespace UnitTest
 
     TEST_F(UrdfParserTest, TestLinkListing)
     {
-        const auto xmlStr = GetURDFWithTranforms();
+        const auto xmlStr = GetURDFWithTransforms();
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
@@ -753,7 +758,7 @@ namespace UnitTest
 
     TEST_F(UrdfParserTest, TestJointLink)
     {
-        const auto xmlStr = GetURDFWithTranforms();
+        const auto xmlStr = GetURDFWithTransforms();
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
@@ -768,7 +773,7 @@ namespace UnitTest
 
     TEST_F(UrdfParserTest, TestTransforms)
     {
-        const auto xmlStr = GetURDFWithTranforms();
+        const auto xmlStr = GetURDFWithTransforms();
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
@@ -791,17 +796,20 @@ namespace UnitTest
         const AZ::Vector3 expected_translation_link2{ -1.2000000476837158, 2.0784599781036377, 0.0 };
         const AZ::Vector3 expected_translation_link3{ -2.4000000953674316, 0.0, 0.0 };
 
-        const AZ::Transform transform_from_urdf_link1 = ROS2::Utils::GetLocalTransformURDF(base_link_ptr);
+        const auto base_link_pose = base_link_ptr->SemanticPose();
+        const AZ::Transform transform_from_urdf_link1 = ROS2::Utils::GetLocalTransformURDF(base_link_pose);
         EXPECT_NEAR(expected_translation_link1.GetX(), transform_from_urdf_link1.GetTranslation().GetX(), 1e-5);
         EXPECT_NEAR(expected_translation_link1.GetY(), transform_from_urdf_link1.GetTranslation().GetY(), 1e-5);
         EXPECT_NEAR(expected_translation_link1.GetZ(), transform_from_urdf_link1.GetTranslation().GetZ(), 1e-5);
 
-        const AZ::Transform transform_from_urdf_link2 = ROS2::Utils::GetLocalTransformURDF(link2_ptr);
+        const auto link2_pose = link2_ptr->SemanticPose();
+        const AZ::Transform transform_from_urdf_link2 = ROS2::Utils::GetLocalTransformURDF(link2_pose);
         EXPECT_NEAR(expected_translation_link2.GetX(), transform_from_urdf_link2.GetTranslation().GetX(), 1e-5);
         EXPECT_NEAR(expected_translation_link2.GetY(), transform_from_urdf_link2.GetTranslation().GetY(), 1e-5);
         EXPECT_NEAR(expected_translation_link2.GetZ(), transform_from_urdf_link2.GetTranslation().GetZ(), 1e-5);
 
-        const AZ::Transform transform_from_urdf_link3 = ROS2::Utils::GetLocalTransformURDF(link3_ptr);
+        const auto link3_pose = link3_ptr->SemanticPose();
+        const AZ::Transform transform_from_urdf_link3 = ROS2::Utils::GetLocalTransformURDF(link3_pose);
         EXPECT_NEAR(expected_translation_link3.GetX(), transform_from_urdf_link3.GetTranslation().GetX(), 1e-5);
         EXPECT_NEAR(expected_translation_link3.GetY(), transform_from_urdf_link3.GetTranslation().GetY(), 1e-5);
         EXPECT_NEAR(expected_translation_link3.GetZ(), transform_from_urdf_link3.GetTranslation().GetZ(), 1e-5);
@@ -809,7 +817,7 @@ namespace UnitTest
 
     TEST_F(UrdfParserTest, TestQueryJointsForParentLink_Succeeds)
     {
-        const auto xmlStr = GetURDFWithTranforms();
+        const auto xmlStr = GetURDFWithTransforms();
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
@@ -834,7 +842,7 @@ namespace UnitTest
 
     TEST_F(UrdfParserTest, TestQueryJointsForChildLink_Succeeds)
     {
-        const auto xmlStr = GetURDFWithTranforms();
+        const auto xmlStr = GetURDFWithTransforms();
         sdf::ParserConfig parserConfig;
         const auto sdfRootOutcome = ROS2::UrdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
@@ -867,7 +875,9 @@ namespace UnitTest
         constexpr AZ::IO::PathView expectedResult = "/usr/ros/humble/meshes/bar.dae";
         auto result = ROS2::Utils::ResolveAssetPath(
             dae,
-            urdf, "", GetTestSettings(),
+            urdf,
+            "",
+            GetTestSettings(),
             [expectedResult](const AZ::IO::PathView& p) -> bool
             {
                 // Only a file name that matches the expected result will return that it exists.
@@ -885,7 +895,9 @@ namespace UnitTest
         constexpr AZ::IO::PathView expectedResult = "";
         auto result = ROS2::Utils::ResolveAssetPath(
             dae,
-            urdf, "", GetTestSettings(),
+            urdf,
+            "",
+            GetTestSettings(),
             [](const AZ::IO::PathView& p) -> bool
             {
                 // Always return "not found" for all file names.
@@ -902,7 +914,9 @@ namespace UnitTest
         constexpr AZ::IO::PathView expectedResult = "/home/foo/ros_ws/install/foo_robot/meshes/bar.dae";
         auto result = ROS2::Utils::ResolveAssetPath(
             dae,
-            urdf, "", GetTestSettings(),
+            urdf,
+            "",
+            GetTestSettings(),
             [expectedResult](const AZ::IO::PathView& p) -> bool
             {
                 // Only a file name that matches the expected result will return that it exists.
@@ -919,7 +933,9 @@ namespace UnitTest
         constexpr AZ::IO::PathView expectedResult = "";
         auto result = ROS2::Utils::ResolveAssetPath(
             dae,
-            urdf, "", GetTestSettings(),
+            urdf,
+            "",
+            GetTestSettings(),
             [](const AZ::IO::PathView& p) -> bool
             {
                 // Always return "not found"
@@ -938,7 +954,9 @@ namespace UnitTest
         constexpr AZ::IO::PathView expectedResult = "";
         auto result = ROS2::Utils::ResolveAssetPath(
             dae,
-            urdf, amentPrefixPath, GetTestSettings(),
+            urdf,
+            amentPrefixPath,
+            GetTestSettings(),
             [](const AZ::IO::PathView& p) -> bool
             {
                 // For an AMENT_PREFIX_PATH to be a valid match, the share/<package>/package.xml and share/<relative path>
@@ -959,7 +977,9 @@ namespace UnitTest
         constexpr AZ::IO::PathView expectedResult = "/ament/path2/share/robot/meshes/bar.dae";
         auto result = ROS2::Utils::ResolveAssetPath(
             dae,
-            urdf, amentPrefixPath, GetTestSettings(),
+            urdf,
+            amentPrefixPath,
+            GetTestSettings(),
             [expectedResult](const AZ::IO::PathView& p) -> bool
             {
                 // For an AMENT_PREFIX_PATH to be a valid match, the share/<package>/package.xml and share/<relative path>


### PR DESCRIPTION
## What does this PR do?

SDFormat allows for `<pose>` tag within the sensor tag. This PR modifies the way sensors are created - instead of adding them directly to the hosting links, separate links are created for each sensor (as for visuals) and `<pose>` value is applied to the link.

## How was this PR tested?

Robotis OP3 robot was imported with and without `<pose>` tag.

![image](https://github.com/o3de/o3de-extras/assets/134940295/ebe574ee-2a76-4a32-afa4-eda7f8dd878e)


***
This PR is set as a draft, as it is built on top of #632 - waiting for AR to be fixed and #632 to be merged.
