### PR TITLE
Adjusted Twist component to apply twist in every phycis step.

### DIFF
--- a/Gems/ROS2/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.cpp
@@ -13,6 +13,7 @@
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <AzFramework/Physics/RigidBodyBus.h>
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
+
 namespace ROS2
 {
     void RigidBodyTwistControlComponent::Reflect(AZ::ReflectContext* context)
@@ -34,7 +35,6 @@ namespace ROS2
 
     void RigidBodyTwistControlComponent::Activate()
     {
-
         AZ::TickBus::Handler::BusConnect();
         TwistNotificationBus::Handler::BusConnect(GetEntityId());
     }

--- a/Gems/ROS2/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.cpp
@@ -86,6 +86,7 @@ namespace ROS2
                 },
                 aznumeric_cast<int32_t>(AzPhysics::SceneEvents::PhysicsStartFinishSimulationPriority::Components));
         sceneInterface->RegisterSceneSimulationFinishHandler(defaultSceneHandle, m_sceneFinishSimHandler);
+        AZ::TickBus::Handler::BusDisconnect();
     }
 
     void RigidBodyTwistControlComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)

--- a/Gems/ROS2/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.cpp
@@ -54,7 +54,6 @@ namespace ROS2
     
     void RigidBodyTwistControlComponent::OnTick([[maybe_unused]]float deltaTime, [[maybe_unused]]AZ::ScriptTimePoint time)
     {
-        AZ_Assert(AZ::Interface<AzPhysics::SystemInterface>::Get(), "No physics system");
         AzPhysics::SceneInterface* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         AZ_Assert(sceneInterface, "No scene interface");
         if (!sceneInterface)

--- a/Gems/ROS2/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.cpp
@@ -52,7 +52,7 @@ namespace ROS2
         }
     }
     
-    void RigidBodyTwistControlComponent::OnTick(float deltaTime, AZ::ScriptTimePoint time)
+    void RigidBodyTwistControlComponent::OnTick([[maybe_unused]]float deltaTime, [[maybe_unused]]AZ::ScriptTimePoint time)
     {
         AZ_Assert(AZ::Interface<AzPhysics::SystemInterface>::Get(), "No physics system");
         AzPhysics::SceneInterface* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
@@ -80,7 +80,7 @@ namespace ROS2
                     // Convert local steering to world frame
                     const AZ::Transform robotTransform = rigidBody->GetTransform();
                     const auto velocityLinearGlobal = robotTransform.TransformVector(m_linearVelocityLocal);
-                    const auto  angularVelocityGlobal = robotTransform.TransformVector(m_angularVelocityLocal);
+                    const auto angularVelocityGlobal = robotTransform.TransformVector(m_angularVelocityLocal);
                     Physics::RigidBodyRequestBus::Event(GetEntityId(), &Physics::RigidBodyRequests::SetLinearVelocity, velocityLinearGlobal);
                     Physics::RigidBodyRequestBus::Event(GetEntityId(), &Physics::RigidBodyRequests::SetAngularVelocity, angularVelocityGlobal);
                 },

--- a/Gems/ROS2/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.h
+++ b/Gems/ROS2/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.h
@@ -9,7 +9,9 @@
 
 #include <AzCore/Component/Component.h>
 #include <ROS2/RobotControl/Twist/TwistBus.h>
-
+#include <AzFramework/Physics/PhysicsSystem.h>
+#include <AzFramework/Physics/RigidBodyBus.h>
+#include <AzCore/Component/TickBus.h>
 namespace ROS2
 {
     //! A component with a simple handler for Twist type of control (linear and angular velocities).
@@ -17,6 +19,7 @@ namespace ROS2
     class RigidBodyTwistControlComponent
         : public AZ::Component
         , private TwistNotificationBus::Handler
+        , private AZ::TickBus::Handler
     {
     public:
         AZ_COMPONENT(RigidBodyTwistControlComponent, "{D994FE1A-AA6A-42B9-8B8E-B3B375891F5B}", AZ::Component);
@@ -36,5 +39,15 @@ namespace ROS2
         // TwistNotificationBus::Handler overrides
         void TwistReceived(const AZ::Vector3& linear, const AZ::Vector3& angular) override;
         //////////////////////////////////////////////////////////////////////////
+
+        //////////////////////////////////////////////////////////////////////////
+        // AZ::TickBus::Handler overrides
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        //////////////////////////////////////////////////////////////////////////
+
+        AZ::Vector3 m_linearVelocityLocal {AZ::Vector3::CreateZero()}; //!< Linear velocity in local frame
+        AZ::Vector3 m_angularVelocityLocal {AZ::Vector3::CreateZero()}; //!< Angular velocity in local frame
+        AzPhysics::SceneEvents::OnSceneSimulationFinishHandler m_sceneFinishSimHandler; //!< Handler called after every physics sub-step
+        AzPhysics::SimulatedBodyHandle m_bodyHandle = AzPhysics::InvalidSimulatedBodyHandle; //!< Handle to the body to apply velocities to
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.h
+++ b/Gems/ROS2/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.h
@@ -10,7 +10,6 @@
 #include <AzCore/Component/Component.h>
 #include <ROS2/RobotControl/Twist/TwistBus.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
-#include <AzFramework/Physics/RigidBodyBus.h>
 #include <AzCore/Component/TickBus.h>
 namespace ROS2
 {


### PR DESCRIPTION
## What does this PR do?

This PR adjusts the behavior of component `RigidBodyTwistControlComponent`.
This component used to apply twist (linear and angular velocity) every ROS 2 message callback.
It caused two problems:
 - robot was not moving smooth
 - the speed was affecting the rate of publication of twist message.
 Theoretically it should enable possibility to have flying robots (multi copters) basic simulation 
 
## How was this PR tested?

The PR will affect the VacuumDemo (probably in positive way). I will test it and remove draft status.
