### PR TITLE
RobotImporter: print sensor import log in wizard

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Pages/RobotDescriptionPage.cpp
@@ -43,6 +43,20 @@ namespace ROS2
         m_log->setMarkdown(status);
         m_success = isSuccess;
         m_warning = isWarning;
+
+        if ((isSuccess && isWarning == false) || isSuccess == false)
+        {
+            m_urdfName->setDisabled(true);
+            m_saveButton->setDisabled(true);
+            m_showButton->setDisabled(true);
+        }
+        else
+        {
+            m_urdfName->setDisabled(false);
+            m_saveButton->setDisabled(false);
+            m_showButton->setDisabled(false);
+        }
+
         emit completeChanged();
     }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -141,7 +141,7 @@ namespace ROS2
             }
         }
 
-        report += "# " + tr("💡Please check the modified code and/or save it using the interface below.") + "\n";
+        report += "\n\n# " + tr("💡Please check the modified code and/or save it using the interface below.") + "\n";
         m_modifiedUrdfWindow->SetUrdfData(AZStd::move(parsedSdfOutcome.m_modifiedURDFContent));
     }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -141,7 +141,7 @@ namespace ROS2
             }
         }
 
-        report += "\n\n# " + tr("💡Please check the modified code and/or save it using the interface below.") + "\n";
+        report += "# " + tr("💡Please check the modified code and/or save it using the interface below.") + "\n";
         m_modifiedUrdfWindow->SetUrdfData(AZStd::move(parsedSdfOutcome.m_modifiedURDFContent));
     }
 
@@ -220,7 +220,7 @@ namespace ROS2
 
             AZStd::string log;
             const bool urdfParsedSuccess{ parsedSdfOutcome };
-            const bool urdfParsedWithWarnings{ parsedSdfOutcome.UrdfParsedWithModifiedContent() };
+            bool urdfParsedWithWarnings{ parsedSdfOutcome.UrdfParsedWithModifiedContent() };
             if (urdfParsedSuccess)
             {
                 if (urdfParsedWithWarnings)
@@ -240,23 +240,26 @@ namespace ROS2
             {
                 log = Utils::JoinSdfErrorsToString(parsedSdfOutcome.GetSdfErrors());
                 report += "# " + tr("The URDF/SDF was not opened") + "\n";
-                report += tr("URDF/SDF parser returned following errors:") + "\n\n";
+                report += "## " + tr("URDF/SDF parser returned following errors:") + "\n\n";
             }
             if (!log.empty())
             {
-                report += "`";
+                report += "```\n";
                 report += QString::fromUtf8(log.data(), int(log.size()));
-                report += "`";
+                report += "\n```\n";
+                AZ_Printf("RobotImporterWidget", "SDF Stream: %s\n", log.c_str());
+                urdfParsedWithWarnings = true;
             }
             const auto& messages = parsedSdfOutcome.GetParseMessages();
             if (!messages.empty())
             {
                 report += "\n\n";
-                report += tr("URDF/SDF parser returned following messages:") + "\n\n";
-                report += "```bash\n";
+                report += "## " + tr("URDF/SDF parser returned following messages:") + "\n\n";
+                report += "```\n";
                 report += QString::fromUtf8(messages.c_str(), int(messages.size()));
                 report += "\n```\n";
                 AZ_Printf("RobotImporterWidget", "SDF Stream: %s\n", messages.c_str());
+                urdfParsedWithWarnings = true;
             }
             m_robotDescriptionPage->ReportParsingResult(report, urdfParsedSuccess, urdfParsedWithWarnings);
         }
@@ -342,15 +345,17 @@ namespace ROS2
             }
             else
             {
-                m_urdfAssetsMapping =
-                    AZStd::make_shared<Utils::UrdfAssetMap>(Utils::FindReferencedAssets(m_assetNames, m_urdfPath.String(), sdfBuilderSettings));
+                m_urdfAssetsMapping = AZStd::make_shared<Utils::UrdfAssetMap>(
+                    Utils::FindReferencedAssets(m_assetNames, m_urdfPath.String(), sdfBuilderSettings));
                 for (const auto& [assetPath, assetReferenceType] : m_assetNames)
                 {
                     if (m_urdfAssetsMapping->contains(assetPath))
                     {
                         const auto& asset = m_urdfAssetsMapping->at(assetPath);
-                        bool visual = (assetReferenceType & Utils::ReferencedAssetType::VisualMesh) == Utils::ReferencedAssetType::VisualMesh;
-                        bool collider = (assetReferenceType & Utils::ReferencedAssetType::ColliderMesh) == Utils::ReferencedAssetType::ColliderMesh;
+                        bool visual =
+                            (assetReferenceType & Utils::ReferencedAssetType::VisualMesh) == Utils::ReferencedAssetType::VisualMesh;
+                        bool collider =
+                            (assetReferenceType & Utils::ReferencedAssetType::ColliderMesh) == Utils::ReferencedAssetType::ColliderMesh;
                         if (visual || collider)
                         {
                             Utils::CreateSceneManifest(asset.m_availableAssetInfo.m_sourceAssetGlobalPath, collider, visual);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -33,12 +33,14 @@ namespace ROS2::SDFormat
             ">lidar>range>min",
             ">lidar>range>max",
             // Gazebo-classic
+            ">ray>scan>horizontal>resolution",
             ">ray>scan>horizontal>samples",
             ">ray>scan>horizontal>min_angle",
             ">ray>scan>horizontal>max_angle",
             ">ray>scan>vertical>samples",
             ">ray>scan>vertical>min_angle",
             ">ray>scan>vertical>max_angle",
+            ">ray>scan>vertical>resolution",
             ">ray>range>min",
             ">ray>range>max",
         };

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
@@ -20,7 +20,7 @@
 
 namespace ROS2
 {
-    void ExecuteSensorHook(
+    void SensorsMaker::ExecuteSensorHook(
         AZ::EntityId entityId,
         const sdf::Sensor* sensor,
         const ROS2::SDFormat::SensorImporterHook* hook,
@@ -49,7 +49,7 @@ namespace ROS2
         SDFormat::HooksUtils::SetSensorEntityTransform(*sensorEntity, *sensor);
     }
 
-    void AddSensor(AZ::EntityId entityId, const sdf::Sensor* sensor, AZStd::vector<AZ::EntityId>& createdEntities)
+    void SensorsMaker::AddSensor(AZ::EntityId entityId, const sdf::Sensor* sensor, AZStd::vector<AZ::EntityId>& createdEntities)
     {
         SDFormat::SensorImporterHooksStorage sensorHooks;
         ROS2::RobotImporterRequestBus::BroadcastResult(sensorHooks, &ROS2::RobotImporterRequest::GetSensorHooks);

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
@@ -11,19 +11,19 @@
 #include <AzCore/Component/EntityId.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <ROS2/RobotImporter/RobotImporterBus.h>
-#include <ROS2/RobotImporter/SDFormatSensorImporterHook.h>
 #include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
 #include <RobotImporter/URDF/PrefabMakerUtils.h>
+#include <RobotImporter/Utils/RobotImporterUtils.h>
 
 #include <sdf/Link.hh>
 #include <sdf/Sensor.hh>
 
 namespace ROS2
 {
-    void SensorsMaker::ExecuteSensorHook(
+    SensorsMaker::SensorHookCallOutcome SensorsMaker::CallSensorHook(
         AZ::EntityId entityId,
         const sdf::Sensor* sensor,
-        const ROS2::SDFormat::SensorImporterHook* hook,
+        const SDFormat::SensorImporterHook* hook,
         AZStd::vector<AZ::EntityId>& createdEntities)
     {
         // Since O3DE does not allow origin for sensors, we need to create a sub-entity and store sensor there
@@ -32,44 +32,76 @@ namespace ROS2
         auto createEntityResult = PrefabMakerUtils::CreateEntity(entityId, subEntityName);
         if (!createEntityResult.IsSuccess())
         {
-            AZ_Error("SensorMaker", false, "Unable to create a sub-entity %s for sensor element\n", subEntityName.c_str());
-            return;
+            return AZ::Failure(AZStd::string::format("Unable to create a sub-entity %s for sensor element\n", subEntityName.c_str()));
         }
 
         auto sensorEntityId = createEntityResult.GetValue();
         if (!sensorEntityId.IsValid())
         {
-            AZ_Error("SensorMaker", false, "Created sub-entity %s for sensor element is invalid\n", subEntityName.c_str());
-            return;
+            return AZ::Failure(AZStd::string::format("Created sub-entity %s for sensor element is invalid\n", subEntityName.c_str()));
         }
 
         createdEntities.emplace_back(sensorEntityId);
         AZ::Entity* sensorEntity = AzToolsFramework::GetEntityById(sensorEntityId);
-        hook->m_sdfSensorToComponentCallback(*sensorEntity, *sensor);
+        const auto sensorResult = hook->m_sdfSensorToComponentCallback(*sensorEntity, *sensor);
         SDFormat::HooksUtils::SetSensorEntityTransform(*sensorEntity, *sensor);
+
+        if (sensorResult.IsSuccess())
+        {
+            const auto sensorElement = sensor->Element();
+            const auto& unsupportedSensorParams = Utils::SDFormat::GetUnsupportedParams(sensorElement, hook->m_supportedSensorParams);
+            AZStd::string status;
+            if (unsupportedSensorParams.empty())
+            {
+                status = AZStd::string::format("%s (type %s) created successfully", sensor->Name().c_str(), sensor->TypeStr().c_str());
+            }
+            else
+            {
+                status = AZStd::string::format(
+                    "%s (type %s) created, %lu parameters not parsed: ",
+                    sensor->Name().c_str(),
+                    sensor->TypeStr().c_str(),
+                    unsupportedSensorParams.size());
+                for (const auto& up : unsupportedSensorParams)
+                {
+                    status.append("\n\t - " + up);
+                }
+            }
+            m_status.emplace(AZStd::move(status));
+        }
+        else
+        {
+            const auto message = AZStd::string::format(
+                "%s (type %s) not created: %s", sensor->Name().c_str(), sensor->TypeStr().c_str(), sensorResult.GetError().c_str());
+            m_status.emplace(message);
+            return AZ::Failure(message);
+        }
+
+        return AZ::Success();
     }
 
-    void SensorsMaker::AddSensor(AZ::EntityId entityId, const sdf::Sensor* sensor, AZStd::vector<AZ::EntityId>& createdEntities)
+    SensorsMaker::SensorHookCallOutcome SensorsMaker::AddSensor(
+        AZ::EntityId entityId, const sdf::Sensor* sensor, AZStd::vector<AZ::EntityId>& createdEntities)
     {
         SDFormat::SensorImporterHooksStorage sensorHooks;
         ROS2::RobotImporterRequestBus::BroadcastResult(sensorHooks, &ROS2::RobotImporterRequest::GetSensorHooks);
 
         const auto& sensorPlugins = sensor->Plugins();
+        // Add sensor without plugins
         if (sensorPlugins.empty())
         {
             for (auto& hook : sensorHooks)
             {
                 if (hook.m_sensorTypes.contains(sensor->Type()))
                 {
-                    ExecuteSensorHook(entityId, sensor, &hook, createdEntities);
-                    return;
+                    return CallSensorHook(entityId, sensor, &hook, createdEntities);
                 }
             }
-            AZ_Warning(
-                "SensorMaker", false, "Cannot find a hook for %s sensor (type %s)", sensor->Name().c_str(), sensor->TypeStr().c_str());
-            return;
+            return AZ::Failure(
+                AZStd::string::format("Cannot find a hook for %s sensor (type %s)", sensor->Name().c_str(), sensor->TypeStr().c_str()));
         }
 
+        // Add sensor with one or more plugins
         for (const auto& sp : sensorPlugins)
         {
             bool sensorProcessed = false;
@@ -80,7 +112,11 @@ namespace ROS2
                 {
                     if (hook.m_pluginNames.contains(sp.Filename().c_str()))
                     {
-                        ExecuteSensorHook(entityId, sensor, &hook, createdEntities);
+                        const auto outcome = CallSensorHook(entityId, sensor, &hook, createdEntities);
+                        if (!outcome.IsSuccess())
+                        {
+                            return outcome;
+                        }
                         sensorProcessed = true;
                         break;
                     }
@@ -91,23 +127,20 @@ namespace ROS2
                 }
             }
 
-            AZ_Warning(
-                "SensorMaker",
-                sensorProcessed,
-                "Cannot find a hook for %s sensor (type %s) with plugin %s",
-                sensor->Name().c_str(),
-                sensor->TypeStr().c_str(),
-                sp.Filename().c_str());
             if (sensorProcessed == false && defaultHook != nullptr)
             {
-                ExecuteSensorHook(entityId, sensor, defaultHook, createdEntities);
-                AZ_Warning(
-                    "SensorMaker", false, "Default hook for %s sensor (type %s) used.", sensor->Name().c_str(), sensor->TypeStr().c_str());
+                const auto outcome = CallSensorHook(entityId, sensor, defaultHook, createdEntities);
+                if (!outcome.IsSuccess())
+                {
+                    return outcome;
+                }
             }
         }
+
+        return AZ::Success();
     }
 
-    AZStd::vector<AZ::EntityId> SensorsMaker::AddSensors(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId) const
+    AZStd::vector<AZ::EntityId> SensorsMaker::AddSensors(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId)
     {
         AZStd::vector<AZ::EntityId> createdEntities;
         for (size_t si = 0; si < link->SensorCount(); ++si)
@@ -117,5 +150,10 @@ namespace ROS2
         }
 
         return createdEntities;
+    }
+
+    const AZStd::set<AZStd::string>& SensorsMaker::GetStatusMessages() const
+    {
+        return m_status;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.h
@@ -8,12 +8,11 @@
 
 #pragma once
 
-#include "UrdfParser.h"
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Outcome/Outcome.h>
-#include <AzCore/std/containers/map.h>
 #include <AzCore/std/containers/set.h>
+#include <ROS2/RobotImporter/SDFormatSensorImporterHook.h>
 
 #include <sdf/sdf.hh>
 
@@ -29,14 +28,21 @@ namespace ROS2
         //! @param link A parsed SDF tree link node used to identify link being currently processed.
         //! @param entityId A non-active entity which will be affected.
         //! @return List containing any entities with sensors that were created.
-        AZStd::vector<AZ::EntityId>AddSensors(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId);
+        AZStd::vector<AZ::EntityId> AddSensors(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId);
 
-        //! Returns a reference to collection of status messages (read-only)
+        //! Get a reference to collection of status messages (read-only)
+        //! @return A reference to set containing status messages.
         const AZStd::set<AZStd::string>& GetStatusMessages() const;
 
     private:
         AZStd::set<AZStd::string> m_status;
 
-        void AddSensor(AZ::EntityId entityId, const sdf::Sensor* sensor);
+        using SensorHookCallOutcome = AZ::Outcome<void, AZStd::string>;
+        SensorHookCallOutcome AddSensor(AZ::EntityId entityId, const sdf::Sensor* sensor, AZStd::vector<AZ::EntityId>& createdEntities);
+        SensorHookCallOutcome CallSensorHook(
+            AZ::EntityId entityId,
+            const sdf::Sensor* sensor,
+            const SDFormat::SensorImporterHook* hook,
+            AZStd::vector<AZ::EntityId>& createdEntities);
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.h
@@ -8,9 +8,12 @@
 
 #pragma once
 
+#include "UrdfParser.h"
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Outcome/Outcome.h>
+#include <AzCore/std/containers/map.h>
+#include <AzCore/std/containers/set.h>
 
 #include <sdf/sdf.hh>
 
@@ -26,6 +29,14 @@ namespace ROS2
         //! @param link A parsed SDF tree link node used to identify link being currently processed.
         //! @param entityId A non-active entity which will be affected.
         //! @return List containing any entities with sensors that were created.
-        AZStd::vector<AZ::EntityId> AddSensors(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId) const;
+        AZStd::vector<AZ::EntityId>AddSensors(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId);
+
+        //! Returns a reference to collection of status messages (read-only)
+        const AZStd::set<AZStd::string>& GetStatusMessages() const;
+
+    private:
+        AZStd::set<AZStd::string> m_status;
+
+        void AddSensor(AZ::EntityId entityId, const sdf::Sensor* sensor);
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -688,13 +688,6 @@ namespace ROS2
             m_collidersMaker.AddColliders(*attachedModel, &link, entityId);
             auto createdSensorEntities = m_sensorsMaker.AddSensors(*attachedModel, &link, entityId);
             createdEntities.insert(createdEntities.end(), createdSensorEntities.begin(), createdSensorEntities.end());
-
-            AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
-            const auto& sensorStatus = m_sensorsMaker.GetStatusMessages();
-            for (const auto& ss : sensorStatus)
-            {
-                m_status.emplace(StatusMessageType::Sensor, ss);
-            }
         }
         return AZ::Success(entityId);
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -56,6 +56,7 @@ namespace ROS2
         {
             AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
             m_status.clear();
+            m_articulationsCounter = 0u;
         }
 
         if (!ContainsModel())
@@ -670,6 +671,7 @@ namespace ROS2
                     m_status.emplace(
                         StatusMessageType::Joint,
                         AZStd::string::format("%s created as articulation link: %llu", azLinkName.c_str(), linkResult.GetValue()));
+                    m_articulationsCounter++;
                 }
                 else
                 {
@@ -729,6 +731,14 @@ namespace ROS2
     {
         AZStd::string report;
         AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
+
+        // Print warnings first
+        constexpr unsigned int articulationsLimit = 64;
+        if (m_articulationsCounter >= articulationsLimit)
+        {
+            report += "\n## 💡 Note: the number of articulations (" + AZStd::to_string(m_articulationsCounter) +
+                ") might not be supported by the physics engine.\n";
+        }
 
         report += "# The following components were found and parsed:\n";
 

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -676,6 +676,13 @@ namespace ROS2
             m_collidersMaker.AddColliders(*attachedModel, &link, entityId);
             auto createdSensorEntities = m_sensorsMaker.AddSensors(*attachedModel, &link, entityId);
             createdEntities.insert(createdEntities.end(), createdSensorEntities.begin(), createdSensorEntities.end());
+
+            AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
+            const auto& sensorStatus = m_sensorsMaker.GetStatusMessages();
+            for (const auto& ss : sensorStatus)
+            {
+                m_status.emplace(StatusMessageType::Sensor, ss);
+            }
         }
         return AZ::Success(entityId);
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -502,6 +502,16 @@ namespace ROS2
             }
         }
 
+        // Get the remaining log information (sensors, plugins)
+        {
+            AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
+            const auto& sensorStatus = m_sensorsMaker.GetStatusMessages();
+            for (const auto& ss : sensorStatus)
+            {
+                m_status.emplace(StatusMessageType::Sensor, ss);
+            }
+        }
+
         // Create prefab, save it to disk immediately
         // Remove prefab, if it was already created.
 

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.h
@@ -104,6 +104,7 @@ namespace ROS2
         };
         AZStd::mutex m_statusLock;
         AZStd::multimap<StatusMessageType, AZStd::string> m_status;
+        unsigned int m_articulationsCounter{ 0u };
 
         AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;
         bool m_useArticulations{ false };


### PR DESCRIPTION
## What does this PR do?

This PR adds the functionality of printing log messages about created sensors in the RobotImporter wizard. It also lists SDFormat tags that were not parsed correctly:
![Screenshot from 2024-01-08 13-02-45](https://github.com/o3de/o3de-extras/assets/134940295/2672cb7e-3c51-44fc-9a34-149610f5d62c)

Additionally:
- buttons to save modified URDF were disabled in cases URDF is not modified
- SDFormat parser logs are also treated as import warnings and displayed in the wizard
- wizard dialog that was intended to be skipped is skipped now (this part of the code was refactored)
- titles/logs sizes were unified
- a warning about too many articulation links (causing segfault) was added in the _PrefabMaker_ window

![Screenshot from 2024-01-09 16-40-56](https://github.com/o3de/o3de-extras/assets/134940295/3cb64108-2653-4893-9011-d959f85e8a51)

## How was this PR tested?

Multiple different URDF, Xacro and SDFormat models were imported

***
Set to draft: waiting for #632 to be merged
