### PR TITLE
RobotImporter: add Ackermann model hook

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Utilities/Controllers/PidConfiguration.h
+++ b/Gems/ROS2/Code/Include/ROS2/Utilities/Controllers/PidConfiguration.h
@@ -19,6 +19,15 @@ namespace ROS2::Controllers
     public:
         AZ_TYPE_INFO(PidConfiguration, "{814E0D1E-2C33-44A5-868E-C914640E2F7E}");
         static void Reflect(AZ::ReflectContext* context);
+        PidConfiguration() = default;
+        PidConfiguration(
+            const double p,
+            const double i,
+            const double d,
+            const double iMax,
+            const double iMin,
+            const bool antiWindup,
+            const double outputLimit);
 
         //! Initialize PID using member fields as set by the user.
         void InitializePid();

--- a/Gems/ROS2/Code/Include/ROS2/Utilities/Controllers/PidConfiguration.h
+++ b/Gems/ROS2/Code/Include/ROS2/Utilities/Controllers/PidConfiguration.h
@@ -20,6 +20,15 @@ namespace ROS2::Controllers
         AZ_TYPE_INFO(PidConfiguration, "{814E0D1E-2C33-44A5-868E-C914640E2F7E}");
         static void Reflect(AZ::ReflectContext* context);
         PidConfiguration() = default;
+
+        //! Parametrized constructor of PidConfiguration
+        //! @param p Proportional gain.
+        //! @param i Integral gain.
+        //! @param d Derivative gain.
+        //! @param iMax Maximal allowable integral term.
+        //! @param iMin Minimal allowable integral term.
+        //! @param antiWindup Prevents condition of integrator overflow in integral action.
+        //! @param outputLimit Limit PID output; set to 0.0 to disable.
         PidConfiguration(
             const double p,
             const double i,

--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -40,6 +40,7 @@ namespace ROS2
             const auto& importerHookImu = SDFormat::ROS2SensorHooks::ROS2ImuSensor();
             const auto& importerHookLidar = SDFormat::ROS2SensorHooks::ROS2LidarSensor();
             const auto& importerHookSkidSteering = SDFormat::ROS2ModelPluginHooks::ROS2SkidSteeringModel();
+            const auto& importerHookAckermann = SDFormat::ROS2ModelPluginHooks::ROS2AckermannModel();
             serializeContext->Class<ROS2RobotImporterEditorSystemComponent, ROS2RobotImporterSystemComponent>()
                 ->Version(0)
                 ->Attribute(
@@ -48,7 +49,9 @@ namespace ROS2
                                                           AZStd::move(importerHookGNSS),
                                                           AZStd::move(importerHookImu),
                                                           AZStd::move(importerHookLidar) })
-                ->Attribute("ModelPluginImporterHooks", SDFormat::ModelPluginImporterHooksStorage{ AZStd::move(importerHookSkidSteering) });
+                ->Attribute(
+                    "ModelPluginImporterHooks",
+                    SDFormat::ModelPluginImporterHooksStorage{ AZStd::move(importerHookSkidSteering), AZStd::move(importerHookAckermann) });
         }
 
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2AckermannModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2AckermannModelHook.cpp
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <AzToolsFramework/ToolsComponents/TransformComponent.h>
+#include <PhysX/EditorColliderComponentRequestBus.h>
+#include <ROS2/Frame/ROS2FrameComponent.h>
+#include <ROS2/RobotControl/ControlConfiguration.h>
+#include <RobotControl/Controllers/AckermannController/AckermannControlComponent.h>
+#include <RobotControl/ROS2RobotControlComponent.h>
+#include <RobotImporter/SDFormat/ROS2ModelPluginHooks.h>
+#include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
+#include <Source/EditorColliderComponent.h>
+#include <Source/EditorHingeJointComponent.h>
+#include <VehicleDynamics/ModelComponents/AckermannModelComponent.h>
+#include <VehicleDynamics/Utilities.h>
+#include <VehicleDynamics/WheelControllerComponent.h>
+
+#include <gz/math/Vector2.hh>
+#include <gz/math/Vector3.hh>
+#include <sdf/Joint.hh>
+#include <sdf/Link.hh>
+#include <sdf/Model.hh>
+#include <sdf/Plugin.hh>
+
+namespace ROS2::SDFormat
+{
+    namespace AckermannParser
+    {
+        static constexpr float epsilon = 0.001f;
+
+        namespace Wheels
+        {
+            static constexpr unsigned int FrontLeft = 0;
+            static constexpr unsigned int FrontRight = 1;
+            static constexpr unsigned int RearLeft = 2;
+            static constexpr unsigned int RearRight = 3;
+            static constexpr unsigned int SteeringLeft = 4;
+            static constexpr unsigned int SteeringRight = 5;
+            static constexpr unsigned int Total = 6;
+        } // namespace Wheels
+
+        AZ::Outcome<AZ::Vector3, AZStd::string> GetPosition(const AZ::Entity* entity)
+        {
+            if (entity)
+            {
+                auto* transformInterface = entity->FindComponent<AzToolsFramework::Components::TransformComponent>();
+                if (transformInterface)
+                {
+                    return AZ::Success(transformInterface->GetWorldTM().GetTranslation());
+                }
+            }
+
+            return AZ::Failure(AZStd::string("Failed to obtain position parameter for wheel entity."));
+        }
+
+        float GetTrack(const AZ::Entity* entityLeft, const AZ::Entity* entityRight)
+        {
+            const auto positionLeft = GetPosition(entityLeft);
+            const auto positionRight = GetPosition(entityRight);
+
+            if (positionLeft.IsSuccess() && positionLeft.IsSuccess())
+            {
+                return positionLeft.GetValue().GetDistance(positionRight.GetValue());
+            }
+
+            return 0.0f;
+        }
+
+        bool IsSteeringWheel(const std::string& jointNameSteering, const std::string& jointNameWheel, const sdf::Model& sdfModel)
+        {
+            const auto jointPtrSteering = sdfModel.JointByName(jointNameSteering);
+            const auto jointPtrWheel = sdfModel.JointByName(jointNameWheel);
+            if (jointPtrSteering != nullptr && jointPtrWheel != nullptr)
+            {
+                return (jointPtrSteering->ChildName() == jointPtrWheel->ParentName());
+            }
+
+            return false;
+        }
+
+        float GetWheelRadius(AZ::Entity* entity)
+        {
+            if (entity != nullptr)
+            {
+                PhysX::EditorColliderComponent* colliderComponent = entity->FindComponent<PhysX::EditorColliderComponent>();
+                if (colliderComponent != nullptr)
+                {
+                    float radius = 0.0f;
+                    entity->Activate();
+                    if (entity->GetState() == AZ::Entity::State::Active)
+                    {
+                        PhysX::EditorPrimitiveColliderComponentRequestBus::EventResult(
+                            radius,
+                            AZ::EntityComponentIdPair(entity->GetId(), colliderComponent->GetId()),
+                            &PhysX::EditorPrimitiveColliderComponentRequests::GetCylinderRadius);
+                        entity->Deactivate();
+                    }
+                    return radius;
+                }
+            }
+
+            return 0.0f;
+        }
+
+        float GetWheelRadius(AZ::Entity* entityLeft, AZ::Entity* entityRight)
+        {
+            const float radiusLeft = GetWheelRadius(entityLeft);
+            const float radiusRight = GetWheelRadius(entityRight);
+
+            if (fabsf(radiusLeft - radiusRight) < epsilon)
+            {
+                return radiusLeft;
+            }
+            else
+            {
+                AZ_Warning(
+                    "ROS2AckermannModelPluginHook",
+                    false,
+                    "VehicleConfiguration parsing error: left and right wheel radii does not match. (%f and %f)",
+                    radiusLeft,
+                    radiusRight);
+                return 0.0f;
+            }
+        }
+
+        AZ::Vector3 GetWheelTranslation(const AZ::EntityId& entityId)
+        {
+            AZ::Entity* entity = nullptr;
+            AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, entityId);
+            if (entity != nullptr)
+            {
+                auto* transformInterface = entity->FindComponent<AzToolsFramework::Components::TransformComponent>();
+                if (transformInterface)
+                {
+                    return transformInterface->GetLocalTM().GetTranslation();
+                }
+            }
+
+            AZ_Warning(
+                "ROS2AckermannModelPluginHook", false, "Cannot find wheel position; track and wheelbase parameters might be incorrect.");
+            return AZ::Vector3();
+        }
+
+        Controllers::PidConfiguration GetModelPidConfiguration(const sdf::ElementPtr element)
+        {
+            auto pid = element->Get<gz::math::Vector3d>("linear_velocity_pid_gain", gz::math::Vector3d::Zero).first;
+            auto iRange = element->Get<gz::math::Vector2d>("linear_velocity_i_range", gz::math::Vector2d::Zero).first;
+
+            Controllers::PidConfiguration config(pid.X(), pid.Y(), pid.Z(), iRange.Y(), iRange.X(), false, 0.0);
+            return config;
+        }
+
+        VehicleDynamics::VehicleConfiguration GetConfiguration(
+            const sdf::ElementPtr element, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)
+        {
+            const AZStd::array<std::string, Wheels::Total> jointNamesSDFormat{ { "front_left_joint",
+                                                                                 "front_right_joint",
+                                                                                 "rear_left_joint",
+                                                                                 "rear_right_joint",
+                                                                                 "left_steering_joint",
+                                                                                 "right_steering_joint" } };
+            // Stores description of all joints in the SDF and a mapping to O3DE entities
+            struct JointMapping
+            {
+                std::string m_jointName;
+                AZ::EntityId m_entityId;
+                AZ::Entity* m_entity{};
+            };
+            AZStd::array<JointMapping, Wheels::Total> jointMapper;
+
+            for (unsigned int i = 0; i < Wheels::Total; ++i)
+            {
+                const std::string& name = jointNamesSDFormat[i];
+                AZ_Warning(
+                    "ROS2AckermannModelPluginHook",
+                    element->HasElement(name),
+                    "VehicleConfiguration parsing error: cannot find joint %s",
+                    name.c_str());
+                jointMapper[i].m_jointName = element->Get<std::string>(name, name).first;
+                jointMapper[i].m_entityId = HooksUtils::GetJointEntityId(jointMapper[i].m_jointName, sdfModel, createdEntities);
+                if (jointMapper[i].m_entityId.IsValid())
+                {
+                    jointMapper[i].m_entity = AzToolsFramework::GetEntityById(jointMapper[i].m_entityId);
+                }
+            }
+
+            bool foundSteeringWheels = false;
+            VehicleDynamics::VehicleConfiguration configuration;
+            auto addAxle = [&](const unsigned int wheelIdLeft, const unsigned int wheelIdRight, AZStd::string tag) -> void
+            {
+                const auto& jointLeft = jointMapper[wheelIdLeft];
+                const auto& jointRight = jointMapper[wheelIdRight];
+                const auto& jointNameSteeringLeft = jointMapper[Wheels::SteeringLeft].m_jointName;
+                const auto& jointNameSteeringRight = jointMapper[Wheels::SteeringRight].m_jointName;
+                if (jointLeft.m_entityId.IsValid() && jointRight.m_entityId.IsValid())
+                {
+                    const bool isSteering = IsSteeringWheel(jointNameSteeringLeft, jointLeft.m_jointName, sdfModel) &&
+                        IsSteeringWheel(jointNameSteeringRight, jointRight.m_jointName, sdfModel);
+                    const bool isDrive = !isSteering;
+                    const float wheelRadius = GetWheelRadius(jointLeft.m_entity, jointRight.m_entity);
+                    configuration.m_axles.emplace_back(ROS2::VehicleDynamics::Utilities::Create2WheelAxle(
+                        jointLeft.m_entityId, jointRight.m_entityId, AZStd::move(tag), wheelRadius, isSteering, isDrive));
+
+                    const float track = GetTrack(jointLeft.m_entity, jointRight.m_entity);
+                    if (track > epsilon)
+                    {
+                        AZ_Warning(
+                            "ROS2AckermannModelPluginHook",
+                            (fabsf(configuration.m_track) < epsilon && fabsf(configuration.m_track - track) < epsilon),
+                            "VehicleConfiguration parsing error: different track per axis not supported.");
+                        configuration.m_track = track;
+                    }
+
+                    if (isSteering)
+                    {
+                        const auto entityIdSteeringLeft = HooksUtils::GetJointEntityId(jointNameSteeringLeft, sdfModel, createdEntities);
+                        HooksUtils::CreateComponent<VehicleDynamics::WheelControllerComponent>(
+                            jointLeft.m_entityId, entityIdSteeringLeft, 1.0f);
+                        HooksUtils::EnableMotor(entityIdSteeringLeft);
+
+                        const auto entityIdSteeringRight = HooksUtils::GetJointEntityId(jointNameSteeringRight, sdfModel, createdEntities);
+                        HooksUtils::CreateComponent<VehicleDynamics::WheelControllerComponent>(
+                            jointRight.m_entityId, entityIdSteeringRight, 1.0f);
+                        HooksUtils::EnableMotor(entityIdSteeringRight);
+                        foundSteeringWheels = true;
+                    }
+                    else
+                    {
+                        HooksUtils::CreateComponent<VehicleDynamics::WheelControllerComponent>(jointLeft.m_entityId);
+                        HooksUtils::CreateComponent<VehicleDynamics::WheelControllerComponent>(jointRight.m_entityId);
+                    }
+                    HooksUtils::EnableMotor(jointLeft.m_entityId);
+                    HooksUtils::EnableMotor(jointRight.m_entityId);
+                }
+                else
+                {
+                    AZ_Warning(
+                        "ROS2AckermannModelPluginHook",
+                        false,
+                        "Cannot find entity ID for one of the joints: %s or %s",
+                        jointLeft.m_jointName.c_str(),
+                        jointRight.m_jointName.c_str());
+                }
+            };
+
+            addAxle(Wheels::FrontLeft, Wheels::FrontRight, "Front");
+            addAxle(Wheels::RearLeft, Wheels::RearRight, "Rear");
+
+            AZ_Warning(
+                "ROS2AckermannModelPluginHook", foundSteeringWheels, "VehicleConfiguration parsing error: did not create steering joints.");
+
+            const auto positionFrontLeft = GetPosition(jointMapper[Wheels::FrontLeft].m_entity);
+            const auto positionFrontRight = GetPosition(jointMapper[Wheels::FrontRight].m_entity);
+            const auto positionRearLeft = GetPosition(jointMapper[Wheels::RearLeft].m_entity);
+            const auto positionRearRight = GetPosition(jointMapper[Wheels::RearRight].m_entity);
+            if (positionFrontLeft.IsSuccess() && positionFrontRight.IsSuccess() && positionRearLeft.IsSuccess() &&
+                positionRearRight.IsSuccess())
+            {
+                const auto positionFrontAxle = (positionFrontLeft.GetValue() + positionFrontRight.GetValue()) / 2.0f;
+                const auto positionRearAxle = (positionRearLeft.GetValue() + positionRearRight.GetValue()) / 2.0f;
+                configuration.m_wheelbase = positionFrontAxle.GetDistance(positionRearAxle);
+            }
+
+            return configuration;
+        }
+
+        VehicleDynamics::AckermannModelLimits GetModelLimits(const sdf::ElementPtr element)
+        {
+            // Set default limits as in libgazebo_ros_ackermann_drive plugin, see:
+            // https://github.com/ros-simulation/gazebo_ros_pkgs/blob/79fd94c6da76781a91499bc0f54b70560b90a9d2/gazebo_plugins/src/gazebo_ros_ackermann_drive.cpp#L306C1-L307C65
+            const float speedLimit = element->Get<double>("max_speed", 20.0).first;
+            const float steeringLimit = element->Get<double>("max_steer", 0.6).first;
+            return VehicleDynamics::AckermannModelLimits(speedLimit, steeringLimit, speedLimit);
+        }
+    } // namespace AckermannParser
+
+    ModelPluginImporterHook ROS2ModelPluginHooks::ROS2AckermannModel()
+    {
+        ModelPluginImporterHook importerHook;
+        importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_ackermann_drive.so" };
+
+        importerHook.m_sdfPluginToComponentCallback =
+            [](AZ::Entity& entity, const sdf::Plugin& sdfPlugin, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)
+            -> ModelPluginImporterHook::ConvertPluginOutcome
+        {
+            // Parse parameters
+            const sdf::ElementPtr element = sdfPlugin.Element();
+            VehicleDynamics::VehicleConfiguration vehicleConfiguration =
+                AckermannParser::GetConfiguration(element, sdfModel, createdEntities);
+            VehicleDynamics::AckermannModelLimits modelLimits = AckermannParser::GetModelLimits(element);
+            Controllers::PidConfiguration steeringPid = AckermannParser::GetModelPidConfiguration(element);
+            ControlConfiguration controlConfiguration;
+            controlConfiguration.m_steering = ControlConfiguration::Steering::Ackermann;
+
+            // Create required components
+            HooksUtils::CreateComponent<ROS2FrameComponent>(entity);
+            HooksUtils::CreateComponent<ROS2RobotControlComponent>(entity, controlConfiguration);
+            HooksUtils::CreateComponent<VehicleDynamics::AckermannVehicleModelComponent>(
+                entity, vehicleConfiguration, VehicleDynamics::AckermannDriveModel(modelLimits, steeringPid));
+
+            // Create Ackermann Control Component
+            if (HooksUtils::CreateComponent<AckermannControlComponent>(entity))
+            {
+                return AZ::Success();
+            }
+            else
+            {
+                return AZ::Failure(AZStd::string("Failed to create ROS2 Ackermann Control Component"));
+            }
+        };
+
+        return importerHook;
+    }
+} // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2SkidSteeringModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2SkidSteeringModelHook.cpp
@@ -22,7 +22,7 @@
 
 namespace ROS2::SDFormat
 {
-    namespace Parser
+    namespace SkidSteeringParser
     {
         VehicleDynamics::VehicleConfiguration CreateVehicleConfiguration(
             const sdf::ElementPtr element, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)
@@ -38,8 +38,10 @@ namespace ROS2::SDFormat
                 const auto entityIdRight = HooksUtils::GetJointEntityId(jointNameRight, sdfModel, createdEntities);
                 if (entityIdLeft.IsValid() && entityIdRight.IsValid())
                 {
-                    HooksUtils::SetWheelEntity(entityIdLeft);
-                    HooksUtils::SetWheelEntity(entityIdRight);
+                    HooksUtils::EnableMotor(entityIdLeft);
+                    HooksUtils::CreateComponent<VehicleDynamics::WheelControllerComponent>(entityIdLeft);
+                    HooksUtils::EnableMotor(entityIdRight);
+                    HooksUtils::CreateComponent<VehicleDynamics::WheelControllerComponent>(entityIdRight);
                     constexpr bool steering = false; // Skid steering model does not have any steering wheels.
                     constexpr bool drive = true;
                     configuration.m_axles.emplace_back(VehicleDynamics::Utilities::Create2WheelAxle(
@@ -168,7 +170,7 @@ namespace ROS2::SDFormat
 
             return modelLimits;
         }
-    } // namespace Parser
+    } // namespace SkidSteeringParser
 
     ModelPluginImporterHook ROS2ModelPluginHooks::ROS2SkidSteeringModel()
     {
@@ -183,8 +185,8 @@ namespace ROS2::SDFormat
             // Parse parameters
             const sdf::ElementPtr element = sdfPlugin.Element();
             VehicleDynamics::VehicleConfiguration vehicleConfiguration =
-                Parser::CreateVehicleConfiguration(element, sdfModel, createdEntities);
-            VehicleDynamics::SkidSteeringModelLimits modelLimits = Parser::CreateModelLimits(element);
+                SkidSteeringParser::CreateVehicleConfiguration(element, sdfModel, createdEntities);
+            VehicleDynamics::SkidSteeringModelLimits modelLimits = SkidSteeringParser::CreateModelLimits(element);
 
             // Create required components
             HooksUtils::CreateComponent<ROS2FrameComponent>(entity);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2ModelPluginHooks.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2ModelPluginHooks.h
@@ -16,4 +16,8 @@ namespace ROS2::SDFormat::ROS2ModelPluginHooks
     //! components.
     ModelPluginImporterHook ROS2SkidSteeringModel();
 
+    //! Retrieve a model plugin importer hook which is used to map SDFormat model plugin of type Ackermann model drive into O3DE
+    //! components.
+    ModelPluginImporterHook ROS2AckermannModel();
+
 } // namespace ROS2::SDFormat::ROS2ModelPluginHooks

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -42,7 +42,7 @@ namespace ROS2::SDFormat
         return AZ::EntityId();
     }
 
-    void HooksUtils::SetWheelEntity(const AZ::EntityId& entityId)
+    void HooksUtils::EnableMotor(const AZ::EntityId& entityId)
     {
         AZ::Entity* entity = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, entityId);
@@ -67,9 +67,5 @@ namespace ROS2::SDFormat
                 entity->Deactivate();
             }
         }
-
-        // Add WheelControllerComponent
-        AZ::Component* wheelComponentPtr = HooksUtils::CreateComponent<VehicleDynamics::WheelControllerComponent>(*entity);
-        AZ_Warning("HooksUtils", wheelComponentPtr != nullptr, "Cannot create WheelControllerComponent in wheel entity.");
     }
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -44,9 +44,9 @@ namespace ROS2::SDFormat
         //! @return entity id (invalid id if not found)
         AZ::EntityId GetJointEntityId(const std::string& jointName, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities);
 
-        //! Enable motor in EditorHingeJointComponent if possible and create WheelControllerComponent
+        //! Enable motor in EditorHingeJointComponent if possible
         //! @param entityId entity id of the modified entity
-        void SetWheelEntity(const AZ::EntityId& entityId);
+        void EnableMotor(const AZ::EntityId& entityId);
 
         //! Create a component and attach the component to the entity.
         //! This method ensures that game components are wrapped into GenericComponentWrapper.
@@ -86,6 +86,24 @@ namespace ROS2::SDFormat
                 }
             }
             return component;
+        }
+
+        //! Create a component and attach the component to the entity.
+        //! This method ensures that game components are wrapped into GenericComponentWrapper.
+        //! @param entityId entity id to which the new component is added
+        //! @param args constructor arguments used to create the new component
+        //! @return A pointer to the component. Returns a null pointer if the component could not be created.
+        template<class ComponentType, typename... Args>
+        AZ::Component* CreateComponent(const AZ::EntityId& entityId, Args&&... args)
+        {
+            AZ::Entity* entity = nullptr;
+            AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, entityId);
+            if (entity != nullptr)
+            {
+                return CreateComponent<ComponentType>(*entity, AZStd::forward<Args>(args)...);
+            }
+
+            return nullptr;
         }
     } // namespace HooksUtils
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/Utilities/Controllers/PidConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Utilities/Controllers/PidConfiguration.cpp
@@ -50,6 +50,23 @@ namespace ROS2::Controllers
             }
         }
     }
+    PidConfiguration::PidConfiguration(
+        const double p,
+        const double i,
+        const double d,
+        const double iMax,
+        const double iMin,
+        const bool antiWindup,
+        const double outputLimit)
+        : m_p(p)
+        , m_i(i)
+        , m_d(d)
+        , m_iMax(iMax)
+        , m_iMin(iMin)
+        , m_antiWindup(antiWindup)
+        , m_outputLimit(outputLimit)
+    {
+    }
 
     void PidConfiguration::InitializePid()
     {

--- a/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/AckermannDriveModel.cpp
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/AckermannDriveModel.cpp
@@ -43,6 +43,12 @@ namespace ROS2::VehicleDynamics
         }
     }
 
+    AckermannDriveModel::AckermannDriveModel(const AckermannModelLimits& limits, const ROS2::Controllers::PidConfiguration& steeringPid)
+        : m_limits(limits)
+        , m_steeringPid(steeringPid)
+    {
+    }
+
     void AckermannDriveModel::Activate(const VehicleConfiguration& vehicleConfig)
     {
         m_driveWheelsData.clear();

--- a/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/AckermannDriveModel.h
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/AckermannDriveModel.h
@@ -22,6 +22,8 @@ namespace ROS2::VehicleDynamics
     {
     public:
         AZ_RTTI(AckermannDriveModel, "{104AC31D-E30B-4454-BF42-4FB37B8CFD9B}", DriveModel);
+        AckermannDriveModel() = default;
+        AckermannDriveModel(const AckermannModelLimits& limits, const ROS2::Controllers::PidConfiguration& steeringPid);
 
         // DriveModel overrides
         void Activate(const VehicleConfiguration& vehicleConfig) override;

--- a/Gems/ROS2/Code/Source/VehicleDynamics/ModelComponents/AckermannModelComponent.cpp
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/ModelComponents/AckermannModelComponent.cpp
@@ -39,6 +39,13 @@ namespace ROS2::VehicleDynamics
         }
     }
 
+    AckermannVehicleModelComponent::AckermannVehicleModelComponent(
+        const VehicleConfiguration& vehicleConfiguration, const AckermannDriveModel& driveModel)
+        : m_driveModel(driveModel)
+    {
+        m_vehicleConfiguration = vehicleConfiguration;
+    }
+
     void AckermannVehicleModelComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
     {
         provided.push_back(AZ_CRC_CE("AckermannModelService"));

--- a/Gems/ROS2/Code/Source/VehicleDynamics/ModelComponents/AckermannModelComponent.h
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/ModelComponents/AckermannModelComponent.h
@@ -20,6 +20,7 @@ namespace ROS2::VehicleDynamics
     public:
         AZ_COMPONENT(AckermannVehicleModelComponent, "{7618dbb9-fad4-44b3-8587-0d4f97336d3c}", VehicleModelComponent);
         AckermannVehicleModelComponent() = default;
+        AckermannVehicleModelComponent(const VehicleConfiguration& vehicleConfiguration, const AckermannDriveModel& driveModel);
 
         static void Reflect(AZ::ReflectContext* context);
 
@@ -29,10 +30,10 @@ namespace ROS2::VehicleDynamics
         void Activate() override;
 
     private:
-        VehicleDynamics::AckermannDriveModel m_driveModel;
+        AckermannDriveModel m_driveModel;
 
     protected:
         // VehicleModelComponent overrides
-        VehicleDynamics::DriveModel* GetDriveModel() override;
+        DriveModel* GetDriveModel() override;
     };
 } // namespace ROS2::VehicleDynamics

--- a/Gems/ROS2/Code/Source/VehicleDynamics/ModelLimits/AckermannModelLimits.cpp
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/ModelLimits/AckermannModelLimits.cpp
@@ -21,7 +21,7 @@ namespace ROS2::VehicleDynamics
                 ->Version(1)
                 ->Field("SpeedLimit", &AckermannModelLimits::m_speedLimit)
                 ->Field("SteeringLimit", &AckermannModelLimits::m_steeringLimit)
-                ->Field("Acceleration", &AckermannModelLimits::m_accelearation);
+                ->Field("Acceleration", &AckermannModelLimits::m_acceleration);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
@@ -37,18 +37,25 @@ namespace ROS2::VehicleDynamics
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                     ->Attribute(AZ::Edit::Attributes::Max, 1.57f)
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &AckermannModelLimits::m_accelearation, "Acceleration", "Acceleration in m/s²")
+                        AZ::Edit::UIHandlers::Default, &AckermannModelLimits::m_acceleration, "Acceleration", "Acceleration in m/s²")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                     ->Attribute(AZ::Edit::Attributes::Max, 100.0f);
             }
         }
     }
 
+    AckermannModelLimits::AckermannModelLimits(const float speedLimit, const float steeringLimit, const float acceleration)
+    {
+        m_speedLimit = AZStd::clamp(speedLimit, 0.0f, 100.0f);
+        m_steeringLimit = AZStd::clamp(steeringLimit, 0.0f, 1.57f);
+        m_acceleration = AZStd::clamp(acceleration, 0.0f, 100.0f);
+    }
+
     VehicleInputs AckermannModelLimits::LimitState(const VehicleInputs& inputState) const
     {
         VehicleInputs ret = inputState;
-        ret.m_angularRates = AZ::Vector3{ 0 };
-        ret.m_speed = AZ::Vector3{ LimitValue(ret.m_speed.GetX(), m_speedLimit), 0.f, 0.f };
+        ret.m_angularRates = AZ::Vector3{ 0.0f };
+        ret.m_speed = AZ::Vector3{ LimitValue(ret.m_speed.GetX(), m_speedLimit), 0.0f, 0.0f };
         if (!ret.m_jointRequestedPosition.empty())
         {
             ret.m_jointRequestedPosition.front() = LimitValue(ret.m_jointRequestedPosition.front(), m_steeringLimit);
@@ -59,7 +66,7 @@ namespace ROS2::VehicleDynamics
     VehicleInputs AckermannModelLimits::GetMaximumState() const
     {
         VehicleInputs ret;
-        ret.m_speed = { m_speedLimit, 0, 0 };
+        ret.m_speed = { m_speedLimit, 0.0f, 0.0f };
         ret.m_jointRequestedPosition = { m_steeringLimit };
         return ret;
     }
@@ -71,7 +78,7 @@ namespace ROS2::VehicleDynamics
 
     float AckermannModelLimits::GetLinearAcceleration() const
     {
-        return m_accelearation;
+        return m_acceleration;
     }
 
 } // namespace ROS2::VehicleDynamics

--- a/Gems/ROS2/Code/Source/VehicleDynamics/ModelLimits/AckermannModelLimits.h
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/ModelLimits/AckermannModelLimits.h
@@ -19,6 +19,7 @@ namespace ROS2::VehicleDynamics
     public:
         AZ_RTTI(AckermannModelLimits, "{796928D9-436F-472D-B841-E67F28F9CC82}", VehicleModelLimits);
         AckermannModelLimits() = default;
+        AckermannModelLimits(const float speedLimit, const float steeringLimit, const float acceleration);
         static void Reflect(AZ::ReflectContext* context);
 
         // VehicleModelLimits overrides
@@ -31,6 +32,6 @@ namespace ROS2::VehicleDynamics
     private:
         float m_speedLimit = 10.0f; //!< [Mps] Applies to absolute value
         float m_steeringLimit = 0.7f; //!< [rad] Applies to absolute value
-        float m_accelearation = 10.0f; //!< [m*s^(-2)] Linear acceleration limit
+        float m_acceleration = 10.0f; //!< [m*s^(-2)] Linear acceleration limit
     };
 } // namespace ROS2::VehicleDynamics

--- a/Gems/ROS2/Code/Source/VehicleDynamics/WheelControllerComponent.cpp
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/WheelControllerComponent.cpp
@@ -86,4 +86,10 @@ namespace ROS2::VehicleDynamics
             }
         }
     }
+
+    WheelControllerComponent::WheelControllerComponent(const AZ::EntityId& steeringEntity, const float steeringScale)
+        : m_steeringEntity(steeringEntity)
+        , m_steeringScale(steeringScale)
+    {
+    }
 } // namespace ROS2::VehicleDynamics

--- a/Gems/ROS2/Code/Source/VehicleDynamics/WheelControllerComponent.h
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/WheelControllerComponent.h
@@ -20,6 +20,7 @@ namespace ROS2::VehicleDynamics
     public:
         AZ_COMPONENT(WheelControllerComponent, "{AC594E08-DA5C-4B8D-9388-84D0840C177A}", AZ::Component);
         WheelControllerComponent() = default;
+        WheelControllerComponent(const AZ::EntityId& steeringEntity, const float steeringScale);
         ~WheelControllerComponent() = default;
 
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -36,6 +36,7 @@ set(FILES
     Source/RobotImporter/RobotImporterWidget.h
     Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
     Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.h
+    Source/RobotImporter/SDFormat/Hooks/ROS2AckermannModelHook.cpp
     Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
     Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
     Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp


### PR DESCRIPTION
## What does this PR do?

This PR adds a hook for importing Ackermann plugin from SDFormat data.

## How was this PR tested?

This hook was tested using the attached model. When imported with articulations, the only missing part is setting `use motor = true` in steering joints, which is currently impossible due to missing interfaces in articulations (impossible to change any settings). The same setting is set correctly for wheels based on wheel material information. When importer without articulations, all parameters are set accordingly.
[ackermann_nomesh.zip](https://github.com/o3de/o3de-extras/files/13948582/ackermann_nomesh.zip)

The movement of robots is not perfect after the import and all parameters such as motor force and damping, links' weights, etc., should be adjusted manually. But the import works as expected - please use the following command to see the robot movement:
```
ros2 topic pub -r 10 /body_link/default_topic ackermann_msgs/msg/AckermannDrive "{steering_angle: 1.0, steering_angle_velocity: 0.0, speed: 0.5, acceleration: 0.0, jerk: 0.0}"

```
Due to changes in the skid steering hook, such robots were imported and tested as well.