### PR TITLE
Add feature to prevent camera from tilting

### DIFF
--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.cpp
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.cpp
@@ -29,6 +29,8 @@ namespace ROS2
     {
     }
 
+
+
     void FollowingCameraComponent::Reflect(AZ::ReflectContext* reflection)
     {
         FollowingCameraConfiguration::Reflect(reflection);
@@ -98,6 +100,40 @@ namespace ROS2
         InputChannelEventListener::Disconnect();
     }
 
+    AZ::Transform FollowingCameraComponent::RemoveTiltFromTransform(const AZ::Transform& transform)
+    {
+        const AZ::Vector3& entityTranslation = transform.GetTranslation();
+        const AZ::Vector3 axisX = transform.GetBasisX();
+        const AZ::Vector3 axisY = transform.GetBasisY();
+
+        const AZ::Matrix3x3 projectionOnXY {AZ::Matrix3x3::CreateFromColumns(AZ::Vector3::CreateAxisX(), AZ::Vector3::CreateAxisY(), AZ::Vector3::CreateZero())};
+
+        const AZ::Vector3 newAxisZ = AZ::Vector3::CreateAxisZ(); // new axis Z points up
+
+        // project axisX on the XY plane
+        const AZ::Vector3 projectedAxisX = (projectionOnXY * axisX);
+        const AZ::Vector3 projectedAxisY = (projectionOnXY * axisY);
+
+        AZ::Vector3 newAxisX = AZ::Vector3::CreateZero();
+        AZ::Vector3 newAxisY = AZ::Vector3::CreateZero();
+
+        // get 3rd vector of the new basis from the cross product of the projected vectors.
+        // Primarily we want to use the projectedAxisX as the newAxisX, but if it is zero-length, we use the projectedAxisY as the newAxisY.
+        if (!projectedAxisX.IsZero())
+        {
+            newAxisX = projectedAxisX.GetNormalized();
+            newAxisY = newAxisZ.Cross(newAxisX);
+        }
+        else
+        {
+            newAxisY = projectedAxisY.GetNormalized();
+            newAxisX = newAxisY.Cross(newAxisZ);
+        }
+
+        // create new transform from the new basis vectors and the old translation
+        return AZ::Transform::CreateFromMatrix3x3AndTranslation(AZ::Matrix3x3::CreateFromColumns(projectedAxisX, projectedAxisY, newAxisZ), entityTranslation);
+    }
+
     void FollowingCameraComponent::CacheTransform(const AZ::Transform& transform, float deltaTime)
     {
         // update the smoothing buffer
@@ -129,7 +165,7 @@ namespace ROS2
         // get parent's transform
         const AZ::Transform parent_transform = target_world_transform * target_local_transform.GetInverse();
 
-        CacheTransform(parent_transform, deltaTime);
+        CacheTransform(m_configuration.m_lockZAxis?RemoveTiltFromTransform(parent_transform):parent_transform , deltaTime);
 
         // get the averaged translation and quaternion
         AZ::Transform filtered_parent_transform = { SmoothTranslation(), SmoothRotation(), 1.f };

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.cpp
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.cpp
@@ -100,9 +100,8 @@ namespace ROS2
         InputChannelEventListener::Disconnect();
     }
 
-    AZ::Transform FollowingCameraComponent::RemoveTiltFromTransform(const AZ::Transform& transform)
+    AZ::Transform FollowingCameraComponent::RemoveTiltFromTransform(AZ::Transform transform)
     {
-        const AZ::Vector3& entityTranslation = transform.GetTranslation();
         const AZ::Vector3 axisX = transform.GetBasisX();
         const AZ::Vector3 axisY = transform.GetBasisY();
 
@@ -129,9 +128,9 @@ namespace ROS2
             newAxisY = projectedAxisY.GetNormalized();
             newAxisX = newAxisY.Cross(newAxisZ);
         }
-
-        // create new transform from the new basis vectors and the old translation
-        return AZ::Transform::CreateFromMatrix3x3AndTranslation(AZ::Matrix3x3::CreateFromColumns(projectedAxisX, projectedAxisY, newAxisZ), entityTranslation);
+        // apply rotation using created basis
+        transform.SetRotation(AZ::Quaternion::CreateFromBasis(newAxisX, newAxisY, newAxisZ));
+        return transform;
     }
 
     void FollowingCameraComponent::CacheTransform(const AZ::Transform& transform, float deltaTime)
@@ -165,7 +164,8 @@ namespace ROS2
         // get parent's transform
         const AZ::Transform parent_transform = target_world_transform * target_local_transform.GetInverse();
 
-        CacheTransform(m_configuration.m_lockZAxis?RemoveTiltFromTransform(parent_transform):parent_transform , deltaTime);
+        const AZ::Transform transformToCache = m_configuration.m_lockZAxis ? RemoveTiltFromTransform(parent_transform) : parent_transform;
+        CacheTransform(transformToCache, deltaTime);
 
         // get the averaged translation and quaternion
         AZ::Transform filtered_parent_transform = { SmoothTranslation(), SmoothRotation(), 1.f };

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
@@ -48,13 +48,11 @@ namespace ROS2
         bool OnInputChannelEventFiltered(const AzFramework::InputChannel& inputChannel) override;
         void OnKeyboardEvent(const AzFramework::InputChannel& inputChannel);
 
-
         //! Remove the tilt from the transform.
-        //!
+        //! The tilt is removed by projecting the transform basis of rotation matrix to the ground plane.
         //! @param transform The transform to remove the tilt.
         //! @return The transform without tilt.
-
-        AZ::Transform RemoveTiltFromTransform(const AZ::Transform& transform);
+        AZ::Transform RemoveTiltFromTransform(AZ::Transform transform);
 
         //! Compute weighted average of the vectors in the buffer.
         //! @param buffer The buffer to compute the average.

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
@@ -48,6 +48,14 @@ namespace ROS2
         bool OnInputChannelEventFiltered(const AzFramework::InputChannel& inputChannel) override;
         void OnKeyboardEvent(const AzFramework::InputChannel& inputChannel);
 
+
+        //! Remove the tilt from the transform.
+        //!
+        //! @param transform The transform to remove the tilt.
+        //! @return The transform without tilt.
+
+        AZ::Transform RemoveTiltFromTransform(const AZ::Transform& transform);
+
         //! Compute weighted average of the vectors in the buffer.
         //! @param buffer The buffer to compute the average.
         //! @return The average vector.

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraConfiguration.cpp
@@ -22,6 +22,7 @@ namespace ROS2
                 ->Field("SmoothingLength", &FollowingCameraConfiguration::m_smoothingBuffer)
                 ->Field("ZoomSpeed", &FollowingCameraConfiguration::m_zoomSpeed)
                 ->Field("RotationSpeed", &FollowingCameraConfiguration::m_rotationSpeed)
+                ->Field("LockZAxis", &FollowingCameraConfiguration::m_lockZAxis)
                 ->Field("DefaultView", &FollowingCameraConfiguration::m_defaultView);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
@@ -43,6 +44,7 @@ namespace ROS2
                         "Rotation Speed around the target")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &FollowingCameraConfiguration::m_predefinedViews, "Views", "Views to follow")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &FollowingCameraConfiguration::m_lockZAxis, "Lock Z Axis", "Prevent camera from tilting")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &FollowingCameraConfiguration::m_defaultView,

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraConfiguration.h
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraConfiguration.h
@@ -26,6 +26,7 @@ namespace ROS2
         int m_smoothingBuffer = 30; //!< Number of past transforms used to smooth, larger value gives smoother result, but more lag
         float m_zoomSpeed = 0.06f; //!< Speed of zooming
         float m_rotationSpeed = 0.05f; //!< Rotation Speed around the target
+        bool m_lockZAxis = false; //!< Lock the Z axis of the camera
         const float m_opticalAxisTranslationMin = 0.0f; //!< Minimum zoom distance
     };
 } // namespace ROS2


### PR DESCRIPTION
## What does this PR do?

Following camera allows to switch camera to many different location, but it can tilt (horizon tilts with robot).
With this feature, the rotation matrix is decomposed in such manner that pitch and yaw is removed.

## How was this PR tested?
Manual test with internal project.
