### PR TITLE
Add AzRunUnitTests Hook to Editor Tests

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -243,7 +243,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                         AZ::AzTest
                         AZ::AzTestShared
                         AZ::AzToolsFramework
-                        Gem::${gem_name}.Editor
+                        Gem::${gem_name}.Editor.Static
                         3rdParty::sdformat
             )
 

--- a/Gems/ROS2/Code/Tests/ROS2EditorTest.cpp
+++ b/Gems/ROS2/Code/Tests/ROS2EditorTest.cpp
@@ -7,3 +7,5 @@
  */
 
 #include <AzTest/AzTest.h>
+
+AZ_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);


### PR DESCRIPTION
## What does this PR do?
fixes: #656 
By adding necessary hook for running Unit Tests.

After this PR only ros2 python smoke tests are failing.

## How was this PR tested?

Building all ros2 gem tests:

```
cmake --build . --config debug --target ROS2.Editor.Tests ROS2.Tests ROS2.Frame.Tests
```
and running 
```
ctest -C debug -R "ROS2" --output-on-failure
```
Introducing failure inside Editor tests correctly shows failing test.

on commits
- o3de - `5ae4e51252`
- o3de-extras - `85cd1399`