### PR TITLE
UI handler for effective namespace

### DIFF
--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameConfiguration.cpp
@@ -26,8 +26,7 @@ namespace ROS2
                 ->Field("Namespace Configuration", &ROS2FrameConfiguration::m_namespaceConfiguration)
                 ->Field("Frame Name", &ROS2FrameConfiguration::m_frameName)
                 ->Field("Joint Name", &ROS2FrameConfiguration::m_jointName)
-                ->Field("Publish Transform", &ROS2FrameConfiguration::m_publishTransform)
-                ->Field("Effective namespace", &ROS2FrameConfiguration::m_effectiveNamespace);
+                ->Field("Publish Transform", &ROS2FrameConfiguration::m_publishTransform);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
@@ -45,8 +44,8 @@ namespace ROS2
                         &ROS2FrameConfiguration::m_publishTransform,
                         "Publish Transform",
                         "Publish Transform")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2FrameConfiguration::m_effectiveNamespace, "Effective namespace", "")
-                    ->Attribute(AZ::Edit::Attributes::ReadOnly, true);
+                    ->UIElement(AZ::Edit::UIHandlers::Label, "Effective namespace", "")
+                    ->Attribute(AZ::Edit::Attributes::ValueText, &ROS2FrameConfiguration::m_effectiveNamespace);
             }
         }
     }


### PR DESCRIPTION
## Dependencies
This PR depends on #659.

## Fixes
Fixes #661

## What does this PR do?

This PR changes the edit context for effective namespace in the ROS2FrameEditorComponent. This will prevent the o3de engine form showing the effective namespace as overridden.

The UI changes:
![image](https://github.com/o3de/o3de-extras/assets/130671280/bcdbcbfb-7209-4780-97ac-93acb1bbe405)


## How was this PR tested?
By importing a robot using the robot importer.
