### PR TITLE
Enable ROS2 Gem for testing

### DIFF
--- a/.automatedtesting.json
+++ b/.automatedtesting.json
@@ -6,7 +6,8 @@
     ],
     "REGISTER_GEMS": [
         "Gems/XR",
-        "Gems/OpenXRVk"
+        "Gems/OpenXRVk",
+        "Gems/ROS2"
     ],
     "REGISTER_TEMPLATES": [
         "Templates/Multiplayer"

--- a/.automatedtesting.json
+++ b/.automatedtesting.json
@@ -15,6 +15,7 @@
     ],
     "ENABLE_GEMS": [
         "Gems/XR",
-        "Gems/OpenXRVk"
+        "Gems/OpenXRVk",
+        "Gems/ROS2"
     ]
 }


### PR DESCRIPTION
## What does this PR do?

This PR is an attempt to enable ROS2 Gem for testing via AutomatedTesting.

Goal of this PR is to validate what needs to be improved to correctly run tests automatically on each PR.

## How was this PR tested?

Most of ROS2 Gem Tests are successful while running locally.
It is to be validated if they also run correctly in AR.