### PR TITLE
fix reflection in ROS2FrameEditorComponent

### DIFF
--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -102,7 +102,7 @@ namespace ROS2
     {
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<ROS2FrameEditorComponent>()->Version(1)->Field(
+            serialize->Class<ROS2FrameEditorComponent, AzToolsFramework::Components::EditorComponentBase>()->Version(1)->Field(
                 "ROS2FrameConfiguration", &ROS2FrameEditorComponent::m_configuration);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())


### PR DESCRIPTION
## What does this PR do?

`ROS2FrameEditorComponent` was not reflecting its base class and, as a result, it was triggering an error message. This is fixed now.

## How was this PR tested?

The code was built and the project using `ROS2FrameEditorComponent` loaded with no error messages.
