### PR TITLE
don't use scale in MVP calculation for sensors

### DIFF
--- a/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
@@ -169,7 +169,9 @@ namespace ROS2
     void CameraSensor::RequestFrame(
         const AZ::Transform& cameraPose, AZStd::function<void(const AZ::RPI::AttachmentReadback::ReadbackResult& result)> callback)
     {
-        const AZ::Transform inverse = (cameraPose * AtomToRos).GetInverse();
+        const AZ::Transform cameraPoseNoScaling =
+            AZ::Transform::CreateFromQuaternionAndTranslation(cameraPose.GetRotation(), cameraPose.GetTranslation());
+        const AZ::Transform inverse = (cameraPoseNoScaling * AtomToRos).GetInverse();
         m_view->SetWorldToViewMatrix(AZ::Matrix4x4::CreateFromQuaternionAndTranslation(inverse.GetRotation(), inverse.GetTranslation()));
 
         AZ::Render::FrameCaptureOutcome captureOutcome;

--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
@@ -142,7 +142,8 @@ namespace ROS2
         auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         auto requestResults = sceneInterface->QuerySceneBatch(m_sceneHandle, requests);
         AZ_Assert(requestResults.size() == rayDirections.size(), "Request size should be equal to directions size");
-        const auto localTransform = lidarTransform.GetInverse();
+        const auto localTransform =
+            AZ::Transform::CreateFromQuaternionAndTranslation(lidarTransform.GetRotation(), lidarTransform.GetTranslation()).GetInverse();
         const float maxRange = m_addMaxRangePoints ? m_range : AZStd::numeric_limits<float>::infinity();
 
         for (int i = 0; i < requestResults.size(); i++)


### PR DESCRIPTION
## What does this PR do?

Fixes #674.

`AZ::Transform` contains translation, rotation, and scale. When calculating MVP for lidar sensor and camera sensor we only care about translation and rotation, hence the scale should be ignored. 

## How was this PR tested?

A robot was scaled up and down, the camera outputs were compared.

![Screenshot from 2024-03-12 12-42-56](https://github.com/o3de/o3de-extras/assets/134940295/1d346e3f-75c7-4d07-b1cd-208a25c67e01)
![Screenshot from 2024-03-12 12-43-30](https://github.com/o3de/o3de-extras/assets/134940295/6d540f2a-9e61-48b3-bd0a-3a6f7806d3e3)
