### PR TITLE
RobotImporter: print model control plugins import log in wizard

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2AckermannModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2AckermannModelHook.cpp
@@ -283,6 +283,10 @@ namespace ROS2::SDFormat
     {
         ModelPluginImporterHook importerHook;
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_ackermann_drive.so" };
+        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{
+            ">front_left_joint",     ">front_right_joint",        ">rear_left_joint",         ">rear_right_joint", ">left_steering_joint",
+            ">right_steering_joint", ">linear_velocity_pid_gain", ">linear_velocity_i_range", ">max_speed",        ">max_steer"
+        };
 
         importerHook.m_sdfPluginToComponentCallback =
             [](AZ::Entity& entity, const sdf::Plugin& sdfPlugin, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2SkidSteeringModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2SkidSteeringModelHook.cpp
@@ -177,6 +177,11 @@ namespace ROS2::SDFormat
         ModelPluginImporterHook importerHook;
         importerHook.m_pluginNames =
             AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_skid_steer_drive.so", "libgazebo_ros_diff_drive.so" };
+        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{
+            ">wheelSeparation",        ">wheelDiameter",   ">wheelAcceleration", ">leftJoint",      ">rightJoint",       ">wheelDiameter",
+            ">leftFrontJoint",         ">rightFrontJoint", ">leftRearJoint",     ">rightRearJoint", ">wheel_separation", ">wheel_diameter",
+            ">max_wheel_acceleration", ">num_wheel_pairs", ">left_joint",        ">right_joint"
+        };
 
         importerHook.m_sdfPluginToComponentCallback =
             [](AZ::Entity& entity, const sdf::Plugin& sdfPlugin, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/RobotControlMaker.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/RobotControlMaker.h
@@ -11,6 +11,7 @@
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Outcome/Outcome.h>
+#include <AzCore/std/containers/set.h>
 #include <ROS2/RobotImporter/SDFormatModelPluginImporterHook.h>
 
 #include <sdf/sdf.hh>
@@ -26,6 +27,17 @@ namespace ROS2
         //! @param model A parsed SDF model which could hold information about a model control plugin.
         //! @param entityId A non-active entity which will be affected.
         //! @param createdEntities A map of all created entities that can be used by plugins.
-        void AddControlPlugins(const sdf::Model& model, AZ::EntityId entityId, const SDFormat::CreatedEntitiesMap& createdEntities) const;
+        void AddControlPlugins(const sdf::Model& model, AZ::EntityId entityId, const SDFormat::CreatedEntitiesMap& createdEntities);
+
+        //! Get a reference to collection of status messages (read-only)
+        //! @return A reference to set containing status messages.
+        const AZStd::set<AZStd::string>& GetStatusMessages() const;
+
+    private:
+        AZStd::set<AZStd::string> m_status;
+
+        using ControlHookCallOutcome = AZ::Outcome<void, AZStd::string>;
+        ControlHookCallOutcome AddPlugin(
+            AZ::EntityId entityId, const sdf::Plugin& plugin, const sdf::Model& model, const SDFormat::CreatedEntitiesMap& createdEntities);
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
@@ -97,8 +97,10 @@ namespace ROS2
                     return CallSensorHook(entityId, sensor, &hook, createdEntities);
                 }
             }
-            return AZ::Failure(
-                AZStd::string::format("Cannot find a hook for %s sensor (type %s)", sensor->Name().c_str(), sensor->TypeStr().c_str()));
+            const auto message =
+                AZStd::string::format("%s (type %s) not created: cannot find the hook", sensor->Name().c_str(), sensor->TypeStr().c_str());
+            m_status.emplace(message);
+            return AZ::Failure(message);
         }
 
         // Add sensor with one or more plugins
@@ -146,7 +148,8 @@ namespace ROS2
         for (size_t si = 0; si < link->SensorCount(); ++si)
         {
             const auto* sensor = link->SensorByIndex(si);
-            AddSensor(entityId, sensor, createdEntities);
+            const auto outcome = AddSensor(entityId, sensor, createdEntities);
+            AZ_Warning("SensorsMaker", outcome.IsSuccess(), outcome.GetError().c_str());
         }
 
         return createdEntities;

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -506,6 +506,12 @@ namespace ROS2
         // Get the remaining log information (sensors, plugins)
         {
             AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
+            const auto& modelPluginStatus = m_controlMaker.GetStatusMessages();
+            for (const auto& mps : modelPluginStatus)
+            {
+                m_status.emplace(StatusMessageType::ModelPlugin, mps);
+            }
+
             const auto& sensorStatus = m_sensorsMaker.GetStatusMessages();
             for (const auto& ss : sensorStatus)
             {


### PR DESCRIPTION
## What does this PR do?

This PR adds the functionality of printing log messages about created model control plugins in the RobotImporter wizard, as in  #648 for sensors. It also lists SDFormat tags that were not parsed correctly:
![Screenshot from 2024-03-12 17-51-43](https://github.com/o3de/o3de-extras/assets/134940295/440d57de-f867-498c-ab46-474ce20d6ef0)

## How was this PR tested?

SDFormat data with Ackermann and Skid Steering examples were imported.
[sample_models.zip](https://github.com/o3de/o3de-extras/files/14587299/sample_models.zip)
