### PR TITLE
Make Multiplayer Template Usable Again

### DIFF
--- a/Templates/Multiplayer/Template/Gem/Code/Source/Spawners/RoundRobinSpawner.cpp
+++ b/Templates/Multiplayer/Template/Gem/Code/Source/Spawners/RoundRobinSpawner.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
@@ -29,7 +29,7 @@ namespace ${SanitizedCppName}
             AZLOG_WARN("No active NetworkPlayerSpawnerComponents were found on player spawn request.")
             return AZStd::make_pair<Multiplayer::PrefabEntityId, AZ::Transform>(Multiplayer::PrefabEntityId(), AZ::Transform::CreateIdentity());
         }
-        
+
         if (m_spawnIndex >= m_spawners.size())
         {
             AZLOG_WARN("RoundRobinSpawner has an out-of-bounds spawner index. Resetting spawn index to 0.")
@@ -41,7 +41,7 @@ namespace ${SanitizedCppName}
         // NetworkEntityManager currently operates against/validates AssetId or Path, opt for Path via Hint
         Multiplayer::PrefabEntityId prefabEntityId(AZ::Name(spawner->GetSpawnableAsset().GetHint().c_str()));
 
-        return AZStd::make_pair<Multiplayer::PrefabEntityId, AZ::Transform>(
+        return AZStd::make_pair(
             prefabEntityId, spawner->GetEntity()->GetTransform()->GetWorldTM());
     }
 
@@ -56,7 +56,7 @@ namespace ${SanitizedCppName}
             {
                 m_spawnIndex = 0;
             }
-            
+
             return true;
         }
 

--- a/Templates/Multiplayer/Template/Gem/Code/enabled_gems.cmake
+++ b/Templates/Multiplayer/Template/Gem/Code/enabled_gems.cmake
@@ -1,6 +1,6 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #
@@ -33,7 +33,6 @@ set(ENABLED_GEMS
     GraphModel
     LandscapeCanvas
     NvCloth
-    Blast
     Maestro
     TextureAtlas
     LmbrCentral

--- a/Templates/Multiplayer/Template/default.blastconfiguration
+++ b/Templates/Multiplayer/Template/default.blastconfiguration
@@ -1,7 +1,0 @@
-<ObjectStream version="3">
-	<Class name="BlastGlobalConfiguration" version="1" type="{0B9DB6DD-0008-4EF6-9D75-141061144353}">
-		<Class name="Asset" field="BlastMaterialLibrary" value="id={00000000-0000-0000-0000-000000000000}:0,type={55F38C86-0767-4E7F-830A-A4BF624BE4DA},hint={},loadBehavior=2" version="2" type="{77A19D40-8731-4D3C-9041-1B43047366A4}"/>
-		<Class name="unsigned int" field="StressSolverIterations" value="180" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-	</Class>
-</ObjectStream>
-

--- a/Templates/Multiplayer/template.json
+++ b/Templates/Multiplayer/template.json
@@ -1112,10 +1112,6 @@
             "isTemplated": false
         },
         {
-            "file": "default.blastconfiguration",
-            "isTemplated": false
-        },
-        {
             "file": "editor.cfg",
             "isTemplated": false
         },

--- a/repo.json
+++ b/repo.json
@@ -1525,10 +1525,6 @@
                     "isTemplated": false
                 },
                 {
-                    "file": "default.blastconfiguration",
-                    "isTemplated": false
-                },
-                {
                     "file": "editor.cfg",
                     "isTemplated": false
                 },


### PR DESCRIPTION
## What does this PR do?

We noticed that the Multiplayer template was in an unusable state. This fixes the two errors I ran into.

1. The Blast Gem had been moved to a now-stale Experimental branch. The template had included it as a dependency, causing Project Manager to throw up errors about it being missing. Removing the references to the Blast Gem fixes this.
2. Once past that, it wouldn't build at all, choking on an explicit template function call, despite the types matching. Removing the types in the call fixes this.

## How was this PR tested?

Manual.

To test:
1. Download the Multiplayer template
2. Create a new project using it
3. It
    - Should not give Blast errors
    - Should build without error
    - Should run a Game, start the Game Server, and connect to it without error 
