### PR TITLE
Remove duplicated textures

### DIFF
--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/1K_Wall_Paint_Basecolor.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/1K_Wall_Paint_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3806a2e8313019b0452e67bedae65f38a1708b0fe943b924960611f25c5460ea
-size 941371

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/1K_Wall_Paint_Normal.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/1K_Wall_Paint_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:682b5a1e4998c0e3654ff6816abe9e9b6a7b5233b431ecf79d23cf97e7c99037
-size 750087

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/1K_Wall_Paint_Specular.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/1K_Wall_Paint_Specular.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3458d0491873af8b3457e63308093583bd03c7b6fe04b4603c26feeae4cc35f
-size 433573

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Concrete_019_Basecolor.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Concrete_019_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49589c044503aea10ae32563ec76d2c1767c43ecb625433b5551643fa5722294
-size 233126

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Concrete_019_Normal.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Concrete_019_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c8a5f794c1f4890f67036d7a1d7521609c50528e9a2a11805192ce3df6339a5
-size 247435

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Concrete_019_Roughness.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Concrete_019_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f794f2423e51d27c27bb421720b4d4d3b23a30f860a7ed4569c336e289ac6a48
-size 397616

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Concrete_Wall_005_Basecolor.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Concrete_Wall_005_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a75529564ecd804bcac087fb665d4d153aa59d8437abedbf5a237f8a61a73b9d
-size 366624

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Concrete_Wall_005_Normal.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Concrete_Wall_005_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bfd4f053d2933dab920de52ee5e218c815700583c0169344bdb9a5ff2255a6ae
-size 378620

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Concrete_Wall_005_Roughness.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Concrete_Wall_005_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee7b3e0b89108c4dd966c84c6e3aa3e21cd590f6e029e185c384dd87c4dfee66
-size 371048

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Extinguisher_Basecolor.png
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Extinguisher_Basecolor.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:99522633d729b44b1a1fbba4bab334a42b5db04c6d7ceb4a68aeb1e72f78a166
-size 89208

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Grass_001_Basecolor.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Grass_001_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c87d75c9a915641ab4ed26770d8af32bca9342bf250cceee4db5d09b5c2ea592
-size 423514

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Grass_001_Displacement.png
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Grass_001_Displacement.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e771e05b857adf8b4e79971a5b3704539990b7d1b9297dcaa07568fe6755b802
-size 1179548

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Grass_001_Normal.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Grass_001_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc9c81448581ac7ec2cd6db850854ff58eb2709f5825b34c6f3a31a851b2c353
-size 772514

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Grass_001_Roughness.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Grass_001_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60243de986f42840655162097448513429424da81e807c805383eeceb2bdc79b
-size 361180

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Galvanized_001_Basecolor.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Galvanized_001_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8fe79f1ad98f4cabfd33c43d911271006241d24ae6b73841a2547567bceff624
-size 221597

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Galvanized_001_Normal.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Galvanized_001_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a0098e193f4871d5a27b64662cd4a513d2175d1c8c64c465e234b392c6b45b1
-size 160038

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Galvanized_001_Roughness.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Galvanized_001_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5e74236f276e459566a2e7a91acae92a031b28f78e2c4b29bd4f566b1809d6d6
-size 148620

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Painted_002_Normal.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Painted_002_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ed97beccf5f2c998438a6096ab4a0fbcb5e0c1ce79b4c7d50a77fe6ee1ac92f
-size 111880

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Painted_002_Roughness.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Painted_002_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:36f3f7e200a3d7e9c3c4fcfbfa95189650a0cd28ac862365c31f12f170facbc4
-size 235752

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Painted_Red_002_Basecolor.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Painted_Red_002_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ccd1443a9d5c5d255ebb5622979ea0abc4983356c4f3237ebc631ee77d47db1a
-size 283730

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Painted_White_002_Basecolor.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Painted_White_002_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74d773ef652d9f3938913998e3d94bba02c8bb35b6b57d672c81d022b396b5a9
-size 231940

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Painted_Yellow_002_Basecolor.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Painted_Yellow_002_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1bf04c492c943bd267fcc280ad5e8c2dc603b7675de1435777dcb06d43acfa88
-size 329569

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Rusted_001_Basecolor.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Rusted_001_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c6c62762472dd010d1d4cd3485356e5c712beea8a428a5c4f227dd4998679a4
-size 935767

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Rusted_001_Normal.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Rusted_001_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5ffd5fb27297ba5407134bda959478f99dfefc599f1895f2ae2ef353af20c5b
-size 297432

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Rusted_001_Specular.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Rusted_001_Specular.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08e33eea7c5ffbe8066d2d31b6d9576e750b7eb5507ee9eb9e317206b3f443f3
-size 1857850

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Scratched_007_Basecolor.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Scratched_007_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e5c2bf636d7fe20538eae85b6dfd192efb4821ea22cccafd6345a97c8913b57
-size 116012

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Scratched_007_Normal.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Scratched_007_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:525600a9bce238db5a0c17959f60cfe36de44b2faa54c570046afb9954f20a82
-size 64539

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Scratched_007_Roughness.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Metal_Scratched_007_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0328f3c1eed23de0b87d5fa68f680a5781338b1aba8c9ca68422087e284a263
-size 6669

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Paper_Recycled_001_Basecolor.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Paper_Recycled_001_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f67fcdf5f64d320d1cd51a632657870d9e77070e003e780af37f45fbf4b89ea4
-size 310784

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Paper_Recycled_001_Normal.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Paper_Recycled_001_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b15a744ad24c8371abbdc1b0c5ada611f7a8ef6ee5da0edca2d3df556f487c7
-size 126298

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Paper_Recycled_001_Roughness.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Paper_Recycled_001_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30fec350284d6910f0199abf252fa626691a68daf41ca80eff0a48f4f9f28ccc
-size 97171

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Steering_Panel_Basecolor.png
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Steering_Panel_Basecolor.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6e1e633c220c2ffcdc1eef8d1193c9b1820ca0598a0e327a765195f12272d6f
-size 97487

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Tire_Normal.png
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Tire_Normal.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb0c423d69f903d790d36e3e16c9c825ec7ba93b7f6eda2238fede3e9f2fe2d4
-size 2317251

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Wood_026_Basecolor.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Wood_026_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7960d02ec014a9a8528020a4ab3a4ec5703a08015ed2ef02a4a5790e6b2e71fc
-size 419046

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Wood_026_Normal.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Wood_026_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0448dd2110a281ff7e63a8e39e858c7323c08b64e4a43452eb4b8a98756df915
-size 47215

--- a/Gems/WarehouseAssets/Assets/assets/misc/Textures/Wood_026_Roughness.jpg
+++ b/Gems/WarehouseAssets/Assets/assets/misc/Textures/Wood_026_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e15b9ee524fbed52848fbc1fdfdc009ee85638704b4d3e1f8c0b93a0be0a0d6
-size 39763

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/1K_Wall_Paint_Basecolor.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/1K_Wall_Paint_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3806a2e8313019b0452e67bedae65f38a1708b0fe943b924960611f25c5460ea
-size 941371

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/1K_Wall_Paint_Normal.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/1K_Wall_Paint_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:682b5a1e4998c0e3654ff6816abe9e9b6a7b5233b431ecf79d23cf97e7c99037
-size 750087

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/1K_Wall_Paint_Specular.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/1K_Wall_Paint_Specular.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c3458d0491873af8b3457e63308093583bd03c7b6fe04b4603c26feeae4cc35f
-size 433573

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/BaseColor.png
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/BaseColor.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe151dcee84355b1b83baaa3fc679b3b7f7691f2ce1f2dfb4dfc9fc4b2a3085c
-size 11869136

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Concrete_019_Basecolor.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Concrete_019_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49589c044503aea10ae32563ec76d2c1767c43ecb625433b5551643fa5722294
-size 233126

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Concrete_019_Normal.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Concrete_019_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c8a5f794c1f4890f67036d7a1d7521609c50528e9a2a11805192ce3df6339a5
-size 247435

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Concrete_019_Roughness.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Concrete_019_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f794f2423e51d27c27bb421720b4d4d3b23a30f860a7ed4569c336e289ac6a48
-size 397616

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Concrete_Wall_005_Basecolor.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Concrete_Wall_005_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a75529564ecd804bcac087fb665d4d153aa59d8437abedbf5a237f8a61a73b9d
-size 366624

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Concrete_Wall_005_Normal.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Concrete_Wall_005_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bfd4f053d2933dab920de52ee5e218c815700583c0169344bdb9a5ff2255a6ae
-size 378620

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Concrete_Wall_005_Roughness.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Concrete_Wall_005_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee7b3e0b89108c4dd966c84c6e3aa3e21cd590f6e029e185c384dd87c4dfee66
-size 371048

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Extinguisher_Basecolor.png
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Extinguisher_Basecolor.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:99522633d729b44b1a1fbba4bab334a42b5db04c6d7ceb4a68aeb1e72f78a166
-size 89208

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Grass_001_Basecolor.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Grass_001_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c87d75c9a915641ab4ed26770d8af32bca9342bf250cceee4db5d09b5c2ea592
-size 423514

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Grass_001_Displacement.png
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Grass_001_Displacement.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e771e05b857adf8b4e79971a5b3704539990b7d1b9297dcaa07568fe6755b802
-size 1179548

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Grass_001_Normal.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Grass_001_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc9c81448581ac7ec2cd6db850854ff58eb2709f5825b34c6f3a31a851b2c353
-size 772514

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Grass_001_Roughness.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Grass_001_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60243de986f42840655162097448513429424da81e807c805383eeceb2bdc79b
-size 361180

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Galvanized_001_Basecolor.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Galvanized_001_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8fe79f1ad98f4cabfd33c43d911271006241d24ae6b73841a2547567bceff624
-size 221597

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Galvanized_001_Normal.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Galvanized_001_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a0098e193f4871d5a27b64662cd4a513d2175d1c8c64c465e234b392c6b45b1
-size 160038

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Galvanized_001_Roughness.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Galvanized_001_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5e74236f276e459566a2e7a91acae92a031b28f78e2c4b29bd4f566b1809d6d6
-size 148620

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Painted_002_Normal.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Painted_002_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ed97beccf5f2c998438a6096ab4a0fbcb5e0c1ce79b4c7d50a77fe6ee1ac92f
-size 111880

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Painted_002_Roughness.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Painted_002_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:36f3f7e200a3d7e9c3c4fcfbfa95189650a0cd28ac862365c31f12f170facbc4
-size 235752

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Painted_Red_002_Basecolor.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Painted_Red_002_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ccd1443a9d5c5d255ebb5622979ea0abc4983356c4f3237ebc631ee77d47db1a
-size 283730

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Painted_White_002_Basecolor.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Painted_White_002_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74d773ef652d9f3938913998e3d94bba02c8bb35b6b57d672c81d022b396b5a9
-size 231940

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Painted_Yellow_002_Basecolor.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Painted_Yellow_002_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1bf04c492c943bd267fcc280ad5e8c2dc603b7675de1435777dcb06d43acfa88
-size 329569

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Rusted_001_Basecolor.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Rusted_001_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1c6c62762472dd010d1d4cd3485356e5c712beea8a428a5c4f227dd4998679a4
-size 935767

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Rusted_001_Normal.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Rusted_001_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5ffd5fb27297ba5407134bda959478f99dfefc599f1895f2ae2ef353af20c5b
-size 297432

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Rusted_001_Specular.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Rusted_001_Specular.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08e33eea7c5ffbe8066d2d31b6d9576e750b7eb5507ee9eb9e317206b3f443f3
-size 1857850

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Scratched_007_Basecolor.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Scratched_007_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e5c2bf636d7fe20538eae85b6dfd192efb4821ea22cccafd6345a97c8913b57
-size 116012

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Scratched_007_Normal.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Scratched_007_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:525600a9bce238db5a0c17959f60cfe36de44b2faa54c570046afb9954f20a82
-size 64539

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Scratched_007_Roughness.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metal_Scratched_007_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0328f3c1eed23de0b87d5fa68f680a5781338b1aba8c9ca68422087e284a263
-size 6669

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metallic.png
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Metallic.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74df2fc300e36d14fb502d270a6843349bb150dfb4923761df6ebc47d386f0ef
-size 5366992

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Normal.png
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Normal.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ba8c161e75ddd8f0051f6ca7b6f279eb3e6ef407f9af89063d741510558dd48
-size 382024

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Paper_Recycled_001_Basecolor.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Paper_Recycled_001_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f67fcdf5f64d320d1cd51a632657870d9e77070e003e780af37f45fbf4b89ea4
-size 310784

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Paper_Recycled_001_Normal.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Paper_Recycled_001_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b15a744ad24c8371abbdc1b0c5ada611f7a8ef6ee5da0edca2d3df556f487c7
-size 126298

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Paper_Recycled_001_Roughness.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Paper_Recycled_001_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30fec350284d6910f0199abf252fa626691a68daf41ca80eff0a48f4f9f28ccc
-size 97171

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Roughness.png
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Roughness.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c3cb7c149d7ff234f6d17cc58f699394f811175d6076c8a6b309e653b4e3602
-size 4393285

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Specular.png
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Specular.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:de35fa2fdda999fa7446950a0ab2c8f4e14618680a2ef384a5c8134ac9da4a65
-size 4917412

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Steering_Panel_Basecolor.png
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Steering_Panel_Basecolor.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6e1e633c220c2ffcdc1eef8d1193c9b1820ca0598a0e327a765195f12272d6f
-size 97487

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Tire_Normal.png
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Tire_Normal.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cb0c423d69f903d790d36e3e16c9c825ec7ba93b7f6eda2238fede3e9f2fe2d4
-size 2317251

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Wood_026_Basecolor.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Wood_026_Basecolor.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7960d02ec014a9a8528020a4ab3a4ec5703a08015ed2ef02a4a5790e6b2e71fc
-size 419046

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Wood_026_Normal.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Wood_026_Normal.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0448dd2110a281ff7e63a8e39e858c7323c08b64e4a43452eb4b8a98756df915
-size 47215

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Wood_026_Roughness.jpg
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/Textures/Wood_026_Roughness.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e15b9ee524fbed52848fbc1fdfdc009ee85638704b4d3e1f8c0b93a0be0a0d6
-size 39763


### PR DESCRIPTION
## What does this PR do?

Duplicated assets between projects and gems were removed. 

## How was this PR tested?

Canonical projects (and project templates) using the selected gems were built and tested; o3de `6f814273e8` was used.

**Draft PR**: this PR is branched out of #681 and should be merged only after #681
