### PR TITLE
Following camera freely setting offset

### DIFF
--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.cpp
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
+#include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 #include <MathConversion.h>
 
 namespace ROS2
@@ -28,8 +29,6 @@ namespace ROS2
         : m_configuration(configuration)
     {
     }
-
-
 
     void FollowingCameraComponent::Reflect(AZ::ReflectContext* reflection)
     {
@@ -81,6 +80,9 @@ namespace ROS2
 
     void FollowingCameraComponent::Activate()
     {
+        InputChannelEventListener::Connect();
+        AZ::TickBus::Handler::BusConnect();
+
         if (m_configuration.m_predefinedViews.size() == 0)
         {
             AZ_Warning("FollowingCameraComponent", false, "No predefined views");
@@ -89,9 +91,8 @@ namespace ROS2
         if (m_configuration.m_defaultView < m_configuration.m_predefinedViews.size())
         {
             m_currentView = m_configuration.m_predefinedViews[m_configuration.m_defaultView];
+            m_cameraOffset = GetEntityLocalPose(m_currentView);
         }
-        InputChannelEventListener::Connect();
-        AZ::TickBus::Handler::BusConnect();
     }
 
     void FollowingCameraComponent::Deactivate()
@@ -105,7 +106,8 @@ namespace ROS2
         const AZ::Vector3 axisX = transform.GetBasisX();
         const AZ::Vector3 axisY = transform.GetBasisY();
 
-        const AZ::Matrix3x3 projectionOnXY {AZ::Matrix3x3::CreateFromColumns(AZ::Vector3::CreateAxisX(), AZ::Vector3::CreateAxisY(), AZ::Vector3::CreateZero())};
+        const AZ::Matrix3x3 projectionOnXY{ AZ::Matrix3x3::CreateFromColumns(
+            AZ::Vector3::CreateAxisX(), AZ::Vector3::CreateAxisY(), AZ::Vector3::CreateZero()) };
 
         const AZ::Vector3 newAxisZ = AZ::Vector3::CreateAxisZ(); // new axis Z points up
 
@@ -133,12 +135,24 @@ namespace ROS2
         return transform;
     }
 
-    void FollowingCameraComponent::CacheTransform(const AZ::Transform& transform, float deltaTime)
+    void FollowingCameraComponent::CacheTransform(const AZ::Transform& targetTransform, float deltaTime)
     {
-        // update the smoothing buffer
-        m_lastTranslationsBuffer.push_back(AZStd::make_pair(transform.GetTranslation(), deltaTime));
-        m_lastRotationsBuffer.push_back(AZStd::make_pair(transform.GetRotation(), deltaTime));
+        // Convert targetTransform to Matrix4x4 for consistency with m_cameraOffset
+        AZ::Matrix4x4 targetMatrix = AZ::Matrix4x4::CreateFromTransform(targetTransform);
 
+        // Combine the target transform with the camera offset to get the camera's world pose
+        // m_cameraOffset already contains translation and rotation changes applied by keyboard inputs
+        AZ::Matrix4x4 cameraWorldPose = targetMatrix * m_cameraOffset;
+
+        // Update the smoothing buffers
+        // Extract translation and rotation from cameraWorldPose
+        AZ::Vector3 translation = cameraWorldPose.GetTranslation();
+        AZ::Quaternion rotation = AZ::Quaternion::CreateFromMatrix4x4(cameraWorldPose);
+
+        m_lastTranslationsBuffer.push_back(AZStd::make_pair(translation, deltaTime));
+        m_lastRotationsBuffer.push_back(AZStd::make_pair(rotation, deltaTime));
+
+        // Ensure the buffers do not exceed the configured smoothing buffer size
         if (m_lastTranslationsBuffer.size() > m_configuration.m_smoothingBuffer)
         {
             m_lastTranslationsBuffer.pop_front();
@@ -148,13 +162,17 @@ namespace ROS2
             m_lastRotationsBuffer.pop_front();
         }
     }
+
     void FollowingCameraComponent::OnTick(float deltaTime, AZ::ScriptTimePoint /*time*/)
     {
+        // m_currentView refers to camera ID
         AZ_Warning("FollowingCameraComponent", m_currentView.IsValid(), "View is not valid");
         if (!m_currentView.IsValid())
         {
             return;
         }
+
+        // Follow the target
         // obtain the current view transform
         AZ::Transform target_local_transform;
         AZ::Transform target_world_transform;
@@ -170,93 +188,294 @@ namespace ROS2
         // get the averaged translation and quaternion
         AZ::Transform filtered_parent_transform = { SmoothTranslation(), SmoothRotation(), 1.f };
 
-        auto modifiedTransformZoom = AZ::Transform::CreateIdentity();
-        modifiedTransformZoom.SetTranslation(AZ::Vector3::CreateAxisY(m_opticalAxisTranslation));
-
-        // adjust the camera's transform
-        //  - rotation is applied in the parent's frame
-        //  - translation is applied in the camera's frame
-        AZ::Transform filteredTransformAdjusted = filtered_parent_transform *
-            AZ::Transform::CreateFromQuaternion(AZ::Quaternion::CreateFromAxisAngle(AZ::Vector3::CreateAxisZ(1.f), m_rotationOffset)) *
-            target_local_transform * modifiedTransformZoom;
-
-        // apply the transform to the camera
-        AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetWorldTM, filteredTransformAdjusted);
+        AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetWorldTM, filtered_parent_transform);
     }
 
-    AZ::Vector3 FollowingCameraComponent::AverageVector(const AZStd::deque<AZStd::pair<AZ::Vector3, float>>& buffer) const
+    AZ::Vector3 FollowingCameraComponent::WeightedAverageVector(const AZStd::deque<AZStd::pair<AZ::Vector3, float>>& buffer) const
     {
-        AZ::Vector3 sum{ 0 };
-        float normalization{ 0 };
-        for (const auto& p : buffer)
+        AZ::Vector3 weightedSum = AZ::Vector3::CreateZero();
+        float totalWeight = 0.0f;
+        float currentWeight = 1.0f; // Start with a weight of 1 for the oldest entry
+        float weightIncreaseFactor = m_configuration.m_smoothFactor; // Increase each subsequent weight by 10%
+
+        for (const auto& entry : buffer)
         {
-            sum += p.first * p.second;
-            normalization += p.second;
+            weightedSum += entry.first * currentWeight; // Apply current weight to the vector
+            totalWeight += currentWeight; // Accumulate total weight for normalization
+            currentWeight *= weightIncreaseFactor; // Increase weight for the next, more recent entry
         }
-        return sum / normalization;
+
+        if (totalWeight > 0.0f)
+        {
+            return weightedSum / totalWeight; // Normalize weighted sum by total weight
+        }
+
+        return AZ::Vector3::CreateZero(); // Return zero vector if buffer is empty or totalWeight is somehow zero
     }
 
     AZ::Vector3 FollowingCameraComponent::SmoothTranslation() const
     {
-        return AverageVector(m_lastTranslationsBuffer);
+        // Use the modified weighted average calculation for smoothing
+        return WeightedAverageVector(m_lastTranslationsBuffer);
     }
 
     AZ::Quaternion FollowingCameraComponent::SmoothRotation() const
     {
-        AZ::Quaternion q = m_lastRotationsBuffer.front().first;
-        for (int i = 1; i < m_lastRotationsBuffer.size(); i++)
+        if (m_lastRotationsBuffer.empty())
         {
-            q = q.Slerp(m_lastRotationsBuffer[i].first, m_lastRotationsBuffer[i].second);
+            return AZ::Quaternion::CreateIdentity(); // Return identity quaternion if the buffer is empty
         }
-        return q;
+
+        // Start with the oldest rotation in the buffer
+        AZ::Quaternion smoothedRotation = m_lastRotationsBuffer.front().first;
+        float totalWeight = 0.0f;
+        float currentWeight = 1.0f; // Initial weight
+        float weightIncreaseFactor = m_configuration.m_smoothFactor; // Determines how much more influence each subsequent rotation has
+
+        for (size_t i = 1; i < m_lastRotationsBuffer.size(); ++i)
+        {
+            totalWeight += currentWeight;
+            float t = currentWeight / totalWeight; // Calculate interpolation factor
+
+            // Progressively slerp towards each newer rotation, with increasing influence
+            smoothedRotation = smoothedRotation.Slerp(m_lastRotationsBuffer[i].first, t);
+
+            currentWeight *= weightIncreaseFactor; // Increase the weight for the next rotation
+        }
+
+        return smoothedRotation;
     }
 
     bool FollowingCameraComponent::OnInputChannelEventFiltered(const AzFramework::InputChannel& inputChannel)
     {
         const AzFramework::InputDeviceId& deviceId = inputChannel.GetInputDevice().GetInputDeviceId();
 
-        if (AzFramework::InputDeviceKeyboard::IsKeyboardDevice(deviceId) && inputChannel.IsStateBegan())
+        // Handle mouse events
+        if (AzFramework::InputDeviceMouse::IsMouseDevice(deviceId))
         {
-            OnKeyboardEvent(inputChannel);
+            mouseEvent(inputChannel);
+        }
+
+        if (AzFramework::InputDeviceKeyboard::IsKeyboardDevice(deviceId))
+        {
+            keyboardEvent(inputChannel);
         }
 
         return false;
     }
 
-    void FollowingCameraComponent::OnKeyboardEvent(const AzFramework::InputChannel& inputChannel)
+    void FollowingCameraComponent::mouseEvent(const AzFramework::InputChannel& inputChannel)
     {
         const AzFramework::InputChannelId& channelId = inputChannel.GetInputChannelId();
-        if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericW)
+
+        if (channelId == AzFramework::InputDeviceMouse::Button::Right)
         {
-            m_opticalAxisTranslation += m_configuration.m_zoomSpeed;
-            m_opticalAxisTranslation = AZStd::min(m_opticalAxisTranslation, m_configuration.m_opticalAxisTranslationMin);
-            return;
-        }
-        if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericS)
-        {
-            m_opticalAxisTranslation -= m_configuration.m_zoomSpeed;
-            return;
-        }
-        if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericA)
-        {
-            m_rotationOffset -= m_configuration.m_rotationSpeed;
-            return;
-        }
-        if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericD)
-        {
-            m_rotationOffset += m_configuration.m_rotationSpeed;
-            return;
+            if (inputChannel.IsStateBegan())
+            {
+                m_isRightMouseButtonPressed = true;
+
+                // Capture the initial mouse position and cursor state
+                m_initialMousePosition = GetCurrentMousePosition();
+            }
+            else if (inputChannel.IsStateEnded())
+            {
+                m_isRightMouseButtonPressed = false;
+
+                // Restore the cursor's original position
+                AzFramework::InputSystemCursorRequestBus::Event(
+                    AzFramework::InputDeviceMouse::Id,
+                    &AzFramework::InputSystemCursorRequests::SetSystemCursorPositionNormalized,
+                    m_initialMousePosition);
+
+                // Update m_lastMousePosition to the restored position to prevent the jump on the next rotation start
+                m_lastMousePosition = m_initialMousePosition;
+            }
         }
 
-        // channelId is a numeric key (Key::Alphanumeric0-Key::Alphanumeric9)
-        if (auto it = KeysToView.find(channelId); it != KeysToView.end())
+        if (m_isRightMouseButtonPressed &&
+            (channelId == AzFramework::InputDeviceMouse::Movement::X || channelId == AzFramework::InputDeviceMouse::Movement::Y))
         {
-            if (int viewId = it->second; viewId < m_configuration.m_predefinedViews.size())
+            AZ::Vector2 currentMousePosition = GetCurrentMousePosition();
+            AZ::Vector2 mouseDelta = currentMousePosition - m_lastMousePosition;
+
+            RotateCameraOnMouse(mouseDelta);
+
+            const auto center = AZ::Vector2(0.5f, 0.5f);
+
+            // Recenter the cursor to avoid edge constraints
+            AzFramework::InputSystemCursorRequestBus::Event(
+                AzFramework::InputDeviceMouse::Id, &AzFramework::InputSystemCursorRequests::SetSystemCursorPositionNormalized, center);
+
+            // Then update m_lastMousePosition accordingly
+            m_lastMousePosition = center;
+        }
+    }
+
+    AZ::Vector2 FollowingCameraComponent::GetCurrentMousePosition()
+    {
+        AZ::Vector2 mousePosition(0.0f, 0.0f);
+
+        // Query the input system for the current mouse position
+        AzFramework::InputSystemCursorRequestBus::EventResult(
+            mousePosition, AzFramework::InputDeviceMouse::Id, &AzFramework::InputSystemCursorRequests::GetSystemCursorPositionNormalized);
+
+        return mousePosition;
+    }
+
+    void FollowingCameraComponent::RotateCameraOnMouse(const AZ::Vector2& mouseDelta)
+    {
+        const float rotationSensitivity = m_configuration.m_rotationSensitivity;
+
+        // Convert mouse delta to rotation angles
+        float yawRotation = -mouseDelta.GetX() * rotationSensitivity; // Inverted X for reversed yaw rotation
+        float pitchRotation = -mouseDelta.GetY() * rotationSensitivity; // Inverted Y for pitch, adjust as needed
+
+        // Fetch the current camera orientation from m_cameraOffset
+        AZ::Quaternion currentRotation = AZ::Quaternion::CreateFromMatrix4x4(m_cameraOffset);
+
+        // Global Z-axis for yaw rotation
+        AZ::Vector3 globalZAxis = AZ::Vector3(0, 0, 1);
+        AZ::Quaternion yawQuat = AZ::Quaternion::CreateFromAxisAngle(globalZAxis, yawRotation);
+
+        // Apply yaw rotation to current camera orientation
+        AZ::Quaternion tempRotation = yawQuat * currentRotation;
+        tempRotation.Normalize();
+
+        // Calculate pitch rotation around the camera's local X-axis after applying yaw
+        // This ensures that pitch adjustments are made relative to the camera's adjusted orientation
+        AZ::Vector3 localXAxis = tempRotation.TransformVector(AZ::Vector3(1, 0, 0));
+        AZ::Quaternion pitchQuat = AZ::Quaternion::CreateFromAxisAngle(localXAxis, pitchRotation);
+
+        // Apply pitch rotation
+        AZ::Quaternion newRotation = pitchQuat * tempRotation;
+        newRotation.Normalize();
+
+        // Update the camera's offset matrix with the new orientation, keeping the position unchanged
+        AZ::Vector3 currentPosition = m_cameraOffset.GetTranslation();
+        m_cameraOffset = AZ::Matrix4x4::CreateFromQuaternionAndTranslation(newRotation, currentPosition);
+    }
+
+    void FollowingCameraComponent::MoveCameraOnKeys()
+    {
+        AZ::Matrix4x4 localCamPoseChange = AZ::Matrix4x4::CreateIdentity();
+        float translationSpeed = m_configuration.m_translationSpeed;
+
+        // Check each key state and adjust the camera pose change accordingly
+        if (m_keyStates[AzFramework::InputDeviceKeyboard::Key::AlphanumericW])
+        {
+            localCamPoseChange = localCamPoseChange * AZ::Matrix4x4::CreateTranslation(AZ::Vector3::CreateAxisY() * translationSpeed);
+        }
+        if (m_keyStates[AzFramework::InputDeviceKeyboard::Key::AlphanumericS])
+        {
+            localCamPoseChange = localCamPoseChange * AZ::Matrix4x4::CreateTranslation(AZ::Vector3::CreateAxisY() * -translationSpeed);
+        }
+        if (m_keyStates[AzFramework::InputDeviceKeyboard::Key::AlphanumericA])
+        {
+            localCamPoseChange = localCamPoseChange * AZ::Matrix4x4::CreateTranslation(AZ::Vector3::CreateAxisX() * -translationSpeed);
+        }
+        if (m_keyStates[AzFramework::InputDeviceKeyboard::Key::AlphanumericD])
+        {
+            localCamPoseChange = localCamPoseChange * AZ::Matrix4x4::CreateTranslation(AZ::Vector3::CreateAxisX() * translationSpeed);
+        }
+
+        m_cameraOffset = m_cameraOffset * localCamPoseChange;
+    }
+
+    void FollowingCameraComponent::RotateCameraOnKeys()
+    {
+        const float rotationSpeed = m_configuration.m_rotationSpeed; // Reduce rotation speed for keys
+
+        float yawRotation = 0.0f; // Initialize yaw rotation to 0
+
+        if (m_keyStates[AzFramework::InputDeviceKeyboard::Key::AlphanumericQ])
+        {
+            yawRotation = rotationSpeed; // Rotate left
+        }
+        else if (m_keyStates[AzFramework::InputDeviceKeyboard::Key::AlphanumericE])
+        {
+            yawRotation = -rotationSpeed; // Rotate right
+        }
+
+        if (yawRotation != 0.0f) // Only proceed if there's a rotation to apply
+        {
+            // Fetch the current camera orientation from m_cameraOffset
+            AZ::Quaternion currentRotation = AZ::Quaternion::CreateFromMatrix4x4(m_cameraOffset);
+
+            // Global Z-axis for yaw rotation
+            AZ::Vector3 globalZAxis = AZ::Vector3(0, 0, 1);
+            AZ::Quaternion yawQuat = AZ::Quaternion::CreateFromAxisAngle(globalZAxis, yawRotation);
+
+            // Apply yaw rotation to current camera orientation
+            AZ::Quaternion newRotation = yawQuat * currentRotation;
+            newRotation.Normalize();
+
+            // Update the camera's offset matrix with the new orientation, keeping the position unchanged
+            AZ::Vector3 currentPosition = m_cameraOffset.GetTranslation();
+            m_cameraOffset = AZ::Matrix4x4::CreateFromQuaternionAndTranslation(newRotation, currentPosition);
+        }
+    }
+
+    void FollowingCameraComponent::keyboardEvent(const AzFramework::InputChannel& inputChannel)
+    {
+        const AzFramework::InputChannelId& channelId = inputChannel.GetInputChannelId();
+        // Determine if the key was pressed down or released
+        bool isKeyDown = inputChannel.IsStateBegan(); // true if the key was pressed down
+        bool isKeyUp = inputChannel.IsStateEnded(); // true if the key was released
+
+        // Update the key state in the map
+        if (isKeyDown)
+        {
+            m_keyStates[channelId] = true;
+        }
+        else if (isKeyUp)
+        {
+            m_keyStates[channelId] = false;
+        }
+
+        if (isKeyDown) // Only proceed if a key was pressed down
+        {
+            if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericW ||
+                channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericS ||
+                channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericA ||
+                channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericD)
             {
-                m_currentView = m_configuration.m_predefinedViews[viewId];
-                m_lastTranslationsBuffer.clear();
-                m_lastRotationsBuffer.clear();
+                MoveCameraOnKeys();
+            }
+            else if (
+                channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericQ ||
+                channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericE)
+            {
+                RotateCameraOnKeys();
+            }
+
+            // Handle view switching with numeric keys
+            if (auto it = KeysToView.find(channelId); it != KeysToView.end())
+            {
+                if (int viewId = it->second; viewId < m_configuration.m_predefinedViews.size())
+                {
+                    m_currentView = m_configuration.m_predefinedViews[viewId];
+                    m_lastTranslationsBuffer.clear();
+                    m_lastRotationsBuffer.clear();
+
+                    m_cameraOffset = GetEntityLocalPose(m_currentView); // Reset camera offset to the view's pose
+                }
             }
         }
     }
+
+    AZ::Matrix4x4 FollowingCameraComponent::GetEntityLocalPose(AZ::EntityId entityId)
+    {
+        if (!entityId.IsValid())
+        {
+            return AZ::Matrix4x4::CreateIdentity();
+        }
+
+        // Get the entity's local transform
+        AZ::Transform target_local_transform = AZ::Transform::CreateIdentity();
+        AZ::TransformBus::EventResult(target_local_transform, entityId, &AZ::TransformBus::Events::GetLocalTM);
+
+        AZ::Matrix4x4 matrix = AZ::Matrix4x4::CreateFromTransform(target_local_transform);
+        return matrix;
+    }
+
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.cpp
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.cpp
@@ -248,7 +248,10 @@ namespace ROS2
             totalWeight += currentWeight;
             float t = currentWeight / totalWeight; // Calculate interpolation factor
 
+            AZ_Assert(t >= 0.0f && t <= 1.0f, "Interpolation factor must be in the range [0, 1]");
+
             // Progressively slerp towards each newer rotation, with increasing influence
+            // Interpolates between series of rotations to get a smooth rotation with new rotations having more influence (less lag)
             smoothedRotation = smoothedRotation.Slerp(m_lastRotationsBuffer[i].first, t);
 
             currentWeight *= weightIncreaseFactor; // Increase the weight for the next rotation

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.cpp
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.cpp
@@ -366,6 +366,7 @@ namespace ROS2
 
         // Apply pitch rotation
         auto newRotation = pitchQuat * tempRotation;
+        newRotation.Normalize();  // Normalize the quaternion to prevent drift and ensure no numerical instability
 
         // Update the camera's offset matrix with the new orientation, keeping the position unchanged
         const AZ::Vector3 currentPosition = m_cameraOffset.GetTranslation();

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
@@ -22,9 +22,9 @@ namespace std
     template<>
     struct hash<AzFramework::InputChannelId>
     {
-        std::size_t operator()(const AzFramework::InputChannelId& channelId) const noexcept
+        size_t operator()(const AzFramework::InputChannelId& channelId) const noexcept
         {
-            return std::hash<std::string>()(channelId.GetName());
+            return hash<string>()(channelId.GetName());
         }
     };
 } // namespace std
@@ -127,7 +127,6 @@ namespace ROS2
         //! The smoothing buffer for rotation, the first element is the tangential vector, the second element is the weight.
         AZStd::deque<AZStd::pair<AZ::Quaternion, float>> m_lastRotationsBuffer;
 
-        float m_opticalAxisTranslation = 0.0f; //!< The zoom change from the input.
         AZ::EntityId m_currentView; //!< Current used view point.
         AZ::Transform m_frozenTransform;
         bool m_isFollowingEnabled = true;
@@ -136,26 +135,20 @@ namespace ROS2
         AZ::Vector2 m_lastMousePosition = AZ::Vector2(0.0f, 0.0f);
         float m_mouseDeltaX = 0.0f;
         float m_mouseDeltaY = 0.0f;
-
-        bool m_ignoreNextMovement = false; //!< Ignore the next movement to avoid camera jump.
+        bool m_ignoreNextMovement = false; //!< Ignore the next mouse movement to avoid camera jump.
 
         AZ::Matrix4x4 m_cameraOffset = AZ::Matrix4x4::CreateIdentity(); //!< The current relative camera pose.
-        std::unordered_map<AzFramework::InputChannelId, bool, InputChannelIdHash> m_keyStates; //!< For multiple key press detection.
-
-        // smoothing camera
-        AZ::Vector3 m_cameraVelocity = AZ::Vector3::CreateZero(); //! Camera's current velocity
-        float m_springConstant = 50.0f; //! Spring constant (springiness)
-        float m_dampingConstant = 5.0f; //! Damping constant (resistance)
+        AZStd::unordered_map<AzFramework::InputChannelId, bool, InputChannelIdHash> m_keyStates; //!< For multiple key press detection.
 
         FollowingCameraConfiguration m_configuration; //!< The configuration of the following camera.
 
         // The keys for camera movement and rotation.
 
-        const std::unordered_set<AzFramework::InputChannelId> moveKeys = {
+        const AZStd::unordered_set<AzFramework::InputChannelId> moveKeys = {
             Key::AlphanumericW, Key::AlphanumericS, Key::AlphanumericA, Key::AlphanumericD
         };
-        const std::unordered_set<AzFramework::InputChannelId> rotateKeys = { Key::AlphanumericQ, Key::AlphanumericE };
-        const std::unordered_set<AzFramework::InputChannelId> shiftKeys = { Key::ModifierShiftL, Key::ModifierShiftR };
+        const AZStd::unordered_set<AzFramework::InputChannelId> rotateKeys = { Key::AlphanumericQ, Key::AlphanumericE };
+        const AZStd::unordered_set<AzFramework::InputChannelId> shiftKeys = { Key::ModifierShiftL, Key::ModifierShiftR };
     };
 
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
@@ -13,8 +13,8 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Math/Matrix4x4.h>
 #include <AzFramework/Components/TransformComponent.h>
-#include <AzFramework/Input/Events/InputChannelEventListener.h>
 #include <AzFramework/Input/Buses/Requests/InputSystemCursorRequestBus.h>
+#include <AzFramework/Input/Events/InputChannelEventListener.h>
 
 namespace std
 {
@@ -113,6 +113,9 @@ namespace ROS2
         //! @param deltaTime The time between the last frame and the current frame.
         void CacheTransform(const AZ::Transform& transform, float deltaTime);
 
+        void FreezeCamera(); //! Freeze the camera in current position.
+        void ResumeCamera(); //! Resume the camera to follow the target.
+
         //! The smoothing buffer for translation, the first element is the translation, the second element is the weight.
         AZStd::deque<AZStd::pair<AZ::Vector3, float>> m_lastTranslationsBuffer;
 
@@ -121,7 +124,8 @@ namespace ROS2
 
         float m_opticalAxisTranslation = 0.0f; //!< The zoom change from the input.
         AZ::EntityId m_currentView; //!< Current used view point.
-
+        AZ::Transform m_frozenTransform;
+        bool m_isFollowingEnabled = true;
         bool m_isRightMouseButtonPressed = false; //!< Apply mouse rotation whether the right mouse button is pressed.
         AZ::Vector2 m_initialMousePosition; //!< The initial mouse position when the right mouse button is pressed.
         AZ::Vector2 m_lastMousePosition = AZ::Vector2(0.0f, 0.0f);

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
@@ -14,6 +14,7 @@
 #include <AzCore/Math/Matrix4x4.h>
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzFramework/Input/Buses/Requests/InputSystemCursorRequestBus.h>
+#include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
 #include <AzFramework/Input/Events/InputChannelEventListener.h>
 
 namespace std
@@ -38,6 +39,8 @@ struct InputChannelIdHash
 
 namespace ROS2
 {
+    using Key = AzFramework::InputDeviceKeyboard::Key;
+
     //! The component used for cameras that follow moving objects
     //! It allows to switch between different cameras attached to entities, and to control the active camera using keyboard.
     class FollowingCameraComponent
@@ -104,9 +107,11 @@ namespace ROS2
         //! @return The average translation.
         AZ::Vector3 SmoothTranslation() const;
 
-        //! Compute weighted average of rotation in the buffer.
         //! @return The average rotation.
         AZ::Quaternion SmoothRotation() const;
+
+        //! Compute weighted average of rotation in the buffer.
+        AZ::Quaternion CalculateSmoothedRotation() const;
 
         //! Cache the transform in smoothing buffer.
         //! @param transform The transform to cache.
@@ -143,5 +148,14 @@ namespace ROS2
         float m_dampingConstant = 5.0f; //! Damping constant (resistance)
 
         FollowingCameraConfiguration m_configuration; //!< The configuration of the following camera.
+
+        // The keys for camera movement and rotation.
+
+        const std::unordered_set<AzFramework::InputChannelId> moveKeys = {
+            Key::AlphanumericW, Key::AlphanumericS, Key::AlphanumericA, Key::AlphanumericD
+        };
+        const std::unordered_set<AzFramework::InputChannelId> rotateKeys = { Key::AlphanumericQ, Key::AlphanumericE };
+        const std::unordered_set<AzFramework::InputChannelId> shiftKeys = { Key::ModifierShiftL, Key::ModifierShiftR };
     };
+
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
@@ -132,6 +132,8 @@ namespace ROS2
         float m_mouseDeltaX = 0.0f;
         float m_mouseDeltaY = 0.0f;
 
+        bool m_ignoreNextMovement = false; //!< Ignore the next movement to avoid camera jump.
+
         AZ::Matrix4x4 m_cameraOffset = AZ::Matrix4x4::CreateIdentity(); //!< The current relative camera pose.
         std::unordered_map<AzFramework::InputChannelId, bool, InputChannelIdHash> m_keyStates; //!< For multiple key press detection.
 

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraConfiguration.cpp
@@ -20,9 +20,11 @@ namespace ROS2
                 ->Version(1)
                 ->Field("PredefinedViews", &FollowingCameraConfiguration::m_predefinedViews)
                 ->Field("SmoothingLength", &FollowingCameraConfiguration::m_smoothingBuffer)
-                ->Field("ZoomSpeed", &FollowingCameraConfiguration::m_zoomSpeed)
+                ->Field("SmoothFactor", &FollowingCameraConfiguration::m_smoothFactor)
                 ->Field("RotationSpeed", &FollowingCameraConfiguration::m_rotationSpeed)
+                ->Field("TranslationSpeed", &FollowingCameraConfiguration::m_translationSpeed)
                 ->Field("LockZAxis", &FollowingCameraConfiguration::m_lockZAxis)
+                ->Field("RotationSensitivity", &FollowingCameraConfiguration::m_rotationSensitivity)
                 ->Field("DefaultView", &FollowingCameraConfiguration::m_defaultView);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
@@ -36,15 +38,34 @@ namespace ROS2
                     ->Attribute(AZ::Edit::Attributes::Min, 1)
                     ->Attribute(AZ::Edit::Attributes::Max, 100)
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &FollowingCameraConfiguration::m_zoomSpeed, "Zoom Speed", "Speed of zooming")
+                        AZ::Edit::UIHandlers::Default,
+                        &FollowingCameraConfiguration::m_smoothFactor,
+                        "Smooth Factor",
+                        "Smoothing factor for camera movement (the higher the value, the newer entries have a progressively higher influence on the result.). Value 1.1 increase each subsequent weight by 10%")
+                    ->Attribute(AZ::Edit::Attributes::Min, 1.0f)
+                    ->Attribute(AZ::Edit::Attributes::Max, 10.0f)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &FollowingCameraConfiguration::m_rotationSpeed,
                         "Rotation Speed",
-                        "Rotation Speed around the target")
+                        "Rotation Speed around with keyboard QE movement")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &FollowingCameraConfiguration::m_translationSpeed,
+                        "Translation Speed",
+                        "Translation Speed with keyboard WSAD movement")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &FollowingCameraConfiguration::m_rotationSensitivity,
+                        "Rotation Sensitivity",
+                        "Sensitivity of mouse rotation")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &FollowingCameraConfiguration::m_predefinedViews, "Views", "Views to follow")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &FollowingCameraConfiguration::m_lockZAxis, "Lock Z Axis", "Prevent camera from tilting")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &FollowingCameraConfiguration::m_lockZAxis,
+                        "Lock Z Axis",
+                        "Prevent camera from tilting")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &FollowingCameraConfiguration::m_defaultView,

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraConfiguration.cpp
@@ -43,7 +43,7 @@ namespace ROS2
                         "Smooth Factor",
                         "Smoothing factor for camera movement (the higher the value, the newer entries have a progressively higher influence on the result.). Value 1.1 increase each subsequent weight by 10%")
                     ->Attribute(AZ::Edit::Attributes::Min, 1.0f)
-                    ->Attribute(AZ::Edit::Attributes::Max, 10.0f)
+                    ->Attribute(AZ::Edit::Attributes::Max, 2.0f)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &FollowingCameraConfiguration::m_rotationSpeed,

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraConfiguration.h
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraConfiguration.h
@@ -24,9 +24,10 @@ namespace ROS2
         AZStd::vector<AZ::EntityId> m_predefinedViews; //!< List of predefined views.
         int m_defaultView{ 0 }; //!< Index of the default view.
         int m_smoothingBuffer = 30; //!< Number of past transforms used to smooth, larger value gives smoother result, but more lag
-        float m_zoomSpeed = 0.06f; //!< Speed of zooming
+        float m_smoothFactor = 1.1f; //!< Smoothing factor for camera movement (the higher the value, the newer entries have a progressively higher influence on the result.
         float m_rotationSpeed = 0.05f; //!< Rotation Speed around the target
+        float m_translationSpeed = 0.15f; //!< Translation Speed
         bool m_lockZAxis = false; //!< Lock the Z axis of the camera
-        const float m_opticalAxisTranslationMin = 0.0f; //!< Minimum zoom distance
+        float m_rotationSensitivity = 1.0f; //!< Sensitivity of mouse rotation
     };
 } // namespace ROS2


### PR DESCRIPTION
## What does this PR do?

Modifies behavior of ros2 following camera by modifying:
- Add free movement (Removed always look at target in consequence)
- Add rotation on mouse movement 
- Add improved smoothing 
- Add multi-key input handling
- Changes key rotation behavior (instead of rotating around target now rotates around it's axis [Q/E]) 
- Add camera freeze (camera not moving on shift press)

As a consequence during the game/simulation, the camera can be moved by the user similar to the Editor camera. Movement is on WSAD and rotation on mouse right button pressed + move. The camera is still following the target when it moves. The camera has anti-roll mechanism. The view can be changed on num keys 1-9 and pressing the current view num resets the position. 

## How was this PR tested?

Tested on two local projects and a new ros2 project from the template. 
