### PR TITLE
ROS2 Spawner add setting parent TF and modifiable service names 

### DIFF
--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -34,15 +34,17 @@ namespace ROS2
         auto ros2Node = ROS2Interface::Get()->GetNode();
         AZ_Assert(ros2Node, "ROS 2 node is not initialized");
 
+        auto serviceNames = m_controller.GetServiceNames();
+
         m_getSpawnablesNamesService = ros2Node->create_service<gazebo_msgs::srv::GetWorldProperties>(
-            "get_available_spawnable_names",
+            serviceNames.availableSpawnableNamesServiceName.c_str(),
             [this](const GetAvailableSpawnableNamesRequest request, GetAvailableSpawnableNamesResponse response)
             {
                 GetAvailableSpawnableNames(request, response);
             });
 
         m_spawnService = ros2Node->create_service<gazebo_msgs::srv::SpawnEntity>(
-            "spawn_entity",
+            serviceNames.spawnEntityServiceName.c_str(),
             [this](
                 const SpawnEntityServiceHandle service_handle,
                 const std::shared_ptr<rmw_request_id_t> header,
@@ -52,7 +54,7 @@ namespace ROS2
             });
 
         m_deleteService = ros2Node->create_service<gazebo_msgs::srv::DeleteEntity>(
-            "delete_entity",
+            serviceNames.deleteEntityServiceName.c_str(),
             [this](
                 const DeleteEntityServiceHandle service_handle, const std::shared_ptr<rmw_request_id_t> header, DeleteEntityRequest request)
             {
@@ -60,14 +62,14 @@ namespace ROS2
             });
 
         m_getSpawnPointInfoService = ros2Node->create_service<gazebo_msgs::srv::GetModelState>(
-            "get_spawn_point_info",
+            serviceNames.spawnPointInfoServiceName.c_str(),
             [this](const GetSpawnPointInfoRequest request, GetSpawnPointInfoResponse response)
             {
                 GetSpawnPointInfo(request, response);
             });
 
         m_getSpawnPointsNamesService = ros2Node->create_service<gazebo_msgs::srv::GetWorldProperties>(
-            "get_spawn_points_names",
+            serviceNames.spawnPointsNamesServiceName.c_str(),
             [this](const GetSpawnPointsNamesRequest request, GetSpawnPointsNamesResponse response)
             {
                 GetSpawnPointsNames(request, response);
@@ -213,6 +215,7 @@ namespace ROS2
 
         auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
         transformInterface->SetWorldTM(transform);
+        transformInterface->SetParent(GetEntityId());
 
         AZStd::string instanceName = AZStd::string::format("%s_%d", spawnableName.c_str(), m_counter++);
         for (AZ::Entity* entity : view)

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -34,17 +34,17 @@ namespace ROS2
         auto ros2Node = ROS2Interface::Get()->GetNode();
         AZ_Assert(ros2Node, "ROS 2 node is not initialized");
 
-        auto serviceNames = m_controller.GetServiceNames();
+        const auto serviceNames = m_controller.GetServiceNames();
 
         m_getSpawnablesNamesService = ros2Node->create_service<gazebo_msgs::srv::GetWorldProperties>(
-            serviceNames.availableSpawnableNamesServiceName.c_str(),
+            serviceNames.m_availableSpawnableNamesServiceName.c_str(),
             [this](const GetAvailableSpawnableNamesRequest request, GetAvailableSpawnableNamesResponse response)
             {
                 GetAvailableSpawnableNames(request, response);
             });
 
         m_spawnService = ros2Node->create_service<gazebo_msgs::srv::SpawnEntity>(
-            serviceNames.spawnEntityServiceName.c_str(),
+            serviceNames.m_spawnEntityServiceName.c_str(),
             [this](
                 const SpawnEntityServiceHandle service_handle,
                 const std::shared_ptr<rmw_request_id_t> header,
@@ -54,7 +54,7 @@ namespace ROS2
             });
 
         m_deleteService = ros2Node->create_service<gazebo_msgs::srv::DeleteEntity>(
-            serviceNames.deleteEntityServiceName.c_str(),
+            serviceNames.m_deleteEntityServiceName.c_str(),
             [this](
                 const DeleteEntityServiceHandle service_handle, const std::shared_ptr<rmw_request_id_t> header, DeleteEntityRequest request)
             {
@@ -62,14 +62,14 @@ namespace ROS2
             });
 
         m_getSpawnPointInfoService = ros2Node->create_service<gazebo_msgs::srv::GetModelState>(
-            serviceNames.spawnPointInfoServiceName.c_str(),
+            serviceNames.m_spawnPointInfoServiceName.c_str(),
             [this](const GetSpawnPointInfoRequest request, GetSpawnPointInfoResponse response)
             {
                 GetSpawnPointInfo(request, response);
             });
 
         m_getSpawnPointsNamesService = ros2Node->create_service<gazebo_msgs::srv::GetWorldProperties>(
-            serviceNames.spawnPointsNamesServiceName.c_str(),
+            serviceNames.m_spawnPointsNamesServiceName.c_str(),
             [this](const GetSpawnPointsNamesRequest request, GetSpawnPointsNamesResponse response)
             {
                 GetSpawnPointsNames(request, response);

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.cpp
@@ -19,15 +19,65 @@
 
 namespace ROS2
 {
+
+    void ServiceNames::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<ServiceNames>()
+                ->Version(1)
+                ->Field("Get available spawnable names service name", &ServiceNames::availableSpawnableNamesServiceName)
+                ->Field("Spawn entity service name", &ServiceNames::spawnEntityServiceName)
+                ->Field("Delete entity service name", &ServiceNames::deleteEntityServiceName)
+                ->Field("Get spawn point info service name", &ServiceNames::spawnPointInfoServiceName)
+                ->Field("Get spawn points names service name", &ServiceNames::spawnPointsNamesServiceName);
+
+            if (auto editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<ServiceNames>("ServiceNames", "Service names for ROS2SpawnerComponent")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ServiceNames::availableSpawnableNamesServiceName,
+                        "Get available spawnable names service name",
+                        "Service name for getting available spawnable names")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ServiceNames::spawnEntityServiceName,
+                        "Spawn entity service name",
+                        "Service name for spawning entity")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ServiceNames::deleteEntityServiceName,
+                        "Delete entity service name",
+                        "Service name for deleting entity")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ServiceNames::spawnPointInfoServiceName,
+                        "Get spawn point info service name",
+                        "Service name for getting spawn point info")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ServiceNames::spawnPointsNamesServiceName,
+                        "Get spawn points names service name",
+                        "Service name for getting spawn points names");
+            }
+        }
+    }
+
     void ROS2SpawnerComponentConfig::Reflect(AZ::ReflectContext* context)
     {
+
+        ServiceNames::Reflect(context);
+
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<ROS2SpawnerComponentConfig, AZ::ComponentConfig>()
                 ->Version(1)
                 ->Field("Editor entity id", &ROS2SpawnerComponentConfig::m_editorEntityId)
                 ->Field("Spawnables", &ROS2SpawnerComponentConfig::m_spawnables)
-                ->Field("Default spawn pose", &ROS2SpawnerComponentConfig::m_defaultSpawnPose);
+                ->Field("Default spawn pose", &ROS2SpawnerComponentConfig::m_defaultSpawnPose)
+                ->Field("Service names", &ROS2SpawnerComponentConfig::m_serviceNames);
 
             if (auto editContext = serializeContext->GetEditContext())
             {
@@ -38,7 +88,9 @@ namespace ROS2
                         AZ::Edit::UIHandlers::Default,
                         &ROS2SpawnerComponentConfig::m_defaultSpawnPose,
                         "Default spawn pose",
-                        "Default spawn pose");
+                        "Default spawn pose")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &ROS2SpawnerComponentConfig::m_serviceNames, "Service names", "Service names");
             }
         }
     }
@@ -136,6 +188,11 @@ namespace ROS2
     const ROS2SpawnerComponentConfig& ROS2SpawnerComponentController::GetConfiguration() const
     {
         return m_config;
+    }
+
+    const ServiceNames ROS2SpawnerComponentController::GetServiceNames() const
+    {
+        return m_config.m_serviceNames;
     }
 
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.cpp
@@ -20,45 +20,45 @@
 namespace ROS2
 {
 
-    void ServiceNames::Reflect(AZ::ReflectContext* context)
+    void ROS2SpawnerServiceNames::Reflect(AZ::ReflectContext* context)
     {
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<ServiceNames>()
+            serializeContext->Class<ROS2SpawnerServiceNames>()
                 ->Version(1)
-                ->Field("Get available spawnable names service name", &ServiceNames::availableSpawnableNamesServiceName)
-                ->Field("Spawn entity service name", &ServiceNames::spawnEntityServiceName)
-                ->Field("Delete entity service name", &ServiceNames::deleteEntityServiceName)
-                ->Field("Get spawn point info service name", &ServiceNames::spawnPointInfoServiceName)
-                ->Field("Get spawn points names service name", &ServiceNames::spawnPointsNamesServiceName);
+                ->Field("Get available spawnable names service name", &ROS2SpawnerServiceNames::m_availableSpawnableNamesServiceName)
+                ->Field("Spawn entity service name", &ROS2SpawnerServiceNames::m_spawnEntityServiceName)
+                ->Field("Delete entity service name", &ROS2SpawnerServiceNames::m_deleteEntityServiceName)
+                ->Field("Get spawn point info service name", &ROS2SpawnerServiceNames::m_spawnPointInfoServiceName)
+                ->Field("Get spawn points names service name", &ROS2SpawnerServiceNames::m_spawnPointsNamesServiceName);
 
             if (auto editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<ServiceNames>("ServiceNames", "Service names for ROS2SpawnerComponent")
+                editContext->Class<ROS2SpawnerServiceNames>("ROS2SpawnerServiceNames", "Service names for ROS2SpawnerComponent")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &ServiceNames::availableSpawnableNamesServiceName,
+                        &ROS2SpawnerServiceNames::m_availableSpawnableNamesServiceName,
                         "Get available spawnable names service name",
                         "Service name for getting available spawnable names")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &ServiceNames::spawnEntityServiceName,
+                        &ROS2SpawnerServiceNames::m_spawnEntityServiceName,
                         "Spawn entity service name",
                         "Service name for spawning entity")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &ServiceNames::deleteEntityServiceName,
+                        &ROS2SpawnerServiceNames::m_deleteEntityServiceName,
                         "Delete entity service name",
                         "Service name for deleting entity")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &ServiceNames::spawnPointInfoServiceName,
+                        &ROS2SpawnerServiceNames::m_spawnPointInfoServiceName,
                         "Get spawn point info service name",
                         "Service name for getting spawn point info")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &ServiceNames::spawnPointsNamesServiceName,
+                        &ROS2SpawnerServiceNames::m_spawnPointsNamesServiceName,
                         "Get spawn points names service name",
                         "Service name for getting spawn points names");
             }
@@ -67,8 +67,7 @@ namespace ROS2
 
     void ROS2SpawnerComponentConfig::Reflect(AZ::ReflectContext* context)
     {
-
-        ServiceNames::Reflect(context);
+        ROS2SpawnerServiceNames::Reflect(context);
 
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
@@ -77,7 +76,9 @@ namespace ROS2
                 ->Field("Editor entity id", &ROS2SpawnerComponentConfig::m_editorEntityId)
                 ->Field("Spawnables", &ROS2SpawnerComponentConfig::m_spawnables)
                 ->Field("Default spawn pose", &ROS2SpawnerComponentConfig::m_defaultSpawnPose)
-                ->Field("Service names", &ROS2SpawnerComponentConfig::m_serviceNames);
+                ->Field("Service names", &ROS2SpawnerComponentConfig::m_serviceNames)
+                ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
 
             if (auto editContext = serializeContext->GetEditContext())
             {
@@ -190,7 +191,7 @@ namespace ROS2
         return m_config;
     }
 
-    const ServiceNames ROS2SpawnerComponentController::GetServiceNames() const
+    const ROS2SpawnerServiceNames& ROS2SpawnerComponentController::GetServiceNames() const
     {
         return m_config.m_serviceNames;
     }

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.h
@@ -20,14 +20,14 @@
 namespace ROS2
 {
 
-    struct ServiceNames
+    struct ROS2SpawnerServiceNames
     {
-        AZ_TYPE_INFO(ServiceNames, "{10D75AAC-BD51-4F33-BCAA-9001CFA219AE}");
-        AZStd::string availableSpawnableNamesServiceName = "get_available_spawnable_names";
-        AZStd::string spawnEntityServiceName = "spawn_entity";
-        AZStd::string deleteEntityServiceName = "delete_entity";
-        AZStd::string spawnPointInfoServiceName = "get_spawn_point_info";
-        AZStd::string spawnPointsNamesServiceName = "get_spawn_points_names";
+        AZ_TYPE_INFO(ROS2SpawnerServiceNames, "{10D75AAC-BD51-4F33-BCAA-9001CFA219AE}");
+        AZStd::string m_availableSpawnableNamesServiceName = "get_available_spawnable_names";
+        AZStd::string m_spawnEntityServiceName = "spawn_entity";
+        AZStd::string m_deleteEntityServiceName = "delete_entity";
+        AZStd::string m_spawnPointInfoServiceName = "get_spawn_point_info";
+        AZStd::string m_spawnPointsNamesServiceName = "get_spawn_points_names";
 
         static void Reflect(AZ::ReflectContext* context);
     };
@@ -45,7 +45,7 @@ namespace ROS2
         AZ::EntityId m_editorEntityId;
         AZ::Transform m_defaultSpawnPose = { AZ::Vector3{ 0, 0, 0 }, AZ::Quaternion{ 0, 0, 0, 1 }, 1.0 };
 
-        ServiceNames m_serviceNames;
+        ROS2SpawnerServiceNames m_serviceNames;
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables;
     };
 
@@ -73,7 +73,7 @@ namespace ROS2
         SpawnPointInfoMap GetAllSpawnPointInfos() const override;
         //////////////////////////////////////////////////////////////////////////
 
-        const ServiceNames GetServiceNames() const;
+        const ROS2SpawnerServiceNames& GetServiceNames() const;
         SpawnPointInfoMap GetSpawnPoints() const;
         AZ::EntityId GetEditorEntityId() const;
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> GetSpawnables() const;

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.h
@@ -19,6 +19,19 @@
 
 namespace ROS2
 {
+
+    struct ServiceNames
+    {
+        AZ_TYPE_INFO(ServiceNames, "{10D75AAC-BD51-4F33-BCAA-9001CFA219AE}");
+        AZStd::string availableSpawnableNamesServiceName = "get_available_spawnable_names";
+        AZStd::string spawnEntityServiceName = "spawn_entity";
+        AZStd::string deleteEntityServiceName = "delete_entity";
+        AZStd::string spawnPointInfoServiceName = "get_spawn_point_info";
+        AZStd::string spawnPointsNamesServiceName = "get_spawn_points_names";
+
+        static void Reflect(AZ::ReflectContext* context);
+    };
+
     class ROS2SpawnerComponentConfig final : public AZ::ComponentConfig
     {
     public:
@@ -32,6 +45,7 @@ namespace ROS2
         AZ::EntityId m_editorEntityId;
         AZ::Transform m_defaultSpawnPose = { AZ::Vector3{ 0, 0, 0 }, AZ::Quaternion{ 0, 0, 0, 1 }, 1.0 };
 
+        ServiceNames m_serviceNames;
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables;
     };
 
@@ -59,6 +73,7 @@ namespace ROS2
         SpawnPointInfoMap GetAllSpawnPointInfos() const override;
         //////////////////////////////////////////////////////////////////////////
 
+        const ServiceNames GetServiceNames() const;
         SpawnPointInfoMap GetSpawnPoints() const;
         AZ::EntityId GetEditorEntityId() const;
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> GetSpawnables() const;


### PR DESCRIPTION
## What does this PR do?

Modifies the ROS2 spawner by: 
- Adding the option to set custom names for the spawner services (from the Editor)
- Adding a parent to the spawned entities that modifies the TF hierarchy in some scenarios.
- Extends functionality
- Add more flexibility
- Does not complicate implementation

Compared to the previous version, in the Editor the user can see `Service names` field
![Screenshot from 2024-04-23 12-55-52](https://github.com/o3de/o3de-extras/assets/29305346/22f5e4c3-07f3-494b-9f39-2cdc77e78525)
![Screenshot from 2024-04-23 13-09-12](https://github.com/o3de/o3de-extras/assets/29305346/2663440e-d2a7-4304-bbd3-09942cae4a5d)


## How was this PR tested?

Tested on an external project and blank template project from o3de-extras. Tested by 
1. Open demo level and add ROS2 Spawner to the `Warehouse` entity
2. Add test prefab to rosbot spawner
3. Execute services on game mode 
4. Change service names and test again


