### PR TITLE
Add [[maybe_unused]] to PrintXrError parameters

### DIFF
--- a/Gems/OpenXRVk/Code/Source/OpenXRVkUtils.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkUtils.cpp
@@ -44,7 +44,7 @@ namespace OpenXRVk
         return to_string(result);
     }
 
-    void PrintXrError(const char* windowName, const XrResult error, const char* fmt, ...)
+    void PrintXrError([[maybe_unused]]const char* windowName, [[maybe_unused]]const XrResult error, const char* fmt, ...)
     {
         va_list argList;
         va_start(argList, fmt);


### PR DESCRIPTION
## What does this PR do?

Fixes C2220 errors and warnings for the `PrintXrError` function. Addresses: https://github.com/o3de/o3de-extras/issues/687

## How was this PR tested?

Tested in a separate branch
