### PR TITLE
Remove non-existing include in ROS2 tests

### DIFF
--- a/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
+++ b/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
@@ -20,7 +20,6 @@
 #include <AzCore/std/string/string_view.h>
 #include <AzQtComponents/Utilities/QtPluginPaths.h>
 #include <AzTest/GemTestEnvironment.h>
-#include <AzToolsFramework/Commands/PreemptiveUndoCache.h>
 #include <AzToolsFramework/Entity/EditorEntityContextComponent.h>
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
 #include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>


### PR DESCRIPTION
## What does this PR do?

Tests would not build with the more recent o3de `development` due to some changes in includes: 
```
[build] /home/jhanca/devroot/o3de-extras/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp:23:10: fatal error: 'AzToolsFramework/Commands/PreemptiveUndoCache.h' file not found
[build] #include <AzToolsFramework/Commands/PreemptiveUndoCache.h>
[build]          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[build] 1 error generated.
[build] ninja: build stopped: subcommand failed.
```

This PR fixes it by removing this include.

## How was this PR tested?

The code builds now correctly and the test passes.

```
[proc] Executing command: /usr/bin/ctest -j16 -C profile -T test --output-on-failure -R ^Gem\:\:ROS2\.Frame\.Tests\.main\:\:TEST_RUN$
[ctest]    Site: jhanca-buntu
[ctest]    Build name: Linux-clang++
[ctest] Create new tag: 20240424-0626 - Experimental
[ctest] Test project /home/jhanca/devroot/projects/R2PT/build/linux
[ctest]     Start 148: Gem::ROS2.Frame.Tests.main::TEST_RUN
[ctest] 1/1 Test #148: Gem::ROS2.Frame.Tests.main::TEST_RUN ...   Passed    0.83 sec
[ctest] 
[ctest] 100% tests passed, 0 tests failed out of 1
[ctest] 
[ctest] Label Time Summary:
[ctest] FRAMEWORK_googletest    =   0.83 sec*proc (1 test)
[ctest] SUITE_main              =   0.83 sec*proc (1 test)
[ctest] 
[ctest] Total Test time (real) =   0.98 sec
[ctest] CTest finished with return code 0
```
