### PR TITLE
Added [[maybe_unused]] to fix release build

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
@@ -40,7 +40,7 @@ namespace ROS2
         for (size_t si = 0; si < link->SensorCount(); ++si)
         {
             const auto* sensor = link->SensorByIndex(si);
-            const bool success = AddSensor(entityId, sensor);
+            [[maybe_unused]] const bool success = AddSensor(entityId, sensor);
             AZ_Warning("SensorMaker", success, "Cannot find a sensor hook for sensor %d", sensor->Type());
         }
     }


### PR DESCRIPTION
## What does this PR do?

The release build of ROS2 Gem failed due to unused variable. 
 
## How was this PR tested?

Project centric, release build on ubuntu 22.04 with Ros2Project template.