### PR TITLE
Update ROS2 Related prefabs

### DIFF
--- a/Gems/ProteusRobot/Assets/Proteus.prefab
+++ b/Gems/ProteusRobot/Assets/Proteus.prefab
@@ -369,7 +369,7 @@
                                     "guid": "{8A2E7A82-D7C3-5E9C-A56C-6EDA70876347}",
                                     "subId": 268721130
                                 },
-                                "assetHint": "materialeditor/viewportmodels/cylinder.azmodel"
+                                "assetHint": "materialeditor/viewportmodels/cylinder.fbx.azmodel"
                             }
                         }
                     }
@@ -1400,7 +1400,7 @@
                                     "guid": "{42648578-F5A3-52BC-89BF-0D5FC8608250}",
                                     "subId": 276024436
                                 },
-                                "assetHint": "proteus2_lift.azmodel"
+                                "assetHint": "proteus2_lift.fbx.azmodel"
                             }
                         }
                     }
@@ -1759,7 +1759,7 @@
                                     "guid": "{F9B95287-0FA8-5624-92A1-217B33F08280}",
                                     "subId": 277942675
                                 },
-                                "assetHint": "proteus_wheel.azmodel"
+                                "assetHint": "proteus_wheel.fbx.azmodel"
                             }
                         }
                     }
@@ -1875,7 +1875,7 @@
                                     "guid": "{F9B95287-0FA8-5624-92A1-217B33F08280}",
                                     "subId": 277942675
                                 },
-                                "assetHint": "proteus_wheel.azmodel"
+                                "assetHint": "proteus_wheel.fbx.azmodel"
                             }
                         }
                     }
@@ -2036,7 +2036,7 @@
                                     "guid": "{60318C54-1D60-53EC-85AA-2CADBFD83ED9}",
                                     "subId": 278773777
                                 },
-                                "assetHint": "proteus2_chassis.azmodel"
+                                "assetHint": "proteus2_chassis.fbx.azmodel"
                             }
                         }
                     }

--- a/Gems/ProteusRobot/Assets/Proteus.prefab
+++ b/Gems/ProteusRobot/Assets/Proteus.prefab
@@ -728,12 +728,12 @@
                 },
                 "Component_[639102350977932618]": {
                     "$type": "ROS2FrameEditorComponent",
+                    "Id": 1381491360893018223,
                     "ROS2FrameConfiguration": {
                         "Namespace Configuration": {
                             "Namespace": "base_link"
                         },
-                        "Frame Name": "base_link",
-                        "Effective namespace": "base_link"
+                        "Frame Name": "base_link"
                     }
                 },
                 "Component_[6563269519356188309]": {

--- a/Gems/ROS2/Assets/Prefabs/Sensors/CameraOrbbeck.prefab
+++ b/Gems/ROS2/Assets/Prefabs/Sensors/CameraOrbbeck.prefab
@@ -77,7 +77,7 @@
                         "MaterialSlots": {
                             "Slots": [
                                 {
-                                    "Name": "Entire object"
+                                    "Name": "DefaultMaterial"
                                 }
                             ]
                         }
@@ -89,7 +89,7 @@
                                     "guid": "{0E27CF27-5752-5557-B77A-4B29A5870E0E}",
                                     "subId": 3865077323
                                 },
-                                "assetHint": "models/sensors/camera/cameraorbbeck.pxmesh"
+                                "assetHint": "models/sensors/camera/cameraorbbeck.fbx.pxmesh"
                             },
                             "Configuration": {
                                 "PhysicsAsset": {
@@ -98,7 +98,7 @@
                                         "subId": 3865077323
                                     },
                                     "loadBehavior": "QueueLoad",
-                                    "assetHint": "models/sensors/camera/cameraorbbeck.pxmesh"
+                                    "assetHint": "models/sensors/camera/cameraorbbeck.fbx.pxmesh"
                                 }
                             }
                         }

--- a/Gems/ROS2/Assets/Prefabs/Sensors/LidarOS2.prefab
+++ b/Gems/ROS2/Assets/Prefabs/Sensors/LidarOS2.prefab
@@ -174,7 +174,7 @@
                                     "guid": "{99D850A3-8E59-5E78-93FE-AE8DB228684D}",
                                     "subId": 2574200790
                                 },
-                                "assetHint": "models/sensors/lidaros2/lidaros2.pxmesh"
+                                "assetHint": "models/sensors/lidaros2/lidaros2.fbx.pxmesh"
                             },
                             "Configuration": {
                                 "PhysicsAsset": {
@@ -183,7 +183,7 @@
                                         "subId": 2574200790
                                     },
                                     "loadBehavior": "QueueLoad",
-                                    "assetHint": "models/sensors/lidaros2/lidaros2.pxmesh"
+                                    "assetHint": "models/sensors/lidaros2/lidaros2.fbx.pxmesh"
                                 }
                             }
                         }

--- a/Gems/WarehouseAssets/Assets/Prefabs/WarehouseScene.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/WarehouseScene.prefab
@@ -215,7 +215,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -296,7 +296,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -372,7 +372,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -488,7 +488,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -562,7 +562,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -592,7 +592,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -673,7 +673,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -842,7 +842,7 @@
                                 "assetId": {
                                     "guid": "{C36BF373-CBAF-52C0-8515-283579CBFBDE}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end2.material.azmaterial"
                             }
                         }
                     }
@@ -868,7 +868,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -944,7 +944,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -1069,7 +1069,7 @@
                                 "assetId": {
                                     "guid": "{F4C96494-A086-59D2-A605-06E760588573}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end1.material.azmaterial"
                             }
                         }
                     }
@@ -1135,7 +1135,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -1165,7 +1165,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -1285,7 +1285,7 @@
                                 "assetId": {
                                     "guid": "{C36BF373-CBAF-52C0-8515-283579CBFBDE}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end2.material.azmaterial"
                             }
                         }
                     }
@@ -1355,7 +1355,7 @@
                                 "assetId": {
                                     "guid": "{39CC958C-1BBB-512A-816D-919023CE3E90}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_corner.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_corner.material.azmaterial"
                             }
                         }
                     }
@@ -1381,7 +1381,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -1457,7 +1457,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -1533,7 +1533,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -1653,7 +1653,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -1679,7 +1679,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -1755,7 +1755,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -1836,7 +1836,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -1956,7 +1956,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -1982,7 +1982,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -2058,7 +2058,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -2182,7 +2182,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -2252,7 +2252,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -2322,7 +2322,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -2348,7 +2348,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -2440,7 +2440,7 @@
                                             "assetId": {
                                                 "guid": "{78879384-5BC4-5B59-AE24-BE2FBE4D915E}"
                                             },
-                                            "assetHint": "assets/misc/number_board_05.azmaterial"
+                                            "assetHint": "assets/misc/number_board_05.material.azmaterial"
                                         }
                                     }
                                 }
@@ -2475,7 +2475,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -2522,7 +2522,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -2598,7 +2598,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -2674,7 +2674,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -2766,7 +2766,7 @@
                                             "assetId": {
                                                 "guid": "{084A4B56-C808-5092-8813-4837E69FFAE7}"
                                             },
-                                            "assetHint": "assets/misc/number_board_02.azmaterial"
+                                            "assetHint": "assets/misc/number_board_02.material.azmaterial"
                                         }
                                     }
                                 }
@@ -2801,7 +2801,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -2848,7 +2848,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -2924,7 +2924,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -3128,7 +3128,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -3248,7 +3248,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -3318,7 +3318,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -3380,7 +3380,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -3414,7 +3414,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -3602,7 +3602,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -3636,7 +3636,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -3869,7 +3869,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -3903,7 +3903,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -3995,7 +3995,7 @@
                                             "assetId": {
                                                 "guid": "{566906E6-BE40-55C3-A6C1-7A48468D0523}"
                                             },
-                                            "assetHint": "assets/misc/number_board_03.azmaterial"
+                                            "assetHint": "assets/misc/number_board_03.material.azmaterial"
                                         }
                                     }
                                 }
@@ -4030,7 +4030,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -4113,7 +4113,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -4191,7 +4191,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -4217,7 +4217,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -4293,7 +4293,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -4477,7 +4477,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -4556,7 +4556,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -4582,7 +4582,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -4716,7 +4716,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -4796,7 +4796,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -5013,7 +5013,7 @@
                                 "assetId": {
                                     "guid": "{F4C96494-A086-59D2-A605-06E760588573}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end1.material.azmaterial"
                             }
                         }
                     }
@@ -5160,7 +5160,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -5186,7 +5186,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -5262,7 +5262,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -5576,7 +5576,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -5652,7 +5652,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -5890,7 +5890,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -5916,7 +5916,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -6252,7 +6252,7 @@
                                 "assetId": {
                                     "guid": "{F4C96494-A086-59D2-A605-06E760588573}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end1.material.azmaterial"
                             }
                         }
                     }
@@ -6322,7 +6322,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -6348,7 +6348,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -6699,7 +6699,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -6769,7 +6769,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -6807,7 +6807,7 @@
                                             "assetId": {
                                                 "guid": "{78879384-5BC4-5B59-AE24-BE2FBE4D915E}"
                                             },
-                                            "assetHint": "assets/misc/number_board_05.azmaterial"
+                                            "assetHint": "assets/misc/number_board_05.material.azmaterial"
                                         }
                                     }
                                 }
@@ -6842,7 +6842,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -6889,7 +6889,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -6965,7 +6965,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -7041,7 +7041,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -7166,7 +7166,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -7208,7 +7208,7 @@
                                             "assetId": {
                                                 "guid": "{084A4B56-C808-5092-8813-4837E69FFAE7}"
                                             },
-                                            "assetHint": "assets/misc/number_board_02.azmaterial"
+                                            "assetHint": "assets/misc/number_board_02.material.azmaterial"
                                         }
                                     }
                                 }
@@ -7248,7 +7248,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -7400,7 +7400,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -7517,7 +7517,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -7551,7 +7551,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -7718,7 +7718,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -7788,7 +7788,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -7854,7 +7854,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -7909,7 +7909,7 @@
                                             "assetId": {
                                                 "guid": "{6EC3D25B-1212-54B7-A5E0-548405FB3698}"
                                             },
-                                            "assetHint": "assets/misc/number_board_04.azmaterial"
+                                            "assetHint": "assets/misc/number_board_04.material.azmaterial"
                                         }
                                     }
                                 }
@@ -7949,7 +7949,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -8153,7 +8153,7 @@
                                 "assetId": {
                                     "guid": "{F4C96494-A086-59D2-A605-06E760588573}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end1.material.azmaterial"
                             }
                         }
                     }
@@ -8179,7 +8179,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -8356,7 +8356,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -8382,7 +8382,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -8458,7 +8458,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -8534,7 +8534,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -8678,7 +8678,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -8754,7 +8754,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -8830,7 +8830,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -8950,7 +8950,7 @@
                                 "assetId": {
                                     "guid": "{F4C96494-A086-59D2-A605-06E760588573}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end1.material.azmaterial"
                             }
                         }
                     }
@@ -9077,7 +9077,7 @@
                                 "assetId": {
                                     "guid": "{C36BF373-CBAF-52C0-8515-283579CBFBDE}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end2.material.azmaterial"
                             }
                         }
                     }
@@ -9103,7 +9103,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -9199,7 +9199,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -9302,7 +9302,7 @@
                                 "assetId": {
                                     "guid": "{C36BF373-CBAF-52C0-8515-283579CBFBDE}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end2.material.azmaterial"
                             }
                         }
                     }
@@ -9385,7 +9385,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -9477,7 +9477,7 @@
                                             "assetId": {
                                                 "guid": "{6EC3D25B-1212-54B7-A5E0-548405FB3698}"
                                             },
-                                            "assetHint": "assets/misc/number_board_04.azmaterial"
+                                            "assetHint": "assets/misc/number_board_04.material.azmaterial"
                                         }
                                     }
                                 }
@@ -9517,7 +9517,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -9622,7 +9622,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -9698,7 +9698,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -9790,7 +9790,7 @@
                                             "assetId": {
                                                 "guid": "{566906E6-BE40-55C3-A6C1-7A48468D0523}"
                                             },
-                                            "assetHint": "assets/misc/number_board_03.azmaterial"
+                                            "assetHint": "assets/misc/number_board_03.material.azmaterial"
                                         }
                                     }
                                 }
@@ -9830,7 +9830,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -9893,7 +9893,7 @@
                                             "assetId": {
                                                 "guid": "{0CC5177E-B5F4-554E-AFFA-F709DBCAFD84}"
                                             },
-                                            "assetHint": "assets/misc/number_board_01.azmaterial"
+                                            "assetHint": "assets/misc/number_board_01.material.azmaterial"
                                         }
                                     }
                                 }
@@ -9928,7 +9928,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -10142,7 +10142,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -10184,7 +10184,7 @@
                                             "assetId": {
                                                 "guid": "{566906E6-BE40-55C3-A6C1-7A48468D0523}"
                                             },
-                                            "assetHint": "assets/misc/number_board_03.azmaterial"
+                                            "assetHint": "assets/misc/number_board_03.material.azmaterial"
                                         }
                                     }
                                 }
@@ -10219,7 +10219,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -10539,7 +10539,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -10589,7 +10589,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -10665,7 +10665,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -10856,7 +10856,7 @@
                                             "assetId": {
                                                 "guid": "{566906E6-BE40-55C3-A6C1-7A48468D0523}"
                                             },
-                                            "assetHint": "assets/misc/number_board_03.azmaterial"
+                                            "assetHint": "assets/misc/number_board_03.material.azmaterial"
                                         }
                                     }
                                 }
@@ -10896,7 +10896,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -10987,7 +10987,7 @@
                                 "assetId": {
                                     "guid": "{C36BF373-CBAF-52C0-8515-283579CBFBDE}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end2.material.azmaterial"
                             }
                         }
                     }
@@ -11013,7 +11013,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -11089,7 +11089,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -11170,7 +11170,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -11246,7 +11246,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -11322,7 +11322,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -11398,7 +11398,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -11566,7 +11566,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -11647,7 +11647,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -11780,7 +11780,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -11956,7 +11956,7 @@
                                 "assetId": {
                                     "guid": "{F4C96494-A086-59D2-A605-06E760588573}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end1.material.azmaterial"
                             }
                         }
                     }
@@ -12026,7 +12026,7 @@
                                 "assetId": {
                                     "guid": "{C36BF373-CBAF-52C0-8515-283579CBFBDE}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end2.material.azmaterial"
                             }
                         }
                     }
@@ -12150,7 +12150,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -12176,7 +12176,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -12296,7 +12296,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -12366,7 +12366,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -12464,7 +12464,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -12615,7 +12615,7 @@
                                             "assetId": {
                                                 "guid": "{084A4B56-C808-5092-8813-4837E69FFAE7}"
                                             },
-                                            "assetHint": "assets/misc/number_board_02.azmaterial"
+                                            "assetHint": "assets/misc/number_board_02.material.azmaterial"
                                         }
                                     }
                                 }
@@ -12650,7 +12650,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -12741,7 +12741,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -12767,7 +12767,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -12859,7 +12859,7 @@
                                             "assetId": {
                                                 "guid": "{084A4B56-C808-5092-8813-4837E69FFAE7}"
                                             },
-                                            "assetHint": "assets/misc/number_board_02.azmaterial"
+                                            "assetHint": "assets/misc/number_board_02.material.azmaterial"
                                         }
                                     }
                                 }
@@ -12899,7 +12899,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -13048,7 +13048,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -13090,7 +13090,7 @@
                                             "assetId": {
                                                 "guid": "{01897C6E-77F3-5E79-987B-39B24B12BD02}"
                                             },
-                                            "assetHint": "assets/misc/number_board_06.azmaterial"
+                                            "assetHint": "assets/misc/number_board_06.material.azmaterial"
                                         }
                                     }
                                 }
@@ -13125,7 +13125,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -13271,7 +13271,7 @@
                                 "assetId": {
                                     "guid": "{39CC958C-1BBB-512A-816D-919023CE3E90}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_corner.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_corner.material.azmaterial"
                             }
                         }
                     }
@@ -13297,7 +13297,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -13373,7 +13373,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -13498,7 +13498,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -13568,7 +13568,7 @@
                                 "assetId": {
                                     "guid": "{C36BF373-CBAF-52C0-8515-283579CBFBDE}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end2.material.azmaterial"
                             }
                         }
                     }
@@ -13638,7 +13638,7 @@
                                 "assetId": {
                                     "guid": "{F4C96494-A086-59D2-A605-06E760588573}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_end1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_end1.material.azmaterial"
                             }
                         }
                     }
@@ -13717,7 +13717,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -13787,7 +13787,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -13813,7 +13813,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -13937,7 +13937,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -14007,7 +14007,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -14033,7 +14033,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -14109,7 +14109,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -14201,7 +14201,7 @@
                                             "assetId": {
                                                 "guid": "{6EC3D25B-1212-54B7-A5E0-548405FB3698}"
                                             },
-                                            "assetHint": "assets/misc/number_board_04.azmaterial"
+                                            "assetHint": "assets/misc/number_board_04.material.azmaterial"
                                         }
                                     }
                                 }
@@ -14236,7 +14236,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -14323,7 +14323,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -14417,7 +14417,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -14509,7 +14509,7 @@
                                             "assetId": {
                                                 "guid": "{78879384-5BC4-5B59-AE24-BE2FBE4D915E}"
                                             },
-                                            "assetHint": "assets/misc/number_board_05.azmaterial"
+                                            "assetHint": "assets/misc/number_board_05.material.azmaterial"
                                         }
                                     }
                                 }
@@ -14549,7 +14549,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -14640,7 +14640,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -14719,7 +14719,7 @@
                                 "assetId": {
                                     "guid": "{3F853EDA-6BB1-52CD-BF8E-9E8495880526}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid1.material.azmaterial"
                             }
                         }
                     }
@@ -14745,7 +14745,7 @@
                                 "assetId": {
                                     "guid": "{9155DEE2-04C0-5585-83E0-99F37228ABB5}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces1.material.azmaterial"
                             }
                         }
                     }
@@ -14842,7 +14842,7 @@
                                             "assetId": {
                                                 "guid": "{6EC3D25B-1212-54B7-A5E0-548405FB3698}"
                                             },
-                                            "assetHint": "assets/misc/number_board_04.azmaterial"
+                                            "assetHint": "assets/misc/number_board_04.material.azmaterial"
                                         }
                                     }
                                 }
@@ -14877,7 +14877,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -14995,7 +14995,7 @@
                                             "assetId": {
                                                 "guid": "{78879384-5BC4-5B59-AE24-BE2FBE4D915E}"
                                             },
-                                            "assetHint": "assets/misc/number_board_05.azmaterial"
+                                            "assetHint": "assets/misc/number_board_05.material.azmaterial"
                                         }
                                     }
                                 }
@@ -15035,7 +15035,7 @@
                                     "guid": "{C15CD465-9589-56ED-945F-8416FA4798A3}",
                                     "subId": 284301017
                                 },
-                                "assetHint": "objects/_primitives/_box_1x1.azmodel"
+                                "assetHint": "objects/_primitives/_box_1x1.fbx.azmodel"
                             }
                         }
                     }
@@ -15082,7 +15082,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -15303,7 +15303,7 @@
                                 "assetId": {
                                     "guid": "{BF7DF511-C611-51C6-98E3-25D0A4DED8F2}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_mid2.material.azmaterial"
                             }
                         }
                     }
@@ -15397,7 +15397,7 @@
                                 "assetId": {
                                     "guid": "{1CB13800-517D-5CF8-B335-BE50BA250515}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/tire_traces_circle.material.azmaterial"
                             }
                         }
                     }
@@ -15664,184 +15664,6 @@
             "Source": "Prefabs/Warehouse_storage/Storage_rack1.prefab",
             "Patches": [
                 {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72084182530494]/Components/Component_[3937996073827386159]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72084182530494]/Components/Component_[3937996073827386159]/Child Entity Order/2"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[71500066978238]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[71470002207166]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[71504361945534]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[71448527370686]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[71414167632318]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[71465707239870]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[71461412272574]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[71422757566910]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[71396987763134]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[71457117305278]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/39"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/38"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/37"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/36"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/35"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/34"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/33"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/32"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/31"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/30"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/29"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/28"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/27"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/26"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/25"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/24"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/23"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/22"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/21"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[1543914289413346359]/Parent Entity",
                     "value": "../Entity_[81667327274478]"
@@ -15860,420 +15682,12 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[1543914289413346359]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[71371217959358]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[71478592141758]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[71379807893950]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[71388397828542]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[71431347501502]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[71439937436094]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[71427052534206]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[71409872665022]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[71487182076350]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[71405577697726]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[72088477497790]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[72092772465086]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[72079887563198]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/7"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/6"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[71384102861246]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[71392692795838]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[71444232403390]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[71495772010942]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[71482887109054]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[71435642468798]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[71452822337982]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[71375512926654]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[71474297174462]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/28"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/27"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/26"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/25"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/24"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/23"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/22"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/21"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/9"
                 }
             ]
         },
         "Instance_[1467354579315595]": {
             "Source": "Prefabs/Warehouse_storage/Storage_rack2.prefab",
             "Patches": [
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[151111580776894]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[112224946878910]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[151098695875006]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[151085810973118]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[112220651911614]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[112229241846206]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[112207767009726]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[112194882107838]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[5971750943166]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[5997520746942]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[6027585518014]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[5984635845054]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[6010405648830]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[6023290550718]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[6122074798526]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[6096304994750]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[6104894929342]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[6117779831230]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/10",
-                    "value": "Instance_[6126369765822]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/11",
-                    "value": "Instance_[6113484863934]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/12",
-                    "value": "Instance_[6109189896638]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/13",
-                    "value": "Instance_[6134959700414]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/14",
-                    "value": "Instance_[6100599962046]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[186489226394046]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[186484931426750]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[186480636459454]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13145888225493921784]/Parent Entity",
@@ -16293,10 +15707,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13145888225493921784]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186497816328638]/Components/Component_[3937996073827386159]/Child Entity Order/2"
                 }
             ]
         },
@@ -16322,215 +15732,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[4386105510620949505]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[259933167155646]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[259950347024830]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[260019066501566]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[260014771534270]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[259958936959422]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[259976116828606]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/9"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/8"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/7"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/6"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[259937462122942]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[259984706763198]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[260040541338046]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[260001886632382]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[260023361468862]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[259989001730494]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[260306829310398]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[260293944408510]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/9"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/8"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[295529856104894]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[260431383361982]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[295456841660862]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[295491201399230]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/10",
-                    "value": "Instance_[295461136628158]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/11",
-                    "value": "Instance_[260444268263870]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/12",
-                    "value": "Instance_[295495496366526]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/13",
-                    "value": "Instance_[295452546693566]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/14",
-                    "value": "Instance_[295499791333822]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/15",
-                    "value": "Instance_[295538446039486]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/16",
-                    "value": "Instance_[295534151072190]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367745436219838]/Components/Component_[3937996073827386159]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367745436219838]/Components/Component_[3937996073827386159]/Child Entity Order/2"
                 }
             ]
         },
@@ -16556,228 +15757,12 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8299323846030470908]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[10201320632057]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[10179845795577]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[10111126318841]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[10162665926393]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[10115421286137]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[10145486057209]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[10205615599353]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[10197025664761]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[10214205533945]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/23"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/22"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/21"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/9"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[147885087239929]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[147876497305337]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[147880792272633]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/6"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147893677174521]/Components/Component_[3937996073827386159]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147893677174521]/Components/Component_[3937996073827386159]/Child Entity Order/2"
                 }
             ]
         },
         "Instance_[1468093313690507]": {
             "Source": "Prefabs/Warehouse_storage/Storage_rack5.prefab",
             "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[339380499099385]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[339389089033977]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[339376204132089]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339380499099385]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[199742522371833]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339380499099385]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[246003615117049]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339380499099385]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[246016500018937]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339389089033977]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[246059449691897]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339389089033977]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[246046564790009]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339389089033977]/Components/Component_[4058468385591425268]/Child Entity Order/10",
-                    "value": "Instance_[246072334593785]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339376204132089]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[292732859297529]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339376204132089]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[292737154264825]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339376204132089]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[292719974395641]/ContainerEntity"
-                },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[226710958716547824]/Parent Entity",
@@ -17025,266 +16010,6 @@
             "Patches": [
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[71371217959358]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[71478592141758]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[71379807893950]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[71388397828542]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[71431347501502]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[71439937436094]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[71427052534206]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[71409872665022]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[71487182076350]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[71405577697726]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[71500066978238]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[71470002207166]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[71504361945534]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[71448527370686]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[71414167632318]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[71465707239870]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[71461412272574]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[71422757566910]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[71396987763134]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[71457117305278]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/39"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/38"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/37"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/36"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/35"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/34"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/33"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/32"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/31"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/30"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/29"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/28"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/27"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/26"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/25"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/24"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/23"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/22"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/21"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[1543914289413346359]/Parent Entity",
                     "value": "../Entity_[81667327274478]"
                 },
@@ -17302,174 +16027,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[1543914289413346359]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[71384102861246]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[71392692795838]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[71444232403390]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[71495772010942]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[71482887109054]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[71435642468798]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[71452822337982]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[71375512926654]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[71474297174462]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/28"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/27"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/26"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/25"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/24"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/23"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/22"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/21"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/9"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[72088477497790]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[72092772465086]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[72079887563198]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/7"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/6"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72084182530494]/Components/Component_[3937996073827386159]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72084182530494]/Components/Component_[3937996073827386159]/Child Entity Order/2"
                 }
             ]
         },
@@ -17495,150 +16052,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8299323846030470908]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147893677174521]/Components/Component_[3937996073827386159]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147893677174521]/Components/Component_[3937996073827386159]/Child Entity Order/2"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[10201320632057]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[10179845795577]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[10111126318841]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[10162665926393]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[10115421286137]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[10145486057209]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[10205615599353]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[10197025664761]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[10214205533945]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/23"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/22"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/21"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/9"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[147885087239929]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[147876497305337]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[147880792272633]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/6"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/3"
                 }
             ]
         },
@@ -17664,88 +16077,12 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[226710958716547824]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[339380499099385]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[339389089033977]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[339376204132089]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339389089033977]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[246059449691897]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339389089033977]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[246046564790009]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339389089033977]/Components/Component_[4058468385591425268]/Child Entity Order/10",
-                    "value": "Instance_[246072334593785]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339376204132089]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[292732859297529]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339376204132089]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[292737154264825]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339376204132089]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[292719974395641]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339380499099385]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[199742522371833]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339380499099385]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[246003615117049]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339380499099385]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[246016500018937]/ContainerEntity"
                 }
             ]
         },
         "Instance_[1665477125712779]": {
             "Source": "Prefabs/Warehouse_storage/Storage_rack2.prefab",
             "Patches": [
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186497816328638]/Components/Component_[3937996073827386159]/Child Entity Order/2"
-                },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13145888225493921784]/Parent Entity",
@@ -17765,323 +16102,12 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13145888225493921784]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[186489226394046]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[186484931426750]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[186480636459454]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[151111580776894]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[112224946878910]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[151098695875006]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[151085810973118]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[112220651911614]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[112229241846206]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[112207767009726]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[112194882107838]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[5971750943166]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[5997520746942]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[6027585518014]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[5984635845054]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[6010405648830]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[6023290550718]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[6122074798526]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[6096304994750]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[6104894929342]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[6117779831230]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/10",
-                    "value": "Instance_[6126369765822]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/11",
-                    "value": "Instance_[6113484863934]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/12",
-                    "value": "Instance_[6109189896638]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/13",
-                    "value": "Instance_[6134959700414]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/14",
-                    "value": "Instance_[6100599962046]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/15"
                 }
             ]
         },
         "Instance_[1665481420680075]": {
             "Source": "Prefabs/Warehouse_storage/Storage_rack3.prefab",
             "Patches": [
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367745436219838]/Components/Component_[3937996073827386159]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367745436219838]/Components/Component_[3937996073827386159]/Child Entity Order/2"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[295529856104894]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[260431383361982]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[295456841660862]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[295491201399230]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/10",
-                    "value": "Instance_[295461136628158]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/11",
-                    "value": "Instance_[260444268263870]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/12",
-                    "value": "Instance_[295495496366526]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/13",
-                    "value": "Instance_[295452546693566]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/14",
-                    "value": "Instance_[295499791333822]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/15",
-                    "value": "Instance_[295538446039486]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/16",
-                    "value": "Instance_[295534151072190]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[259933167155646]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[259950347024830]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[260019066501566]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[260014771534270]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[259958936959422]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[259976116828606]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/9"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/8"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/7"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/6"
-                },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[4386105510620949505]/Parent Entity",
@@ -18101,158 +16127,12 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[4386105510620949505]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[259937462122942]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[259984706763198]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[260040541338046]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[260001886632382]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[260023361468862]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[259989001730494]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[260306829310398]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[260293944408510]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/9"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/8"
                 }
             ]
         },
         "Instance_[1666765615901579]": {
             "Source": "Prefabs/Warehouse_storage/Storage_rack1.prefab",
             "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[71371217959358]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[71478592141758]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[71379807893950]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[71388397828542]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[71431347501502]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[71439937436094]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[71427052534206]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[71409872665022]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[71487182076350]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[71405577697726]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[1543914289413346359]/Parent Entity",
@@ -18272,344 +16152,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[1543914289413346359]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72084182530494]/Components/Component_[3937996073827386159]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72084182530494]/Components/Component_[3937996073827386159]/Child Entity Order/2"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[72088477497790]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[72092772465086]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[72079887563198]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/7"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/6"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[71384102861246]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[71392692795838]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[71444232403390]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[71495772010942]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[71482887109054]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[71435642468798]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[71452822337982]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[71375512926654]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[71474297174462]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/28"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/27"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/26"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/25"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/24"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/23"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/22"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/21"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/9"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[71500066978238]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[71470002207166]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[71504361945534]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[71448527370686]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[71414167632318]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[71465707239870]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[71461412272574]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[71422757566910]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[71396987763134]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[71457117305278]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/39"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/38"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/37"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/36"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/35"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/34"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/33"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/32"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/31"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/30"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/29"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/28"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/27"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/26"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/25"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/24"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/23"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/22"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/21"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/10"
                 }
             ]
         },
@@ -18635,220 +16177,12 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8299323846030470908]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147893677174521]/Components/Component_[3937996073827386159]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147893677174521]/Components/Component_[3937996073827386159]/Child Entity Order/2"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[147885087239929]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[147876497305337]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[147880792272633]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/6"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[10201320632057]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[10179845795577]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[10111126318841]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[10162665926393]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[10115421286137]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[10145486057209]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[10205615599353]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[10197025664761]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[10214205533945]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/23"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/22"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/21"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/9"
                 }
             ]
         },
         "Instance_[1667238062304139]": {
             "Source": "Prefabs/Warehouse_storage/Storage_rack3.prefab",
             "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[259937462122942]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[259984706763198]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[260040541338046]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[260001886632382]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[260023361468862]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[259989001730494]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[260306829310398]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[260293944408510]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/9"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367741141252542]/Components/Component_[4058468385591425268]/Child Entity Order/8"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367745436219838]/Components/Component_[3937996073827386159]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367745436219838]/Components/Component_[3937996073827386159]/Child Entity Order/2"
-                },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[4386105510620949505]/Parent Entity",
@@ -18868,151 +16202,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[4386105510620949505]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[295529856104894]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[260431383361982]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[295456841660862]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[295491201399230]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/10",
-                    "value": "Instance_[295461136628158]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/11",
-                    "value": "Instance_[260444268263870]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/12",
-                    "value": "Instance_[295495496366526]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/13",
-                    "value": "Instance_[295452546693566]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/14",
-                    "value": "Instance_[295499791333822]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/15",
-                    "value": "Instance_[295538446039486]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[367736846285246]/Components/Component_[4058468385591425268]/Child Entity Order/16",
-                    "value": "Instance_[295534151072190]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[259933167155646]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[259950347024830]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[260019066501566]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[260014771534270]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[259958936959422]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[259976116828606]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/9"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/8"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/7"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[367732551317950]/Components/Component_[4058468385591425268]/Child Entity Order/6"
                 }
             ]
         },
@@ -19038,168 +16227,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13145888225493921784]/Transform Data/Rotate/2",
                     "value": -89.99994659423828
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186497816328638]/Components/Component_[3937996073827386159]/Child Entity Order/2"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[151111580776894]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[112224946878910]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[151098695875006]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[151085810973118]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[112220651911614]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[112229241846206]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[112207767009726]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[112194882107838]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[5971750943166]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[5997520746942]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[6027585518014]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[5984635845054]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[6010405648830]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[6023290550718]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[6122074798526]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[6096304994750]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[6104894929342]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[6117779831230]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/10",
-                    "value": "Instance_[6126369765822]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/11",
-                    "value": "Instance_[6113484863934]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/12",
-                    "value": "Instance_[6109189896638]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/13",
-                    "value": "Instance_[6134959700414]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/14",
-                    "value": "Instance_[6100599962046]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[186489226394046]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[186484931426750]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[186480636459454]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/3"
                 }
             ]
         },
@@ -19225,213 +16252,12 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8299323846030470908]/Transform Data/Rotate/2",
                     "value": 90.00000762939453
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[10201320632057]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[10179845795577]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[10111126318841]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[10162665926393]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[10115421286137]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[10145486057209]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[10205615599353]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[10197025664761]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[10214205533945]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/23"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/22"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/21"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/9"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[147885087239929]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[147876497305337]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[147880792272633]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/6"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147893677174521]/Components/Component_[3937996073827386159]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147893677174521]/Components/Component_[3937996073827386159]/Child Entity Order/2"
                 }
             ]
         },
         "Instance_[1667792113085323]": {
             "Source": "Prefabs/Warehouse_storage/Storage_rack5.prefab",
             "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[339380499099385]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[339389089033977]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[339376204132089]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339389089033977]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[246059449691897]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339389089033977]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[246046564790009]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339389089033977]/Components/Component_[4058468385591425268]/Child Entity Order/10",
-                    "value": "Instance_[246072334593785]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339376204132089]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[292732859297529]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339376204132089]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[292737154264825]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339376204132089]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[292719974395641]/ContainerEntity"
-                },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[226710958716547824]/Parent Entity",
@@ -19451,118 +16277,12 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[226710958716547824]/Transform Data/Rotate/2",
                     "value": 90.00000762939453
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339380499099385]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[199742522371833]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339380499099385]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[246003615117049]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339380499099385]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[246016500018937]/ContainerEntity"
                 }
             ]
         },
         "Instance_[1667796408052619]": {
             "Source": "Prefabs/Warehouse_storage/Storage_rack2.prefab",
             "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[5971750943166]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[5997520746942]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[6027585518014]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[5984635845054]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[6010405648830]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[6023290550718]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[6122074798526]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[6096304994750]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[6104894929342]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[6117779831230]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/10",
-                    "value": "Instance_[6126369765822]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/11",
-                    "value": "Instance_[6113484863934]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/12",
-                    "value": "Instance_[6109189896638]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/13",
-                    "value": "Instance_[6134959700414]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/14",
-                    "value": "Instance_[6100599962046]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13145888225493921784]/Parent Entity",
@@ -19582,77 +16302,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13145888225493921784]/Transform Data/Rotate/2",
                     "value": 90.00000762939453
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186497816328638]/Components/Component_[3937996073827386159]/Child Entity Order/2"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[151111580776894]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[112224946878910]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[151098695875006]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[151085810973118]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[112220651911614]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[112229241846206]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[112207767009726]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[112194882107838]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[186489226394046]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[186484931426750]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[186480636459454]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/3"
                 }
             ]
         },
@@ -19678,150 +16327,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8299323846030470908]/Transform Data/Rotate/2",
                     "value": 90.00000762939453
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[147885087239929]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[147876497305337]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[147880792272633]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/6"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147889382207225]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147893677174521]/Components/Component_[3937996073827386159]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147893677174521]/Components/Component_[3937996073827386159]/Child Entity Order/2"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[10201320632057]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[10179845795577]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[10111126318841]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[10162665926393]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[10115421286137]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[10145486057209]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[10205615599353]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[10197025664761]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[10214205533945]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/23"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/22"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/21"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[147876497305337]/Components/Component_[4058468385591425268]/Child Entity Order/9"
                 }
             ]
         },
@@ -20017,221 +16522,6 @@
             "Patches": [
                 {
                     "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[71371217959358]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[71478592141758]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[71379807893950]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[71388397828542]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[71431347501502]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[71439937436094]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[71427052534206]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[71409872665022]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[71487182076350]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[71405577697726]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72088477497790]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[71384102861246]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[71392692795838]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[71444232403390]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[71495772010942]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[71482887109054]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[71435642468798]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[71452822337982]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[71375512926654]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[71474297174462]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/28"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/27"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/26"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/25"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/24"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/23"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/22"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/21"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72092772465086]/Components/Component_[4058468385591425268]/Child Entity Order/9"
-                },
-                {
-                    "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[1543914289413346359]/Parent Entity",
                     "value": "../Entity_[81667327274478]"
                 },
@@ -20249,282 +16539,12 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[1543914289413346359]/Transform Data/Rotate/2",
                     "value": 90.00000762939453
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[71500066978238]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[71470002207166]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[71504361945534]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[71448527370686]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[71414167632318]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[71465707239870]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[71461412272574]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[71422757566910]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[71396987763134]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[71457117305278]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/39"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/38"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/37"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/36"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/35"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/34"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/33"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/32"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/31"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/30"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/29"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/28"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/27"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/26"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/25"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/24"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/23"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/22"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/21"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/20"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/19"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/14"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/13"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/12"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/11"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72079887563198]/Components/Component_[4058468385591425268]/Child Entity Order/10"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[72088477497790]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[72092772465086]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[72079887563198]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/7"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/6"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72075592595902]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72084182530494]/Components/Component_[3937996073827386159]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[72084182530494]/Components/Component_[3937996073827386159]/Child Entity Order/2"
                 }
             ]
         },
         "Instance_[1667813587921803]": {
             "Source": "Prefabs/Warehouse_storage/Storage_rack5.prefab",
             "Patches": [
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339389089033977]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[246059449691897]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339389089033977]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[246046564790009]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339389089033977]/Components/Component_[4058468385591425268]/Child Entity Order/10",
-                    "value": "Instance_[246072334593785]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339376204132089]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[292732859297529]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339376204132089]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[292737154264825]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339376204132089]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[292719974395641]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[339380499099385]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[339389089033977]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[339376204132089]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[339384794066681]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[226710958716547824]/Parent Entity",
@@ -20544,149 +16564,12 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[226710958716547824]/Transform Data/Rotate/2",
                     "value": 90.00000762939453
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339380499099385]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[199742522371833]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339380499099385]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[246003615117049]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[339380499099385]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[246016500018937]/ContainerEntity"
                 }
             ]
         },
         "Instance_[1667817882889099]": {
             "Source": "Prefabs/Warehouse_storage/Storage_rack2.prefab",
             "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/0",
-                    "value": "Instance_[5971750943166]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[5997520746942]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[6027585518014]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[5984635845054]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[6010405648830]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[6023290550718]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[6122074798526]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[6096304994750]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[6104894929342]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/9",
-                    "value": "Instance_[6117779831230]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/10",
-                    "value": "Instance_[6126369765822]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/11",
-                    "value": "Instance_[6113484863934]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/12",
-                    "value": "Instance_[6109189896638]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/13",
-                    "value": "Instance_[6134959700414]/ContainerEntity"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/14",
-                    "value": "Instance_[6100599962046]/ContainerEntity"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/18"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/17"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/16"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186484931426750]/Components/Component_[4058468385591425268]/Child Entity Order/15"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/0",
-                    "value": "Entity_[186489226394046]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/1",
-                    "value": "Entity_[186484931426750]"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/2",
-                    "value": "Entity_[186480636459454]"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/5"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/4"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186493521361342]/Components/Component_[13951741074857396852]/Child Entity Order/3"
-                },
-                {
-                    "op": "remove",
-                    "path": "/Entities/Entity_[186497816328638]/Components/Component_[3937996073827386159]/Child Entity Order/2"
-                },
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13145888225493921784]/Parent Entity",
@@ -20706,46 +16589,6 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[13145888225493921784]/Transform Data/Rotate/2",
                     "value": 90.00000762939453
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/1",
-                    "value": "Instance_[151111580776894]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/2",
-                    "value": "Instance_[112224946878910]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/3",
-                    "value": "Instance_[151098695875006]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/4",
-                    "value": "Instance_[151085810973118]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/5",
-                    "value": "Instance_[112220651911614]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/6",
-                    "value": "Instance_[112229241846206]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/7",
-                    "value": "Instance_[112207767009726]/ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[186480636459454]/Components/Component_[4058468385591425268]/Child Entity Order/8",
-                    "value": "Instance_[112194882107838]/ContainerEntity"
                 }
             ]
         },

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox1.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox1.prefab
@@ -107,7 +107,7 @@
                                             "assetId": {
                                                 "guid": "{5468360F-1789-50A3-96FF-118192B81B48}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehouseboxes.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehouseboxes.material.azmaterial"
                                         }
                                     }
                                 }
@@ -125,7 +125,7 @@
                                     "guid": "{8A03C41F-AC4F-5852-8AA7-0A4EFA5E2D61}",
                                     "subId": 282632013
                                 },
-                                "assetHint": "assets/warehouse/models/box1.azmodel"
+                                "assetHint": "assets/warehouse/models/box1.fbx.azmodel"
                             }
                         }
                     }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox2.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox2.prefab
@@ -107,7 +107,7 @@
                                             "assetId": {
                                                 "guid": "{5468360F-1789-50A3-96FF-118192B81B48}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehouseboxes.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehouseboxes.material.azmaterial"
                                         }
                                     }
                                 }
@@ -125,7 +125,7 @@
                                     "guid": "{198A15B4-31E6-5693-BCF6-6C3D49884F59}",
                                     "subId": 282185463
                                 },
-                                "assetHint": "assets/warehouse/models/box2.azmodel"
+                                "assetHint": "assets/warehouse/models/box2.fbx.azmodel"
                             }
                         }
                     }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox3.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox3.prefab
@@ -107,7 +107,7 @@
                                             "assetId": {
                                                 "guid": "{5468360F-1789-50A3-96FF-118192B81B48}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehouseboxes.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehouseboxes.material.azmaterial"
                                         }
                                     }
                                 }
@@ -125,7 +125,7 @@
                                     "guid": "{6B552C1C-B7A0-5029-AEF6-C0FE06A69877}",
                                     "subId": 280128450
                                 },
-                                "assetHint": "assets/warehouse/models/box4.azmodel"
+                                "assetHint": "assets/warehouse/models/box4.fbx.azmodel"
                             }
                         }
                     }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox4.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox4.prefab
@@ -119,7 +119,7 @@
                                             "assetId": {
                                                 "guid": "{5468360F-1789-50A3-96FF-118192B81B48}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehouseboxes.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehouseboxes.material.azmaterial"
                                         }
                                     }
                                 }
@@ -146,7 +146,7 @@
                                     "guid": "{198A15B4-31E6-5693-BCF6-6C3D49884F59}",
                                     "subId": 282185463
                                 },
-                                "assetHint": "assets/warehouse/models/box2.azmodel"
+                                "assetHint": "assets/warehouse/models/box2.fbx.azmodel"
                             }
                         }
                     }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseRack.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseRack.prefab
@@ -123,7 +123,7 @@
                                     "guid": "{665AB396-251A-55E3-83E2-AAB98CB864FB}",
                                     "subId": 1812650258
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_rack.pxmesh"
+                                "assetHint": "assets/warehouse/models/warehouse_rack.fbx.pxmesh"
                             },
                             "Configuration": {
                                 "PhysicsAsset": {
@@ -132,7 +132,7 @@
                                         "subId": 1812650258
                                     },
                                     "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_rack.pxmesh"
+                                    "assetHint": "assets/warehouse/models/warehouse_rack.fbx.pxmesh"
                                 }
                             }
                         }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseRack.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseRack.prefab
@@ -72,7 +72,7 @@
                                     "guid": "{665AB396-251A-55E3-83E2-AAB98CB864FB}",
                                     "subId": 280860284
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_rack.azmodel"
+                                "assetHint": "assets/warehouse/models/warehouse_rack.fbx.azmodel"
                             }
                         }
                     }
@@ -92,7 +92,7 @@
                                             "assetId": {
                                                 "guid": "{0F02CB79-3194-5377-808F-5EEF328D40DF}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehousestorage.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehousestorage.material.azmaterial"
                                         }
                                     }
                                 }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Misc/Movable_blue.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Misc/Movable_blue.prefab
@@ -122,7 +122,7 @@
                                 "assetId": {
                                     "guid": "{8DE38686-852C-5110-96BB-BB1361502266}"
                                 },
-                                "assetHint": "assets/warehouse/floor_markings/markings_blue.azmaterial"
+                                "assetHint": "assets/warehouse/floor_markings/markings_blue.material.azmaterial"
                             }
                         }
                     }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_front_protector.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_front_protector.prefab
@@ -153,7 +153,7 @@
                                             "assetId": {
                                                 "guid": "{DC927EEA-A70D-5383-96AA-665AC07DC591}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehouseprops.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehouseprops.material.azmaterial"
                                         }
                                     }
                                 },
@@ -166,7 +166,7 @@
                                             "assetId": {
                                                 "guid": "{DC927EEA-A70D-5383-96AA-665AC07DC591}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehouseprops.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehouseprops.material.azmaterial"
                                         }
                                     }
                                 }
@@ -192,7 +192,7 @@
                                     "guid": "{9928FCBB-9AD8-5B3E-94FF-3516CC574ED1}",
                                     "subId": 271948536
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_frontrackprotector.azmodel"
+                                "assetHint": "assets/warehouse/models/warehouse_frontrackprotector.fbx.azmodel"
                             }
                         }
                     }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_front_protector.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_front_protector.prefab
@@ -81,7 +81,7 @@
                                     "guid": "{9928FCBB-9AD8-5B3E-94FF-3516CC574ED1}",
                                     "subId": 4102061829
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_frontrackprotector.pxmesh"
+                                "assetHint": "assets/warehouse/models/warehouse_frontrackprotector.fbx.pxmesh"
                             },
                             "Configuration": {
                                 "PhysicsAsset": {
@@ -90,7 +90,7 @@
                                         "subId": 4102061829
                                     },
                                     "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_frontrackprotector.pxmesh"
+                                    "assetHint": "assets/warehouse/models/warehouse_frontrackprotector.fbx.pxmesh"
                                 }
                             }
                         }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_side_protector.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_side_protector.prefab
@@ -115,7 +115,7 @@
                                     "guid": "{663633B0-B67A-5957-BC3A-53FA65F40353}",
                                     "subId": 282952590
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_siderackprotector.azmodel"
+                                "assetHint": "assets/warehouse/models/warehouse_siderackprotector.fbx.azmodel"
                             }
                         }
                     }
@@ -147,7 +147,7 @@
                                             "assetId": {
                                                 "guid": "{DC927EEA-A70D-5383-96AA-665AC07DC591}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehouseprops.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehouseprops.material.azmaterial"
                                         }
                                     }
                                 }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_side_protector.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_side_protector.prefab
@@ -174,7 +174,7 @@
                                     "guid": "{663633B0-B67A-5957-BC3A-53FA65F40353}",
                                     "subId": 3163433385
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_siderackprotector.pxmesh"
+                                "assetHint": "assets/warehouse/models/warehouse_siderackprotector.fbx.pxmesh"
                             },
                             "Configuration": {
                                 "PhysicsAsset": {
@@ -183,7 +183,7 @@
                                         "subId": 3163433385
                                     },
                                     "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_siderackprotector.pxmesh"
+                                    "assetHint": "assets/warehouse/models/warehouse_siderackprotector.fbx.pxmesh"
                                 }
                             }
                         }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Storage_on_wheels.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Storage_on_wheels.prefab
@@ -85,7 +85,7 @@
                                             "assetId": {
                                                 "guid": "{B59DB34C-8CCC-5B6A-8F32-749689632151}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehousestorageonwheels.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehousestorageonwheels.material.azmaterial"
                                         }
                                     }
                                 }
@@ -111,7 +111,7 @@
                                     "guid": "{FD1A02B5-A597-52A4-88EF-33D00822FDD6}",
                                     "subId": 281610153
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_storage_on_wheels.azmodel"
+                                "assetHint": "assets/warehouse/models/warehouse_storage_on_wheels.fbx.azmodel"
                             }
                         }
                     }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Components/Ceiling_Lamp.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Components/Ceiling_Lamp.prefab
@@ -304,7 +304,7 @@
                                             "assetId": {
                                                 "guid": "{EF5EE945-8A4F-578E-8AF5-2D545FA4CDEE}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehousemodules_lamps.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehousemodules_lamps.material.azmaterial"
                                         }
                                     }
                                 }
@@ -358,7 +358,7 @@
                                     "guid": "{3FE74ABC-001D-5AA5-ADBE-20F0964178DD}",
                                     "subId": 277792031
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_ceiling_lamp.azmodel"
+                                "assetHint": "assets/warehouse/models/warehouse_ceiling_lamp.fbx.azmodel"
                             }
                         }
                     }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Floor.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Floor.prefab
@@ -64,7 +64,7 @@
                                     "guid": "{4687EDB6-F57B-592A-8451-4A41BD678D9A}",
                                     "subId": 270838499
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_floor.azmodel"
+                                "assetHint": "assets/warehouse/models/warehouse_floor.fbx.azmodel"
                             }
                         }
                     }
@@ -199,7 +199,7 @@
                                             "assetId": {
                                                 "guid": "{67470786-4A32-5D05-9EE2-73060764DC1D}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehousefloor.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehousefloor.material.azmaterial"
                                         }
                                     }
                                 }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Floor.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Floor.prefab
@@ -130,7 +130,7 @@
                                     "guid": "{4687EDB6-F57B-592A-8451-4A41BD678D9A}",
                                     "subId": 2070809848
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_floor.pxmesh"
+                                "assetHint": "assets/warehouse/models/warehouse_floor.fbx.pxmesh"
                             },
                             "Configuration": {
                                 "Scale": [
@@ -144,12 +144,13 @@
                                         "subId": 2070809848
                                     },
                                     "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_floor.pxmesh"
+                                    "assetHint": "assets/warehouse/models/warehouse_floor.fbx.pxmesh"
                                 }
                             }
                         },
                         "HasNonUniformScale": true
-                    }
+                    },
+                    "HasNonUniformScale": true
                 },
                 "Component_[17647558825107464022]": {
                     "$type": "EditorVisibilityComponent",

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Roof.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Roof.prefab
@@ -510,7 +510,7 @@
                                     "guid": "{C8DB7BC9-31FC-5548-9E7A-CE1A886BE5E4}",
                                     "subId": 277880160
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_ceiling.azmodel"
+                                "assetHint": "assets/warehouse/models/warehouse_ceiling.fbx.azmodel"
                             }
                         }
                     }
@@ -542,7 +542,7 @@
                                             "assetId": {
                                                 "guid": "{4D881031-88E9-5300-B525-6F6E35182D97}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehousemodules_roof.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehousemodules_roof.material.azmaterial"
                                         }
                                     }
                                 }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Walls.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Walls.prefab
@@ -160,7 +160,7 @@
                                     "guid": "{9F3790A0-9383-5BBA-BB91-2AD9F04086B3}",
                                     "subId": 279508339
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_gate_closed.azmodel"
+                                "assetHint": "assets/warehouse/models/warehouse_gate_closed.fbx.azmodel"
                             }
                         }
                     }
@@ -180,7 +180,7 @@
                                             "assetId": {
                                                 "guid": "{9FF0270B-8936-528A-89EC-3E73A01AF755}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehousemodules.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehousemodules.material.azmaterial"
                                         }
                                     }
                                 },
@@ -193,7 +193,7 @@
                                             "assetId": {
                                                 "guid": "{06298918-E750-5053-B55B-10D158B1ED8C}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehousegate.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehousegate.material.azmaterial"
                                         }
                                     }
                                 }
@@ -295,7 +295,7 @@
                                     "guid": "{34CA9168-D5C7-5554-BE7D-8485A3D67AB6}",
                                     "subId": 279103289
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.azmodel"
+                                "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.fbx.azmodel"
                             }
                         }
                     }
@@ -324,7 +324,7 @@
                                             "assetId": {
                                                 "guid": "{9FF0270B-8936-528A-89EC-3E73A01AF755}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehousemodules.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehousemodules.material.azmaterial"
                                         }
                                     }
                                 }
@@ -414,7 +414,7 @@
                                     "guid": "{995CFC9D-3583-51BC-B46E-4554DEF0650E}",
                                     "subId": 269507228
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_walls_front.azmodel"
+                                "assetHint": "assets/warehouse/models/warehouse_walls_front.fbx.azmodel"
                             }
                         }
                     }
@@ -439,7 +439,7 @@
                                             "assetId": {
                                                 "guid": "{9FF0270B-8936-528A-89EC-3E73A01AF755}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehousemodules.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehousemodules.material.azmaterial"
                                         }
                                     }
                                 }
@@ -567,7 +567,7 @@
                                             "assetId": {
                                                 "guid": "{9FF0270B-8936-528A-89EC-3E73A01AF755}"
                                             },
-                                            "assetHint": "assets/warehouse/materials/mwarehousemodules.azmaterial"
+                                            "assetHint": "assets/warehouse/materials/mwarehousemodules.material.azmaterial"
                                         }
                                     }
                                 }
@@ -623,7 +623,7 @@
                                     "guid": "{1DB458F4-42D7-5377-995B-415257F59549}",
                                     "subId": 277096602
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_walls_side.azmodel"
+                                "assetHint": "assets/warehouse/models/warehouse_walls_side.fbx.azmodel"
                             }
                         }
                     }
@@ -747,7 +747,7 @@
                                             "guid": "{995CFC9D-3583-51BC-B46E-4554DEF0650E}",
                                             "subId": 269507228
                                         },
-                                        "assetHint": "assets/warehouse/models/warehouse_walls_front.azmodel"
+                                        "assetHint": "assets/warehouse/models/warehouse_walls_front.fbx.azmodel"
                                     }
                                 }
                             }
@@ -807,7 +807,7 @@
                                                     "assetId": {
                                                         "guid": "{9FF0270B-8936-528A-89EC-3E73A01AF755}"
                                                     },
-                                                    "assetHint": "assets/warehouse/materials/mwarehousemodules.azmaterial"
+                                                    "assetHint": "assets/warehouse/materials/mwarehousemodules.material.azmaterial"
                                                 }
                                             }
                                         }
@@ -883,7 +883,7 @@
                                             "guid": "{34CA9168-D5C7-5554-BE7D-8485A3D67AB6}",
                                             "subId": 279103289
                                         },
-                                        "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.azmodel"
+                                        "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.fbx.azmodel"
                                     }
                                 }
                             }
@@ -943,7 +943,7 @@
                                                     "assetId": {
                                                         "guid": "{9FF0270B-8936-528A-89EC-3E73A01AF755}"
                                                     },
-                                                    "assetHint": "assets/warehouse/materials/mwarehousemodules.azmaterial"
+                                                    "assetHint": "assets/warehouse/materials/mwarehousemodules.material.azmaterial"
                                                 }
                                             }
                                         }
@@ -989,7 +989,7 @@
                                             "guid": "{9F3790A0-9383-5BBA-BB91-2AD9F04086B3}",
                                             "subId": 279508339
                                         },
-                                        "assetHint": "assets/warehouse/models/warehouse_gate_closed.azmodel"
+                                        "assetHint": "assets/warehouse/models/warehouse_gate_closed.fbx.azmodel"
                                     }
                                 }
                             }
@@ -1086,7 +1086,7 @@
                                                     "assetId": {
                                                         "guid": "{9FF0270B-8936-528A-89EC-3E73A01AF755}"
                                                     },
-                                                    "assetHint": "assets/warehouse/materials/mwarehousemodules.azmaterial"
+                                                    "assetHint": "assets/warehouse/materials/mwarehousemodules.material.azmaterial"
                                                 }
                                             }
                                         },
@@ -1099,7 +1099,7 @@
                                                     "assetId": {
                                                         "guid": "{06298918-E750-5053-B55B-10D158B1ED8C}"
                                                     },
-                                                    "assetHint": "assets/warehouse/materials/mwarehousegate.azmaterial"
+                                                    "assetHint": "assets/warehouse/materials/mwarehousegate.material.azmaterial"
                                                 }
                                             }
                                         }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Walls.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Walls.prefab
@@ -231,7 +231,7 @@
                                     "guid": "{9F3790A0-9383-5BBA-BB91-2AD9F04086B3}",
                                     "subId": 675098786
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_gate_closed.pxmesh"
+                                "assetHint": "assets/warehouse/models/warehouse_gate_closed.fbx.pxmesh"
                             },
                             "Configuration": {
                                 "PhysicsAsset": {
@@ -240,7 +240,7 @@
                                         "subId": 675098786
                                     },
                                     "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_gate_closed.pxmesh"
+                                    "assetHint": "assets/warehouse/models/warehouse_gate_closed.fbx.pxmesh"
                                 }
                             }
                         }
@@ -351,7 +351,7 @@
                                     "guid": "{34CA9168-D5C7-5554-BE7D-8485A3D67AB6}",
                                     "subId": 3814177680
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.pxmesh"
+                                "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.fbx.pxmesh"
                             },
                             "Configuration": {
                                 "PhysicsAsset": {
@@ -360,7 +360,7 @@
                                         "subId": 3814177680
                                     },
                                     "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.pxmesh"
+                                    "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.fbx.pxmesh"
                                 }
                             }
                         }
@@ -478,7 +478,7 @@
                                     "guid": "{995CFC9D-3583-51BC-B46E-4554DEF0650E}",
                                     "subId": 2510506373
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_walls_front.pxmesh"
+                                "assetHint": "assets/warehouse/models/warehouse_walls_front.fbx.pxmesh"
                             },
                             "Configuration": {
                                 "PhysicsAsset": {
@@ -487,7 +487,7 @@
                                         "subId": 2510506373
                                     },
                                     "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_walls_front.pxmesh"
+                                    "assetHint": "assets/warehouse/models/warehouse_walls_front.fbx.pxmesh"
                                 }
                             }
                         }
@@ -594,7 +594,7 @@
                                     "guid": "{1DB458F4-42D7-5377-995B-415257F59549}",
                                     "subId": 1364068586
                                 },
-                                "assetHint": "assets/warehouse/models/warehouse_walls_side.pxmesh"
+                                "assetHint": "assets/warehouse/models/warehouse_walls_side.fbx.pxmesh"
                             },
                             "Configuration": {
                                 "PhysicsAsset": {
@@ -603,7 +603,7 @@
                                         "subId": 1364068586
                                     },
                                     "loadBehavior": "QueueLoad",
-                                    "assetHint": "assets/warehouse/models/warehouse_walls_side.pxmesh"
+                                    "assetHint": "assets/warehouse/models/warehouse_walls_side.fbx.pxmesh"
                                 }
                             }
                         }
@@ -736,8 +736,23 @@
                 "Component_[7017245480046407512]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 7017245480046407512,
-                    "DisabledComponents": [
-                        {
+                    "DisabledComponents": {
+                        "Component_[10232715223514738948]": {
+                            "$type": "AZ::Render::EditorMeshComponent",
+                            "Id": 10232715223514738948,
+                            "Controller": {
+                                "Configuration": {
+                                    "ModelAsset": {
+                                        "assetId": {
+                                            "guid": "{995CFC9D-3583-51BC-B46E-4554DEF0650E}",
+                                            "subId": 269507228
+                                        },
+                                        "assetHint": "assets/warehouse/models/warehouse_walls_front.azmodel"
+                                    }
+                                }
+                            }
+                        },
+                        "Component_[3790789121538053334]": {
                             "$type": "EditorColliderComponent",
                             "Id": 3790789121538053334,
                             "ColliderConfiguration": {
@@ -770,29 +785,14 @@
                                     }
                                 }
                             }
-                        },
-                        {
-                            "$type": "AZ::Render::EditorMeshComponent",
-                            "Id": 10232715223514738948,
-                            "Controller": {
-                                "Configuration": {
-                                    "ModelAsset": {
-                                        "assetId": {
-                                            "guid": "{995CFC9D-3583-51BC-B46E-4554DEF0650E}",
-                                            "subId": 269507228
-                                        },
-                                        "assetHint": "assets/warehouse/models/warehouse_walls_front.azmodel"
-                                    }
-                                }
-                            }
                         }
-                    ]
+                    }
                 },
                 "Component_[8212625672736002681]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 8212625672736002681,
-                    "PendingComponents": [
-                        {
+                    "PendingComponents": {
+                        "Component_[11718397946111790072]": {
                             "$type": "EditorMaterialComponent",
                             "Id": 11718397946111790072,
                             "Controller": {
@@ -815,7 +815,7 @@
                                 }
                             }
                         }
-                    ]
+                    }
                 },
                 "Component_[9253383058600544919]": {
                     "$type": "EditorInspectorComponent",
@@ -872,8 +872,23 @@
                 "Component_[7017245480046407512]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 7017245480046407512,
-                    "DisabledComponents": [
-                        {
+                    "DisabledComponents": {
+                        "Component_[10232715223514738948]": {
+                            "$type": "AZ::Render::EditorMeshComponent",
+                            "Id": 10232715223514738948,
+                            "Controller": {
+                                "Configuration": {
+                                    "ModelAsset": {
+                                        "assetId": {
+                                            "guid": "{34CA9168-D5C7-5554-BE7D-8485A3D67AB6}",
+                                            "subId": 279103289
+                                        },
+                                        "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.azmodel"
+                                    }
+                                }
+                            }
+                        },
+                        "Component_[1554132197757752789]": {
                             "$type": "EditorColliderComponent",
                             "Id": 1554132197757752789,
                             "ColliderConfiguration": {
@@ -906,29 +921,14 @@
                                     }
                                 }
                             }
-                        },
-                        {
-                            "$type": "AZ::Render::EditorMeshComponent",
-                            "Id": 10232715223514738948,
-                            "Controller": {
-                                "Configuration": {
-                                    "ModelAsset": {
-                                        "assetId": {
-                                            "guid": "{34CA9168-D5C7-5554-BE7D-8485A3D67AB6}",
-                                            "subId": 279103289
-                                        },
-                                        "assetHint": "assets/warehouse/models/warehouse_walls_front_gate.azmodel"
-                                    }
-                                }
-                            }
                         }
-                    ]
+                    }
                 },
                 "Component_[8212625672736002681]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 8212625672736002681,
-                    "PendingComponents": [
-                        {
+                    "PendingComponents": {
+                        "Component_[11718397946111790072]": {
                             "$type": "EditorMaterialComponent",
                             "Id": 11718397946111790072,
                             "Controller": {
@@ -951,7 +951,7 @@
                                 }
                             }
                         }
-                    ]
+                    }
                 },
                 "Component_[9253383058600544919]": {
                     "$type": "EditorInspectorComponent",
@@ -978,8 +978,8 @@
                 "Component_[17614188821325671055]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 17614188821325671055,
-                    "DisabledComponents": [
-                        {
+                    "DisabledComponents": {
+                        "Component_[10387122939797774050]": {
                             "$type": "AZ::Render::EditorMeshComponent",
                             "Id": 10387122939797774050,
                             "Controller": {
@@ -994,7 +994,7 @@
                                 }
                             }
                         },
-                        {
+                        "Component_[16809483465388003559]": {
                             "$type": "EditorColliderComponent",
                             "Id": 16809483465388003559,
                             "ColliderConfiguration": {
@@ -1031,7 +1031,7 @@
                                 }
                             }
                         }
-                    ]
+                    }
                 },
                 "Component_[17714278481541526192]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -1070,8 +1070,8 @@
                 "Component_[8806906810237163444]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 8806906810237163444,
-                    "PendingComponents": [
-                        {
+                    "PendingComponents": {
+                        "Component_[12188643545659218893]": {
                             "$type": "EditorMaterialComponent",
                             "Id": 12188643545659218893,
                             "Controller": {
@@ -1107,7 +1107,7 @@
                                 }
                             }
                         }
-                    ]
+                    }
                 },
                 "Component_[9994022325695796853]": {
                     "$type": "EditorStaticRigidBodyComponent",


### PR DESCRIPTION
## What does this PR do?
This PR updates prefabs in WarehouseAssets, ROS2/Assets, ProteusRobot to match changes introduced in o3de.

Using o3de: `92921487211bf1cf859027fedf076afafb43215e`

I created new project from `Ros2FleetRobotTemplate` and went through every prefab in listed Gems in order smallest to largest.
1. Instantiate prefab
2. Enter prefab editing mode
3. Ctrl + S
4. Remove prefab instance from level

Changes adding ...`.fbx`... are the result of [#16517](https://github.com/o3de/o3de/pull/16517)

## How was this PR tested?
Prefabs were manually verified that their visualizations didn't change.

