### PR TITLE
Fix issue with position control index processing

### DIFF
--- a/Gems/ROS2/Code/Source/Manipulation/JointsPositionsComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsPositionsComponent.cpp
@@ -94,19 +94,19 @@ namespace ROS2
             return;
         }
 
-        auto commandIter = message.data.cbegin();
-        for (const auto& jointName : m_jointNames)
+        for(int i=0; i<message.data.size(); i++)
         {
             AZ::Outcome<void, AZStd::string> result;
             JointsManipulationRequestBus::EventResult(
-                result, m_rootOfArticulation, &JointsManipulationRequests::MoveJointToPosition, jointName, *commandIter);
+                result, m_rootOfArticulation, &JointsManipulationRequests::MoveJointToPosition, m_jointNames[i], message.data[i]);
             if (!result.IsSuccess())
             {
                 AZ_Error(
                     "JointsPositionsComponent",
                     result,
-                    "PositionController: command failed for joint %s: ",
-                    jointName.c_str(),
+                    "PositionController: failed for joint %s and command %d: ",
+                    m_jointNames[i].c_str(),
+                    message.data[i],
                     result.GetError().c_str());
             }
         }


### PR DESCRIPTION
## What does this PR do?

This fixes an issue where the joints positions command at the first index is sent to all joints, instead of their respective commands.

I do not know the preferred convention for dual range loop iteration in C++17 (which I believe is what O3DE targets) so feel free to make changes!

## How was this PR tested?
1. Build an engine from the `92df6b` PhysX Gem Split
2. Build a Ros2RoboticManipulationTemplate project from this PR
3. Added a JointsPositionsEditorComponent with J1-7  to panda_link0
![image](https://github.com/o3de/o3de-extras/assets/5314817/377246e8-76ae-46ad-a84a-dad55edb8f5c)
4. Command `ros2 topic pub --once /position_controller/commands std_msgs/msg/Float64MultiArray "{data: [0.1, -0.69, 0.1, -2.26, 0.1, 1.47, 0.89]}"` (this is 0.1 rad from the default starting position) from another terminal with the simulator running

If you build the project from upstream, the arm will attempt to move all joints to `0.1`

## Other notes
As a side note, servoing the arm using relative positions (e.g. with moveit_servo) has some issues with the default Articulation link settings for the Panda. They are quite aggressive motions, which ends up with a sort of bang-bang feedback loop that makes servoing unstable.