### PR TITLE
Update gem.json files of ROS2 related Gems

### DIFF
--- a/Gems/ProteusRobot/gem.json
+++ b/Gems/ProteusRobot/gem.json
@@ -32,3 +32,4 @@
     "restricted": "ProteusRobot",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/proteusrobot-1.1.0-gem.zip"
 }
+

--- a/Gems/ProteusRobot/gem.json
+++ b/Gems/ProteusRobot/gem.json
@@ -25,8 +25,8 @@
     ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "compatible_engines": [
-        "o3de-sdk>=4.1.0",
-        "o3de>=4.1.0"
+        "o3de-sdk>=2.3.0",
+        "o3de>=2.3.0"
     ],
     "engine_api_dependencies": [],
     "restricted": "ProteusRobot",

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -8,7 +8,8 @@
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
     "origin": "RobotecAI",
-    "origin_url": "https://github.com/o3de/o3de-extras/development/Gems/ROS2",
+    "origin_url": "https://robotec.ai",
+    "source_control_uri": "https://github.com/o3de/o3de-extras/development/Gems/ROS2",
     "type": "Code",
     "summary": "Tools and components to support creating simulations for ROS 2 systems such as robots",
     "canonical_tags": [
@@ -23,7 +24,7 @@
     ],
     "icon_path": "preview.png",
     "requirements": "Requires ROS 2 installation (supported distributions: Humble). Source your workspace before building the Gem",
-    "documentation_url": "https://o3de.org/docs/user-guide/gems/reference/design/ros2/",
+    "documentation_url": "https://docs.o3de.org/docs/user-guide/gems/reference/robotics/ros2/",
     "dependencies": [
         "Atom_RPI",
         "Atom_Feature_Common",

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -38,3 +38,4 @@
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.1.0-gem.zip"
 }
+

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -18,8 +18,8 @@
         "ROS2"
     ],
     "compatible_engines": [
-        "o3de-sdk>=4.1.0",
-        "o3de>=4.1.0"
+        "o3de-sdk>=2.3.0",
+        "o3de>=2.3.0"
     ],
     "icon_path": "preview.png",
     "requirements": "Requires ROS 2 installation (supported distributions: Humble). Source your workspace before building the Gem",

--- a/Gems/RosRobotSample/gem.json
+++ b/Gems/RosRobotSample/gem.json
@@ -24,8 +24,8 @@
         "ROS2>=3.1.0"
     ],
     "compatible_engines": [
-        "o3de-sdk>=4.1.0",
-        "o3de>=4.1.0"
+        "o3de-sdk>=2.3.0",
+        "o3de>=2.3.0"
     ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "restricted": "",

--- a/Gems/RosRobotSample/gem.json
+++ b/Gems/RosRobotSample/gem.json
@@ -31,3 +31,4 @@
     "restricted": "",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/rosrobotsample-1.1.0-gem.zip"
 }
+

--- a/Gems/WarehouseAutomation/gem.json
+++ b/Gems/WarehouseAutomation/gem.json
@@ -15,8 +15,8 @@
         "WarehouseAutomation"
     ],
     "compatible_engines": [
-        "o3de-sdk>=4.1.0",
-        "o3de>=4.1.0"
+        "o3de-sdk>=2.3.0",
+        "o3de>=2.3.0"
     ],
     "platforms": [
         "Linux"

--- a/Gems/WarehouseAutomation/gem.json
+++ b/Gems/WarehouseAutomation/gem.json
@@ -30,3 +30,4 @@
     "restricted": "WarehouseAutomation",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehouseautomation-1.1.0-gem.zip"
 }
+


### PR DESCRIPTION
## What does this PR do?

Update `gem.json` file of ROS2 Gem to allow the Gem use with stabilization branch (see the https://github.com/o3de/o3de/pull/17903) and fix the URLs.
Update other `gem.json` files in ROS2 related gems.

This change will be later cherry-picked to `o3de-extras/stabilization` branch.

## How was this PR tested?

the code was built against the `o3de/stabilization` branch and the errors like the following
```
[build]   RosRobotSample is incompatible because: o3de 2.3.0 does not match any
[build]   version specifiers in the list of compatible engines: ['o3de-sdk>=4.1.0',
[build]   'o3de>=4.1.0']
```
is gone
