### PR TITLE
Added option to spawn entities with WGS84 coords using existing ros service

### DIFF
--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -120,6 +120,7 @@ namespace ROS2
         {
             response.success = false;
             response.status_message = "Level is not geographically positioned. Action aborted.";
+            service_handle->send_response(*header, response);
             return;
         }
 

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -112,7 +112,7 @@ namespace ROS2
         const SpawnEntityServiceHandle service_handle, const std::shared_ptr<rmw_request_id_t> header, const SpawnEntityRequest request)
     {
         AZStd::string referenceFrame(request->reference_frame.c_str());
-        bool isWGS{ referenceFrame == "wgs84" };
+        const bool isWGS{ referenceFrame == "wgs84" && m_controller.GetSupportWGS() };
 
         SpawnEntityResponse response;
 
@@ -184,7 +184,7 @@ namespace ROS2
         {
             ROS2::WGS::WGS84Coordinate coordinate;
             AZ::Vector3 coordinateInLevel = AZ::Vector3(-1);
-            AZ::Quaternion rotationInENU = AZ::Quaternion::CreateZero();
+            AZ::Quaternion rotationInENU = AZ::Quaternion::CreateIdentity();
             coordinate.m_latitude = request->initial_pose.position.x;
             coordinate.m_longitude = request->initial_pose.position.y;
             coordinate.m_altitude = request->initial_pose.position.z;

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.cpp
@@ -74,6 +74,7 @@ namespace ROS2
             serializeContext->Class<ROS2SpawnerComponentConfig, AZ::ComponentConfig>()
                 ->Version(1)
                 ->Field("Editor entity id", &ROS2SpawnerComponentConfig::m_editorEntityId)
+                ->Field("Support WGS", &ROS2SpawnerComponentConfig::m_supportWGS)
                 ->Field("Spawnables", &ROS2SpawnerComponentConfig::m_spawnables)
                 ->Field("Default spawn pose", &ROS2SpawnerComponentConfig::m_defaultSpawnPose)
                 ->Field("Service names", &ROS2SpawnerComponentConfig::m_serviceNames)
@@ -84,6 +85,7 @@ namespace ROS2
             {
                 editContext->Class<ROS2SpawnerComponentConfig>("ROS2SpawnerComponentConfig", "Config for ROS2SpawnerComponent")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2SpawnerComponentConfig::m_supportWGS, "Support WGS", "Support for spawning entities using WGS84 coordinate system")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2SpawnerComponentConfig::m_spawnables, "Spawnables", "Spawnables")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
@@ -114,6 +116,11 @@ namespace ROS2
     AZStd::unordered_map<AZStd::string, SpawnPointInfo> ROS2SpawnerComponentController::GetAllSpawnPointInfos() const
     {
         return GetSpawnPoints();
+    }
+
+    bool ROS2SpawnerComponentController::GetSupportWGS() const
+    {
+        return m_config.m_supportWGS;
     }
 
     void ROS2SpawnerComponentController::Reflect(AZ::ReflectContext* context)

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.h
@@ -47,6 +47,7 @@ namespace ROS2
 
         ROS2SpawnerServiceNames m_serviceNames;
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables;
+        bool m_supportWGS{ true };
     };
 
     class ROS2SpawnerComponentController : public SpawnerRequestsBus::Handler
@@ -77,6 +78,7 @@ namespace ROS2
         SpawnPointInfoMap GetSpawnPoints() const;
         AZ::EntityId GetEditorEntityId() const;
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> GetSpawnables() const;
+        bool GetSupportWGS() const;
 
     private:
         ROS2SpawnerComponentConfig m_config;


### PR DESCRIPTION
## What does this PR do?

Added option in ROS2 Spawner component to spawn entities using WGS84 coords using existing spawn_entity service. To switch to WGS84 coords parameter 'reference_frame' needs to be set to 'wgs84'.

Usage example: ros2 service call /spawn_entity gazebo_msgs/srv/SpawnEntity "{name: 'some', xml: '', robot_namespace: '', initial_pose: { position: { x: 32.5896238486642, y: 35.1930592634115, z: 135.0 }, orientation: { x: 0.0, y: 0.0, z: 0.0, w: 1.0 } }, reference_frame: 'wgs84' }"

## How was this PR tested?

By using level with geo reference (made by @michalpelka) and spawning entities with different rotation,