### PR TITLE
Fix ROS 2 System component to work with Simulate in Editor

### DIFF
--- a/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
@@ -150,11 +150,18 @@ namespace ROS2
     {
         AZ::TickBus::Handler::BusDisconnect();
         ROS2RequestBus::Handler::BusDisconnect();
-        m_simulationClock->Deactivate();
+        if (m_simulationClock) {
+            m_simulationClock->Deactivate();
+        }
         m_dynamicTFBroadcaster.reset();
         m_staticTFBroadcaster.reset();
-        m_executor->remove_node(m_ros2Node);
-        m_executor.reset();
+        if (m_executor)
+        {
+            if (m_ros2Node) {
+                m_executor->remove_node(m_ros2Node);
+            }
+            m_executor.reset();
+        }
         m_simulationClock.reset();
         m_ros2Node.reset();
         m_nodeChangedEvent.Signal(m_ros2Node);


### PR DESCRIPTION
## What does this PR do?

This PR prevents null pointer dereference when the ROS2 System component is deactivated at the start of the simulation in the editor.

#705 
## How was this PR tested?

Run against manipulation template with o3de/stabilization/2409

Note:
This is PR is crash-fix. ROS 2 functionality is partially usable in simulation mode. The ROS 2, sensors, and others are paused on the Editor's window loses focus. However, I think it is unrelated to ROS 2 and is some feature or bug in o3de.