### PR TITLE
Fix spelling in georeference.

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Georeference/GeoreferenceBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Georeference/GeoreferenceBus.h
@@ -15,20 +15,20 @@
 
 namespace ROS2
 {
-    //! Interface that allows to convert between level and WSG84 coordinates.
+    //! Interface that allows to convert between level and WGS84 coordinates.
     class GeoreferenceRequests
     {
     public:
 
-        //! Function converts from Level's coordinate system to WSG84.
+        //! Function converts from Level's coordinate system to WGS84.
         //! @param xyz Vector3 in Level's coordinate system.
-        //! @return Vector3 in WSG84 coordinate system as @class WGS::WGS84Coordinate.
-        virtual WGS::WGS84Coordinate ConvertFromLevelToWSG84(const AZ::Vector3& xyz) = 0;
+        //! @return Vector3 in WGS84 coordinate system as @class WGS::WGS84Coordinate.
+        virtual WGS::WGS84Coordinate ConvertFromLevelToWGS84(const AZ::Vector3& xyz) = 0;
 
-        //! Function converts from WSG84 coordinate system to Level's.
-        //!  @param latLon Vector3 in WSG84 coordinate system, where x is latitude, y is longitude and z is altitude.
+        //! Function converts from WGS84 coordinate system to Level's.
+        //!  @param latLon Vector3 in WGS84 coordinate system, where x is latitude, y is longitude and z is altitude.
         //!  @return Vector3 in Level's coordinate system.
-        virtual AZ::Vector3 ConvertFromWSG84ToLevel(const WGS::WGS84Coordinate& latLon) = 0;
+        virtual AZ::Vector3 ConvertFromWGS84ToLevel(const WGS::WGS84Coordinate& latLon) = 0;
 
         //! Function returns rotation from Level's frame to ENU's (East-North-Up) rotation.
         //! Function is useful to fin georeference rotation of the level.

--- a/Gems/ROS2/Code/Include/ROS2/Georeference/GeoreferenceStructures.h
+++ b/Gems/ROS2/Code/Include/ROS2/Georeference/GeoreferenceStructures.h
@@ -14,7 +14,7 @@ namespace ROS2::WGS
 {
 
     //! WGS84Coordinate is a 3D vector with double precision.
-    //! It is used to represent coordinates in WSG84 coordinate system.
+    //! It is used to represent coordinates in WGS84 coordinate system.
     struct WGS84Coordinate
     {
         AZ_RTTI(WGS84Coordinate, "{577a5637-b31a-44c5-a33f-50df2922af2a}");

--- a/Gems/ROS2/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/GNSS/ROS2GNSSSensorComponent.cpp
@@ -97,7 +97,7 @@ namespace ROS2
 
         WGS::WGS84Coordinate currentPositionWGS84;
         ROS2::GeoreferenceRequestsBus::BroadcastResult(
-            currentPositionWGS84, &GeoreferenceRequests::ConvertFromLevelToWSG84, currentPosition);
+            currentPositionWGS84, &GeoreferenceRequests::ConvertFromLevelToWGS84, currentPosition);
 
         m_gnssMsg.latitude = currentPositionWGS84.m_latitude;
         m_gnssMsg.longitude = currentPositionWGS84.m_longitude;

--- a/Gems/ROS2/Code/Source/Georeference/GeoreferenceLevelComponent.cpp
+++ b/Gems/ROS2/Code/Source/Georeference/GeoreferenceLevelComponent.cpp
@@ -23,7 +23,7 @@ namespace ROS2
         {
             serialize->Class<GeoReferenceLevelConfig, AZ::ComponentConfig>()
                 ->Version(1)
-                ->Field("EnuOriginWSG84", &GeoReferenceLevelConfig::m_originLocation)
+                ->Field("EnuOriginWGS84", &GeoReferenceLevelConfig::m_originLocation)
                 ->Field("EnuOriginLocationEntityId", &GeoReferenceLevelConfig::m_enuOriginLocationEntityId);
 
             if (auto* editContext = serialize->GetEditContext())
@@ -92,7 +92,7 @@ namespace ROS2
         AZ::EntityBus::Handler::BusDisconnect();
     }
 
-    WGS::WGS84Coordinate GeoReferenceLevelController::ConvertFromLevelToWSG84(const AZ::Vector3& xyz)
+    WGS::WGS84Coordinate GeoReferenceLevelController::ConvertFromLevelToWGS84(const AZ::Vector3& xyz)
     {
         using namespace ROS2::Utils::GeodeticConversions;
         const auto enu = WGS::Vector3d(m_enuOriginTransform.TransformPoint(xyz));
@@ -100,7 +100,7 @@ namespace ROS2
         return ECEFToWGS84(ecef);
     }
 
-    AZ::Vector3 GeoReferenceLevelController::ConvertFromWSG84ToLevel(const WGS::WGS84Coordinate& latLon)
+    AZ::Vector3 GeoReferenceLevelController::ConvertFromWGS84ToLevel(const WGS::WGS84Coordinate& latLon)
     {
         using namespace ROS2::Utils::GeodeticConversions;
         const auto ecef = WGS84ToECEF(latLon);

--- a/Gems/ROS2/Code/Source/Georeference/GeoreferenceLevelComponent.h
+++ b/Gems/ROS2/Code/Source/Georeference/GeoreferenceLevelComponent.h
@@ -49,8 +49,8 @@ namespace ROS2
         void OnEntityActivated(const AZ::EntityId& entityId) override;
 
         // GeoreferenceRequestsBus::Handler overrides ...
-        WGS::WGS84Coordinate ConvertFromLevelToWSG84(const AZ::Vector3& xyz) override;
-        AZ::Vector3 ConvertFromWSG84ToLevel(const WGS::WGS84Coordinate& latLon) override;
+        WGS::WGS84Coordinate ConvertFromLevelToWGS84(const AZ::Vector3& xyz) override;
+        AZ::Vector3 ConvertFromWGS84ToLevel(const WGS::WGS84Coordinate& latLon) override;
         AZ::Quaternion GetRotationFromLevelToENU() override;
 
         GeoReferenceLevelConfig m_config;

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -191,7 +191,7 @@ namespace ROS2
             coordinate.m_altitude = request->initial_pose.position.z;
             ROS2::GeoreferenceRequestsBus::BroadcastResult(rotationInENU, &ROS2::GeoreferenceRequests::GetRotationFromLevelToENU);
             ROS2::GeoreferenceRequestsBus::BroadcastResult(
-                coordinateInLevel, &ROS2::GeoreferenceRequests::ConvertFromWSG84ToLevel, coordinate);
+                coordinateInLevel, &ROS2::GeoreferenceRequests::ConvertFromWGS84ToLevel, coordinate);
 
             rotationInENU = (rotationInENU.GetInverseFast() *
                              AZ::Quaternion(

--- a/Gems/ROS2/Code/Tests/GNSSTest.cpp
+++ b/Gems/ROS2/Code/Tests/GNSSTest.cpp
@@ -80,7 +80,7 @@ namespace UnitTest
         }
     }
 
-    TEST_F(GNSSTest, ECEFToWSG84)
+    TEST_F(GNSSTest, ECEFToWGS84)
     {
         using namespace ROS2::WGS;
         const AZStd::vector<AZStd::pair<Vector3d, WGS84Coordinate>> inputGoldSet = {


### PR DESCRIPTION
## What does this PR do?

It simple change of name of a few methods. 
Some of the fields and methods were misspelled (it was WSG, it should be WGS).

## How was this PR tested?

Build localy, run the unit test.