### PR TITLE
[ROS2] Lidar add instance and semantic segmentation

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -69,7 +69,7 @@ ly_add_target(
             Gem::LmbrCentral.API
 )
 
-target_depends_on_ros2_packages(${gem_name}.Static rclcpp builtin_interfaces std_msgs sensor_msgs nav_msgs tf2_ros ackermann_msgs gazebo_msgs)
+target_depends_on_ros2_packages(${gem_name}.Static rclcpp builtin_interfaces std_msgs sensor_msgs nav_msgs tf2_ros ackermann_msgs gazebo_msgs vision_msgs)
 target_depends_on_ros2_package(${gem_name}.Static control_toolbox 2.2.0 REQUIRED)
 
 ly_add_target(

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
@@ -97,6 +97,8 @@ namespace ROS2
     {
         AZStd::vector<AZ::Vector3> m_points;
         AZStd::vector<float> m_ranges;
+        AZStd::optional<AZStd::vector<int32_t>> m_ids;
+        AZStd::optional<AZStd::vector<AZ::u8>> m_classes;
     };
 
     //! Interface class that allows for communication with a single Lidar instance.
@@ -164,6 +166,14 @@ namespace ROS2
         virtual void ExcludeEntities([[maybe_unused]] const AZStd::vector<AZ::EntityId>& excludedEntities)
         {
             AZ_Assert(false, "This Lidar Implementation does not support entity exclusion!");
+        }
+
+        //! Configures segmentation classes.
+        //! @param classTags Set of pairs of class names and their corresponding class indices.
+        virtual void ConfigureSegmentationClasses(
+            [[maybe_unused]] const AZStd::unordered_set<AZStd::pair<AZStd::string, uint8_t>>& classTags)
+        {
+            AZ_Assert(false, "This Lidar Implementation does not support segmentation class configuration!");
         }
 
         //! Configures max range point addition.

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
@@ -22,6 +22,7 @@ namespace ROS2
         EntityExclusion         = 1 << 2,
         MaxRangePoints          = 1 << 3,
         PointcloudPublishing    = 1 << 4,
+        Segmentation            = 1 << 5,
         All                     = 0b1111111111111111,
     };
 

--- a/Gems/ROS2/Code/Source/Lidar/LidarCore.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarCore.cpp
@@ -99,6 +99,18 @@ namespace ROS2
                 &LidarRaycasterRequestBus::Events::ConfigureMaxRangePointAddition,
                 m_lidarConfiguration.m_addPointsAtMax);
         }
+
+        if (m_lidarConfiguration.m_lidarSystemFeatures & LidarSystemFeatures::Segmentation) {
+            AZStd::unordered_set<AZStd::pair<AZStd::string, uint8_t> > classTags;
+            for (const auto &segmentation_class: m_lidarConfiguration.m_segmentationClasses) {
+                classTags.insert({segmentation_class.m_className, segmentation_class.m_classId});
+            }
+
+            LidarRaycasterRequestBus::Event(
+                m_lidarRaycasterId,
+                &LidarRaycasterRequestBus::Events::ConfigureSegmentationClasses,
+                classTags);
+        }
     }
 
     LidarCore::LidarCore(const AZStd::vector<LidarTemplate::LidarModel>& availableModels)

--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
@@ -138,6 +138,8 @@ namespace ROS2
         if (handlePoints)
         {
             results.m_points.reserve(rayDirections.size());
+            results.m_ids = {};
+            results.m_classes = {};
         }
         if (handleRanges)
         {

--- a/Gems/ROS2/Code/Source/Lidar/LidarSegmentationClassConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSegmentationClassConfiguration.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "LidarSegmentationClassConfiguration.h"
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/EditContextConstants.inl>
+
+namespace ROS2
+{
+    void LidarSegmentationClassConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<LidarSegmentationClassConfiguration>()
+                ->Version(2)
+                ->Field("className", &LidarSegmentationClassConfiguration::m_className)
+                ->Field("classId", &LidarSegmentationClassConfiguration::m_classId)
+                ->Field("classColor", &LidarSegmentationClassConfiguration::m_classColor);
+
+            if (AZ::EditContext* ec = serializeContext->GetEditContext())
+            {
+                ec->Class<LidarSegmentationClassConfiguration>("Lidar Segmentation Class Configuration", "Lidar Segmentation Class configuration")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &LidarSegmentationClassConfiguration::m_className,
+                        "Class Name",
+                        "Name of the class")
+                    ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, true)
+                    ->DataElement(
+                            AZ::Edit::UIHandlers::Default,
+                            &LidarSegmentationClassConfiguration::m_classId,
+                                "Class Id",
+                            "Id of the class")
+                    ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, true)
+                    ->DataElement(
+                            AZ::Edit::UIHandlers::Default,
+                            &LidarSegmentationClassConfiguration::m_classColor,
+                            "Class Color",
+                            "Color of the class")
+                    ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, true);
+
+            }
+        }
+    }
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarSegmentationClassConfiguration.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSegmentationClassConfiguration.h
@@ -1,0 +1,48 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/string/string.h>
+#include "LidarRegistrarSystemComponent.h"
+
+namespace ROS2
+{
+    //! A structure capturing configuration of a lidar sensor (to be used with LidarCore).
+    class LidarSegmentationClassConfiguration
+    {
+    public:
+        AZ_TYPE_INFO(LidarSegmentationClassConfiguration, "{e46e75f4-1e0e-48ca-a22f-43afc8f25133}");
+        static void Reflect(AZ::ReflectContext* context);
+
+        LidarSegmentationClassConfiguration() = default;
+
+        LidarSegmentationClassConfiguration(AZStd::string className, const uint8_t classId, const AZ::Color& classColor)
+            : m_className(AZStd::move(className))
+              , m_classId(classId)
+              , m_classColor(classColor)
+        {
+        };
+
+        static LidarSegmentationClassConfiguration UnknownClass()
+        {
+            return { "Unknown", 0, AZ::Color(1.0f, 1.0f, 1.0f, 1.0f) };
+        }
+
+        static LidarSegmentationClassConfiguration GroundClass()
+        {
+            return { "Ground", 1, AZ::Color(0.5f, 0.25f, 0.0f, 1.0f) };
+        }
+
+        AZStd::string m_className = "Default";
+        uint8_t m_classId = 0;
+        AZ::Color m_classColor = AZ::Color(1.0f, 1.0f, 1.0f, 1.0f);
+    };
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarSensorConfiguration.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSensorConfiguration.h
@@ -15,6 +15,7 @@
 #include "LidarRegistrarSystemComponent.h"
 #include "LidarTemplate.h"
 #include "LidarTemplateUtils.h"
+#include "LidarSegmentationClassConfiguration.h"
 
 namespace ROS2
 {
@@ -29,6 +30,9 @@ namespace ROS2
 
         //! Update the lidar system features based on the current lidar system selected.
         void FetchLidarImplementationFeatures();
+        static constexpr size_t maxClass = 256;
+        [[nodiscard]] AZStd::array<AZ::Color, maxClass> GenerateSegmentationColorsLookupTable() const;
+
 
         LidarSystemFeatures m_lidarSystemFeatures;
 
@@ -39,6 +43,8 @@ namespace ROS2
         AZStd::unordered_set<AZ::u32> m_ignoredCollisionLayers;
         AZStd::vector<AZ::EntityId> m_excludedEntities;
 
+        AZStd::vector<LidarSegmentationClassConfiguration> m_segmentationClasses;
+        bool m_isSegmentationEnabled = false;
         bool m_addPointsAtMax = false;
 
     private:
@@ -46,12 +52,13 @@ namespace ROS2
         bool IsIgnoredLayerConfigurationVisible() const;
         bool IsEntityExclusionVisible() const;
         bool IsMaxPointsConfigurationVisible() const;
-
+        bool IsSegmentationConfigurationVisible() const;
         //! Update the lidar configuration based on the current lidar model selected.
         void FetchLidarModelConfiguration();
 
         AZ::Crc32 OnLidarModelSelected();
         AZ::Crc32 OnLidarImplementationSelected();
+        AZ::Crc32 SegmentationClassesChangeNotify();
 
         //! Get all models this configuration can be set to (for example all 2D lidar models).
         AZStd::vector<AZStd::string> GetAvailableModels() const;

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -15,6 +15,7 @@
 #include <ROS2/Sensor/ROS2SensorComponentBase.h>
 #include <rclcpp/publisher.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <vision_msgs/msg/label_info.hpp>
 
 #include "LidarCore.h"
 #include "LidarRaycaster.h"
@@ -47,6 +48,7 @@ namespace ROS2
 
         bool m_canRaycasterPublish = false;
         std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointCloudPublisher;
+        std::shared_ptr<rclcpp::Publisher<vision_msgs::msg::LabelInfo>> m_segmentationClassesPublisher;
 
         LidarCore m_lidarCore;
 

--- a/Gems/ROS2/Code/ros2_files.cmake
+++ b/Gems/ROS2/Code/ros2_files.cmake
@@ -64,6 +64,8 @@ set(FILES
         Source/Lidar/LidarRegistrarSystemComponent.h
         Source/Lidar/LidarSensorConfiguration.cpp
         Source/Lidar/LidarSensorConfiguration.h
+        Source/Lidar/LidarSegmentationClassConfiguration.cpp
+        Source/Lidar/LidarSegmentationClassConfiguration.h
         Source/Lidar/LidarSystem.cpp
         Source/Lidar/LidarSystem.h
         Source/Lidar/LidarTemplate.cpp


### PR DESCRIPTION
## What does this PR do?
This pr adds support for new lidar feature, that is instance and semantic segmentation.
It extends relevant fields and classes to allow implementations of lidar to support this.
It's is made in such a way that lidar implementation that do not support this feature will not be impacted.

## How was this PR tested?

It was tested internally, and on simple projects