### PR TITLE
Use simulation time to compute time difference.

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Manipulation/MotorizedJoints/JointMotorControllerComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Manipulation/MotorizedJoints/JointMotorControllerComponent.h
@@ -13,6 +13,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <ImGuiBus.h>
 #include <ROS2/Manipulation/MotorizedJoints/JointMotorControllerConfiguration.h>
+#include <ROS2/ROS2Bus.h>
 
 namespace ROS2
 {
@@ -58,5 +59,6 @@ namespace ROS2
 
         // AZ::TickBus overrides
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        builtin_interfaces::msg::Time m_lastTickTime;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Manipulation/MotorizedJoints/JointMotorControllerComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Manipulation/MotorizedJoints/JointMotorControllerComponent.h
@@ -13,7 +13,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <ImGuiBus.h>
 #include <ROS2/Manipulation/MotorizedJoints/JointMotorControllerConfiguration.h>
-#include <ROS2/ROS2Bus.h>
+#include <builtin_interfaces/msg/time.hpp>
 
 namespace ROS2
 {
@@ -59,6 +59,7 @@ namespace ROS2
 
         // AZ::TickBus overrides
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
-        builtin_interfaces::msg::Time m_lastTickTime;
+
+        builtin_interfaces::msg::Time m_lastTickTime; //!< ROS 2 Timestamp during last OnTick call
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Manipulation/MotorizedJoints/JointMotorControllerComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Manipulation/MotorizedJoints/JointMotorControllerComponent.h
@@ -60,6 +60,6 @@ namespace ROS2
         // AZ::TickBus overrides
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
 
-        builtin_interfaces::msg::Time m_lastTickTime; //!< ROS 2 Timestamp during last OnTick call
+        builtin_interfaces::msg::Time m_lastTickTimestamp; //!< ROS 2 Timestamp during last OnTick call
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Utilities/ROS2Conversions.h
+++ b/Gems/ROS2/Code/Include/ROS2/Utilities/ROS2Conversions.h
@@ -13,7 +13,7 @@
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
-
+#include "builtin_interfaces/msg/time.hpp"
 namespace ROS2
 {
     //! Utility class for conversions between ROS2 types and O3DE (AZ::) types.
@@ -28,5 +28,6 @@ namespace ROS2
         AZ::Vector3 FromROS2Point(const geometry_msgs::msg::Point& ros2point);
         AZ::Quaternion FromROS2Quaternion(const geometry_msgs::msg::Quaternion& ros2quaternion);
         std::array<double, 9> ToROS2Covariance(const AZ::Matrix3x3& covariance);
+        float GetTimeDifference(const builtin_interfaces::msg::Time& start, const builtin_interfaces::msg::Time& end);
     }; // namespace ROS2Conversions
 } // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Utilities/ROS2Conversions.h
+++ b/Gems/ROS2/Code/Include/ROS2/Utilities/ROS2Conversions.h
@@ -13,7 +13,7 @@
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
-#include "builtin_interfaces/msg/time.hpp"
+#include <builtin_interfaces/msg/time.hpp>
 namespace ROS2
 {
     //! Utility class for conversions between ROS2 types and O3DE (AZ::) types.

--- a/Gems/ROS2/Code/Include/ROS2/Utilities/ROS2Conversions.h
+++ b/Gems/ROS2/Code/Include/ROS2/Utilities/ROS2Conversions.h
@@ -14,6 +14,7 @@
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <builtin_interfaces/msg/time.hpp>
+
 namespace ROS2
 {
     //! Utility class for conversions between ROS2 types and O3DE (AZ::) types.

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.cpp
@@ -183,7 +183,7 @@ namespace ROS2
         publisherContext.m_entityId = GetEntityId();
 
         m_jointStatePublisher = AZStd::make_unique<JointStatePublisher>(m_jointStatePublisherConfiguration, publisherContext);
-        m_lastTickTime = ROS2Interface::Get()->GetROSTimestamp();
+        m_lastTickTimestamp = ROS2Interface::Get()->GetROSTimestamp();
         AZ::TickBus::Handler::BusConnect();
         JointsManipulationRequestBus::Handler::BusConnect(GetEntityId());
     }
@@ -450,8 +450,8 @@ namespace ROS2
             m_jointStatePublisher->InitializePublisher();
         }
         auto simTimestamp = ROS2Interface::Get()->GetROSTimestamp();
-        float deltaSimTime = ROS2Conversions::GetTimeDifference(m_lastTickTime, simTimestamp);
+        float deltaSimTime = ROS2Conversions::GetTimeDifference(m_lastTickTimestamp, simTimestamp);
         MoveToSetPositions(deltaSimTime);
-        m_lastTickTime = simTimestamp;
+        m_lastTickTimestamp = simTimestamp;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
@@ -86,6 +86,6 @@ namespace ROS2
         ManipulationJoints m_manipulationJoints; //!< Map of JointInfo where the key is a joint name (with namespace included)
         AZStd::vector<AZStd::pair<AZStd::string, float>> 
             m_initialPositions; //!< Initial positions per joint name (without namespace included)
-        builtin_interfaces::msg::Time m_lastTickTime; //!< ROS 2 Timestamp during last OnTick call
+        builtin_interfaces::msg::Time m_lastTickTimestamp; //!< ROS 2 Timestamp during last OnTick call
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
@@ -86,6 +86,6 @@ namespace ROS2
         ManipulationJoints m_manipulationJoints; //!< Map of JointInfo where the key is a joint name (with namespace included)
         AZStd::vector<AZStd::pair<AZStd::string, float>> 
             m_initialPositions; //!< Initial positions per joint name (without namespace included)
-        builtin_interfaces::msg::Time m_lastTickTime;
+        builtin_interfaces::msg::Time m_lastTickTime; //!< ROS 2 Timestamp during last OnTick call
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationComponent.h
@@ -86,5 +86,6 @@ namespace ROS2
         ManipulationJoints m_manipulationJoints; //!< Map of JointInfo where the key is a joint name (with namespace included)
         AZStd::vector<AZStd::pair<AZStd::string, float>> 
             m_initialPositions; //!< Initial positions per joint name (without namespace included)
+        builtin_interfaces::msg::Time m_lastTickTime;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
@@ -25,7 +25,7 @@ namespace ROS2
         m_followTrajectoryServer = AZStd::make_unique<FollowJointTrajectoryActionServer>(namespacedAction, GetEntityId());
         AZ::TickBus::Handler::BusConnect();
         JointsTrajectoryRequestBus::Handler::BusConnect(GetEntityId());
-        m_lastTickTime = ROS2Interface::Get()->GetROSTimestamp();
+        m_lastTickTimestamp = ROS2Interface::Get()->GetROSTimestamp();
     }
 
     ManipulationJoints& JointsTrajectoryComponent::GetManipulationJoints()
@@ -256,8 +256,8 @@ namespace ROS2
             return;
         }
         const auto simTimestamp = ROS2Interface::Get()->GetROSTimestamp();
-        const float deltaSimulatedTime = ROS2Conversions::GetTimeDifference(simTimestamp, m_lastTickTime);
-        m_lastTickTime = simTimestamp;
+        const float deltaSimulatedTime = ROS2Conversions::GetTimeDifference(simTimestamp, m_lastTickTimestamp);
+        m_lastTickTimestamp = simTimestamp;
         const uint64_t deltaTimeNs = deltaSimulatedTime * 1'000'000'000;
         FollowTrajectory(deltaTimeNs);
         UpdateFeedback();

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
@@ -13,6 +13,7 @@
 #include <ROS2/Manipulation/JointsManipulationRequests.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/Utilities/ROS2Names.h>
+#include <ROS2/Utilities/ROS2Conversions.h>
 
 namespace ROS2
 {
@@ -24,6 +25,7 @@ namespace ROS2
         m_followTrajectoryServer = AZStd::make_unique<FollowJointTrajectoryActionServer>(namespacedAction, GetEntityId());
         AZ::TickBus::Handler::BusConnect();
         JointsTrajectoryRequestBus::Handler::BusConnect(GetEntityId());
+        m_lastTickTime = ROS2Interface::Get()->GetROSTimestamp();
     }
 
     ManipulationJoints& JointsTrajectoryComponent::GetManipulationJoints()
@@ -246,14 +248,17 @@ namespace ROS2
         }
     }
 
-    void JointsTrajectoryComponent::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    void JointsTrajectoryComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
         if (m_manipulationJoints.empty())
         {
             GetManipulationJoints();
             return;
         }
-        uint64_t deltaTimeNs = deltaTime * 1'000'000'000;
+        const auto simTimestamp = ROS2Interface::Get()->GetROSTimestamp();
+        const float deltaSimulatedTime = ROS2Conversions::GetTimeDifference(simTimestamp, m_lastTickTime);
+        m_lastTickTime = simTimestamp;
+        const uint64_t deltaTimeNs = deltaSimulatedTime * 1'000'000'000;
         FollowTrajectory(deltaTimeNs);
         UpdateFeedback();
     }

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
@@ -66,6 +66,6 @@ namespace ROS2
         rclcpp::Time m_trajectoryExecutionStartTime;
         ManipulationJoints m_manipulationJoints;
         bool m_trajectoryInProgress{ false };
-        builtin_interfaces::msg::Time m_lastTickTime;
+        builtin_interfaces::msg::Time m_lastTickTimestamp; //!< ROS 2 Timestamp during last OnTick call
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
@@ -66,5 +66,6 @@ namespace ROS2
         rclcpp::Time m_trajectoryExecutionStartTime;
         ManipulationJoints m_manipulationJoints;
         bool m_trajectoryInProgress{ false };
+        builtin_interfaces::msg::Time m_lastTickTime;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Manipulation/MotorizedJoints/JointMotorControllerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/MotorizedJoints/JointMotorControllerComponent.cpp
@@ -12,6 +12,7 @@
 #include <PhysX/Joint/PhysXJointRequestsBus.h>
 #include <PrismaticJointComponent.h>
 #include <ROS2/Manipulation/MotorizedJoints/JointMotorControllerComponent.h>
+#include <ROS2/ROS2Bus.h>
 #include <ROS2/Utilities/ROS2Conversions.h>
 #include <imgui/imgui.h>
 
@@ -19,7 +20,7 @@ namespace ROS2
 {
     void JointMotorControllerComponent::Activate()
     {
-        m_lastTickTime = ROS2::ROS2Interface::Get()->GetROSTimestamp();
+        m_lastTickTimestamp = ROS2::ROS2Interface::Get()->GetROSTimestamp();
         AZ::TickBus::Handler::BusConnect();
         ImGui::ImGuiUpdateListenerBus::Handler::BusConnect();
         AZ::EntityBus::Handler::BusConnect(GetEntityId());
@@ -88,10 +89,10 @@ namespace ROS2
         PhysX::JointRequestBus::EventResult(m_currentPosition, m_jointComponentIdPair, &PhysX::JointRequests::GetPosition);
 
         const auto timestamp = ROS2::ROS2Interface::Get()->GetROSTimestamp();
-        const float deltaSimTime = ROS2Conversions::GetTimeDifference(m_lastTickTime, timestamp);
+        const float deltaSimTime = ROS2Conversions::GetTimeDifference(m_lastTickTimestamp, timestamp);
         const float setSpeed = CalculateMotorSpeed(deltaSimTime);
         PhysX::JointRequestBus::Event(m_jointComponentIdPair, &PhysX::JointRequests::SetVelocity, setSpeed);
-        m_lastTickTime = timestamp;
+        m_lastTickTimestamp = timestamp;
     }
 
     void JointMotorControllerComponent::OnEntityActivated(const AZ::EntityId& entityId)

--- a/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
@@ -220,10 +220,8 @@ namespace ROS2
         }
     }
 
-    void ROS2SystemComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
-    {
-        if (rclcpp::ok())
-        {
+    void ROS2SystemComponent::OnTick([[maybe_unused]]float deltaTime, [[maybe_unused]]AZ::ScriptTimePoint time) {
+        if (rclcpp::ok()) {
             m_dynamicTFBroadcaster->sendTransform(m_frameTransforms);
             m_frameTransforms.clear();
 

--- a/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
@@ -220,8 +220,10 @@ namespace ROS2
         }
     }
 
-    void ROS2SystemComponent::OnTick([[maybe_unused]]float deltaTime, [[maybe_unused]]AZ::ScriptTimePoint time) {
-        if (rclcpp::ok()) {
+    void ROS2SystemComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    {
+        if (rclcpp::ok())
+        {
             m_dynamicTFBroadcaster->sendTransform(m_frameTransforms);
             m_frameTransforms.clear();
 

--- a/Gems/ROS2/Code/Source/Utilities/ROS2Conversions.cpp
+++ b/Gems/ROS2/Code/Source/Utilities/ROS2Conversions.cpp
@@ -83,4 +83,9 @@ namespace ROS2
         return ros2Covariance;
     }
 
+    float ROS2Conversions::GetTimeDifference(const builtin_interfaces::msg::Time &start,
+                                             const builtin_interfaces::msg::Time &end) {
+        return static_cast<float>(end.sec - start.sec) + static_cast<float>(end.nanosec - start.nanosec) / 1e9;
+    }
+
 } // namespace ROS2


### PR DESCRIPTION
## What does this PR do?

This PR changes number of places in codebase, where delta time is used.
In current development (and release) the delta time was taken from AZ::TickBus::OnTick.
That is a time between two OnTick. It is not simulation time.
I've changed code to get simulation time.

## How was this PR tested?

Build and run. The test effort should be part of https://github.com/o3de/o3de-extras/issues/710
