### PR TITLE
Lidar: Internal storage changed from Euler to quaternion

### DIFF
--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.cpp
@@ -64,7 +64,12 @@ namespace ROS2
     void LidarRaycaster::ConfigureRayOrientations(const AZStd::vector<AZ::Vector3>& orientations)
     {
         ValidateRayOrientations(orientations);
-        m_rayRotations = orientations;
+
+        m_rayRotations.reserve(orientations.size());
+        for (const auto& angle : orientations)
+        {
+            m_rayRotations.emplace_back(AZ::Quaternion::CreateFromEulerRadiansZYX({ 0.0f, -angle.GetY(), angle.GetZ() }));
+        }
     }
 
     void LidarRaycaster::ConfigureRayRange(float range)

--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.h
@@ -48,7 +48,7 @@ namespace ROS2
         float m_minRange{ 0.0f };
         float m_range{ 1.0f };
         bool m_addMaxRangePoints{ false };
-        AZStd::vector<AZ::Vector3> m_rayRotations{ { AZ::Vector3::CreateZero() } };
+        AZStd::vector<AZ::Quaternion> m_rayRotations{ { AZ::Quaternion::CreateZero() } };
 
         AZStd::unordered_set<AZ::u32> m_ignoredCollisionLayers;
     };

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.cpp
@@ -266,14 +266,13 @@ namespace ROS2
     }
 
     AZStd::vector<AZ::Vector3> LidarTemplateUtils::RotationsToDirections(
-        const AZStd::vector<AZ::Vector3>& rotations, const AZ::Transform& rootTransform)
+        const AZStd::vector<AZ::Quaternion>& rotations, const AZ::Transform& rootTransform)
     {
         AZStd::vector<AZ::Vector3> directions;
         directions.reserve(rotations.size());
         for (const auto& angle : rotations)
         {
-            const AZ::Quaternion rotation =
-                rootTransform.GetRotation() * AZ::Quaternion::CreateFromEulerRadiansZYX({ 0.0f, -angle.GetY(), angle.GetZ() });
+            const AZ::Quaternion rotation = rootTransform.GetRotation() * angle;
             directions.emplace_back(rotation.TransformVector(AZ::Vector3::CreateAxisX()));
         }
 

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.h
@@ -43,6 +43,7 @@ namespace ROS2
         //! @param rotations Rotations as Euler angles in radians to compute directions from.
         //! @param rootRotation Root rotation as Euler angles in radians.
         //! @return Ray directions constructed by transforming an X axis unit vector by the provided rotations.
-        AZStd::vector<AZ::Vector3> RotationsToDirections(const AZStd::vector<AZ::Vector3>& rotations, const AZ::Transform& rootTransform);
+        AZStd::vector<AZ::Vector3> RotationsToDirections(
+            const AZStd::vector<AZ::Quaternion>& rotations, const AZ::Transform& rootTransform);
     }; // namespace LidarTemplateUtils
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarTemplateUtils.h
@@ -40,8 +40,8 @@ namespace ROS2
         AZStd::vector<AZ::Vector3> PopulateRayRotations(const LidarTemplate& lidarTemplate);
 
         //! Compute ray directions from rotations.
-        //! @param rotations Rotations as Euler angles in radians to compute directions from.
-        //! @param rootRotation Root rotation as Euler angles in radians.
+        //! @param rotations Rotations as quaternions to compute directions from.
+        //! @param rootTransform root transformation of Lidar sensor.
         //! @return Ray directions constructed by transforming an X axis unit vector by the provided rotations.
         AZStd::vector<AZ::Vector3> RotationsToDirections(
             const AZStd::vector<AZ::Quaternion>& rotations, const AZ::Transform& rootTransform);


### PR DESCRIPTION
## What does this PR do?

Closes #488 

Now Lidar converts data about raycast angles right after receiving them as input, instead of converting them only during performing raycast requests.

## How was this PR tested?

Tested on basic ROS2 project template using rviz2. Outputs correspond with previous version both for 2D and 3D Lidar components.
