### PR TITLE
Fixes for templates

### DIFF
--- a/Gems/RosRobotSample/Assets/ROSbot.prefab
+++ b/Gems/RosRobotSample/Assets/ROSbot.prefab
@@ -284,7 +284,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{D5BE771A-53A9-534E-8DCC-A91D6127540D}"
-                                            }
+                                            },
+                                            "assetHint": "robot/rosbot_xl_description/meshes/materials/antenna_plastic_-_matte_black_.azmaterial"
                                         }
                                     }
                                 }
@@ -332,7 +333,8 @@
                                         "MaterialAsset": {
                                             "assetId": {
                                                 "guid": "{D5BE771A-53A9-534E-8DCC-A91D6127540D}"
-                                            }
+                                            },
+                                            "assetHint": "robot/rosbot_xl_description/meshes/materials/antenna_plastic_-_matte_black_.azmaterial"
                                         }
                                     }
                                 }
@@ -1306,7 +1308,7 @@
                                     "guid": "{7F445A99-8C11-5417-9D63-8BCC7DCA76C8}",
                                     "subId": 1509562746
                                 },
-                                "assetHint": "robot/rosbot_xl_description/meshes/body_colision.pxmesh"
+                                "assetHint": "robot/rosbot_xl_description/meshes/body_colision.stl.pxmesh"
                             },
                             "Configuration": {
                                 "PhysicsAsset": {
@@ -1315,7 +1317,7 @@
                                         "subId": 1509562746
                                     },
                                     "loadBehavior": "QueueLoad",
-                                    "assetHint": "robot/rosbot_xl_description/meshes/body_colision.pxmesh"
+                                    "assetHint": "robot/rosbot_xl_description/meshes/body_colision.stl.pxmesh"
                                 },
                                 "UseMaterialsFromAsset": false
                             }
@@ -1389,8 +1391,8 @@
                                     "IsDrive": true
                                 }
                             ],
-                            "Track": 0.17000000178813934,
-                            "Wheelbase": 0.24799999594688416
+                            "Track": 0.27000001072883606,
+                            "Wheelbase": 0.3319999873638153
                         },
                         "DriveModel": {
                             "Limits": {
@@ -2032,8 +2034,7 @@
                     "Id": 16056351394850261418,
                     "Controller": {
                         "Configuration": {
-                            "Field of View": 60.0,
-                            "EditorEntityId": 15598184734561212878
+                            "Field of View": 60.0
                         }
                     }
                 },

--- a/Gems/RosRobotSample/gem.json
+++ b/Gems/RosRobotSample/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "RosRobotSample",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "display_name": "ROS Robot Sample",
     "license": "Apache-2.0 or MIT",
     "license_url": "https://opensource.org/licenses/Apache-2.0",

--- a/Templates/Multiplayer/Template/Gem/Source/${Name}Module.cpp
+++ b/Templates/Multiplayer/Template/Gem/Source/${Name}Module.cpp
@@ -2,7 +2,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
 
-#include "${Name}SystemComponent.h"
+#include "${SanitizedCppName}SystemComponent.h"
 
 #include <${SanitizedCppName}/${SanitizedCppName}TypeIds.h>
 #include <Components/AttachPlayerWeaponComponent.h>

--- a/Templates/Multiplayer/Template/Gem/Source/${Name}Module.cpp
+++ b/Templates/Multiplayer/Template/Gem/Source/${Name}Module.cpp
@@ -2,7 +2,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
 
-#include "${SanitizedCppName}SystemComponent.h"
+#include "${Name}SystemComponent.h"
 
 #include <${SanitizedCppName}/${SanitizedCppName}TypeIds.h>
 #include <Components/AttachPlayerWeaponComponent.h>

--- a/Templates/Ros2FleetRobotTemplate/Template/project.json
+++ b/Templates/Ros2FleetRobotTemplate/Template/project.json
@@ -39,6 +39,7 @@
         "StartingPointInput",
         "TextureAtlas",
         "WhiteBox",
-        "WarehouseAssets"
+        "WarehouseAssets",
+        "${Name}"
     ]
 }

--- a/Templates/Ros2ProjectTemplate/Template/Gem/Source/${Name}EditorModule.cpp
+++ b/Templates/Ros2ProjectTemplate/Template/Gem/Source/${Name}EditorModule.cpp
@@ -11,7 +11,7 @@
 #include <${Name}ModuleInterface.h>
 #include "${Name}EditorSystemComponent.h"
 
-#include "${SanitizedCppName}SampleComponent.h"
+#include "${Name}SampleComponent.h"
 namespace ${SanitizedCppName}
 {
     class ${SanitizedCppName}EditorModule

--- a/Templates/Ros2ProjectTemplate/Template/Gem/Source/${Name}Module.cpp
+++ b/Templates/Ros2ProjectTemplate/Template/Gem/Source/${Name}Module.cpp
@@ -12,7 +12,7 @@
 #include <AzCore/Module/Module.h>
 
 #include "${Name}SystemComponent.h"
-#include "${SanitizedCppName}SampleComponent.h"
+#include "${Name}SampleComponent.h"
 
 namespace ${SanitizedCppName}
 {

--- a/Templates/Ros2ProjectTemplate/Template/Gem/Source/${Name}SampleComponent.cpp
+++ b/Templates/Ros2ProjectTemplate/Template/Gem/Source/${Name}SampleComponent.cpp
@@ -9,7 +9,7 @@
  */
 // {END_LICENSE}
 
-#include "${SanitizedCppName}SampleComponent.h"
+#include "${Name}SampleComponent.h"
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Math/Transform.h>

--- a/Templates/Ros2ProjectTemplate/Template/project.json
+++ b/Templates/Ros2ProjectTemplate/Template/project.json
@@ -41,6 +41,6 @@
         "StartingPointInput",
         "TextureAtlas",
         "WhiteBox",
-        "WarehouseSample"
+        "${Name}"
     ]    
 }

--- a/Templates/Ros2ProjectTemplate/Template/project.json
+++ b/Templates/Ros2ProjectTemplate/Template/project.json
@@ -41,6 +41,7 @@
         "StartingPointInput",
         "TextureAtlas",
         "WhiteBox",
+        "WarehouseSample",
         "${Name}"
     ]    
 }

--- a/Templates/Ros2RoboticManipulationTemplate/Template/Gem/Source/${Name}Module.cpp
+++ b/Templates/Ros2RoboticManipulationTemplate/Template/Gem/Source/${Name}Module.cpp
@@ -2,7 +2,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
 
-#include "${SanitizedCppName}SystemComponent.h"
+#include "${Name}SystemComponent.h"
 
 namespace ${SanitizedCppName}
 {

--- a/Templates/Ros2RoboticManipulationTemplate/Template/Gem/Source/${Name}SystemComponent.cpp
+++ b/Templates/Ros2RoboticManipulationTemplate/Template/Gem/Source/${Name}SystemComponent.cpp
@@ -3,7 +3,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 
-#include "${SanitizedCppName}SystemComponent.h"
+#include "${Name}SystemComponent.h"
 
 namespace ${SanitizedCppName}
 {

--- a/Templates/Ros2RoboticManipulationTemplate/Template/Gem/Source/${Name}SystemComponent.h
+++ b/Templates/Ros2RoboticManipulationTemplate/Template/Gem/Source/${Name}SystemComponent.h
@@ -3,7 +3,7 @@
 
 #include <AzCore/Component/Component.h>
 
-#include <${SanitizedCppName}/${SanitizedCppName}Bus.h>
+#include <${Name}/${Name}Bus.h>
 
 namespace ${SanitizedCppName}
 {

--- a/Templates/Ros2RoboticManipulationTemplate/Template/project.json
+++ b/Templates/Ros2RoboticManipulationTemplate/Template/project.json
@@ -40,6 +40,7 @@
         "Compression",
         "WarehouseAssets",
         "WarehouseAutomation>=2.0.0",
-        "ROS2>=3.1.0"
+        "ROS2>=3.1.0",
+        "${Name}"
     ]
 }


### PR DESCRIPTION
## What does this PR do?

This PR fixes multiple aspects of templates:
1. The templates were not using own Gems, which causes issues when some implementation matters (closes #722 )
2. Templates used to create the files that were named `{Name}Something.h`, but including `{Sanitized}Something.h`
3. ROSBot prefab parameters were set incorrectly, it was fixed based on the [specification](https://docs-new.s3.eu-west-1.amazonaws.com/pdf/ROSbot_XL_Overall_Dimensions.pdf)
4. Cherry-pick of #721 

Note: this PR conflicts with https://github.com/o3de/o3de-extras/pull/718 and cherry-picks changes from https://github.com/o3de/o3de-extras/pull/721 to reduce the number of conflicts and separate PRs doing the same

## How was this PR tested?

Templates were run. 