### PR TITLE
Lidar: Fixed data acquisition while publishing disabled

### DIFF
--- a/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.cpp
@@ -79,10 +79,6 @@ namespace ROS2
             m_sensorConfiguration.m_frequency,
             [this]([[maybe_unused]] auto&&... args)
             {
-                if (!m_sensorConfiguration.m_publishingEnabled)
-                {
-                    return;
-                }
                 FrequencyTick();
             },
             [this]([[maybe_unused]] auto&&... args)
@@ -111,6 +107,11 @@ namespace ROS2
     void ROS2Lidar2DSensorComponent::FrequencyTick()
     {
         RaycastResult lastScanResults = m_lidarCore.PerformRaycast();
+
+        if (!m_sensorConfiguration.m_publishingEnabled)
+        { // Skip publishing when it is disabled.
+            return;
+        }
 
         auto* ros2Frame = GetEntity()->FindComponent<ROS2FrameComponent>();
         auto message = sensor_msgs::msg::LaserScan();

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -107,10 +107,6 @@ namespace ROS2
             m_sensorConfiguration.m_frequency,
             [this]([[maybe_unused]] auto&&... args)
             {
-                if (!m_sensorConfiguration.m_publishingEnabled)
-                {
-                    return;
-                }
                 FrequencyTick();
             },
             [this]([[maybe_unused]] auto&&... args)
@@ -135,7 +131,7 @@ namespace ROS2
     {
         auto entityTransform = GetEntity()->FindComponent<AzFramework::TransformComponent>();
 
-        if (m_canRaycasterPublish)
+        if (m_canRaycasterPublish && m_sensorConfiguration.m_publishingEnabled)
         {
             const builtin_interfaces::msg::Time timestamp = ROS2Interface::Get()->GetROSTimestamp();
             LidarRaycasterRequestBus::Event(
@@ -146,8 +142,8 @@ namespace ROS2
 
         auto lastScanResults = m_lidarCore.PerformRaycast();
 
-        if (m_canRaycasterPublish)
-        { // Skip publishing when it can be handled by the raycaster.
+        if (m_canRaycasterPublish || !m_sensorConfiguration.m_publishingEnabled)
+        { // Skip publishing when it is disabled or can be handled by the raycaster.
             return;
         }
 


### PR DESCRIPTION
## What does this PR do?

Closes #462

Now Lidar acquires data about raycast results even when publishing is disabled, making it possible to visualise results independently from publishing.

Even though issue #462 suggests otherwise, problem with visualisation seems to only apply to Lidar components and further corrections are unnecessary.

## How was this PR tested?

Tested on basic ROS2 project template using rviz2. Visualisation works independently from publishing (and vice-versa).
