### PR TITLE
Fix bug in a spawner component

### DIFF
--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -189,8 +189,14 @@ namespace ROS2
             PreSpawn(id, view, transform, spawnableName, spawnableNamespace);
         };
 
-        optionalArgs.m_completionCallback = [service_handle, header, ticketName](auto id, auto view)
+        optionalArgs.m_completionCallback = [service_handle, header, ticketName, parentId = GetEntityId()](auto id, auto view)
         {
+            if (!view.empty())
+            {
+                const AZ::Entity* root = *view.begin();
+                auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
+                transformInterface->SetParent(parentId);
+            }
             SpawnEntityResponse response;
             response.success = true;
             response.status_message = ticketName.c_str();
@@ -215,7 +221,6 @@ namespace ROS2
 
         auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
         transformInterface->SetWorldTM(transform);
-        transformInterface->SetParent(GetEntityId());
 
         AZStd::string instanceName = AZStd::string::format("%s_%d", spawnableName.c_str(), m_counter++);
         for (AZ::Entity* entity : view)


### PR DESCRIPTION
## What does this PR do?

This PR is a small fix for ROS2SpawnerComponent. The behavior of setting a parent Id of a spawnable might not work as intended, since the entity id is not yet attached during preinsertion callback.
Old behavior manifested itself as warnings in the log console:
![image](https://github.com/o3de/o3de-extras/assets/1521294/74e35d81-be1f-4b09-bc7c-e9dcbb1b8d32)
The new behavior moves setting the parent into completion callback when the entity id is already well-defined.

## How was this PR tested?

It was tested in an internal project.
