### PR TITLE
Extend description of frames in o3de

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameConfiguration.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameConfiguration.h
@@ -34,6 +34,7 @@ namespace ROS2
 
     private:
         AZStd::string m_effectiveNamespace = "";
+        AZStd::string m_fullName = m_frameName;
     };
 
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameConfiguration.cpp
@@ -44,8 +44,12 @@ namespace ROS2
                         &ROS2FrameConfiguration::m_publishTransform,
                         "Publish Transform",
                         "Publish Transform")
-                    ->UIElement(AZ::Edit::UIHandlers::Label, "Effective namespace", "")
-                    ->Attribute(AZ::Edit::Attributes::ValueText, &ROS2FrameConfiguration::m_effectiveNamespace);
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "Info")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                                ->UIElement(AZ::Edit::UIHandlers::Label, "Effective namespace", "")
+                                ->Attribute(AZ::Edit::Attributes::ValueText, &ROS2FrameConfiguration::m_effectiveNamespace)
+                                ->UIElement(AZ::Edit::UIHandlers::Label, "Full name", "")
+                                ->Attribute(AZ::Edit::Attributes::ValueText, &ROS2FrameConfiguration::m_fullName);
             }
         }
     }
@@ -53,6 +57,7 @@ namespace ROS2
     void ROS2FrameConfiguration::SetEffectiveNamespace(const AZStd::string& effectiveNamespace)
     {
         m_effectiveNamespace = effectiveNamespace;
+        m_fullName = effectiveNamespace + '/' + m_frameName;
     }
 
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameConfiguration.cpp
@@ -46,10 +46,10 @@ namespace ROS2
                         "Publish Transform")
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Info")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                                ->UIElement(AZ::Edit::UIHandlers::Label, "Effective namespace", "")
-                                ->Attribute(AZ::Edit::Attributes::ValueText, &ROS2FrameConfiguration::m_effectiveNamespace)
-                                ->UIElement(AZ::Edit::UIHandlers::Label, "Full name", "")
-                                ->Attribute(AZ::Edit::Attributes::ValueText, &ROS2FrameConfiguration::m_fullName);
+                    ->UIElement(AZ::Edit::UIHandlers::Label, "Effective namespace", "")
+                    ->Attribute(AZ::Edit::Attributes::ValueText, &ROS2FrameConfiguration::m_effectiveNamespace)
+                    ->UIElement(AZ::Edit::UIHandlers::Label, "Full name", "")
+                    ->Attribute(AZ::Edit::Attributes::ValueText, &ROS2FrameConfiguration::m_fullName);
             }
         }
     }

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameSystemComponent.h
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameSystemComponent.h
@@ -20,9 +20,9 @@
 
 namespace ROS2
 {
-    // Handler class for the ROS2FrameEditorComponent. It watches for changes in the entity tree and notifies about moves.
-    // Used by the ROS2FrameSystemComponent, to track changes in the entity tree. It notifies the ROS2FrameSystemComponent
-    // and calls the appropriate functions to update the changes.
+    //! Handler class for the ROS2FrameEditorComponent. It watches for changes in the entity tree and notifies about moves.
+    //! Used by the ROS2FrameSystemComponent, to track changes in the entity tree. It notifies the ROS2FrameSystemComponent
+    //! and calls the appropriate functions to update the changes.
     class ROS2FrameSystemTransformHandler : public AZ::TransformNotificationBus::Handler
     {
     public:

--- a/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarRaycaster.h
@@ -16,6 +16,7 @@
 
 namespace ROS2
 {
+    //! A class for executing lidar raycast.
     class LidarRaycaster : protected LidarRaycasterRequestBus::Handler
     {
     public:

--- a/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarSystem.h
@@ -12,6 +12,7 @@
 
 namespace ROS2
 {
+    //! A class for managing Lidar
     class LidarSystem : protected ROS2::LidarSystemRequestBus::Handler
     {
     public:

--- a/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
@@ -43,7 +43,8 @@ namespace ROS2
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                     ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
-                    ->ElementAttribute(AZ::Edit::Attributes::AutoExpand, true);
+                    ->ElementAttribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->ElementAttribute(AZ::Edit::Attributes::NameLabelOverride, "Publisher configuration");
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Closes #159 

* Adds Info category in O3DE ROS2 Frame description, containing non-editable fields displaying namespace and full name of the Frame.
* Changes awkward category name in O3DE sensor editors to clearer "Publisher configuration".
* Adds and fixes some comments for doxygen documentation.


## How was this PR tested?

With namespace and frame names changes being applied, info category gets changed accordingly, displaying correct information.
