### PR TITLE
Bump minor version for ROS2 gem for the development branch

### DIFF
--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ROS2",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "platforms": [
         "Linux"
     ],
@@ -36,6 +36,5 @@
     ],
     "restricted": "ROS2",
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.1.0-gem.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.2.0-gem.zip"
 }
-

--- a/repo.json
+++ b/repo.json
@@ -201,6 +201,27 @@
                     ],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.1.0-gem.zip",
                     "sha256": "aace14afcbe3feda0be0b11cb3610d93ec8e3e55a7b2f185df51ea468e7e7554"
+                },
+                {
+                    "version": "3.2.0",
+                    "origin_url": "https://robotec.ai",
+                    "source_control_uri": "https://github.com/o3de/o3de-extras/development/Gems/ROS2",
+                    "compatible_engines": [
+                        "o3de-sdk>=2.3.0",
+                        "o3de>=2.3.0"
+                    ],
+                    "documentation_url": "https://docs.o3de.org/docs/user-guide/gems/reference/robotics/ros2/",
+                    "dependencies": [
+                        "Atom_RPI",
+                        "Atom_Feature_Common",
+                        "Atom_Component_DebugCamera",
+                        "CommonFeaturesAtom",
+                        "PhysX5",
+                        "PrimitiveAssets",
+                        "StartingPointInput"
+                    ],
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.2.0-gem.zip",
+                    "sha256": "6711adfe023a96151072fcba3f4757f834607ca596db619bceed8f20f12b3785"
                 }
             ]
         },


### PR DESCRIPTION
## What does this PR do?

This bumps the version of the ROS2 gem from version 3.1.0 -> 3.2.0 now that 3.1.0 is the candidate version for the upcoming O3DE 2409 release.

note: ROS2 version 3.2.0 has been uploaded to o3de-extras releases (https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.2.0-gem.zip)

## How was this PR tested?
Tested configuring projects with ProjectManager
