### PR TITLE
Added support to do MSAA Resolve

### DIFF
--- a/Gems/OpenXRVk/Code/Source/OpenXRVkSwapChain.cpp
+++ b/Gems/OpenXRVk/Code/Source/OpenXRVkSwapChain.cpp
@@ -187,7 +187,12 @@ namespace OpenXRVk
                     swapchainCreateInfo.mipCount = m_mipCount;
                     swapchainCreateInfo.faceCount = m_faceCount;
                     swapchainCreateInfo.sampleCount = m_sampleCount;
-                    swapchainCreateInfo.usageFlags = XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
+                    swapchainCreateInfo.usageFlags = XR_SWAPCHAIN_USAGE_SAMPLED_BIT |
+                                                     XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT |
+                                                     XR_SWAPCHAIN_USAGE_TRANSFER_SRC_BIT |
+                                                     XR_SWAPCHAIN_USAGE_TRANSFER_DST_BIT |
+                                                     XR_SWAPCHAIN_USAGE_INPUT_ATTACHMENT_BIT_KHR
+                                                     ;
 
                     XrSwapchain handle = XR_NULL_HANDLE;
                     result = xrCreateSwapchain(xrSession, &swapchainCreateInfo, &handle);


### PR DESCRIPTION
## What does this PR do?
Added support to do MSAA Resolve
directly on XR Swapchain Attachments by adding
XR_SWAPCHAIN_USAGE_TRANSFER_DST_BIT usage flag
to the XrSwapchainCreateInfo.

Also, matched Swapchain attachment usage flags
as done by Atom Vulkan library in
/o3de/Gems/Atom/RHI/VulkanCode\Source\RHI\SwapChain.cpp
```cpp
createInfo.imageUsage = VK_IMAGE_USAGE_TRANSFER_DST_BIT |
                        VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
			VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
                        VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
```

The whole XR Swapchain creation usage flags changed from:
```cpp
swapchainCreateInfo.usageFlags = XR_SWAPCHAIN_USAGE_SAMPLED_BIT |
                                 XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
```
to:
```cpp
swapchainCreateInfo.usageFlags = XR_SWAPCHAIN_USAGE_SAMPLED_BIT |
                                 XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT |
                                 XR_SWAPCHAIN_USAGE_TRANSFER_SRC_BIT |
                                 XR_SWAPCHAIN_USAGE_TRANSFER_DST_BIT |
                                 XR_SWAPCHAIN_USAGE_INPUT_ATTACHMENT_BIT_KHR;
```
The changes, in addition to enabling direct MSAA Resolve into the Swapchain, also enables the usage of Swapchain attachments as inputs of Vulkan subpasses.


## How was this PR tested?
After these changes the following Validation errors don't show up anymore when using a Render Pipeline that resolves directly
into the SwapChain:
```
[Error] (vkDebugMessage) - [ERROR][Validation] Validation Error: [ VUID-vkCmdBeginRenderPass-initialLayout-00899 ] 
Object 0: handle = 0x25c5eb0000000576, name = [Merged];Root.Right_SubpassPrototypePipeline_-10.RenderToSwapchainForward;Root.Right_SubpassPrototypePipeline_-10.SkyBoxPass, type = VK_OBJECT_TYPE_RENDER_PASS;
Object 1: handle = 0x378ecb0000000577, name = [Merged];Root.Left_SubpassPrototypePipeline_-10.RenderToSwapchainForward;Root.Left_SubpassPrototypePipeline_-10.SkyBoxPass, type = VK_OBJECT_TYPE_FRAMEBUFFER;
Object 2: handle = 0x3abf590000000574, type = VK_OBJECT_TYPE_IMAGE_VIEW;
Object 3: handle = 0x4b7df1000000002f, name = SwapChainImage_0, type = VK_OBJECT_TYPE_IMAGE; 
| MessageID = 0x8b42becf | vkCmdBeginRenderPass(): Layout/usage mismatch for attachment 2 in
 VkRenderPass 0x25c5eb0000000576[[Merged];Root.Right_SubpassPrototypePipeline_-10.RenderToSwapchainForward;Root.Right_SubpassPrototypePipeline_-10.SkyBoxPass]
  - the initial layout is VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL but the image attached to 
  VkFramebuffer 0x378ecb0000000577[[Merged];Root.Left_SubpassPrototypePipeline_-10.RenderToSwapchainForward;Root.Left_SubpassPrototypePipeline_-10.SkyBoxPass]
via VkImageView 0x3abf590000000574[] was not created with VK_IMAGE_USAGE_TRANSFER_DST_BIT.
 Image usage: VK_IMAGE_USAGE_SAMPLED_BIT|VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT. The Vulkan spec states: If any of the initialLayout or finalLayout member of the VkAttachmentDescription structures or the layout member of the VkAttachmentReference structures specified when creating the render pass specified in the renderPass member of pRenderPassBegin is VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL then the corresponding attachment image view of the framebuffer specified in the framebuffer member of pRenderPassBegin must have been created with a usage value including VK_IMAGE_USAGE_TRANSFER_DST_BIT (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdBeginRenderPass-initialLayout-00899)
```
