### PR TITLE
RobotImporter features: topic names, namespaces, handling plugins, joints

### DIFF
--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.cpp
@@ -29,6 +29,11 @@ namespace ROS2
         m_jointStatePublisherConfiguration.m_frequency = 25.0f;
     }
 
+    JointsManipulationEditorComponent::JointsManipulationEditorComponent(const PublisherConfiguration& publisherConfiguration)
+    {
+        m_jointStatePublisherConfiguration = publisherConfiguration;
+    }
+
     void JointsManipulationEditorComponent::BuildGameEntity(AZ::Entity* gameEntity)
     {
         gameEntity->CreateComponent<JointsManipulationComponent>(

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.h
@@ -22,10 +22,7 @@ namespace ROS2
     {
     public:
         JointsManipulationEditorComponent();
-        JointsManipulationEditorComponent(const PublisherConfiguration& publisherConfiguration)
-        {
-            m_jointStatePublisherConfiguration = publisherConfiguration;
-        }
+        JointsManipulationEditorComponent(const PublisherConfiguration& publisherConfiguration);
         ~JointsManipulationEditorComponent() = default;
         AZ_EDITOR_COMPONENT(JointsManipulationEditorComponent, "{BF2F77FD-92FB-4730-92C7-DDEE54F508BF}");
 

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.h
@@ -33,6 +33,8 @@ namespace ROS2
         // AzToolsFramework::Components::EditorComponentBase overrides
         void BuildGameEntity(AZ::Entity* gameEntity) override;
 
+        //! publisherConfiguration seter
+        //! @param publisherConfiguration configuration to be set
         void SetPublisherConfiguration(const PublisherConfiguration& publisherConfiguration)
         {
             m_jointStatePublisherConfiguration = publisherConfiguration;

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.h
@@ -22,6 +22,10 @@ namespace ROS2
     {
     public:
         JointsManipulationEditorComponent();
+        JointsManipulationEditorComponent(const PublisherConfiguration& publisherConfiguration)
+        {
+            m_jointStatePublisherConfiguration = publisherConfiguration;
+        }
         ~JointsManipulationEditorComponent() = default;
         AZ_EDITOR_COMPONENT(JointsManipulationEditorComponent, "{BF2F77FD-92FB-4730-92C7-DDEE54F508BF}");
 
@@ -32,13 +36,6 @@ namespace ROS2
 
         // AzToolsFramework::Components::EditorComponentBase overrides
         void BuildGameEntity(AZ::Entity* gameEntity) override;
-
-        //! publisherConfiguration seter
-        //! @param publisherConfiguration configuration to be set
-        void SetPublisherConfiguration(const PublisherConfiguration& publisherConfiguration)
-        {
-            m_jointStatePublisherConfiguration = publisherConfiguration;
-        }
 
     private:
         AZ::Crc32 ReloadJoints();

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.h
@@ -33,6 +33,11 @@ namespace ROS2
         // AzToolsFramework::Components::EditorComponentBase overrides
         void BuildGameEntity(AZ::Entity* gameEntity) override;
 
+        void SetPublisherConfiguration(const PublisherConfiguration& publisherConfiguration)
+        {
+            m_jointStatePublisherConfiguration = publisherConfiguration;
+        }
+
     private:
         AZ::Crc32 ReloadJoints();
 

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
@@ -18,7 +18,7 @@
 namespace ROS2
 {
     JointsTrajectoryComponent::JointsTrajectoryComponent(AZStd::string followTrajectoryActionName)
-        :m_followTrajectoryActionName(followTrajectoryActionName)
+        : m_followTrajectoryActionName(followTrajectoryActionName)
     {
     }
 

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
@@ -17,7 +17,7 @@
 
 namespace ROS2
 {
-    JointsTrajectoryComponent::JointsTrajectoryComponent(AZStd::string followTrajectoryActionName)
+    JointsTrajectoryComponent::JointsTrajectoryComponent(const AZStd::string& followTrajectoryActionName)
         : m_followTrajectoryActionName(followTrajectoryActionName)
     {
     }

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
@@ -17,6 +17,11 @@
 
 namespace ROS2
 {
+    JointsTrajectoryComponent::JointsTrajectoryComponent(AZStd::string followTrajectoryActionName)
+        :m_followTrajectoryActionName(followTrajectoryActionName)
+    {
+    }
+
     void JointsTrajectoryComponent::Activate()
     {
         auto* ros2Frame = GetEntity()->FindComponent<ROS2FrameComponent>();

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
@@ -26,7 +26,7 @@ namespace ROS2
     {
     public:
         JointsTrajectoryComponent() = default;
-        JointsTrajectoryComponent(AZStd::string followTrajectoryActionName);
+        JointsTrajectoryComponent(const AZStd::string& followTrajectoryActionName);
         ~JointsTrajectoryComponent() = default;
         AZ_COMPONENT(JointsTrajectoryComponent, "{429DE04C-6B6D-4B2D-9D6C-3681F23CBF90}", AZ::Component);
 

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
@@ -26,6 +26,7 @@ namespace ROS2
     {
     public:
         JointsTrajectoryComponent() = default;
+        JointsTrajectoryComponent(AZStd::string followTrajectoryActionName);
         ~JointsTrajectoryComponent() = default;
         AZ_COMPONENT(JointsTrajectoryComponent, "{429DE04C-6B6D-4B2D-9D6C-3681F23CBF90}", AZ::Component);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -71,7 +71,7 @@ namespace ROS2
         m_sensorHooks.emplace_back(SDFormat::ROS2SensorHooks::ROS2GNSSSensor());
         m_sensorHooks.emplace_back(SDFormat::ROS2SensorHooks::ROS2ImuSensor());
         m_sensorHooks.emplace_back(SDFormat::ROS2SensorHooks::ROS2LidarSensor());
-	    m_modelPluginHooks.emplace_back(SDFormat::ROS2ModelPluginHooks::ROS2AckermannModel());
+        m_modelPluginHooks.emplace_back(SDFormat::ROS2ModelPluginHooks::ROS2AckermannModel());
         m_modelPluginHooks.emplace_back(SDFormat::ROS2ModelPluginHooks::ROS2SkidSteeringModel());
         m_modelPluginHooks.emplace_back(SDFormat::ROS2ModelPluginHooks::ROS2JointStatePublisherModel());
         m_modelPluginHooks.emplace_back(SDFormat::ROS2ModelPluginHooks::ROS2JointPoseTrajectoryModel());

--- a/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/ROS2RobotImporterEditorSystemComponent.cpp
@@ -71,8 +71,10 @@ namespace ROS2
         m_sensorHooks.emplace_back(SDFormat::ROS2SensorHooks::ROS2GNSSSensor());
         m_sensorHooks.emplace_back(SDFormat::ROS2SensorHooks::ROS2ImuSensor());
         m_sensorHooks.emplace_back(SDFormat::ROS2SensorHooks::ROS2LidarSensor());
-	m_modelPluginHooks.emplace_back(SDFormat::ROS2ModelPluginHooks::ROS2AckermannModel());
+	    m_modelPluginHooks.emplace_back(SDFormat::ROS2ModelPluginHooks::ROS2AckermannModel());
         m_modelPluginHooks.emplace_back(SDFormat::ROS2ModelPluginHooks::ROS2SkidSteeringModel());
+        m_modelPluginHooks.emplace_back(SDFormat::ROS2ModelPluginHooks::ROS2JointStatePublisherModel());
+        m_modelPluginHooks.emplace_back(SDFormat::ROS2ModelPluginHooks::ROS2JointPoseTrajectoryModel());
 
         // Query user-defined sensor and plugin hooks
         auto serializeContext = AZ::Interface<AZ::ComponentApplicationRequests>::Get()->GetSerializeContext();

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2AckermannModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2AckermannModelHook.cpp
@@ -158,12 +158,12 @@ namespace ROS2::SDFormat
         VehicleDynamics::VehicleConfiguration GetConfiguration(
             const sdf::ElementPtr element, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)
         {
-            const AZStd::array<std::string, Wheels::Total> jointNamesSDFormat{ { "front_left_joint",
-                                                                                 "front_right_joint",
-                                                                                 "rear_left_joint",
-                                                                                 "rear_right_joint",
-                                                                                 "left_steering_joint",
-                                                                                 "right_steering_joint" } };
+            const static AZStd::array<std::string, Wheels::Total> jointNamesSDFormat{ { "front_left_joint",
+                                                                                        "front_right_joint",
+                                                                                        "rear_left_joint",
+                                                                                        "rear_right_joint",
+                                                                                        "left_steering_joint",
+                                                                                        "right_steering_joint" } };
             // Stores description of all joints in the SDF and a mapping to O3DE entities
             struct JointMapping
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2AckermannModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2AckermannModelHook.cpp
@@ -314,7 +314,7 @@ namespace ROS2::SDFormat
             }
             else
             {
-                return AZ::Failure(AZStd::string("Failed to create ROS2 Ackermann Control Component"));
+                return AZ::Failure(AZStd::string("Failed to create ROS 2 Ackermann Control Component"));
             }
         };
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -31,7 +31,8 @@ namespace ROS2::SDFormat
                                                                           "libgazebo_ros_openni_kinect.so" };
         importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{
             ">imageTopicName", ">cameraInfoTopicName", ">depthImageTopicName", ">depthImageCameraInfoTopicName",
-            ">ros>remapping", ">ros>argument"
+            ">ros>remapping",  ">ros>argument",        ">ros>frame_name",      ">ros>namespace",
+            ">frameName",      ">robotNamespace"
         };
         importerHook.m_sdfSensorToComponentCallback = [](AZ::Entity& entity,
                                                          const sdf::Sensor& sdfSensor) -> SensorImporterHook::ConvertSensorOutcome
@@ -68,13 +69,14 @@ namespace ROS2::SDFormat
             sensorConfiguration.m_frequency = sdfSensor.UpdateRate();
 
             const auto cameraPlugins = sdfSensor.Plugins();
-            HooksUtils::PluginParams cameraPluginParams = cameraPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(cameraPlugins[0]);
+            HooksUtils::PluginParams cameraPluginParams =
+                cameraPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(cameraPlugins[0]);
 
             // add depth_camera for plugins kinnect and depth_camera
             // check only the 1st plugin as it's the only one considered afterwards
             if (!cameraPlugins.empty() &&
                 (cameraPlugins[0].Filename() == "libgazebo_ros_depth_camera.so" ||
-                cameraPlugins[0].Filename() == "libgazebo_ros_openni_kinect.so"))
+                 cameraPlugins[0].Filename() == "libgazebo_ros_openni_kinect.so"))
             {
                 cameraConfiguration.m_depthCamera = true;
             }
@@ -83,17 +85,21 @@ namespace ROS2::SDFormat
             { // COLOR_CAMERA and RGBD_CAMERA
                 AZStd::string imageColor = "camera_image_color", colorInfo = "camera_color_info";
 
-                if (cameraPluginParams.contains("image_raw")) {
+                if (cameraPluginParams.contains("image_raw"))
+                {
                     imageColor = cameraPluginParams["image_raw"];
                 }
-                else if (cameraPluginParams.contains("imageTopicName")) {
+                else if (cameraPluginParams.contains("imageTopicName"))
+                {
                     imageColor = HooksUtils::PluginParser::LastOnPath(cameraPluginParams["imageTopicName"]);
                 }
 
-                if (cameraPluginParams.contains("camera_info")) {
+                if (cameraPluginParams.contains("camera_info"))
+                {
                     colorInfo = cameraPluginParams["camera_info"];
                 }
-                else if (cameraPluginParams.contains("cameraInfoTopicName")) {
+                else if (cameraPluginParams.contains("cameraInfoTopicName"))
+                {
                     colorInfo = HooksUtils::PluginParser::LastOnPath(cameraPluginParams["cameraInfoTopicName"]);
                 }
 
@@ -106,17 +112,21 @@ namespace ROS2::SDFormat
             { // DEPTH_CAMERA and RGBD_CAMERA
                 AZStd::string imageDepth = "camera_image_depth", depthInfo = "depth_camera_info";
 
-                if (cameraPluginParams.contains("image_depth")) {
+                if (cameraPluginParams.contains("image_depth"))
+                {
                     imageDepth = cameraPluginParams["image_depth"];
                 }
-                else if (cameraPluginParams.contains("depthImageTopicName")) {
+                else if (cameraPluginParams.contains("depthImageTopicName"))
+                {
                     imageDepth = HooksUtils::PluginParser::LastOnPath(cameraPluginParams["depthImageTopicName"]);
                 }
 
-                if (cameraPluginParams.contains("camera_info_depth")) {
+                if (cameraPluginParams.contains("camera_info_depth"))
+                {
                     depthInfo = cameraPluginParams["camera_info_depth"];
                 }
-                else if (cameraPluginParams.contains("depthImageCameraInfoTopicName")) {
+                else if (cameraPluginParams.contains("depthImageCameraInfoTopicName"))
+                {
                     depthInfo = HooksUtils::PluginParser::LastOnPath(cameraPluginParams["depthImageCameraInfoTopicName"]);
                 }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -127,7 +127,8 @@ namespace ROS2::SDFormat
             }
 
             // Create required components
-            HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
+            auto frameComponent = HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
+            HooksUtils::ConfigureFrame(frameComponent, cameraPluginParams);
 
             // Create Camera component
             if (HooksUtils::CreateComponent<ROS2CameraSensorEditorComponent>(entity, sensorConfiguration, cameraConfiguration))

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -116,7 +116,7 @@ namespace ROS2::SDFormat
             }
             else
             {
-                return AZ::Failure(AZStd::string("Failed to create ROS2 Camera Sensor component"));
+                return AZ::Failure(AZStd::string("Failed to create ROS 2 Camera Sensor component"));
             }
         };
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -77,15 +77,6 @@ namespace ROS2::SDFormat
                 cameraPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(cameraPlugins[0]);
             const sdf::ElementPtr element = sdfSensor.Element();
 
-            // add depth_camera for plugins kinnect and depth_camera
-            // check only the 1st plugin as it's the only one considered afterwards
-            if (!cameraPlugins.empty() &&
-                (cameraPlugins[0].Filename() == "libgazebo_ros_depth_camera.so" ||
-                 cameraPlugins[0].Filename() == "libgazebo_ros_openni_kinect.so"))
-            {
-                cameraConfiguration.m_depthCamera = true;
-            }
-
             if (sdfSensor.Type() != sdf::SensorType::DEPTH_CAMERA)
             { // COLOR_CAMERA and RGBD_CAMERA
                 const AZStd::string imageColor = HooksUtils::PluginParser::LastOnPath(
@@ -99,7 +90,7 @@ namespace ROS2::SDFormat
                 HooksUtils::AddTopicConfiguration(
                     sensorConfiguration, colorInfo, CameraConstants::CameraInfoMessageType, CameraConstants::ColorInfoConfig);
             }
-            if (cameraConfiguration.m_depthCamera)
+            if (sdfSensor.Type() != sdf::SensorType::CAMERA)
             { // DEPTH_CAMERA and RGBD_CAMERA
                 const AZStd::string imageDepth = HooksUtils::PluginParser::LastOnPath(
                     HooksUtils::ValueOfAny(cameraPluginParams, { "image_depth", "depthImageTopicName" }, "camera_image_depth"));

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -88,10 +88,10 @@ namespace ROS2::SDFormat
 
             if (sdfSensor.Type() != sdf::SensorType::DEPTH_CAMERA)
             { // COLOR_CAMERA and RGBD_CAMERA
-                AZStd::string imageColor = HooksUtils::PluginParser::LastOnPath(
+                const AZStd::string imageColor = HooksUtils::PluginParser::LastOnPath(
                     HooksUtils::ValueOfAny(cameraPluginParams, { "image_raw", "imageTopicName" }, "camera_image_color"));
 
-                AZStd::string colorInfo = HooksUtils::PluginParser::LastOnPath(
+                const AZStd::string colorInfo = HooksUtils::PluginParser::LastOnPath(
                     HooksUtils::ValueOfAny(cameraPluginParams, { "camera_info", "cameraInfoTopicName" }, "camera_color_info"));
 
                 HooksUtils::AddTopicConfiguration(
@@ -101,10 +101,10 @@ namespace ROS2::SDFormat
             }
             if (cameraConfiguration.m_depthCamera)
             { // DEPTH_CAMERA and RGBD_CAMERA
-                AZStd::string imageDepth = HooksUtils::PluginParser::LastOnPath(
+                const AZStd::string imageDepth = HooksUtils::PluginParser::LastOnPath(
                     HooksUtils::ValueOfAny(cameraPluginParams, { "image_depth", "depthImageTopicName" }, "camera_image_depth"));
 
-                AZStd::string depthInfo = HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(
+                const AZStd::string depthInfo = HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(
                     cameraPluginParams, { "camera_info_depth", "depthImageCameraInfoTopicName" }, "depth_camera_info"));
 
                 HooksUtils::AddTopicConfiguration(

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -138,7 +138,10 @@ namespace ROS2::SDFormat
 
             // Create required components
             auto frameComponent = HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
-            HooksUtils::ConfigureFrame(frameComponent, cameraPluginParams);
+            if (frameComponent)
+            {
+                HooksUtils::ConfigureFrame(frameComponent, cameraPluginParams);
+            }
 
             // Create Camera component
             if (HooksUtils::CreateComponent<ROS2CameraSensorEditorComponent>(entity, sensorConfiguration, cameraConfiguration))

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -83,25 +83,11 @@ namespace ROS2::SDFormat
 
             if (sdfSensor.Type() != sdf::SensorType::DEPTH_CAMERA)
             { // COLOR_CAMERA and RGBD_CAMERA
-                AZStd::string imageColor = "camera_image_color", colorInfo = "camera_color_info";
+                AZStd::string imageColor = HooksUtils::PluginParser::LastOnPath(
+                    HooksUtils::ValueOfAny(cameraPluginParams, { "image_raw", "imageTopicName" }, "camera_image_color"));
 
-                if (cameraPluginParams.contains("image_raw"))
-                {
-                    imageColor = cameraPluginParams["image_raw"];
-                }
-                else if (cameraPluginParams.contains("imageTopicName"))
-                {
-                    imageColor = HooksUtils::PluginParser::LastOnPath(cameraPluginParams["imageTopicName"]);
-                }
-
-                if (cameraPluginParams.contains("camera_info"))
-                {
-                    colorInfo = cameraPluginParams["camera_info"];
-                }
-                else if (cameraPluginParams.contains("cameraInfoTopicName"))
-                {
-                    colorInfo = HooksUtils::PluginParser::LastOnPath(cameraPluginParams["cameraInfoTopicName"]);
-                }
+                AZStd::string colorInfo = HooksUtils::PluginParser::LastOnPath(
+                    HooksUtils::ValueOfAny(cameraPluginParams, { "camera_info", "cameraInfoTopicName" }, "camera_color_info"));
 
                 HooksUtils::AddTopicConfiguration(
                     sensorConfiguration, imageColor, CameraConstants::ImageMessageType, CameraConstants::ColorImageConfig);
@@ -110,25 +96,11 @@ namespace ROS2::SDFormat
             }
             if (cameraConfiguration.m_depthCamera)
             { // DEPTH_CAMERA and RGBD_CAMERA
-                AZStd::string imageDepth = "camera_image_depth", depthInfo = "depth_camera_info";
+                AZStd::string imageDepth = HooksUtils::PluginParser::LastOnPath(
+                    HooksUtils::ValueOfAny(cameraPluginParams, { "image_depth", "depthImageTopicName" }, "camera_image_depth"));
 
-                if (cameraPluginParams.contains("image_depth"))
-                {
-                    imageDepth = cameraPluginParams["image_depth"];
-                }
-                else if (cameraPluginParams.contains("depthImageTopicName"))
-                {
-                    imageDepth = HooksUtils::PluginParser::LastOnPath(cameraPluginParams["depthImageTopicName"]);
-                }
-
-                if (cameraPluginParams.contains("camera_info_depth"))
-                {
-                    depthInfo = cameraPluginParams["camera_info_depth"];
-                }
-                else if (cameraPluginParams.contains("depthImageCameraInfoTopicName"))
-                {
-                    depthInfo = HooksUtils::PluginParser::LastOnPath(cameraPluginParams["depthImageCameraInfoTopicName"]);
-                }
+                AZStd::string depthInfo = HooksUtils::PluginParser::LastOnPath(
+                    HooksUtils::ValueOfAny(cameraPluginParams, { "camera_info_depth", "depthImageCameraInfoTopicName" }, "depth_camera_info"));
 
                 HooksUtils::AddTopicConfiguration(
                     sensorConfiguration, imageDepth, CameraConstants::ImageMessageType, CameraConstants::DepthImageConfig);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -103,10 +103,7 @@ namespace ROS2::SDFormat
                 HooksUtils::AddTopicConfiguration(
                     sensorConfiguration, depthInfo, CameraConstants::CameraInfoMessageType, CameraConstants::DepthInfoConfig);
             }
-            if (element->HasElement("visualize"))
-            {
-                sensorConfiguration.m_visualize = element->Get<bool>("visualize");
-            }
+            element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 
             // Get frame configuration
             auto frameConfiguration = HooksUtils::GetFrameConfiguration(cameraPluginParams);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -35,7 +35,7 @@ namespace ROS2::SDFormat
                                                                           "libgazebo_ros_openni_kinect.so" };
         importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{
             ">imageTopicName", ">cameraInfoTopicName", ">depthImageTopicName", ">depthImageCameraInfoTopicName",
-            ">ros>remapping",  ">ros>argument",        ">ros>frame_name",      ">ros>namespace",
+            ">ros>remapping",  ">ros>argument",        ">ros>frame_name",      ">ros>namespace", ">updateRate",
             ">frameName",      ">robotNamespace"
         };
         importerHook.m_sdfSensorToComponentCallback = [](AZ::Entity& entity,
@@ -69,11 +69,11 @@ namespace ROS2::SDFormat
                 cameraConfiguration.m_farClipDistance = static_cast<float>(cameraSensor->DepthFarClip());
             }
 
-            SensorConfiguration sensorConfiguration;
-            sensorConfiguration.m_frequency = sdfSensor.UpdateRate();
-
             const auto cameraPluginParams = HooksUtils::GetPluginParams(sdfSensor.Plugins());
             const auto element = sdfSensor.Element();
+
+            SensorConfiguration sensorConfiguration;
+            sensorConfiguration.m_frequency = HooksUtils::GetFrequency(cameraPluginParams);
 
             if (sdfSensor.Type() != sdf::SensorType::DEPTH_CAMERA)
             { // COLOR_CAMERA and RGBD_CAMERA

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -68,24 +68,24 @@ namespace ROS2::SDFormat
             sensorConfiguration.m_frequency = sdfSensor.UpdateRate();
 
             const auto cameraPlugins = sdfSensor.Plugins();
-            HooksUtils::Remaps cameraRemaps = cameraPlugins.empty() ? HooksUtils::Remaps() : HooksUtils::GetSensorRemaps(cameraPlugins[0]);
+            HooksUtils::PluginParams cameraPluginParams = cameraPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(cameraPlugins[0]);
 
             if (sdfSensor.Type() != sdf::SensorType::DEPTH_CAMERA)
             { // COLOR_CAMERA and RGBD_CAMERA
                 AZStd::string imageColor = "camera_image_color", colorInfo = "camera_color_info";
 
-                if (cameraRemaps.contains("image_raw")) {
-                    imageColor = cameraRemaps["image_raw"];
+                if (cameraPluginParams.contains("image_raw")) {
+                    imageColor = cameraPluginParams["image_raw"];
                 }
-                else if (cameraRemaps.contains("imageTopicName")) {
-                    imageColor = HooksUtils::PluginParser::LastOnPath(cameraRemaps["imageTopicName"]);
+                else if (cameraPluginParams.contains("imageTopicName")) {
+                    imageColor = HooksUtils::PluginParser::LastOnPath(cameraPluginParams["imageTopicName"]);
                 }
 
-                if (cameraRemaps.contains("camera_info")) {
-                    colorInfo = cameraRemaps["camera_info"];
+                if (cameraPluginParams.contains("camera_info")) {
+                    colorInfo = cameraPluginParams["camera_info"];
                 }
-                else if (cameraRemaps.contains("cameraInfoTopicName")) {
-                    colorInfo = HooksUtils::PluginParser::LastOnPath(cameraRemaps["cameraInfoTopicName"]);
+                else if (cameraPluginParams.contains("cameraInfoTopicName")) {
+                    colorInfo = HooksUtils::PluginParser::LastOnPath(cameraPluginParams["cameraInfoTopicName"]);
                 }
 
                 HooksUtils::AddTopicConfiguration(
@@ -97,18 +97,18 @@ namespace ROS2::SDFormat
             { // DEPTH_CAMERA and RGBD_CAMERA
                 AZStd::string imageDepth = "camera_image_depth", depthInfo = "depth_camera_info";
 
-                if (cameraRemaps.contains("image_depth")) {
-                    imageDepth = cameraRemaps["image_depth"];
+                if (cameraPluginParams.contains("image_depth")) {
+                    imageDepth = cameraPluginParams["image_depth"];
                 }
-                else if (cameraRemaps.contains("depthImageTopicName")) {
-                    imageDepth = HooksUtils::PluginParser::LastOnPath(cameraRemaps["depthImageTopicName"]);
+                else if (cameraPluginParams.contains("depthImageTopicName")) {
+                    imageDepth = HooksUtils::PluginParser::LastOnPath(cameraPluginParams["depthImageTopicName"]);
                 }
 
-                if (cameraRemaps.contains("camera_info_depth")) {
-                    depthInfo = cameraRemaps["camera_info_depth"];
+                if (cameraPluginParams.contains("camera_info_depth")) {
+                    depthInfo = cameraPluginParams["camera_info_depth"];
                 }
-                else if (cameraRemaps.contains("depthImageCameraInfoTopicName")) {
-                    depthInfo = HooksUtils::PluginParser::LastOnPath(cameraRemaps["depthImageCameraInfoTopicName"]);
+                else if (cameraPluginParams.contains("depthImageCameraInfoTopicName")) {
+                    depthInfo = HooksUtils::PluginParser::LastOnPath(cameraPluginParams["depthImageCameraInfoTopicName"]);
                 }
 
                 HooksUtils::AddTopicConfiguration(

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -72,10 +72,8 @@ namespace ROS2::SDFormat
             SensorConfiguration sensorConfiguration;
             sensorConfiguration.m_frequency = sdfSensor.UpdateRate();
 
-            const auto cameraPlugins = sdfSensor.Plugins();
-            HooksUtils::PluginParams cameraPluginParams =
-                cameraPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(cameraPlugins[0]);
-            const sdf::ElementPtr element = sdfSensor.Element();
+            const auto cameraPluginParams = HooksUtils::GetPluginParams(sdfSensor.Plugins());
+            const auto element = sdfSensor.Element();
 
             if (sdfSensor.Type() != sdf::SensorType::DEPTH_CAMERA)
             { // COLOR_CAMERA and RGBD_CAMERA

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -79,11 +79,11 @@ namespace ROS2::SDFormat
 
             if (sdfSensor.Type() != sdf::SensorType::DEPTH_CAMERA)
             { // COLOR_CAMERA and RGBD_CAMERA
-                const AZStd::string imageColor = HooksUtils::PluginParser::LastOnPath(
-                    HooksUtils::ValueOfAny(cameraPluginParams, { "image_raw", "imageTopicName" }, "camera_image_color"));
+                const static AZStd::vector<AZStd::string> rawImageParamNames = { "image_raw", "imageTopicName" };
+                const static AZStd::vector<AZStd::string> rawInfoParamNames = { "camera_info", "cameraInfoTopicName" };
 
-                const AZStd::string colorInfo = HooksUtils::PluginParser::LastOnPath(
-                    HooksUtils::ValueOfAny(cameraPluginParams, { "camera_info", "cameraInfoTopicName" }, "camera_color_info"));
+                const AZStd::string imageColor = HooksUtils::ValueOfAny(cameraPluginParams, rawImageParamNames, "camera_image_color");
+                const AZStd::string colorInfo = HooksUtils::ValueOfAny(cameraPluginParams, rawInfoParamNames, "camera_color_info");
 
                 HooksUtils::AddTopicConfiguration(
                     sensorConfiguration, imageColor, CameraConstants::ImageMessageType, CameraConstants::ColorImageConfig);
@@ -92,11 +92,11 @@ namespace ROS2::SDFormat
             }
             if (sdfSensor.Type() != sdf::SensorType::CAMERA)
             { // DEPTH_CAMERA and RGBD_CAMERA
-                const AZStd::string imageDepth = HooksUtils::PluginParser::LastOnPath(
-                    HooksUtils::ValueOfAny(cameraPluginParams, { "image_depth", "depthImageTopicName" }, "camera_image_depth"));
+                const static AZStd::vector<AZStd::string> depthImageParamNames = { "image_depth", "depthImageTopicName" };
+                const static AZStd::vector<AZStd::string> depthInfoParamNames = { "camera_info_depth", "depthImageCameraInfoTopicName" };
 
-                const AZStd::string depthInfo = HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(
-                    cameraPluginParams, { "camera_info_depth", "depthImageCameraInfoTopicName" }, "depth_camera_info"));
+                const AZStd::string imageDepth = HooksUtils::ValueOfAny(cameraPluginParams, depthImageParamNames, "camera_image_depth");
+                const AZStd::string depthInfo = HooksUtils::ValueOfAny(cameraPluginParams, depthInfoParamNames, "depth_camera_info");
 
                 HooksUtils::AddTopicConfiguration(
                     sensorConfiguration, imageDepth, CameraConstants::ImageMessageType, CameraConstants::DepthImageConfig);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -70,6 +70,15 @@ namespace ROS2::SDFormat
             const auto cameraPlugins = sdfSensor.Plugins();
             HooksUtils::PluginParams cameraPluginParams = cameraPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(cameraPlugins[0]);
 
+            // add depth_camera for plugins kinnect and depth_camera
+            // check only the 1st plugin as it's the only one considered afterwards
+            if (!cameraPlugins.empty() &&
+                cameraPlugins[0].Filename() == "libgazebo_ros_depth_camera.so" ||
+                cameraPlugins[0].Filename() == "libgazebo_ros_openni_kinect.so")
+            {
+                cameraConfiguration.m_depthCamera = true;
+            }
+
             if (sdfSensor.Type() != sdf::SensorType::DEPTH_CAMERA)
             { // COLOR_CAMERA and RGBD_CAMERA
                 AZStd::string imageColor = "camera_image_color", colorInfo = "camera_color_info";
@@ -93,7 +102,7 @@ namespace ROS2::SDFormat
                 HooksUtils::AddTopicConfiguration(
                     sensorConfiguration, colorInfo, CameraConstants::CameraInfoMessageType, CameraConstants::ColorInfoConfig);
             }
-            if (sdfSensor.Type() != sdf::SensorType::CAMERA)
+            if (cameraConfiguration.m_depthCamera)
             { // DEPTH_CAMERA and RGBD_CAMERA
                 AZStd::string imageDepth = "camera_image_depth", depthInfo = "depth_camera_info";
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -108,12 +108,11 @@ namespace ROS2::SDFormat
                 sensorConfiguration.m_visualize = element->Get<bool>("visualize");
             }
 
+            // Get frame configuration
+            auto frameConfiguration = HooksUtils::GetFrameConfiguration(cameraPluginParams);
+
             // Create required components
-            auto frameComponent = HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
-            if (frameComponent)
-            {
-                HooksUtils::ConfigureFrame(frameComponent, cameraPluginParams);
-            }
+            HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity, frameConfiguration);
 
             // Create Camera component
             if (HooksUtils::CreateComponent<ROS2CameraSensorEditorComponent>(entity, sensorConfiguration, cameraConfiguration))

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -73,8 +73,8 @@ namespace ROS2::SDFormat
             // add depth_camera for plugins kinnect and depth_camera
             // check only the 1st plugin as it's the only one considered afterwards
             if (!cameraPlugins.empty() &&
-                cameraPlugins[0].Filename() == "libgazebo_ros_depth_camera.so" ||
-                cameraPlugins[0].Filename() == "libgazebo_ros_openni_kinect.so")
+                (cameraPlugins[0].Filename() == "libgazebo_ros_depth_camera.so" ||
+                cameraPlugins[0].Filename() == "libgazebo_ros_openni_kinect.so"))
             {
                 cameraConfiguration.m_depthCamera = true;
             }

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2CameraSensorHook.cpp
@@ -104,7 +104,7 @@ namespace ROS2::SDFormat
             element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 
             // Get frame configuration
-            auto frameConfiguration = HooksUtils::GetFrameConfiguration(cameraPluginParams);
+            const auto frameConfiguration = HooksUtils::GetFrameConfiguration(cameraPluginParams);
 
             // Create required components
             HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity, frameConfiguration);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -49,10 +49,7 @@ namespace ROS2::SDFormat
                 std::string topicParam = element->Get<std::string>("topic");
                 messageTopic = AZStd::string(topicParam.c_str(), topicParam.size());
             }
-            if (element->HasElement("visualize"))
-            {
-                sensorConfiguration.m_visualize = element->Get<bool>("visualize");
-            }
+            element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -58,7 +58,7 @@ namespace ROS2::SDFormat
             }
             else
             {
-                return AZ::Failure(AZStd::string("Failed to create ROS2 GNSS Sensor component"));
+                return AZ::Failure(AZStd::string("Failed to create ROS 2 GNSS Sensor component"));
             }
         };
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -46,8 +46,7 @@ namespace ROS2::SDFormat
                 HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(gnssPluginParams, { "topicName", "out" }, "gnss"));
             if (element->HasElement("topic"))
             {
-                std::string topicParam = element->Get<std::string>("topic");
-                messageTopic = AZStd::string(topicParam.c_str(), topicParam.size());
+                messageTopic = element->Get<std::string>("topic").c_str();
             }
             element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -56,12 +56,11 @@ namespace ROS2::SDFormat
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 
+            // Get frame configuration
+            auto frameConfiguration = HooksUtils::GetFrameConfiguration(gnssPluginParams);
+
             // Create required components
-            auto frameComponent = HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
-            if (frameComponent)
-            {
-                HooksUtils::ConfigureFrame(frameComponent, gnssPluginParams);
-            }
+            HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity, frameConfiguration);
 
             if (HooksUtils::CreateComponent<ROS2GNSSSensorComponent>(entity, sensorConfiguration))
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -36,18 +36,18 @@ namespace ROS2::SDFormat
             const AZStd::string messageType = "sensor_msgs::msg::NavSatFix";
 
             const auto gnssPlugins = sdfSensor.Plugins();
+            HooksUtils::PluginParams gnssPluginParams = gnssPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(gnssPlugins[0]);
             
             // setting gnss topic
             AZStd::string messageTopic = "gnss";
-            if (!gnssPlugins.empty()) {
-                HooksUtils::PluginParams gnssPluginParams = HooksUtils::GetPluginParams(gnssPlugins[0]);
-                if (gnssPluginParams.contains("out")) messageTopic = gnssPluginParams["out"];
-            }
+            if (gnssPluginParams.contains("out")) messageTopic = gnssPluginParams["out"];
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 
             // Create required components
-            HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
+            auto frameComponent = HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
+            HooksUtils::ConfigureFrame(frameComponent, gnssPluginParams);
+
 
             if (HooksUtils::CreateComponent<ROS2GNSSSensorComponent>(entity, sensorConfiguration))
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -43,7 +43,13 @@ namespace ROS2::SDFormat
             // setting gnss topic
             AZStd::string messageTopic = "gnss";
             if (gnssPluginParams.contains("out"))
+            {
                 messageTopic = gnssPluginParams["out"];
+            }
+            else if (gnssPluginParams.contains("topicName"))
+            {
+                messageTopic = HooksUtils::PluginParser::LastOnPath(gnssPluginParams["topicName"]);
+            }
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -55,7 +55,10 @@ namespace ROS2::SDFormat
 
             // Create required components
             auto frameComponent = HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
-            HooksUtils::ConfigureFrame(frameComponent, gnssPluginParams);
+            if (frameComponent)
+            {
+                HooksUtils::ConfigureFrame(frameComponent, gnssPluginParams);
+            }
 
             if (HooksUtils::CreateComponent<ROS2GNSSSensorComponent>(entity, sensorConfiguration))
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -42,12 +42,7 @@ namespace ROS2::SDFormat
             const sdf::ElementPtr element = sdfSensor.Element();
 
             // setting gnss topic
-            AZStd::string messageTopic =
-                HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(gnssPluginParams, { "topicName", "out" }, "gnss"));
-            if (element->HasElement("topic"))
-            {
-                messageTopic = element->Get<std::string>("topic").c_str();
-            }
+            AZStd::string messageTopic = HooksUtils::GetTopicName(gnssPluginParams, element, "gnss");
             element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -46,7 +46,7 @@ namespace ROS2::SDFormat
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 
             // Get frame configuration
-            auto frameConfiguration = HooksUtils::GetFrameConfiguration(gnssPluginParams);
+            const auto frameConfiguration = HooksUtils::GetFrameConfiguration(gnssPluginParams);
 
             // Create required components
             HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity, frameConfiguration);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -41,15 +41,8 @@ namespace ROS2::SDFormat
                 gnssPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(gnssPlugins[0]);
 
             // setting gnss topic
-            AZStd::string messageTopic = "gnss";
-            if (gnssPluginParams.contains("out"))
-            {
-                messageTopic = gnssPluginParams["out"];
-            }
-            else if (gnssPluginParams.contains("topicName"))
-            {
-                messageTopic = HooksUtils::PluginParser::LastOnPath(gnssPluginParams["topicName"]);
-            }
+            AZStd::string messageTopic = HooksUtils::PluginParser::LastOnPath(
+                    HooksUtils::ValueOfAny(gnssPluginParams, { "topicName", "out" }, "gnss"));
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -22,7 +22,8 @@ namespace ROS2::SDFormat
         importerHook.m_sensorTypes = AZStd::unordered_set<sdf::SensorType>{ sdf::SensorType::NAVSAT };
         importerHook.m_supportedSensorParams = AZStd::unordered_set<AZStd::string>{ ">pose", ">update_rate" };
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_gps_sensor.so" };
-        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ ">ros>remapping", ">ros>argument" };
+        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ ">ros>remapping", ">ros>argument", ">ros>frame_name",
+                                                                                    ">ros>namespace", ">frameName",    ">robotNamespace" };
         importerHook.m_sdfSensorToComponentCallback = [](AZ::Entity& entity,
                                                          const sdf::Sensor& sdfSensor) -> SensorImporterHook::ConvertSensorOutcome
         {
@@ -36,18 +37,19 @@ namespace ROS2::SDFormat
             const AZStd::string messageType = "sensor_msgs::msg::NavSatFix";
 
             const auto gnssPlugins = sdfSensor.Plugins();
-            HooksUtils::PluginParams gnssPluginParams = gnssPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(gnssPlugins[0]);
-            
+            HooksUtils::PluginParams gnssPluginParams =
+                gnssPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(gnssPlugins[0]);
+
             // setting gnss topic
             AZStd::string messageTopic = "gnss";
-            if (gnssPluginParams.contains("out")) messageTopic = gnssPluginParams["out"];
+            if (gnssPluginParams.contains("out"))
+                messageTopic = gnssPluginParams["out"];
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 
             // Create required components
             auto frameComponent = HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
             HooksUtils::ConfigureFrame(frameComponent, gnssPluginParams);
-
 
             if (HooksUtils::CreateComponent<ROS2GNSSSensorComponent>(entity, sensorConfiguration))
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -36,13 +36,11 @@ namespace ROS2::SDFormat
             sensorConfiguration.m_frequency = sdfSensor.UpdateRate();
             const AZStd::string messageType = "sensor_msgs::msg::NavSatFix";
 
-            const auto gnssPlugins = sdfSensor.Plugins();
-            HooksUtils::PluginParams gnssPluginParams =
-                gnssPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(gnssPlugins[0]);
-            const sdf::ElementPtr element = sdfSensor.Element();
+            const auto gnssPluginParams = HooksUtils::GetPluginParams(sdfSensor.Plugins());
+            const auto element = sdfSensor.Element();
 
             // setting gnss topic
-            AZStd::string messageTopic = HooksUtils::GetTopicName(gnssPluginParams, element, "gnss");
+            const AZStd::string messageTopic = HooksUtils::GetTopicName(gnssPluginParams, element, "gnss");
             element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -39,8 +39,8 @@ namespace ROS2::SDFormat
             // setting gnss topic
             AZStd::string messageTopic = "gnss";
             if (!gnssPlugins.empty()) {
-                HooksUtils::Remaps gnssRemaps = HooksUtils::GetSensorRemaps(gnssPlugins[0]);
-                if (gnssRemaps.contains("out")) messageTopic = gnssRemaps["out"];
+                HooksUtils::PluginParams gnssPluginParams = HooksUtils::GetPluginParams(gnssPlugins[0]);
+                if (gnssPluginParams.contains("out")) messageTopic = gnssPluginParams["out"];
             }
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <GNSS/ROS2GNSSSensorComponent.h>
+#include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
 #include <RobotImporter/SDFormat/ROS2SensorHooks.h>
 
@@ -44,6 +45,9 @@ namespace ROS2::SDFormat
             }
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
+
+            // Create required components
+            HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
 
             if (HooksUtils::CreateComponent<ROS2GNSSSensorComponent>(entity, sensorConfiguration))
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2GNSSSensorHook.cpp
@@ -23,7 +23,8 @@ namespace ROS2::SDFormat
         importerHook.m_supportedSensorParams = AZStd::unordered_set<AZStd::string>{ ">pose", ">update_rate", ">topic", ">visualize" };
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_gps_sensor.so" };
         importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ ">ros>remapping", ">ros>argument", ">ros>frame_name",
-                                                                                    ">ros>namespace", ">frameName",    ">robotNamespace" };
+                                                                                    ">ros>namespace", ">frameName",    ">robotNamespace",
+                                                                                    ">updateRate" };
         importerHook.m_sdfSensorToComponentCallback = [](AZ::Entity& entity,
                                                          const sdf::Sensor& sdfSensor) -> SensorImporterHook::ConvertSensorOutcome
         {
@@ -32,12 +33,12 @@ namespace ROS2::SDFormat
                 return AZ::Failure(AZStd::string("Failed to read parsed SDFormat data of %s NavSat sensor", sdfSensor.Name().c_str()));
             }
 
-            SensorConfiguration sensorConfiguration;
-            sensorConfiguration.m_frequency = sdfSensor.UpdateRate();
-            const AZStd::string messageType = "sensor_msgs::msg::NavSatFix";
-
             const auto gnssPluginParams = HooksUtils::GetPluginParams(sdfSensor.Plugins());
             const auto element = sdfSensor.Element();
+
+            SensorConfiguration sensorConfiguration;
+            sensorConfiguration.m_frequency = HooksUtils::GetFrequency(gnssPluginParams);
+            const AZStd::string messageType = "sensor_msgs::msg::NavSatFix";
 
             // setting gnss topic
             const AZStd::string messageTopic = HooksUtils::GetTopicName(gnssPluginParams, element, "gnss");

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -86,10 +86,10 @@ namespace ROS2::SDFormat
             // setting lidar topic
             AZStd::string messageTopic = "imu";
             if (!imuPlugins.empty()) {
-                HooksUtils::Remaps imuRemaps = HooksUtils::GetSensorRemaps(imuPlugins[0]);
-                if (imuRemaps.contains("out")) messageTopic = imuRemaps["out"];
-                else if (imuRemaps.contains("topicName")) {
-                    messageTopic = HooksUtils::PluginParser::LastOnPath(imuRemaps["topicName"]);
+                HooksUtils::PluginParams imuPluginParams = HooksUtils::GetPluginParams(imuPlugins[0]);
+                if (imuPluginParams.contains("out")) messageTopic = imuPluginParams["out"];
+                else if (imuPluginParams.contains("topicName")) {
+                    messageTopic = HooksUtils::PluginParser::LastOnPath(imuPluginParams["topicName"]);
                 }
             }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -34,7 +34,9 @@ namespace ROS2::SDFormat
                                                                                     ">imu>linear_acceleration>y>noise>mean",
                                                                                     ">imu>linear_acceleration>y>noise>stddev",
                                                                                     ">imu>linear_acceleration>z>noise>mean",
-                                                                                    ">imu>linear_acceleration>z>noise>stddev" };
+                                                                                    ">imu>linear_acceleration>z>noise>stddev",
+                                                                                    ">topic",
+                                                                                    ">visualize" };
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_imu_sensor.so" };
         importerHook.m_supportedPluginParams =
             AZStd::unordered_set<AZStd::string>{ ">topicName",     ">ros>remapping", ">ros>argument",  ">ros>frame_name",
@@ -86,10 +88,20 @@ namespace ROS2::SDFormat
             const auto imuPlugins = sdfSensor.Plugins();
             HooksUtils::PluginParams imuPluginParams =
                 imuPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(imuPlugins[0]);
+            const sdf::ElementPtr element = sdfSensor.Element();
 
             // setting imu topic
-            AZStd::string messageTopic = HooksUtils::PluginParser::LastOnPath(
-                    HooksUtils::ValueOfAny(imuPluginParams, { "topicName", "out" }, "imu"));
+            AZStd::string messageTopic =
+                HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(imuPluginParams, { "topicName", "out" }, "imu"));
+            if (element->HasElement("topic"))
+            {
+                std::string topicParam = element->Get<std::string>("topic");
+                messageTopic = AZStd::string(topicParam.c_str(), topicParam.size());
+            }
+            if (element->HasElement("visualize"))
+            {
+                sensorConfiguration.m_visualize = element->Get<bool>("visualize");
+            }
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -10,7 +10,7 @@
 #include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
 #include <RobotImporter/SDFormat/ROS2SensorHooks.h>
-#include <Source/EditorStaticRigidBodyComponent.h>
+#include <Source/EditorArticulationLinkComponent.h>
 
 #include <sdf/Imu.hh>
 #include <sdf/Sensor.hh>
@@ -97,7 +97,7 @@ namespace ROS2::SDFormat
 
             // Create required components
             HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
-            HooksUtils::CreateComponent<PhysX::EditorStaticRigidBodyComponent>(entity);
+            HooksUtils::CreateComponent<PhysX::EditorArticulationLinkComponent>(entity);
 
             // Create Imu component
             if (HooksUtils::CreateComponent<ROS2ImuSensorComponent>(entity, sensorConfiguration, imuConfiguration))

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -36,7 +36,9 @@ namespace ROS2::SDFormat
                                                                                     ">imu>linear_acceleration>z>noise>mean",
                                                                                     ">imu>linear_acceleration>z>noise>stddev" };
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_imu_sensor.so" };
-        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ ">topicName", ">ros>remapping", ">ros>argument" };
+        importerHook.m_supportedPluginParams =
+            AZStd::unordered_set<AZStd::string>{ ">topicName",     ">ros>remapping", ">ros>argument",  ">ros>frame_name",
+                                                 ">ros>namespace", ">frameName",     ">robotNamespace" };
         importerHook.m_sdfSensorToComponentCallback = [](AZ::Entity& entity,
                                                          const sdf::Sensor& sdfSensor) -> SensorImporterHook::ConvertSensorOutcome
         {
@@ -82,12 +84,15 @@ namespace ROS2::SDFormat
             const AZStd::string messageType = "sensor_msgs::msg::Imu";
 
             const auto imuPlugins = sdfSensor.Plugins();
-            HooksUtils::PluginParams imuPluginParams = imuPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(imuPlugins[0]);
+            HooksUtils::PluginParams imuPluginParams =
+                imuPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(imuPlugins[0]);
 
             // setting lidar topic
             AZStd::string messageTopic = "imu";
-            if (imuPluginParams.contains("out")) messageTopic = imuPluginParams["out"];
-            else if (imuPluginParams.contains("topicName")) {
+            if (imuPluginParams.contains("out"))
+                messageTopic = imuPluginParams["out"];
+            else if (imuPluginParams.contains("topicName"))
+            {
                 messageTopic = HooksUtils::PluginParser::LastOnPath(imuPluginParams["topicName"]);
             }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -87,16 +87,9 @@ namespace ROS2::SDFormat
             HooksUtils::PluginParams imuPluginParams =
                 imuPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(imuPlugins[0]);
 
-            // setting lidar topic
-            AZStd::string messageTopic = "imu";
-            if (imuPluginParams.contains("out"))
-            {
-                messageTopic = imuPluginParams["out"];
-            }
-            else if (imuPluginParams.contains("topicName"))
-            {
-                messageTopic = HooksUtils::PluginParser::LastOnPath(imuPluginParams["topicName"]);
-            }
+            // setting imu topic
+            AZStd::string messageTopic = HooksUtils::PluginParser::LastOnPath(
+                    HooksUtils::ValueOfAny(imuPluginParams, { "topicName", "out" }, "imu"));
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -39,8 +39,8 @@ namespace ROS2::SDFormat
                                                                                     ">visualize" };
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_imu_sensor.so" };
         importerHook.m_supportedPluginParams =
-            AZStd::unordered_set<AZStd::string>{ ">topicName",     ">ros>remapping", ">ros>argument",  ">ros>frame_name",
-                                                 ">ros>namespace", ">frameName",     ">robotNamespace" };
+            AZStd::unordered_set<AZStd::string>{ ">topicName",     ">ros>remapping", ">ros>argument",   ">ros>frame_name",
+                                                 ">ros>namespace", ">frameName",     ">robotNamespace", ">updateRate" };
         importerHook.m_sdfSensorToComponentCallback = [](AZ::Entity& entity,
                                                          const sdf::Sensor& sdfSensor) -> SensorImporterHook::ConvertSensorOutcome
         {
@@ -81,12 +81,12 @@ namespace ROS2::SDFormat
                 }
             }
 
-            SensorConfiguration sensorConfiguration;
-            sensorConfiguration.m_frequency = sdfSensor.UpdateRate();
-            const AZStd::string messageType = "sensor_msgs::msg::Imu";
-
             const auto imuPluginParams = HooksUtils::GetPluginParams(sdfSensor.Plugins());
             const auto element = sdfSensor.Element();
+
+            SensorConfiguration sensorConfiguration;
+            sensorConfiguration.m_frequency = HooksUtils::GetFrequency(imuPluginParams);
+            const AZStd::string messageType = "sensor_msgs::msg::Imu";
 
             // setting imu topic
             const AZStd::string messageTopic = HooksUtils::GetTopicName(imuPluginParams, element, "imu");

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -85,13 +85,11 @@ namespace ROS2::SDFormat
             sensorConfiguration.m_frequency = sdfSensor.UpdateRate();
             const AZStd::string messageType = "sensor_msgs::msg::Imu";
 
-            const auto imuPlugins = sdfSensor.Plugins();
-            HooksUtils::PluginParams imuPluginParams =
-                imuPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(imuPlugins[0]);
-            const sdf::ElementPtr element = sdfSensor.Element();
+            const auto imuPluginParams = HooksUtils::GetPluginParams(sdfSensor.Plugins());
+            const auto element = sdfSensor.Element();
 
             // setting imu topic
-            AZStd::string messageTopic = HooksUtils::GetTopicName(imuPluginParams, element, "imu");
+            const AZStd::string messageTopic = HooksUtils::GetTopicName(imuPluginParams, element, "imu");
             element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -108,7 +108,7 @@ namespace ROS2::SDFormat
             }
             else
             {
-                return AZ::Failure(AZStd::string("Failed to create ROS2 Imu Sensor component"));
+                return AZ::Failure(AZStd::string("Failed to create ROS 2 Imu Sensor component"));
             }
         };
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -90,7 +90,9 @@ namespace ROS2::SDFormat
             // setting lidar topic
             AZStd::string messageTopic = "imu";
             if (imuPluginParams.contains("out"))
+            {
                 messageTopic = imuPluginParams["out"];
+            }
             else if (imuPluginParams.contains("topicName"))
             {
                 messageTopic = HooksUtils::PluginParser::LastOnPath(imuPluginParams["topicName"]);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -105,13 +105,11 @@ namespace ROS2::SDFormat
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 
+            // Get frame configuration
+            auto frameConfiguration = HooksUtils::GetFrameConfiguration(imuPluginParams);
+
             // Create required components
-            auto frameComponent = HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
-            if (frameComponent)
-            {
-                HooksUtils::ConfigureFrame(frameComponent, imuPluginParams);
-            }
-            HooksUtils::CreateComponent<PhysX::EditorArticulationLinkComponent>(entity);
+            HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity, frameConfiguration);
 
             // Create Imu component
             if (HooksUtils::CreateComponent<ROS2ImuSensorComponent>(entity, sensorConfiguration, imuConfiguration))

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -98,10 +98,7 @@ namespace ROS2::SDFormat
                 std::string topicParam = element->Get<std::string>("topic");
                 messageTopic = AZStd::string(topicParam.c_str(), topicParam.size());
             }
-            if (element->HasElement("visualize"))
-            {
-                sensorConfiguration.m_visualize = element->Get<bool>("visualize");
-            }
+            element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -99,7 +99,8 @@ namespace ROS2::SDFormat
 
             // Create required components
             HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity, frameConfiguration);
-
+            HooksUtils::CreateComponent<PhysX::EditorArticulationLinkComponent>(entity);
+            
             // Create Imu component
             if (HooksUtils::CreateComponent<ROS2ImuSensorComponent>(entity, sensorConfiguration, imuConfiguration))
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -95,8 +95,7 @@ namespace ROS2::SDFormat
                 HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(imuPluginParams, { "topicName", "out" }, "imu"));
             if (element->HasElement("topic"))
             {
-                std::string topicParam = element->Get<std::string>("topic");
-                messageTopic = AZStd::string(topicParam.c_str(), topicParam.size());
+                messageTopic = element->Get<std::string>("topic").c_str();
             }
             element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -82,21 +82,20 @@ namespace ROS2::SDFormat
             const AZStd::string messageType = "sensor_msgs::msg::Imu";
 
             const auto imuPlugins = sdfSensor.Plugins();
+            HooksUtils::PluginParams imuPluginParams = imuPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(imuPlugins[0]);
 
             // setting lidar topic
             AZStd::string messageTopic = "imu";
-            if (!imuPlugins.empty()) {
-                HooksUtils::PluginParams imuPluginParams = HooksUtils::GetPluginParams(imuPlugins[0]);
-                if (imuPluginParams.contains("out")) messageTopic = imuPluginParams["out"];
-                else if (imuPluginParams.contains("topicName")) {
-                    messageTopic = HooksUtils::PluginParser::LastOnPath(imuPluginParams["topicName"]);
-                }
+            if (imuPluginParams.contains("out")) messageTopic = imuPluginParams["out"];
+            else if (imuPluginParams.contains("topicName")) {
+                messageTopic = HooksUtils::PluginParser::LastOnPath(imuPluginParams["topicName"]);
             }
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 
             // Create required components
-            HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
+            auto frameComponent = HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
+            HooksUtils::ConfigureFrame(frameComponent, imuPluginParams);
             HooksUtils::CreateComponent<PhysX::EditorArticulationLinkComponent>(entity);
 
             // Create Imu component

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -102,7 +102,10 @@ namespace ROS2::SDFormat
 
             // Create required components
             auto frameComponent = HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
-            HooksUtils::ConfigureFrame(frameComponent, imuPluginParams);
+            if (frameComponent)
+            {
+                HooksUtils::ConfigureFrame(frameComponent, imuPluginParams);
+            }
             HooksUtils::CreateComponent<PhysX::EditorArticulationLinkComponent>(entity);
 
             // Create Imu component

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -95,7 +95,7 @@ namespace ROS2::SDFormat
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 
             // Get frame configuration
-            auto frameConfiguration = HooksUtils::GetFrameConfiguration(imuPluginParams);
+            const auto frameConfiguration = HooksUtils::GetFrameConfiguration(imuPluginParams);
 
             // Create required components
             HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity, frameConfiguration);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
@@ -91,12 +91,7 @@ namespace ROS2::SDFormat
             const sdf::ElementPtr element = sdfSensor.Element();
 
             // setting imu topic
-            AZStd::string messageTopic =
-                HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(imuPluginParams, { "topicName", "out" }, "imu"));
-            if (element->HasElement("topic"))
-            {
-                messageTopic = element->Get<std::string>("topic").c_str();
-            }
+            AZStd::string messageTopic = HooksUtils::GetTopicName(imuPluginParams, element, "imu");
             element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -8,8 +8,8 @@
 
 #include <Manipulation/Controllers/JointsArticulationControllerComponent.h>
 #include <Manipulation/JointsManipulationEditorComponent.h>
-#include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <Manipulation/JointsTrajectoryComponent.h>
+#include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <RobotImporter/SDFormat/ROS2ModelPluginHooks.h>
 #include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
 
@@ -19,7 +19,8 @@ namespace ROS2::SDFormat
     {
         ModelPluginImporterHook importerHook;
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_joint_pose_trajectory.so" };
-        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ ">topicName", ">ros>remapping", ">ros>argument", ">updateRate", ">update_rate" };
+        importerHook.m_supportedPluginParams =
+            AZStd::unordered_set<AZStd::string>{ ">topicName", ">ros>remapping", ">ros>argument", ">updateRate", ">update_rate" };
 
         importerHook.m_sdfPluginToComponentCallback =
             [](AZ::Entity& entity, const sdf::Plugin& sdfPlugin, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)
@@ -50,8 +51,8 @@ namespace ROS2::SDFormat
                 manipulationComponent->SetPublisherConfiguration(publisherConfiguration);
             }
 
-            AZStd::string trajectoryActionName = HooksUtils::PluginParser::LastOnPath(
-                    HooksUtils::ValueOfAny(poseTrajectoryParams, { "set_joint_trajectory", "topicName" }, "arm_controller/follow_joint_trajectory"));
+            AZStd::string trajectoryActionName = HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(
+                poseTrajectoryParams, { "set_joint_trajectory", "topicName" }, "arm_controller/follow_joint_trajectory"));
 
             if (HooksUtils::CreateComponent<JointsTrajectoryComponent>(entity, trajectoryActionName))
             {
@@ -61,8 +62,6 @@ namespace ROS2::SDFormat
             {
                 return AZ::Failure(AZStd::string("Failed to create ROS2 Joint Pose Trajectory"));
             }
-            
-
         };
 
         return importerHook;

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -58,7 +58,7 @@ namespace ROS2::SDFormat
             }
             else
             {
-                return AZ::Failure(AZStd::string("Failed to create ROS2 Joint Pose Trajectory"));
+                return AZ::Failure(AZStd::string("Failed to create ROS2 Joint Pose Trajectory Component"));
             }
         };
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
+#include <RobotImporter/SDFormat/ROS2ModelPluginHooks.h>
+
+namespace ROS2::SDFormat
+{
+    ModelPluginImporterHook ROS2ModelPluginHooks::ROS2JointPoseTrajectoryModel()
+    {
+        ModelPluginImporterHook importerHook;
+        importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_joint_pose_trajectory.so" };
+        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ };
+
+        importerHook.m_sdfPluginToComponentCallback =
+            [](AZ::Entity& entity, const sdf::Plugin& sdfPlugin, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)
+            -> ModelPluginImporterHook::ConvertPluginOutcome
+        {
+            return AZ::Success();
+        };
+
+        return importerHook;
+    }
+} // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -6,6 +6,10 @@
  *
  */
 
+#include <Manipulation/Controllers/JointsArticulationControllerComponent.h>
+#include <Manipulation/JointsManipulationEditorComponent.h>
+#include <ROS2/Frame/ROS2FrameEditorComponent.h>
+#include <Manipulation/JointsTrajectoryComponent.h>
 #include <RobotImporter/SDFormat/ROS2ModelPluginHooks.h>
 #include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
 
@@ -15,13 +19,56 @@ namespace ROS2::SDFormat
     {
         ModelPluginImporterHook importerHook;
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_joint_pose_trajectory.so" };
-        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{};
+        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ ">topicName", ">ros>remapping", ">ros>argument", ">updateRate", ">update_rate" };
 
         importerHook.m_sdfPluginToComponentCallback =
             [](AZ::Entity& entity, const sdf::Plugin& sdfPlugin, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)
             -> ModelPluginImporterHook::ConvertPluginOutcome
         {
-            return AZ::Success();
+            HooksUtils::PluginParams poseTrajectoryParams = HooksUtils::GetPluginParams(sdfPlugin);
+
+            // add required components
+            HooksUtils::CreateComponent<JointsArticulationControllerComponent>(entity);
+            HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
+            auto manipulationElement = HooksUtils::CreateComponent<JointsManipulationEditorComponent>(entity);
+            if (manipulationElement)
+            {
+                //auto manipulationComponent = dynamic_cast<JointsManipulationEditorComponent*>(manipulationElement);
+                PublisherConfiguration publisherConfiguration;
+                if (poseTrajectoryParams.contains("update_rate"))
+                {
+                    std::string freqFromPlugin(poseTrajectoryParams["update_rate"].begin(), poseTrajectoryParams["update_rate"].size());
+                    publisherConfiguration.m_frequency = std::stof(freqFromPlugin);
+                }
+                else if (poseTrajectoryParams.contains("updateRate"))
+                {
+                    std::string freqFromPlugin(poseTrajectoryParams["updateRate"].begin(), poseTrajectoryParams["updateRate"].size());
+                    publisherConfiguration.m_frequency = std::stof(freqFromPlugin);
+                }
+                publisherConfiguration.m_topicConfiguration.m_type = "sensor_msgs::msg::JointState";
+                publisherConfiguration.m_topicConfiguration.m_topic = "joint_states";
+            }
+
+            AZStd::string trajectoryActionName("arm_controller/follow_joint_trajectory");
+            if (poseTrajectoryParams.contains("set_joint_trajectory"))
+            {
+                trajectoryActionName = HooksUtils::PluginParser::LastOnPath(poseTrajectoryParams["set_joint_trajectory"]);
+            }
+            else if (poseTrajectoryParams.contains("topicName"))
+            {
+                trajectoryActionName = HooksUtils::PluginParser::LastOnPath(poseTrajectoryParams["topicName"]);
+            }
+
+            if (HooksUtils::CreateComponent<JointsTrajectoryComponent>(entity, trajectoryActionName))
+            {
+                return AZ::Success();
+            }
+            else
+            {
+                return AZ::Failure(AZStd::string("Failed to create ROS2 Joint Pose Trajectory"));
+            }
+            
+
         };
 
         return importerHook;

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -32,13 +32,11 @@ namespace ROS2::SDFormat
             PublisherConfiguration publisherConfiguration;
             if (poseTrajectoryParams.contains("update_rate"))
             {
-                const std::string freqFromPlugin(poseTrajectoryParams["update_rate"].begin(), poseTrajectoryParams["update_rate"].size());
-                publisherConfiguration.m_frequency = std::stof(freqFromPlugin);
+                publisherConfiguration.m_frequency = AZStd::stof(poseTrajectoryParams["update_rate"]);
             }
             else if (poseTrajectoryParams.contains("updateRate"))
             {
-                const std::string freqFromPlugin(poseTrajectoryParams["updateRate"].begin(), poseTrajectoryParams["updateRate"].size());
-                publisherConfiguration.m_frequency = std::stof(freqFromPlugin);
+                publisherConfiguration.m_frequency = AZStd::stof(poseTrajectoryParams["updateRate"]);
             }
             publisherConfiguration.m_topicConfiguration.m_type = "sensor_msgs::msg::JointState";
             publisherConfiguration.m_topicConfiguration.m_topic = "joint_states";

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -26,18 +26,11 @@ namespace ROS2::SDFormat
             [](AZ::Entity& entity, const sdf::Plugin& sdfPlugin, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)
             -> ModelPluginImporterHook::ConvertPluginOutcome
         {
-            HooksUtils::PluginParams poseTrajectoryParams = HooksUtils::GetPluginParams(sdfPlugin);
+            const auto poseTrajectoryParams = HooksUtils::GetPluginParams({ sdfPlugin });
 
             // configure JointsManipulationEditorComponent publisher
             PublisherConfiguration publisherConfiguration;
-            if (poseTrajectoryParams.contains("update_rate"))
-            {
-                publisherConfiguration.m_frequency = AZStd::stof(poseTrajectoryParams["update_rate"]);
-            }
-            else if (poseTrajectoryParams.contains("updateRate"))
-            {
-                publisherConfiguration.m_frequency = AZStd::stof(poseTrajectoryParams["updateRate"]);
-            }
+            publisherConfiguration.m_frequency = HooksUtils::GetFrequency(poseTrajectoryParams);
             publisherConfiguration.m_topicConfiguration.m_type = "sensor_msgs::msg::JointState";
             publisherConfiguration.m_topicConfiguration.m_topic = "joint_states";
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -50,15 +50,8 @@ namespace ROS2::SDFormat
                 manipulationComponent->SetPublisherConfiguration(publisherConfiguration);
             }
 
-            AZStd::string trajectoryActionName("arm_controller/follow_joint_trajectory");
-            if (poseTrajectoryParams.contains("set_joint_trajectory"))
-            {
-                trajectoryActionName = HooksUtils::PluginParser::LastOnPath(poseTrajectoryParams["set_joint_trajectory"]);
-            }
-            else if (poseTrajectoryParams.contains("topicName"))
-            {
-                trajectoryActionName = HooksUtils::PluginParser::LastOnPath(poseTrajectoryParams["topicName"]);
-            }
+            AZStd::string trajectoryActionName = HooksUtils::PluginParser::LastOnPath(
+                    HooksUtils::ValueOfAny(poseTrajectoryParams, { "set_joint_trajectory", "topicName" }, "arm_controller/follow_joint_trajectory"));
 
             if (HooksUtils::CreateComponent<JointsTrajectoryComponent>(entity, trajectoryActionName))
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -50,7 +50,7 @@ namespace ROS2::SDFormat
             }
             else
             {
-                return AZ::Failure(AZStd::string("Failed to create ROS2 Joint Pose Trajectory Component"));
+                return AZ::Failure(AZStd::string("Failed to create ROS 2 Joint Pose Trajectory Component"));
             }
         };
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Manipulation/Controllers/JointsArticulationControllerComponent.h>
+#include <Manipulation/Controllers/JointsPIDControllerComponent.h>
 #include <Manipulation/JointsManipulationEditorComponent.h>
 #include <Manipulation/JointsTrajectoryComponent.h>
 #include <ROS2/Frame/ROS2FrameEditorComponent.h>
@@ -40,7 +41,10 @@ namespace ROS2::SDFormat
                 HooksUtils::ValueOfAny(poseTrajectoryParams, trajectoryTopicParamNames, "arm_controller/follow_joint_trajectory");
 
             // add required components
-            HooksUtils::CreateComponent<JointsArticulationControllerComponent>(entity);
+            if (!HooksUtils::CreateComponent<JointsArticulationControllerComponent>(entity))
+            {
+                HooksUtils::CreateComponent<JointsPIDControllerComponent>(entity);
+            }
             HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
             HooksUtils::CreateComponent<JointsManipulationEditorComponent>(entity, publisherConfiguration);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
 #include <RobotImporter/SDFormat/ROS2ModelPluginHooks.h>
+#include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
 
 namespace ROS2::SDFormat
 {
@@ -15,7 +15,7 @@ namespace ROS2::SDFormat
     {
         ModelPluginImporterHook importerHook;
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_joint_pose_trajectory.so" };
-        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ };
+        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{};
 
         importerHook.m_sdfPluginToComponentCallback =
             [](AZ::Entity& entity, const sdf::Plugin& sdfPlugin, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -32,19 +32,19 @@ namespace ROS2::SDFormat
             PublisherConfiguration publisherConfiguration;
             if (poseTrajectoryParams.contains("update_rate"))
             {
-                std::string freqFromPlugin(poseTrajectoryParams["update_rate"].begin(), poseTrajectoryParams["update_rate"].size());
+                const std::string freqFromPlugin(poseTrajectoryParams["update_rate"].begin(), poseTrajectoryParams["update_rate"].size());
                 publisherConfiguration.m_frequency = std::stof(freqFromPlugin);
             }
             else if (poseTrajectoryParams.contains("updateRate"))
             {
-                std::string freqFromPlugin(poseTrajectoryParams["updateRate"].begin(), poseTrajectoryParams["updateRate"].size());
+                const std::string freqFromPlugin(poseTrajectoryParams["updateRate"].begin(), poseTrajectoryParams["updateRate"].size());
                 publisherConfiguration.m_frequency = std::stof(freqFromPlugin);
             }
             publisherConfiguration.m_topicConfiguration.m_type = "sensor_msgs::msg::JointState";
             publisherConfiguration.m_topicConfiguration.m_topic = "joint_states";
 
             // configure trajectory action name
-            AZStd::string trajectoryActionName = HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(
+            const AZStd::string trajectoryActionName = HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(
                 poseTrajectoryParams, { "set_joint_trajectory", "topicName" }, "arm_controller/follow_joint_trajectory"));
 
             // add required components

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -8,6 +8,7 @@
 
 #include <Manipulation/Controllers/JointsArticulationControllerComponent.h>
 #include <Manipulation/Controllers/JointsPIDControllerComponent.h>
+#include <Source/EditorArticulationLinkComponent.h>
 #include <Manipulation/JointsManipulationEditorComponent.h>
 #include <Manipulation/JointsTrajectoryComponent.h>
 #include <ROS2/Frame/ROS2FrameEditorComponent.h>
@@ -41,11 +42,13 @@ namespace ROS2::SDFormat
                 HooksUtils::ValueOfAny(poseTrajectoryParams, trajectoryTopicParamNames, "arm_controller/follow_joint_trajectory");
 
             // add required components
-            if (!HooksUtils::CreateComponent<JointsArticulationControllerComponent>(entity))
-            {
-                HooksUtils::CreateComponent<JointsPIDControllerComponent>(entity);
-            }
             HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
+
+            // create controllerComponent based on model joints/articulations
+            entity.FindComponent<PhysX::EditorArticulationLinkComponent>()
+                ? HooksUtils::CreateComponent<JointsArticulationControllerComponent>(entity)
+                : HooksUtils::CreateComponent<JointsPIDControllerComponent>(entity);
+
             HooksUtils::CreateComponent<JointsManipulationEditorComponent>(entity, publisherConfiguration);
 
             if (HooksUtils::CreateComponent<JointsTrajectoryComponent>(entity, trajectoryActionName))

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -33,7 +33,7 @@ namespace ROS2::SDFormat
             auto manipulationElement = HooksUtils::CreateComponent<JointsManipulationEditorComponent>(entity);
             if (manipulationElement)
             {
-                //auto manipulationComponent = dynamic_cast<JointsManipulationEditorComponent*>(manipulationElement);
+                auto manipulationComponent = dynamic_cast<JointsManipulationEditorComponent*>(manipulationElement);
                 PublisherConfiguration publisherConfiguration;
                 if (poseTrajectoryParams.contains("update_rate"))
                 {
@@ -47,6 +47,7 @@ namespace ROS2::SDFormat
                 }
                 publisherConfiguration.m_topicConfiguration.m_type = "sensor_msgs::msg::JointState";
                 publisherConfiguration.m_topicConfiguration.m_topic = "joint_states";
+                manipulationComponent->SetPublisherConfiguration(publisherConfiguration);
             }
 
             AZStd::string trajectoryActionName("arm_controller/follow_joint_trajectory");

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
@@ -42,8 +42,9 @@ namespace ROS2::SDFormat
             publisherConfiguration.m_topicConfiguration.m_topic = "joint_states";
 
             // configure trajectory action name
-            const AZStd::string trajectoryActionName = HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(
-                poseTrajectoryParams, { "set_joint_trajectory", "topicName" }, "arm_controller/follow_joint_trajectory"));
+            const static AZStd::vector<AZStd::string> trajectoryTopicParamNames = { "set_joint_trajectory", "topicName" };
+            const AZStd::string trajectoryActionName =
+                HooksUtils::ValueOfAny(poseTrajectoryParams, trajectoryTopicParamNames, "arm_controller/follow_joint_trajectory");
 
             // add required components
             HooksUtils::CreateComponent<JointsArticulationControllerComponent>(entity);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
@@ -8,6 +8,7 @@
 
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
+#include <Source/EditorArticulationLinkComponent.h>
 #include <Manipulation/Controllers/JointsArticulationControllerComponent.h>
 #include <Manipulation/Controllers/JointsPIDControllerComponent.h>
 #include <Manipulation/JointsManipulationEditorComponent.h>
@@ -41,11 +42,12 @@ namespace ROS2::SDFormat
                 HooksUtils::ValueOfAny(statePublisherParams, topicParamNames, "joint_states");
 
             // add required components
-            if (!HooksUtils::CreateComponent<JointsArticulationControllerComponent>(entity))
-            {
-                HooksUtils::CreateComponent<JointsPIDControllerComponent>(entity);
-            }
             HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
+
+            // create controllerComponent based on model joints/articulations
+            entity.FindComponent<PhysX::EditorArticulationLinkComponent>()
+                ? HooksUtils::CreateComponent<JointsArticulationControllerComponent>(entity)
+                : HooksUtils::CreateComponent<JointsPIDControllerComponent>(entity);
 
             if (HooksUtils::CreateComponent<JointsManipulationEditorComponent>(entity, publisherConfiguration))
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
@@ -33,8 +33,7 @@ namespace ROS2::SDFormat
             PublisherConfiguration publisherConfiguration;
             if (statePublisherParams.contains("update_rate"))
             {
-                const std::string freqFromPlugin(statePublisherParams["update_rate"].begin(), statePublisherParams["update_rate"].size());
-                publisherConfiguration.m_frequency = std::stof(freqFromPlugin);
+                publisherConfiguration.m_frequency = AZStd::stof(statePublisherParams["update_rate"]);
             }
 
             publisherConfiguration.m_topicConfiguration.m_type = "sensor_msgs::msg::JointState";

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
@@ -33,7 +33,7 @@ namespace ROS2::SDFormat
             PublisherConfiguration publisherConfiguration;
             if (statePublisherParams.contains("update_rate"))
             {
-                std::string freqFromPlugin(statePublisherParams["update_rate"].begin(), statePublisherParams["update_rate"].size());
+                const std::string freqFromPlugin(statePublisherParams["update_rate"].begin(), statePublisherParams["update_rate"].size());
                 publisherConfiguration.m_frequency = std::stof(freqFromPlugin);
             }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
@@ -55,7 +55,7 @@ namespace ROS2::SDFormat
             }
             else
             {
-                return AZ::Failure(AZStd::string("Failed to create ROS2 Joint State Publisher"));
+                return AZ::Failure(AZStd::string("Failed to create ROS2 Joint State Publisher Component"));
             }
         };
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
@@ -6,24 +6,24 @@
  *
  */
 
-#include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
-#include <RobotImporter/SDFormat/ROS2ModelPluginHooks.h>
-#include <RobotImporter/Utils/RobotImporterUtils.h>
-#include <AzCore/std/string/string.h>
 #include <AzCore/std/containers/vector.h>
+#include <AzCore/std/string/string.h>
 #include <Manipulation/Controllers/JointsArticulationControllerComponent.h>
 #include <Manipulation/JointsManipulationEditorComponent.h>
+#include <RobotImporter/SDFormat/ROS2ModelPluginHooks.h>
+#include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
+#include <RobotImporter/Utils/RobotImporterUtils.h>
 
 namespace ROS2::SDFormat
 {
     namespace StatePublisherUtils
     {
         // Find all parent links in model and return pointers to their entities
-        AZ::Entity* GetParentLinkEntity(const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities) {
-
+        AZ::Entity* GetParentLinkEntity(const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)
+        {
             auto allLinks = Utils::GetAllLinks(sdfModel);
 
-            for (auto &link : allLinks)
+            for (auto& link : allLinks)
             {
                 AZStd::string linkName = link.first;
                 if (linkName.find_last_of(':') != std::string::npos)
@@ -42,7 +42,7 @@ namespace ROS2::SDFormat
             }
 
             return nullptr;
-        } 
+        }
     } // namespace StatePublisherUtils
 
     ModelPluginImporterHook ROS2ModelPluginHooks::ROS2JointStatePublisherModel()

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
@@ -49,7 +49,7 @@ namespace ROS2::SDFormat
             }
             else
             {
-                return AZ::Failure(AZStd::string("Failed to create ROS2 Joint State Publisher Component"));
+                return AZ::Failure(AZStd::string("Failed to create ROS 2 Joint State Publisher Component"));
             }
         };
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
@@ -21,7 +21,7 @@ namespace ROS2::SDFormat
     {
         ModelPluginImporterHook importerHook;
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_joint_state_publisher.so" };
-        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ ">update_rate", ">ros>namespace", ">ros>argument", ">ros>remapping" };
+        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ ">update_rate", ">ros>argument", ">ros>remapping" };
 
         importerHook.m_sdfPluginToComponentCallback =
             [](AZ::Entity& entity, const sdf::Plugin& sdfPlugin, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)
@@ -36,7 +36,7 @@ namespace ROS2::SDFormat
             auto manipulationElement = HooksUtils::CreateComponent<JointsManipulationEditorComponent>(entity);
             if (manipulationElement)
             {
-                //auto manipulationComponent = dynamic_cast<JointsManipulationEditorComponent*>(manipulationElement);
+                auto manipulationComponent = dynamic_cast<JointsManipulationEditorComponent*>(manipulationElement);
                 PublisherConfiguration publisherConfiguration;
                 if (statePublisherParams.contains("update_rate"))
                 {
@@ -51,7 +51,7 @@ namespace ROS2::SDFormat
                     messageTopic = HooksUtils::PluginParser::LastOnPath(statePublisherParams["joint_states"]);
                 }
                 publisherConfiguration.m_topicConfiguration.m_topic = messageTopic;
-                // manipulationComponent->SetPublisherConfiguration(publisherConfiguration);
+                manipulationComponent->SetPublisherConfiguration(publisherConfiguration);
                 return AZ::Success();
             }
             else

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
@@ -37,11 +37,10 @@ namespace ROS2::SDFormat
             }
 
             publisherConfiguration.m_topicConfiguration.m_type = "sensor_msgs::msg::JointState";
-            AZStd::string messageTopic = "joint_states";
-            if (statePublisherParams.contains("joint_states"))
-            {
-                messageTopic = HooksUtils::PluginParser::LastOnPath(statePublisherParams["joint_states"]);
-            }
+
+            const static AZStd::vector<AZStd::string> topicParamNames = { "joint_states" };
+            const AZStd::string messageTopic = HooksUtils::ValueOfAny(statePublisherParams, topicParamNames, "joint_states");
+
             publisherConfiguration.m_topicConfiguration.m_topic = messageTopic;
 
             // add required components

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/std/string/string.h>
 #include <Manipulation/Controllers/JointsArticulationControllerComponent.h>
 #include <Manipulation/JointsManipulationEditorComponent.h>
+#include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <RobotImporter/SDFormat/ROS2ModelPluginHooks.h>
 #include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
@@ -28,15 +29,14 @@ namespace ROS2::SDFormat
         {
             HooksUtils::PluginParams statePublisherParams = HooksUtils::GetPluginParams(sdfPlugin);
 
-            // add components necessary for publishing to parent link
-            if (!HooksUtils::CreateComponent<JointsArticulationControllerComponent>(entity))
-            {
-                return AZ::Failure(AZStd::string("Failed to create ROS2 Joint State Publisher"));
-            }
+            // add required components
+            HooksUtils::CreateComponent<JointsArticulationControllerComponent>(entity);
+            HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
+
             auto manipulationElement = HooksUtils::CreateComponent<JointsManipulationEditorComponent>(entity);
             if (manipulationElement)
             {
-                auto manipulationComponent = dynamic_cast<JointsManipulationEditorComponent*>(manipulationElement);
+                //auto manipulationComponent = dynamic_cast<JointsManipulationEditorComponent*>(manipulationElement);
                 PublisherConfiguration publisherConfiguration;
                 if (statePublisherParams.contains("update_rate"))
                 {
@@ -51,7 +51,7 @@ namespace ROS2::SDFormat
                     messageTopic = HooksUtils::PluginParser::LastOnPath(statePublisherParams["joint_states"]);
                 }
                 publisherConfiguration.m_topicConfiguration.m_topic = messageTopic;
-                manipulationComponent->SetPublisherConfiguration(publisherConfiguration);
+                // manipulationComponent->SetPublisherConfiguration(publisherConfiguration);
                 return AZ::Success();
             }
             else

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
 #include <Manipulation/Controllers/JointsArticulationControllerComponent.h>
+#include <Manipulation/Controllers/JointsPIDControllerComponent.h>
 #include <Manipulation/JointsManipulationEditorComponent.h>
 #include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <RobotImporter/SDFormat/ROS2ModelPluginHooks.h>
@@ -40,7 +41,10 @@ namespace ROS2::SDFormat
                 HooksUtils::ValueOfAny(statePublisherParams, topicParamNames, "joint_states");
 
             // add required components
-            HooksUtils::CreateComponent<JointsArticulationControllerComponent>(entity);
+            if (!HooksUtils::CreateComponent<JointsArticulationControllerComponent>(entity))
+            {
+                HooksUtils::CreateComponent<JointsPIDControllerComponent>(entity);
+            }
             HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
 
             if (HooksUtils::CreateComponent<JointsManipulationEditorComponent>(entity, publisherConfiguration))

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h>
+#include <RobotImporter/SDFormat/ROS2ModelPluginHooks.h>
+#include <RobotImporter/Utils/RobotImporterUtils.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/containers/vector.h>
+#include <Manipulation/Controllers/JointsArticulationControllerComponent.h>
+#include <Manipulation/JointsManipulationEditorComponent.h>
+
+namespace ROS2::SDFormat
+{
+    namespace StatePublisherUtils
+    {
+        // Find all parent links in model and return pointers to their entities
+        AZ::Entity* GetParentLinkEntity(const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities) {
+
+            auto allLinks = Utils::GetAllLinks(sdfModel);
+
+            for (auto &link : allLinks)
+            {
+                AZStd::string linkName = link.first;
+                if (linkName.find_last_of(':') != std::string::npos)
+                {
+                    int nameBeginning = linkName.find_last_of(':') + 1;
+                    linkName = linkName.substr(nameBeginning, linkName.size() - nameBeginning);
+                }
+                if (!Utils::IsChildLink(sdfModel, linkName))
+                {
+                    auto entityId = HooksUtils::GetLinkEntityId(std::string(linkName.c_str(), linkName.size()), sdfModel, createdEntities);
+                    if (entityId.IsValid())
+                    {
+                        return AzToolsFramework::GetEntityById(entityId);
+                    }
+                }
+            }
+
+            return nullptr;
+        } 
+    } // namespace StatePublisherUtils
+
+    ModelPluginImporterHook ROS2ModelPluginHooks::ROS2JointStatePublisherModel()
+    {
+        ModelPluginImporterHook importerHook;
+        importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_joint_state_publisher.so" };
+        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ ">update_rate", ">ros>namespace", ">ros>argument", ">ros>remapping" };
+
+        importerHook.m_sdfPluginToComponentCallback =
+            [](AZ::Entity& entity, const sdf::Plugin& sdfPlugin, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)
+            -> ModelPluginImporterHook::ConvertPluginOutcome
+        {
+            auto parentLinkEntity = StatePublisherUtils::GetParentLinkEntity(sdfModel, createdEntities);
+
+            HooksUtils::PluginParams statePublisherParams = HooksUtils::GetPluginParams(sdfPlugin);
+
+            // add components necessary for publishing to parent link
+            if (!HooksUtils::CreateComponent<JointsArticulationControllerComponent>(*parentLinkEntity))
+            {
+                return AZ::Failure(AZStd::string("Failed to create ROS2 Joint State Publisher"));
+            }
+            auto manipulationElement = HooksUtils::CreateComponent<JointsManipulationEditorComponent>(*parentLinkEntity);
+            if (manipulationElement)
+            {
+                auto manipulationComponent = dynamic_cast<JointsManipulationEditorComponent*>(manipulationElement);
+                PublisherConfiguration publisherConfiguration;
+                if (statePublisherParams.contains("update_rate"))
+                {
+                    std::string freqFromPlugin(statePublisherParams["update_rate"].begin(), statePublisherParams["update_rate"].size());
+                    publisherConfiguration.m_frequency = std::stof(freqFromPlugin);
+                }
+
+                publisherConfiguration.m_topicConfiguration.m_type = "sensor_msgs::msg::JointState";
+                AZStd::string messageTopic = "joint_states";
+                if (statePublisherParams.contains("joint_states"))
+                {
+                    messageTopic = HooksUtils::PluginParser::LastOnPath(statePublisherParams["joint_states"]);
+                }
+                publisherConfiguration.m_topicConfiguration.m_topic = messageTopic;
+                manipulationComponent->SetPublisherConfiguration(publisherConfiguration);
+                return AZ::Success();
+            }
+            else
+            {
+                return AZ::Failure(AZStd::string("Failed to create ROS2 Joint State Publisher"));
+            }
+        };
+
+        return importerHook;
+    }
+} // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -123,12 +123,11 @@ namespace ROS2::SDFormat
                     "GPU Lidar requires RGL Gem, see https://github.com/RobotecAI/o3de-rgl-gem for more details.\n");
             }
 
+            // Get frame configuration
+            auto frameConfiguration = HooksUtils::GetFrameConfiguration(lidarPluginParams);
+
             // Create required components
-            auto frameComponent = HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
-            if (frameComponent)
-            {
-                HooksUtils::ConfigureFrame(frameComponent, lidarPluginParams);
-            }
+            HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity, frameConfiguration);
 
             // Create Lidar component
             const auto lidarComponent = is2DLidar

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -71,12 +71,7 @@ namespace ROS2::SDFormat
 
             // setting lidar topic
             AZStd::string messageTopic = is2DLidar ? "scan" : "pc";
-            messageTopic =
-                HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(lidarPluginParams, { "topicName", "out" }, messageTopic));
-            if (element->HasElement("topic"))
-            {
-                messageTopic = element->Get<std::string>("topic").c_str();
-            }
+            messageTopic = HooksUtils::GetTopicName(lidarPluginParams, element, messageTopic);
             element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 
             // in ros1, updateRate is an element of the plugin, not a sensor parameter

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -66,10 +66,10 @@ namespace ROS2::SDFormat
             // setting lidar topic
             AZStd::string messageTopic = is2DLidar ? "scan" : "pc";
             if (!lidarPlugins.empty()) {
-                HooksUtils::Remaps lidarRemaps = HooksUtils::GetSensorRemaps(lidarPlugins[0]);
-                if (lidarRemaps.contains("out")) messageTopic = lidarRemaps["out"];
-                else if (lidarRemaps.contains("topicName")) {
-                    messageTopic = HooksUtils::PluginParser::LastOnPath(lidarRemaps["topicName"]);
+                HooksUtils::PluginParams lidarPluginParams = HooksUtils::GetPluginParams(lidarPlugins[0]);
+                if (lidarPluginParams.contains("out")) messageTopic = lidarPluginParams["out"];
+                else if (lidarPluginParams.contains("topicName")) {
+                    messageTopic = HooksUtils::PluginParser::LastOnPath(lidarPluginParams["topicName"]);
                 }
             }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -68,8 +68,7 @@ namespace ROS2::SDFormat
             const auto element = sdfSensor.Element();
 
             // setting lidar topic
-            AZStd::string messageTopic = is2DLidar ? "scan" : "pc";
-            messageTopic = HooksUtils::GetTopicName(lidarPluginParams, element, messageTopic);
+            const AZStd::string messageTopic = HooksUtils::GetTopicName(lidarPluginParams, element, (is2DLidar ? "scan" : "pc"));
             element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 
             // in ros1, updateRate is an element of the plugin, not a sensor parameter

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -75,16 +75,14 @@ namespace ROS2::SDFormat
                 HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(lidarPluginParams, { "topicName", "out" }, messageTopic));
             if (element->HasElement("topic"))
             {
-                std::string topicParam = element->Get<std::string>("topic");
-                messageTopic = AZStd::string(topicParam.c_str(), topicParam.size());
+                messageTopic = element->Get<std::string>("topic").c_str();
             }
             element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 
             // in ros1, updateRate is an element of the plugin, not a sensor parameter
             if (lidarPluginParams.contains("updateRate"))
             {
-                std::string freqFromPlugin(lidarPluginParams["updateRate"].begin(), lidarPluginParams["updateRate"].size());
-                sensorConfiguration.m_frequency = std::stof(freqFromPlugin);
+                sensorConfiguration.m_frequency = AZStd::stof(lidarPluginParams["updateRate"]);
             }
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -69,14 +69,9 @@ namespace ROS2::SDFormat
 
             // setting lidar topic
             AZStd::string messageTopic = is2DLidar ? "scan" : "pc";
-            if (lidarPluginParams.contains("out"))
-            {
-                messageTopic = lidarPluginParams["out"];
-            }
-            else if (lidarPluginParams.contains("topicName"))
-            {
-                messageTopic = HooksUtils::PluginParser::LastOnPath(lidarPluginParams["topicName"]);
-            }
+            messageTopic = HooksUtils::PluginParser::LastOnPath(
+                    HooksUtils::ValueOfAny(lidarPluginParams, { "topicName", "out" }, messageTopic));
+
             // in ros1, updateRate is an element of the plugin, not a sensor parameter
             if (lidarPluginParams.contains("updateRate"))
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -78,10 +78,7 @@ namespace ROS2::SDFormat
                 std::string topicParam = element->Get<std::string>("topic");
                 messageTopic = AZStd::string(topicParam.c_str(), topicParam.size());
             }
-            if (element->HasElement("visualize"))
-            {
-                sensorConfiguration.m_visualize = element->Get<bool>("visualize");
-            }
+            element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 
             // in ros1, updateRate is an element of the plugin, not a sensor parameter
             if (lidarPluginParams.contains("updateRate"))

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -109,7 +109,7 @@ namespace ROS2::SDFormat
             }
 
             // Get frame configuration
-            auto frameConfiguration = HooksUtils::GetFrameConfiguration(lidarPluginParams);
+            const auto frameConfiguration = HooksUtils::GetFrameConfiguration(lidarPluginParams);
 
             // Create required components
             HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity, frameConfiguration);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -119,7 +119,7 @@ namespace ROS2::SDFormat
             }
             else
             {
-                return AZ::Failure(AZStd::string("Failed to create ROS2 Lidar Sensor component"));
+                return AZ::Failure(AZStd::string("Failed to create ROS 2 Lidar Sensor component"));
             }
         };
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -119,7 +119,10 @@ namespace ROS2::SDFormat
 
             // Create required components
             auto frameComponent = HooksUtils::CreateComponent<ROS2FrameEditorComponent>(entity);
-            HooksUtils::ConfigureFrame(frameComponent, lidarPluginParams);
+            if (frameComponent)
+            {
+                HooksUtils::ConfigureFrame(frameComponent, lidarPluginParams);
+            }
 
             // Create Lidar component
             const auto lidarComponent = is2DLidar

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -21,29 +21,30 @@ namespace ROS2::SDFormat
     {
         SensorImporterHook importerHook;
         importerHook.m_sensorTypes = AZStd::unordered_set<sdf::SensorType>{ sdf::SensorType::LIDAR, sdf::SensorType::GPU_LIDAR };
-        importerHook.m_supportedSensorParams = AZStd::unordered_set<AZStd::string>{ ">pose",
-                                                                                    ">update_rate",
-                                                                                    ">lidar>scan>horizontal>samples",
-                                                                                    ">lidar>scan>horizontal>min_angle",
-                                                                                    ">lidar>scan>horizontal>max_angle",
-                                                                                    ">lidar>scan>vertical>samples",
-                                                                                    ">lidar>scan>vertical>min_angle",
-                                                                                    ">lidar>scan>vertical>max_angle",
-                                                                                    ">lidar>range>min",
-                                                                                    ">lidar>range>max",
-                                                                                    // Gazebo-classic
-                                                                                    ">ray>scan>horizontal>resolution",
-                                                                                    ">ray>scan>horizontal>samples",
-                                                                                    ">ray>scan>horizontal>min_angle",
-                                                                                    ">ray>scan>horizontal>max_angle",
-                                                                                    ">ray>scan>vertical>samples",
-                                                                                    ">ray>scan>vertical>min_angle",
-                                                                                    ">ray>scan>vertical>max_angle",
-                                                                                    ">ray>scan>vertical>resolution",
-                                                                                    ">ray>range>min",
-                                                                                    ">ray>range>max",
-                                                                                    ">topic",
-                                                                                    ">visualize" };
+        importerHook.m_supportedSensorParams = AZStd::unordered_set<AZStd::string>{
+            ">pose",
+            ">update_rate",
+            ">lidar>scan>horizontal>samples",
+            ">lidar>scan>horizontal>min_angle",
+            ">lidar>scan>horizontal>max_angle",
+            ">lidar>scan>vertical>samples",
+            ">lidar>scan>vertical>min_angle",
+            ">lidar>scan>vertical>max_angle",
+            ">lidar>range>min",
+            ">lidar>range>max",
+            // Gazebo-classic
+            ">ray>scan>horizontal>resolution",
+            ">ray>scan>horizontal>samples",
+            ">ray>scan>horizontal>min_angle",
+            ">ray>scan>horizontal>max_angle",
+            ">ray>scan>vertical>samples",
+            ">ray>scan>vertical>min_angle",
+            ">ray>scan>vertical>max_angle",
+            ">ray>scan>vertical>resolution",
+            ">ray>range>min",
+            ">ray>range>max",
+            ">topic",
+            ">visualize" };
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_ray_sensor.so", "libgazebo_ros_laser.so" };
         importerHook.m_supportedPluginParams =
             AZStd::unordered_set<AZStd::string>{ ">topicName",      ">ros>remapping", ">ros>argument", ">updateRate",

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -21,29 +21,29 @@ namespace ROS2::SDFormat
     {
         SensorImporterHook importerHook;
         importerHook.m_sensorTypes = AZStd::unordered_set<sdf::SensorType>{ sdf::SensorType::LIDAR, sdf::SensorType::GPU_LIDAR };
-        importerHook.m_supportedSensorParams = AZStd::unordered_set<AZStd::string>{
-            ">pose",
-            ">update_rate",
-            ">lidar>scan>horizontal>samples",
-            ">lidar>scan>horizontal>min_angle",
-            ">lidar>scan>horizontal>max_angle",
-            ">lidar>scan>vertical>samples",
-            ">lidar>scan>vertical>min_angle",
-            ">lidar>scan>vertical>max_angle",
-            ">lidar>range>min",
-            ">lidar>range>max",
-            // Gazebo-classic
-            ">ray>scan>horizontal>resolution",
-            ">ray>scan>horizontal>samples",
-            ">ray>scan>horizontal>min_angle",
-            ">ray>scan>horizontal>max_angle",
-            ">ray>scan>vertical>samples",
-            ">ray>scan>vertical>min_angle",
-            ">ray>scan>vertical>max_angle",
-            ">ray>scan>vertical>resolution",
-            ">ray>range>min",
-            ">ray>range>max",
-        };
+        importerHook.m_supportedSensorParams = AZStd::unordered_set<AZStd::string>{ ">pose",
+                                                                                    ">update_rate",
+                                                                                    ">lidar>scan>horizontal>samples",
+                                                                                    ">lidar>scan>horizontal>min_angle",
+                                                                                    ">lidar>scan>horizontal>max_angle",
+                                                                                    ">lidar>scan>vertical>samples",
+                                                                                    ">lidar>scan>vertical>min_angle",
+                                                                                    ">lidar>scan>vertical>max_angle",
+                                                                                    ">lidar>range>min",
+                                                                                    ">lidar>range>max",
+                                                                                    // Gazebo-classic
+                                                                                    ">ray>scan>horizontal>resolution",
+                                                                                    ">ray>scan>horizontal>samples",
+                                                                                    ">ray>scan>horizontal>min_angle",
+                                                                                    ">ray>scan>horizontal>max_angle",
+                                                                                    ">ray>scan>vertical>samples",
+                                                                                    ">ray>scan>vertical>min_angle",
+                                                                                    ">ray>scan>vertical>max_angle",
+                                                                                    ">ray>scan>vertical>resolution",
+                                                                                    ">ray>range>min",
+                                                                                    ">ray>range>max",
+                                                                                    ">topic",
+                                                                                    ">visualize" };
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_ray_sensor.so", "libgazebo_ros_laser.so" };
         importerHook.m_supportedPluginParams =
             AZStd::unordered_set<AZStd::string>{ ">topicName",      ">ros>remapping", ">ros>argument", ">updateRate",
@@ -66,11 +66,21 @@ namespace ROS2::SDFormat
             const auto lidarPlugins = sdfSensor.Plugins();
             HooksUtils::PluginParams lidarPluginParams =
                 lidarPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(lidarPlugins[0]);
+            const sdf::ElementPtr element = sdfSensor.Element();
 
             // setting lidar topic
             AZStd::string messageTopic = is2DLidar ? "scan" : "pc";
-            messageTopic = HooksUtils::PluginParser::LastOnPath(
-                    HooksUtils::ValueOfAny(lidarPluginParams, { "topicName", "out" }, messageTopic));
+            messageTopic =
+                HooksUtils::PluginParser::LastOnPath(HooksUtils::ValueOfAny(lidarPluginParams, { "topicName", "out" }, messageTopic));
+            if (element->HasElement("topic"))
+            {
+                std::string topicParam = element->Get<std::string>("topic");
+                messageTopic = AZStd::string(topicParam.c_str(), topicParam.size());
+            }
+            if (element->HasElement("visualize"))
+            {
+                sensorConfiguration.m_visualize = element->Get<bool>("visualize");
+            }
 
             // in ros1, updateRate is an element of the plugin, not a sensor parameter
             if (lidarPluginParams.contains("updateRate"))

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -70,7 +70,9 @@ namespace ROS2::SDFormat
             // setting lidar topic
             AZStd::string messageTopic = is2DLidar ? "scan" : "pc";
             if (lidarPluginParams.contains("out"))
+            {
                 messageTopic = lidarPluginParams["out"];
+            }
             else if (lidarPluginParams.contains("topicName"))
             {
                 messageTopic = HooksUtils::PluginParser::LastOnPath(lidarPluginParams["topicName"]);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -58,21 +58,17 @@ namespace ROS2::SDFormat
                 return AZ::Failure(AZStd::string("Failed to read parsed SDFormat data of %s Lidar sensor", sdfSensor.Name().c_str()));
             }
 
-            const bool is2DLidar = (lidarSensor->VerticalScanSamples() == 1);
-
-            SensorConfiguration sensorConfiguration;
-            sensorConfiguration.m_frequency = sdfSensor.UpdateRate();
-            const AZStd::string messageType = is2DLidar ? "sensor_msgs::msg::LaserScan" : "sensor_msgs::msg::PointCloud2";
-
             const auto lidarPluginParams = HooksUtils::GetPluginParams(sdfSensor.Plugins());
             const auto element = sdfSensor.Element();
+
+            SensorConfiguration sensorConfiguration;
+            sensorConfiguration.m_frequency = HooksUtils::GetFrequency(lidarPluginParams);
+            const bool is2DLidar = (lidarSensor->VerticalScanSamples() == 1);
+            const AZStd::string messageType = is2DLidar ? "sensor_msgs::msg::LaserScan" : "sensor_msgs::msg::PointCloud2";
 
             // setting lidar topic
             const AZStd::string messageTopic = HooksUtils::GetTopicName(lidarPluginParams, element, (is2DLidar ? "scan" : "pc"));
             element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
-
-            // in ros1, updateRate is an element of the plugin, not a sensor parameter
-            sensorConfiguration.m_frequency = HooksUtils::GetFrequency(lidarPluginParams, sensorConfiguration.m_frequency);
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -64,10 +64,8 @@ namespace ROS2::SDFormat
             sensorConfiguration.m_frequency = sdfSensor.UpdateRate();
             const AZStd::string messageType = is2DLidar ? "sensor_msgs::msg::LaserScan" : "sensor_msgs::msg::PointCloud2";
 
-            const auto lidarPlugins = sdfSensor.Plugins();
-            HooksUtils::PluginParams lidarPluginParams =
-                lidarPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(lidarPlugins[0]);
-            const sdf::ElementPtr element = sdfSensor.Element();
+            const auto lidarPluginParams = HooksUtils::GetPluginParams(sdfSensor.Plugins());
+            const auto element = sdfSensor.Element();
 
             // setting lidar topic
             AZStd::string messageTopic = is2DLidar ? "scan" : "pc";
@@ -75,10 +73,7 @@ namespace ROS2::SDFormat
             element->Get<bool>("visualize", sensorConfiguration.m_visualize, false);
 
             // in ros1, updateRate is an element of the plugin, not a sensor parameter
-            if (lidarPluginParams.contains("updateRate"))
-            {
-                sensorConfiguration.m_frequency = AZStd::stof(lidarPluginParams["updateRate"]);
-            }
+            sensorConfiguration.m_frequency = HooksUtils::GetFrequency(lidarPluginParams, sensorConfiguration.m_frequency);
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -45,7 +45,7 @@ namespace ROS2::SDFormat
             ">ray>range>max",
         };
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_ray_sensor.so", "libgazebo_ros_laser.so" };
-        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ ">topicName", ">ros>remapping", ">ros>argument" };
+        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ ">topicName", ">ros>remapping", ">ros>argument", ">updateRate" };
         importerHook.m_sdfSensorToComponentCallback = [](AZ::Entity& entity,
                                                          const sdf::Sensor& sdfSensor) -> SensorImporterHook::ConvertSensorOutcome
         {
@@ -70,6 +70,12 @@ namespace ROS2::SDFormat
                 if (lidarPluginParams.contains("out")) messageTopic = lidarPluginParams["out"];
                 else if (lidarPluginParams.contains("topicName")) {
                     messageTopic = HooksUtils::PluginParser::LastOnPath(lidarPluginParams["topicName"]);
+                }
+                // in ros1, updateRate is an element of the plugin, not a sensor parameter
+                if (lidarPluginParams.contains("updateRate"))
+                {
+                    std::string freqFromPlugin(lidarPluginParams["updateRate"].begin(), lidarPluginParams["updateRate"].size());
+                    sensorConfiguration.m_frequency = std::stof(freqFromPlugin);
                 }
             }
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
@@ -45,7 +45,9 @@ namespace ROS2::SDFormat
             ">ray>range>max",
         };
         importerHook.m_pluginNames = AZStd::unordered_set<AZStd::string>{ "libgazebo_ros_ray_sensor.so", "libgazebo_ros_laser.so" };
-        importerHook.m_supportedPluginParams = AZStd::unordered_set<AZStd::string>{ ">topicName", ">ros>remapping", ">ros>argument", ">updateRate" };
+        importerHook.m_supportedPluginParams =
+            AZStd::unordered_set<AZStd::string>{ ">topicName",      ">ros>remapping", ">ros>argument", ">updateRate",
+                                                 ">ros>frame_name", ">ros>namespace", ">frameName",    ">robotNamespace" };
         importerHook.m_sdfSensorToComponentCallback = [](AZ::Entity& entity,
                                                          const sdf::Sensor& sdfSensor) -> SensorImporterHook::ConvertSensorOutcome
         {
@@ -62,12 +64,15 @@ namespace ROS2::SDFormat
             const AZStd::string messageType = is2DLidar ? "sensor_msgs::msg::LaserScan" : "sensor_msgs::msg::PointCloud2";
 
             const auto lidarPlugins = sdfSensor.Plugins();
-            HooksUtils::PluginParams lidarPluginParams = lidarPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(lidarPlugins[0]);
+            HooksUtils::PluginParams lidarPluginParams =
+                lidarPlugins.empty() ? HooksUtils::PluginParams() : HooksUtils::GetPluginParams(lidarPlugins[0]);
 
             // setting lidar topic
             AZStd::string messageTopic = is2DLidar ? "scan" : "pc";
-            if (lidarPluginParams.contains("out")) messageTopic = lidarPluginParams["out"];
-            else if (lidarPluginParams.contains("topicName")) {
+            if (lidarPluginParams.contains("out"))
+                messageTopic = lidarPluginParams["out"];
+            else if (lidarPluginParams.contains("topicName"))
+            {
                 messageTopic = HooksUtils::PluginParser::LastOnPath(lidarPluginParams["topicName"]);
             }
             // in ros1, updateRate is an element of the plugin, not a sensor parameter
@@ -76,7 +81,6 @@ namespace ROS2::SDFormat
                 std::string freqFromPlugin(lidarPluginParams["updateRate"].begin(), lidarPluginParams["updateRate"].size());
                 sensorConfiguration.m_frequency = std::stof(freqFromPlugin);
             }
-
 
             HooksUtils::AddTopicConfiguration(sensorConfiguration, messageTopic, messageType, messageType);
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2ModelPluginHooks.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2ModelPluginHooks.h
@@ -12,20 +12,16 @@
 
 namespace ROS2::SDFormat::ROS2ModelPluginHooks
 {
-    //! Retrieve a model plugin importer hook which is used to map SDFormat model plugin of type skid steering drive into O3DE
-    //! components.
+    //! Get a mapping of SDFormat skid_steer_drive and diff_drive plugins into O3DE components.
     ModelPluginImporterHook ROS2SkidSteeringModel();
 
-    //! Retrieve a model plugin importer hook which is used to map SDFormat model plugin of type Ackermann model drive into O3DE
-    //! components.
+    //! Get a mapping of SDFormat ackermann_drive plugin into O3DE components.
     ModelPluginImporterHook ROS2AckermannModel();
 
-    //! Retrive a model plugin importer hook which is used to map SDFormat model plugin of type Joint state publisher into O3DE
-    //! components
+    //! Get a mapping of SDFormat joint_state_publisher plugin into O3DE components.
     ModelPluginImporterHook ROS2JointStatePublisherModel();
 
-    //! Retrive a model plugin importer hook which is used to map SDFormat model plugin of type Joint pose trajectory into O3DE
-    //! components
+     //! Get a mapping of SDFormat joint_pose_trajectory plugin into O3DE components.
     ModelPluginImporterHook ROS2JointPoseTrajectoryModel();
 
 } // namespace ROS2::SDFormat::ROS2ModelPluginHooks

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2ModelPluginHooks.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2ModelPluginHooks.h
@@ -20,4 +20,12 @@ namespace ROS2::SDFormat::ROS2ModelPluginHooks
     //! components.
     ModelPluginImporterHook ROS2AckermannModel();
 
+    //! Retrive a model plugin importer hook which is used to map SDFormat model plugin of type Joint state publisher into O3DE
+    //! components
+    ModelPluginImporterHook ROS2JointStatePublisherModel();
+
+    //! Retrive a model plugin importer hook which is used to map SDFormat model plugin of type Joint pose trajectory into O3DE
+    //! components
+    ModelPluginImporterHook ROS2JointPoseTrajectoryModel();
+
 } // namespace ROS2::SDFormat::ROS2ModelPluginHooks

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -46,19 +46,6 @@ namespace ROS2::SDFormat
         return AZ::EntityId();
     }
 
-    AZ::EntityId HooksUtils::GetLinkEntityId(
-        const std::string& linkName, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities)
-    {
-        const auto linkPtr = sdfModel.LinkByName(linkName);
-        if (linkPtr != nullptr && createdEntities.contains(linkPtr))
-        {
-            const auto& entityResult = createdEntities.at(linkPtr);
-            return entityResult.IsSuccess() ? entityResult.GetValue() : AZ::EntityId();
-        }
-
-        return AZ::EntityId();
-    }
-
     void HooksUtils::EnableMotor(const AZ::EntityId& entityId)
     {
         AZ::Entity* entity = nullptr;

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -118,7 +118,7 @@ namespace ROS2::SDFormat
             remappings[key] = val;
         }
 
-        // Parses parameters present in <ros> element, inserting them to the map.
+        // Parses parameters present in ros element, inserting them to the map.
         void ParseRos2Remapping(const sdf::Element& rosContent, HooksUtils::PluginParams& remappings)
         {
             if (rosContent.GetName() != "remapping" && rosContent.GetName() != "argument")
@@ -214,7 +214,7 @@ namespace ROS2::SDFormat
             std::string contentName = content->GetName();
             if (contentName == "ros")
             {
-                // when <ros> tag is present, parse it's elements and insert them into the map
+                // when ros tag is present, parse it's elements and insert them into the map
                 auto rosContent = content->GetFirstElement();
                 while (rosContent != nullptr)
                 {

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -232,4 +232,17 @@ namespace ROS2::SDFormat
         return remappings;
     }
 
+    AZStd::string HooksUtils::ValueOfAny(
+        const HooksUtils::PluginParams& pluginParams, AZStd::vector<AZStd::string> paramNameVec, AZStd::string defaultVal)
+    {
+        for (auto paramName : paramNameVec)
+        {
+            if (pluginParams.contains(paramName))
+            {
+                return pluginParams.at(paramName);
+            }
+        }
+        return defaultVal;
+    }
+
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -164,7 +164,7 @@ namespace ROS2::SDFormat
                 startVal = contentValue.find_last_of("/");
             }
             startVal += 1;
-            
+
             if (startVal >= contentValue.size())
             {
                 AZ_Warning("PluginParser", false, "Encountered invalid (empty) remapping while parsing URDF/SDF plugin.");

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -188,39 +188,31 @@ namespace ROS2::SDFormat
         }
     } // namespace HooksUtils::PluginParser
 
-    void HooksUtils::ConfigureFrame(ROS2FrameEditorComponent& frameComponent, const HooksUtils::PluginParams& pluginParams)
+    ROS2FrameConfiguration HooksUtils::GetFrameConfiguration(const HooksUtils::PluginParams& pluginParams)
     {
+        ROS2FrameConfiguration frameConfiguration;
+
         if (pluginParams.contains("robotNamespace"))
         {
-            frameComponent.UpdateNamespaceConfiguration(
+            frameConfiguration.m_namespaceConfiguration.SetNamespace(
                 pluginParams.at("robotNamespace"), NamespaceConfiguration::NamespaceStrategy::Custom);
         }
         else if (pluginParams.contains("namespace"))
         {
-            frameComponent.UpdateNamespaceConfiguration(
+            frameConfiguration.m_namespaceConfiguration.SetNamespace(
                 PluginParser::LastOnPath(pluginParams.at("namespace")), NamespaceConfiguration::NamespaceStrategy::Custom);
         }
+
         if (pluginParams.contains("frameName"))
         {
-            frameComponent.SetFrameID(pluginParams.at("frameName"));
+            frameConfiguration.m_frameName = pluginParams.at("frameName");
         }
         else if (pluginParams.contains("frame_name"))
         {
-            frameComponent.SetFrameID(pluginParams.at("frame_name"));
+            frameConfiguration.m_frameName = pluginParams.at("frame_name");
         }
-    }
 
-    void HooksUtils::ConfigureFrame(AZ::Component& frameComponent, const HooksUtils::PluginParams& pluginParams)
-    {
-        ConfigureFrame(*dynamic_cast<ROS2FrameEditorComponent*>(&frameComponent), pluginParams);
-    }
-
-    void HooksUtils::ConfigureFrame(AZ::Component* frameComponent, const HooksUtils::PluginParams& pluginParams)
-    {
-        if (frameComponent)
-        {
-            ConfigureFrame(*dynamic_cast<ROS2FrameEditorComponent*>(frameComponent), pluginParams);
-        }
+        return frameConfiguration;
     }
 
     HooksUtils::PluginParams HooksUtils::GetPluginParams(const sdf::Plugin& plugin)

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -8,6 +8,7 @@
 
 #include "ROS2SDFormatHooksUtils.h"
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
+#include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <ROS2/Communication/TopicConfiguration.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
 #include <RobotImporter/Utils/TypeConversions.h>
@@ -164,6 +165,32 @@ namespace ROS2::SDFormat
             remappings[key] = val;
         }
     } // namespace PluginParser
+
+    void HooksUtils::ConfigureFrame(ROS2FrameEditorComponent& frameComponent, const HooksUtils::PluginParams& pluginParams) {
+        if (pluginParams.contains("robotNamespace")) {
+            frameComponent.UpdateNamespaceConfiguration(pluginParams.at("robotNamespace"), NamespaceConfiguration::NamespaceStrategy::Custom);
+        }
+        else if (pluginParams.contains("namespace")) {
+            frameComponent.UpdateNamespaceConfiguration(PluginParser::LastOnPath(pluginParams.at("namespace")), NamespaceConfiguration::NamespaceStrategy::Custom);
+        }
+        if (pluginParams.contains("frameName")) {
+            frameComponent.SetFrameID(pluginParams.at("frameName"));
+        }
+        else if (pluginParams.contains("frame_name")) {
+            frameComponent.SetFrameID(pluginParams.at("frame_name"));
+        }
+    }
+
+    void HooksUtils::ConfigureFrame(AZ::Component& frameComponent, const HooksUtils::PluginParams& pluginParams) {
+        ConfigureFrame(*dynamic_cast<ROS2FrameEditorComponent*>(&frameComponent), pluginParams);
+    }
+
+    void HooksUtils::ConfigureFrame(AZ::Component* frameComponent, const HooksUtils::PluginParams& pluginParams) {
+        if (frameComponent) {
+            ConfigureFrame(*dynamic_cast<ROS2FrameEditorComponent*>(frameComponent), pluginParams);
+        }
+    }
+
 
     HooksUtils::PluginParams HooksUtils::GetPluginParams(const sdf::Plugin &plugin)
     {

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -123,7 +123,7 @@ namespace ROS2::SDFormat
         {
             if (rosContent.GetName() != "remapping" && rosContent.GetName() != "argument")
             {
-                // parameter other than <remapping> or <argument> can be handled as regular parameter
+                // parameter other than remapping or argument can be handled as regular parameter
                 ParseRegularContent(rosContent, remappings);
                 return;
             }

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -188,9 +188,15 @@ namespace ROS2::SDFormat
         return frameConfiguration;
     }
 
-    HooksUtils::PluginParams HooksUtils::GetPluginParams(const sdf::Plugin& plugin)
+    HooksUtils::PluginParams HooksUtils::GetPluginParams(const sdf::Plugins& plugins)
     {
         HooksUtils::PluginParams remappings;
+        if (plugins.empty())
+        {
+            return remappings;
+        }
+
+        const auto plugin = plugins[0];
 
         for (const auto& content : plugin.Contents())
         {
@@ -237,6 +243,12 @@ namespace ROS2::SDFormat
 
         const static AZStd::vector<AZStd::string> remapParamNames = { "topicName", "out" };
         return ValueOfAny(pluginParams, remapParamNames, defaultVal);
+    }
+
+    float HooksUtils::GetFrequency(const PluginParams& pluginParams, const float defaultVal)
+    {
+        const static AZStd::vector<AZStd::string> frequencyParamNames = { "updateRate", "update_rate" };
+        return AZStd::stof(ValueOfAny(pluginParams, frequencyParamNames, AZStd::to_string(defaultVal)));
     }
 
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -109,9 +109,14 @@ namespace ROS2::SDFormat
                 AZ_Warning("PluginParser", false, "Encountered empty parameter value while parsing URDF/SDF plugin.");
                 return "";
             }
-            if (path.contains('/'))
+            else if (path.contains('/'))
             {
                 int startPos = path.find_last_of('/') + 1;
+                if (startPos >= path.size())
+                {
+                    AZ_Warning("PluginParser", false, "Encountered empty parameter value while parsing URDF/SDF plugin.");
+                    return "";
+                }
                 path = path.substr(startPos, path.size() - startPos);
             }
             return path;
@@ -121,8 +126,13 @@ namespace ROS2::SDFormat
         void ParseRegularContent(const sdf::Element& content, HooksUtils::PluginParams& remappings)
         {
             std::string contentName = content.GetName();
-            AZStd::string key(contentName.c_str(), contentName.size());
             std::string contentValue = content.GetValue()->GetAsString();
+            if (contentName.empty() || contentValue.empty())
+            {
+                AZ_Warning("PluginParser", false, "Encountered empty parameter value while parsing URDF/SDF plugin.");
+                return;
+            }
+            AZStd::string key(contentName.c_str(), contentName.size());
             AZStd::string val(contentValue.c_str(), contentValue.size());
             remappings[key] = val;
         }
@@ -161,7 +171,14 @@ namespace ROS2::SDFormat
 
             // get previous name of the topic
             contentValue = contentValue.substr(0, contentValue.find_first_of(':'));
-            int startKey = contentValue.find_last_of('/') + 1;
+
+            int startKey = contentValue.find_last_of('/') != std::string::npos ? contentValue.find_last_of('/') + 1 : 0;
+            if (startKey >= contentValue.size())
+            {
+                AZ_Warning("PluginParser", false, "Encountered invalid (empty) remapping while parsing URDF/SDF plugin.");
+                return;
+            }
+
             std::string prevTopic = contentValue.substr(startKey, contentValue.size() - startKey);
 
             // insert data into the map - previous topic name as key and new topic name as val

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -121,9 +121,9 @@ namespace ROS2::SDFormat
         void ParseRegularContent(const sdf::Element& content, HooksUtils::PluginParams& remappings)
         {
             std::string contentName = content.GetName();
-            AZStd::string key(contentName.begin(), contentName.end());
+            AZStd::string key(contentName.c_str(), contentName.size());
             std::string contentValue = content.GetValue()->GetAsString();
-            AZStd::string val(contentValue.begin(), contentValue.end());
+            AZStd::string val(contentValue.c_str(), contentValue.size());
             remappings[key] = val;
         }
 
@@ -159,8 +159,8 @@ namespace ROS2::SDFormat
             std::string prevTopic = contentValue.substr(startKey, contentValue.size() - startKey);
 
             // insert data into the map - previous topic name as key and new topic name as val
-            AZStd::string key(prevTopic.begin(), prevTopic.end());
-            AZStd::string val(newTopic.begin(), newTopic.end());
+            AZStd::string key(prevTopic.c_str(), prevTopic.size());
+            AZStd::string val(newTopic.c_str(), newTopic.size());
             remappings[key] = val;
         }
     } // namespace HooksUtils::PluginParser

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -102,24 +102,9 @@ namespace ROS2::SDFormat
 
     namespace HooksUtils::PluginParser
     {
-        AZStd::string LastOnPath(AZStd::string path)
+        AZStd::string LastOnPath(const AZStd::string& path)
         {
-            if (path.empty())
-            {
-                AZ_Warning("PluginParser", false, "Encountered empty parameter value while parsing URDF/SDF plugin.");
-                return "";
-            }
-            else if (path.contains('/'))
-            {
-                int startPos = path.find_last_of('/') + 1;
-                if (startPos >= path.size())
-                {
-                    AZ_Warning("PluginParser", false, "Encountered empty parameter value while parsing URDF/SDF plugin.");
-                    return "";
-                }
-                path = path.substr(startPos, path.size() - startPos);
-            }
-            return path;
+            return AZ::IO::PathView(path).Filename().String();
         }
 
         // Inserts name (key) and value (val) of given parameter to map.
@@ -146,7 +131,7 @@ namespace ROS2::SDFormat
                 ParseRegularContent(rosContent, remappings);
                 return;
             }
-            std::string contentValue = rosContent.GetValue()->GetAsString();
+            AZStd::string contentValue = rosContent.GetValue()->GetAsString().c_str();
 
             if (contentValue.find_last_of('=') == std::string::npos || contentValue.find_last_of(':') == std::string::npos)
             {
@@ -167,7 +152,7 @@ namespace ROS2::SDFormat
                 AZ_Warning("PluginParser", false, "Encountered invalid (empty) remapping while parsing URDF/SDF plugin.");
                 return;
             }
-            std::string newTopic = contentValue.substr(startVal, contentValue.size() - startVal);
+            AZStd::string newTopic = contentValue.substr(startVal, contentValue.size() - startVal);
 
             // get previous name of the topic
             contentValue = contentValue.substr(0, contentValue.find_first_of(':'));
@@ -179,12 +164,9 @@ namespace ROS2::SDFormat
                 return;
             }
 
-            std::string prevTopic = contentValue.substr(startKey, contentValue.size() - startKey);
-
-            // insert data into the map - previous topic name as key and new topic name as val
-            AZStd::string key(prevTopic.c_str(), prevTopic.size());
-            AZStd::string val(newTopic.c_str(), newTopic.size());
-            remappings[key] = val;
+            AZStd::string prevTopic = contentValue.substr(startKey, contentValue.size() - startKey);
+            
+            remappings[prevTopic] = newTopic;
         }
     } // namespace HooksUtils::PluginParser
 

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -102,6 +102,13 @@ namespace ROS2::SDFormat
     namespace HooksUtils::PluginParser
     {
         AZStd::string LastOnPath(AZStd::string path) {
+            if (path.empty()) {
+                AZ_Warning(
+                    "PluginParser",
+                    false,
+                    "Encountered empty parameter value while parsing URDF/SDF plugin.");
+                return "";
+            }
             if (path.contains('/')) {
                 int startPos = path.find_last_of('/') + 1;
                 path = path.substr(startPos, path.size() - startPos);
@@ -127,8 +134,23 @@ namespace ROS2::SDFormat
             }
             std::string contentValue = rosContent.GetValue()->GetAsString();
 
+            if (contentValue.find_last_of('=') == -1 || contentValue.find_last_of(':') == -1) {
+                AZ_Warning(
+                    "PluginParser",
+                    false,
+                    "Encountered invalid remapping while parsing URDF/SDF plugin.");
+                return;
+            }
+
             // get new name of the topic
             int startVal = std::max(contentValue.find_last_of('/'), contentValue.find_last_of('=')) + 1;
+            if (startVal >= contentValue.size()) {
+                AZ_Warning(
+                    "PluginParser",
+                    false,
+                    "Encountered invalid (empty) remapping while parsing URDF/SDF plugin.");
+                return;
+            }
             std::string newTopic = contentValue.substr(startVal, contentValue.size() - startVal);
 
             // get previous name of the topic

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -118,7 +118,7 @@ namespace ROS2::SDFormat
             remappings[key] = val;
         }
 
-        // Parses parameters present in <ros> element, inserting them to map.
+        // Parses parameters present in <ros> element, inserting them to the map.
         void ParseRos2Remapping(const sdf::Element& rosContent, HooksUtils::PluginParams& remappings)
         {
             if (rosContent.GetName() != "remapping" && rosContent.GetName() != "argument")

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -250,9 +250,9 @@ namespace ROS2::SDFormat
     }
 
     AZStd::string HooksUtils::ValueOfAny(
-        const HooksUtils::PluginParams& pluginParams, AZStd::vector<AZStd::string> paramNameVec, AZStd::string defaultVal)
+        const HooksUtils::PluginParams& pluginParams, const AZStd::vector<AZStd::string>& paramNames, const AZStd::string& defaultVal)
     {
-        for (auto paramName : paramNameVec)
+        for (const auto &paramName : paramNames)
         {
             if (pluginParams.contains(paramName))
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -113,15 +113,6 @@ namespace ROS2::SDFormat
             return nullptr;
         }
 
-        namespace PluginParser
-        {
-            //! For given path, extracts only it's last element.
-            //! Especially useful when parsing ROS2 remappings.
-            //! @param path string representing the path
-            //! @return last element on the path
-            AZStd::string LastOnPath(const AZStd::string& path);
-        } // namespace PluginParser
-
         using PluginParams = AZStd::unordered_map<AZStd::string, AZStd::string>;
 
         //! Get frame configuration from given plugin params
@@ -132,8 +123,8 @@ namespace ROS2::SDFormat
         //! Find all parameters given in plugin element.
         //! Given a ROS2 remapping argument, extracts only names of
         //! elements to be remapped, ignoring their namespaces.
-        //! @param plugin plugin to extract parameters from.
-        //! @return a map of parameters present in plugin.
+        //! @param plugin plugin to extract parameters from
+        //! @return a map of parameters present in plugin
         PluginParams GetPluginParams(const sdf::Plugin& plugin);
 
         //! Find value of any of specified plugin parameters.
@@ -143,6 +134,12 @@ namespace ROS2::SDFormat
         //! @return value on any of the specified parameters or defaultVal when none were present
         AZStd::string ValueOfAny(
             const PluginParams& pluginParams, const AZStd::vector<AZStd::string>& paramNames, const AZStd::string& defaultVal = "");
+
+        //! Get the name of element's general topic after remapping.
+        //! @param pluginParams map of plugin parameters
+        //! @param element pointer to the sdf element
+        //! @param defaultVal value to be returned when no remaps of the topic are present in the map
+        AZStd::string GetTopicName(const PluginParams& pluginParams, sdf::ElementPtr element, const AZStd::string& defaultVal = "");
 
     } // namespace HooksUtils
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -129,7 +129,7 @@ namespace ROS2::SDFormat
 
         //! Find value of any of specified plugin parameters.
         //! @param pluginParams map of plugin parameters defined in model description
-        //! @param paramNames vector parameter names in query
+        //! @param paramNames vector of parameter names in query
         //! @param defaultVal value to be returned when none of the parameters are present in the map
         //! @return value on any of the query parameters or defaultVal when none were present
         AZStd::string ValueOfAny(

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -114,16 +114,21 @@ namespace ROS2::SDFormat
 
         namespace PluginParser
         {
+            //! For given path, extracts only it's last element.
+            //! Especially useful when parsing ROS2 remappings.
+            //! @param path string representing the path
+            //! @return last element on the path
             AZStd::string LastOnPath(AZStd::string path);
         } // namespace PluginParser
 
-        using Remaps = AZStd::unordered_map<AZStd::string, AZStd::string>;
+        using PluginParams = AZStd::unordered_map<AZStd::string, AZStd::string>;
 
-        //! Find all potential remaps present in given plugin.
-        //! Returns both ROS1 and ROS2 remappings.
-        //! @param plugin plugin to extract remaps from.
-        //! @return a map of remaps present in plugin.
-        Remaps GetSensorRemaps(const sdf::Plugin &plugin);
+        //! Find all parameters given in plugin element.
+        //! Given a ROS2 remapping argument, extracts only names of
+        //! elements to be remapped, ignoring their namespaces.
+        //! @param plugin plugin to extract parameters from.
+        //! @return a map of parameters present in plugin.
+        PluginParams GetPluginParams(const sdf::Plugin &plugin);
 
     } // namespace HooksUtils
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -46,6 +46,13 @@ namespace ROS2::SDFormat
         //! @return entity id (invalid id if not found)
         AZ::EntityId GetJointEntityId(const std::string& jointName, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities);
 
+        //! Find O3DE entity id of the SDFormat link based on its name and a map of all created entities.
+        //! @param linkName name of the link in query
+        //! @param sdfModel reference to SDFormat model
+        //! @param createdEntities list of all created entities passed as entity creation results
+        //! @return entity id (invalid id if not found)
+        AZ::EntityId GetLinkEntityId(const std::string& linkName, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities);
+
         //! Enable motor in EditorHingeJointComponent if possible
         //! @param entityId entity id of the modified entity
         void EnableMotor(const AZ::EntityId& entityId);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -14,6 +14,7 @@
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/string/string.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
+#include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 #include <ROS2/RobotImporter/SDFormatModelPluginImporterHook.h>
 #include <ROS2/Sensor/SensorConfiguration.h>
@@ -122,6 +123,15 @@ namespace ROS2::SDFormat
         } // namespace PluginParser
 
         using PluginParams = AZStd::unordered_map<AZStd::string, AZStd::string>;
+
+        //! Configure a frame attached to the entity basing on plugin parameters
+        //! @param frameComponent frame to be configured
+        //! @param componentParams parameters of the plugin for which frame is created
+        void ConfigureFrame(ROS2FrameEditorComponent& frameComponent, const PluginParams& pluginParams);
+        
+        void ConfigureFrame(AZ::Component& frameComponent, const PluginParams& pluginParams);
+
+        void ConfigureFrame(AZ::Component* frameComponent, const PluginParams& pluginParams);
 
         //! Find all parameters given in plugin element.
         //! Given a ROS2 remapping argument, extracts only names of

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -119,7 +119,7 @@ namespace ROS2::SDFormat
             //! Especially useful when parsing ROS2 remappings.
             //! @param path string representing the path
             //! @return last element on the path
-            AZStd::string LastOnPath(AZStd::string path);
+            AZStd::string LastOnPath(const AZStd::string& path);
         } // namespace PluginParser
 
         using PluginParams = AZStd::unordered_map<AZStd::string, AZStd::string>;
@@ -138,7 +138,7 @@ namespace ROS2::SDFormat
 
         //! Find value of any of specified plugin parameters.
         //! @param pluginParams map of plugin parameters
-        //! @param paramNameVec vector of specified parameter names
+        //! @param paramNames vector of specified parameter names
         //! @param defaultVal value to be returned when none of the parameters are present in the map
         //! @return value on any of the specified parameters or defaultVal when none were present
         AZStd::string ValueOfAny(

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -146,7 +146,7 @@ namespace ROS2::SDFormat
         //! @param defaultVal value to be returned when none of the parameters are present in the map
         //! @return value on any of the specified parameters or defaultVal when none were present
         AZStd::string ValueOfAny(
-            const PluginParams& pluginParams, AZStd::vector<AZStd::string> paramNameVec, AZStd::string defaultVal = "");
+            const PluginParams& pluginParams, AZStd::vector<AZStd::string> paramNames, const AZStd::string& defaultVal = "");
 
     } // namespace HooksUtils
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -111,5 +111,19 @@ namespace ROS2::SDFormat
 
             return nullptr;
         }
+
+        namespace PluginParser
+        {
+            AZStd::string LastOnPath(AZStd::string path);
+        } // namespace PluginParser
+
+        using Remaps = AZStd::unordered_map<AZStd::string, AZStd::string>;
+
+        //! Find all potential remaps present in given plugin.
+        //! Returns both ROS1 and ROS2 remappings.
+        //! @param plugin plugin to extract remaps from.
+        //! @return a map of remaps present in plugin.
+        Remaps GetSensorRemaps(const sdf::Plugin &plugin);
+
     } // namespace HooksUtils
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -143,9 +143,10 @@ namespace ROS2::SDFormat
         //! Find value of any of specified plugin parameters.
         //! @param pluginParams map of plugin parameters
         //! @param paramNameVec vector of specified parameter names
-        //! @param defaultVal value to be return when none of the parameters are present in the map
-        //! @return value on any of the specified parameters of defaultVal when none were present
-        AZStd::string ValueOfAny(const PluginParams& pluginParams, AZStd::vector<AZStd::string> paramNameVec, AZStd::string defaultVal = "");
+        //! @param defaultVal value to be returned when none of the parameters are present in the map
+        //! @return value on any of the specified parameters or defaultVal when none were present
+        AZStd::string ValueOfAny(
+            const PluginParams& pluginParams, AZStd::vector<AZStd::string> paramNameVec, AZStd::string defaultVal = "");
 
     } // namespace HooksUtils
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -14,8 +14,8 @@
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/string/string.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
-#include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
+#include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <ROS2/RobotImporter/SDFormatModelPluginImporterHook.h>
 #include <ROS2/Sensor/SensorConfiguration.h>
 #include <Source/EditorArticulationLinkComponent.h>
@@ -128,7 +128,7 @@ namespace ROS2::SDFormat
         //! @param frameComponent frame to be configured
         //! @param componentParams parameters of the plugin for which frame is created
         void ConfigureFrame(ROS2FrameEditorComponent& frameComponent, const PluginParams& pluginParams);
-        
+
         void ConfigureFrame(AZ::Component& frameComponent, const PluginParams& pluginParams);
 
         void ConfigureFrame(AZ::Component* frameComponent, const PluginParams& pluginParams);
@@ -138,7 +138,7 @@ namespace ROS2::SDFormat
         //! elements to be remapped, ignoring their namespaces.
         //! @param plugin plugin to extract parameters from.
         //! @return a map of parameters present in plugin.
-        PluginParams GetPluginParams(const sdf::Plugin &plugin);
+        PluginParams GetPluginParams(const sdf::Plugin& plugin);
 
     } // namespace HooksUtils
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -124,14 +124,10 @@ namespace ROS2::SDFormat
 
         using PluginParams = AZStd::unordered_map<AZStd::string, AZStd::string>;
 
-        //! Configure a frame attached to the entity basing on plugin parameters
-        //! @param frameComponent frame to be configured
-        //! @param componentParams parameters of the plugin for which frame is created
-        void ConfigureFrame(ROS2FrameEditorComponent& frameComponent, const PluginParams& pluginParams);
-
-        void ConfigureFrame(AZ::Component& frameComponent, const PluginParams& pluginParams);
-
-        void ConfigureFrame(AZ::Component* frameComponent, const PluginParams& pluginParams);
+        //! Get frame configuration from given plugin params
+        //! @param pluginParams parameters of the plugin for which frame is created
+        //! @return configuration of the frame
+        ROS2FrameConfiguration GetFrameConfiguration(const HooksUtils::PluginParams& pluginParams);
 
         //! Find all parameters given in plugin element.
         //! Given a ROS2 remapping argument, extracts only names of
@@ -146,7 +142,7 @@ namespace ROS2::SDFormat
         //! @param defaultVal value to be returned when none of the parameters are present in the map
         //! @return value on any of the specified parameters or defaultVal when none were present
         AZStd::string ValueOfAny(
-            const PluginParams& pluginParams, AZStd::vector<AZStd::string> paramNames, const AZStd::string& defaultVal = "");
+            const PluginParams& pluginParams, const AZStd::vector<AZStd::string>& paramNames, const AZStd::string& defaultVal = "");
 
     } // namespace HooksUtils
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -121,7 +121,7 @@ namespace ROS2::SDFormat
         ROS2FrameConfiguration GetFrameConfiguration(const HooksUtils::PluginParams& pluginParams);
 
         //! Find all parameters given in plugin element.
-        //! Given a ROS2 remapping argument, extracts only names of
+        //! Given a ROS 2 remapping argument, extracts only names of
         //! elements to be remapped, ignoring their namespaces.
         //! @param plugin plugin to extract parameters from
         //! @return a map of parameters present in plugin

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -46,13 +46,6 @@ namespace ROS2::SDFormat
         //! @return entity id (invalid id if not found)
         AZ::EntityId GetJointEntityId(const std::string& jointName, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities);
 
-        //! Find O3DE entity id of the SDFormat link based on its name and a map of all created entities.
-        //! @param linkName name of the link in query
-        //! @param sdfModel reference to SDFormat model
-        //! @param createdEntities list of all created entities passed as entity creation results
-        //! @return entity id (invalid id if not found)
-        AZ::EntityId GetLinkEntityId(const std::string& linkName, const sdf::Model& sdfModel, const CreatedEntitiesMap& createdEntities);
-
         //! Enable motor in EditorHingeJointComponent if possible
         //! @param entityId entity id of the modified entity
         void EnableMotor(const AZ::EntityId& entityId);

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -125,13 +125,13 @@ namespace ROS2::SDFormat
         //! elements to be remapped, ignoring their namespaces.
         //! @param plugin plugin to extract parameters from
         //! @return a map of parameters present in plugin
-        PluginParams GetPluginParams(const sdf::Plugin& plugin);
+        PluginParams GetPluginParams(const sdf::Plugins& plugins);
 
         //! Find value of any of specified plugin parameters.
-        //! @param pluginParams map of plugin parameters
-        //! @param paramNames vector of specified parameter names
+        //! @param pluginParams map of plugin parameters defined in model description
+        //! @param paramNames vector parameter names in query
         //! @param defaultVal value to be returned when none of the parameters are present in the map
-        //! @return value on any of the specified parameters or defaultVal when none were present
+        //! @return value on any of the query parameters or defaultVal when none were present
         AZStd::string ValueOfAny(
             const PluginParams& pluginParams, const AZStd::vector<AZStd::string>& paramNames, const AZStd::string& defaultVal = "");
 
@@ -139,7 +139,14 @@ namespace ROS2::SDFormat
         //! @param pluginParams map of plugin parameters
         //! @param element pointer to the sdf element
         //! @param defaultVal value to be returned when no remaps of the topic are present in the map
+        //! @return remapped topic name or defaultVal when no remaps are present
         AZStd::string GetTopicName(const PluginParams& pluginParams, sdf::ElementPtr element, const AZStd::string& defaultVal = "");
+
+        //! Get publisher frequency from plugin.
+        //! @param pluginParams map of plugin parameters
+        //! @param defaultVal value to be returned when frequency param does not appear in pluginParams
+        //! @return publisher frequency or defaultVal when frequency is not specified by element description
+        float GetFrequency(const PluginParams& pluginParams, const float defaultVal = 10.0);
 
     } // namespace HooksUtils
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h
@@ -140,5 +140,12 @@ namespace ROS2::SDFormat
         //! @return a map of parameters present in plugin.
         PluginParams GetPluginParams(const sdf::Plugin& plugin);
 
+        //! Find value of any of specified plugin parameters.
+        //! @param pluginParams map of plugin parameters
+        //! @param paramNameVec vector of specified parameter names
+        //! @param defaultVal value to be return when none of the parameters are present in the map
+        //! @return value on any of the specified parameters of defaultVal when none were present
+        AZStd::string ValueOfAny(const PluginParams& pluginParams, AZStd::vector<AZStd::string> paramNameVec, AZStd::string defaultVal = "");
+
     } // namespace HooksUtils
 } // namespace ROS2::SDFormat

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
@@ -49,10 +49,8 @@ namespace ROS2
         if (sensorResult.IsSuccess())
         {
             const auto sensorElement = sensor->Element();
-            const auto& unsupportedSensorParams = Utils::SDFormat::GetUnsupportedParams(sensorElement,
-                                                                                        hook->m_supportedSensorParams,
-                                                                                        hook->m_pluginNames,
-                                                                                        hook->m_supportedPluginParams);
+            const auto& unsupportedSensorParams = Utils::SDFormat::GetUnsupportedParams(
+                sensorElement, hook->m_supportedSensorParams, hook->m_pluginNames, hook->m_supportedPluginParams);
             AZStd::string status;
             if (unsupportedSensorParams.empty())
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/SensorsMaker.cpp
@@ -49,7 +49,10 @@ namespace ROS2
         if (sensorResult.IsSuccess())
         {
             const auto sensorElement = sensor->Element();
-            const auto& unsupportedSensorParams = Utils::SDFormat::GetUnsupportedParams(sensorElement, hook->m_supportedSensorParams);
+            const auto& unsupportedSensorParams = Utils::SDFormat::GetUnsupportedParams(sensorElement,
+                                                                                        hook->m_supportedSensorParams,
+                                                                                        hook->m_pluginNames,
+                                                                                        hook->m_supportedPluginParams);
             AZStd::string status;
             if (unsupportedSensorParams.empty())
             {

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -961,8 +961,15 @@ namespace ROS2::Utils::SDFormat
     {
         AZStd::vector<AZStd::string> unsupportedParams;
 
-        AZStd::function<void(const sdf::ElementPtr& elementPtr, const std::string& info, const std::string& prefix, const AZStd::unordered_set<AZStd::string>& supportedMap)> elementVisitor =
-            [&](const sdf::ElementPtr& elementPtr, const std::string& info, const std::string& prefix, const AZStd::unordered_set<AZStd::string>& supportedMap) -> void
+        AZStd::function<void(
+            const sdf::ElementPtr& elementPtr,
+            const std::string& info,
+            const std::string& prefix,
+            const AZStd::unordered_set<AZStd::string>& supportedMap)>
+            elementVisitor = [&](const sdf::ElementPtr& elementPtr,
+                                 const std::string& info,
+                                 const std::string& prefix,
+                                 const AZStd::unordered_set<AZStd::string>& supportedMap) -> void
         {
             auto childPtr = elementPtr->GetFirstElement();
 
@@ -992,18 +999,22 @@ namespace ROS2::Utils::SDFormat
         elementVisitor(rootElement, "", "", supportedParams);
 
         auto pluginPtr = rootElement->GetFirstElement();
-        while(pluginPtr)
+        while (pluginPtr)
         {
-            if (pluginPtr->GetName() == "plugin") {
-                if (pluginPtr->HasAttribute("filename")) {
+            if (pluginPtr->GetName() == "plugin")
+            {
+                if (pluginPtr->HasAttribute("filename"))
+                {
                     std::string fileName = pluginPtr->GetAttribute("filename")->GetAsString();
                     std::string info = "plugin \"" + fileName + "\"";
-                    
+
                     AZStd::string fileNameAz(fileName.c_str(), fileName.size());
-                    if (!pluginNames.contains(fileNameAz)) {
+                    if (!pluginNames.contains(fileNameAz))
+                    {
                         unsupportedParams.push_back(AZStd::string(info.c_str(), info.size()));
                     }
-                    else {
+                    else
+                    {
                         info.append(": ");
                         elementVisitor(pluginPtr, info, "", supportedPluginParams);
                     }
@@ -1049,20 +1060,21 @@ namespace ROS2::Utils::SDFormat
 
         // If any files couldn't be found using our supplied prefix mappings, this callback will get called.
         // Attempt to use our full path resolution, and print a warning if it still couldn't be resolved.
-        sdfConfig.SetFindCallback([settings, baseFilePath](const std::string &fileName) -> std::string
-        {
-            auto amentPrefixPath = Utils::GetAmentPrefixPath();
-
-            auto resolved = Utils::ResolveAssetPath(AZ::IO::Path(fileName.c_str()), baseFilePath, amentPrefixPath, settings);
-            if (!resolved.empty())
+        sdfConfig.SetFindCallback(
+            [settings, baseFilePath](const std::string& fileName) -> std::string
             {
-                AZ_Trace("SdfParserConfig", "SDF SetFindCallback resolved '%s' -> '%s'", fileName.c_str(), resolved.c_str());
-                return resolved.c_str();
-            }
+                auto amentPrefixPath = Utils::GetAmentPrefixPath();
 
-            AZ_Warning("SdfParserConfig", false, "SDF SetFindCallback failed to resolve '%s'", fileName.c_str());
-            return fileName;
-        });
+                auto resolved = Utils::ResolveAssetPath(AZ::IO::Path(fileName.c_str()), baseFilePath, amentPrefixPath, settings);
+                if (!resolved.empty())
+                {
+                    AZ_Trace("SdfParserConfig", "SDF SetFindCallback resolved '%s' -> '%s'", fileName.c_str(), resolved.c_str());
+                    return resolved.c_str();
+                }
+
+                AZ_Warning("SdfParserConfig", false, "SDF SetFindCallback failed to resolve '%s'", fileName.c_str());
+                return fileName;
+            });
 
         return sdfConfig;
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -954,18 +954,22 @@ namespace ROS2::Utils::SDFormat
     }
 
     AZStd::vector<AZStd::string> GetUnsupportedParams(
-        const sdf::ElementPtr& rootElement, const AZStd::unordered_set<AZStd::string>& supportedParams)
+        const sdf::ElementPtr& rootElement,
+        const AZStd::unordered_set<AZStd::string>& supportedParams,
+        const AZStd::unordered_set<AZStd::string>& pluginNames,
+        const AZStd::unordered_set<AZStd::string>& supportedPluginParams)
     {
         AZStd::vector<AZStd::string> unsupportedParams;
 
-        AZStd::function<void(const sdf::ElementPtr& elementPtr, const std::string& prefix)> elementVisitor =
-            [&](const sdf::ElementPtr& elementPtr, const std::string& prefix) -> void
+        AZStd::function<void(const sdf::ElementPtr& elementPtr, const std::string& info, const std::string& prefix, const AZStd::unordered_set<AZStd::string>& supportedMap)> elementVisitor =
+            [&](const sdf::ElementPtr& elementPtr, const std::string& info, const std::string& prefix, const AZStd::unordered_set<AZStd::string>& supportedMap) -> void
         {
             auto childPtr = elementPtr->GetFirstElement();
 
             AZStd::string prefixAz(prefix.c_str(), prefix.size());
-            if (!childPtr && !prefixAz.empty() && !supportedParams.contains(prefixAz))
+            if (!childPtr && !prefixAz.empty() && !supportedMap.contains(prefixAz))
             {
+                prefixAz.insert(0, AZStd::string(info.c_str(), info.size()));
                 unsupportedParams.push_back(prefixAz);
             }
 
@@ -980,12 +984,33 @@ namespace ROS2::Utils::SDFormat
                 currentName.append(">");
                 currentName.append(childPtr->GetName());
 
-                elementVisitor(childPtr, currentName);
+                elementVisitor(childPtr, info, currentName, supportedMap);
                 childPtr = childPtr->GetNextElement();
             }
         };
 
-        elementVisitor(rootElement, "");
+        elementVisitor(rootElement, "", "", supportedParams);
+
+        auto pluginPtr = rootElement->GetFirstElement();
+        while(pluginPtr)
+        {
+            if (pluginPtr->GetName() == "plugin") {
+                if (pluginPtr->HasAttribute("filename")) {
+                    std::string fileName = pluginPtr->GetAttribute("filename")->GetAsString();
+                    std::string info = "plugin \"" + fileName + "\"";
+                    
+                    AZStd::string fileNameAz(fileName.c_str(), fileName.size());
+                    if (!pluginNames.contains(fileNameAz)) {
+                        unsupportedParams.push_back(AZStd::string(info.c_str(), info.size()));
+                    }
+                    else {
+                        info.append(": ");
+                        elementVisitor(pluginPtr, info, "", supportedPluginParams);
+                    }
+                }
+            }
+            pluginPtr = pluginPtr->GetNextElement();
+        }
 
         return unsupportedParams;
     }

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -281,23 +281,6 @@ namespace ROS2::Utils
         return joints;
     }
 
-    bool IsChildLink(const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints)
-    {
-        bool isChild = false;
-        auto GatherJointsWhereLinkIsChild = [&isChild, linkName](const sdf::Joint& joint, const ModelStack& modelStack)
-        {
-            if (AZStd::string_view jointChildName{ joint.ChildName().c_str(), joint.ChildName().size() }; jointChildName == linkName)
-            {
-                isChild = true;
-            }
-
-            return true;
-        };
-
-        VisitJoints(sdfModel, GatherJointsWhereLinkIsChild, gatherNestedModelJoints);
-        return isChild;
-    }
-
     AZStd::vector<const sdf::Joint*> GetJointsForChildLink(
         const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints)
     {

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -965,16 +965,16 @@ namespace ROS2::Utils::SDFormat
             const sdf::ElementPtr& elementPtr,
             const std::string& info,
             const std::string& prefix,
-            const AZStd::unordered_set<AZStd::string>& supportedMap)>
+            const AZStd::unordered_set<AZStd::string>& supportedSet)>
             elementVisitor = [&](const sdf::ElementPtr& elementPtr,
                                  const std::string& info,
                                  const std::string& prefix,
-                                 const AZStd::unordered_set<AZStd::string>& supportedMap) -> void
+                                 const AZStd::unordered_set<AZStd::string>& supportedSet) -> void
         {
             auto childPtr = elementPtr->GetFirstElement();
 
             AZStd::string prefixAz(prefix.c_str(), prefix.size());
-            if (!childPtr && !prefixAz.empty() && !supportedMap.contains(prefixAz))
+            if (!childPtr && !prefixAz.empty() && !supportedSet.contains(prefixAz))
             {
                 prefixAz.insert(0, AZStd::string(info.c_str(), info.size()));
                 unsupportedParams.push_back(prefixAz);
@@ -991,7 +991,7 @@ namespace ROS2::Utils::SDFormat
                 currentName.append(">");
                 currentName.append(childPtr->GetName());
 
-                elementVisitor(childPtr, info, currentName, supportedMap);
+                elementVisitor(childPtr, info, currentName, supportedSet);
                 childPtr = childPtr->GetNextElement();
             }
         };

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -281,6 +281,23 @@ namespace ROS2::Utils
         return joints;
     }
 
+    bool IsChildLink(const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints)
+    {
+        bool isChild = false;
+        auto GatherJointsWhereLinkIsChild = [&isChild, linkName](const sdf::Joint& joint, const ModelStack& modelStack)
+        {
+            if (AZStd::string_view jointChildName{ joint.ChildName().c_str(), joint.ChildName().size() }; jointChildName == linkName)
+            {
+                isChild = true;
+            }
+
+            return true;
+        };
+
+        VisitJoints(sdfModel, GatherJointsWhereLinkIsChild, gatherNestedModelJoints);
+        return isChild;
+    }
+
     AZStd::vector<const sdf::Joint*> GetJointsForChildLink(
         const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints)
     {

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -229,9 +229,14 @@ namespace ROS2::Utils::SDFormat
     //! Allows to store the list of unsupported parameters in metadata and logs. It is typically used with sensors and plugins.
     //! @param rootElement pointer to a root Element in parsed XML data that will be a subject to heuristics
     //! @param supportedParams set of predefined parameters that are supported
+    //! @param supportedPlugins set of predefined plugins that are supported
+    //! @param supportedPluginParams set of predefined supported plugin params that are supported
     //! @returns list of unsupported parameters defined for given element
     AZStd::vector<AZStd::string> GetUnsupportedParams(
-        const sdf::ElementPtr& rootElement, const AZStd::unordered_set<AZStd::string>& supportedParams);
+        const sdf::ElementPtr& rootElement,
+        const AZStd::unordered_set<AZStd::string>& supportedParams,
+        const AZStd::unordered_set<AZStd::string>& supportedPlugins = AZStd::unordered_set<AZStd::string>(),
+        const AZStd::unordered_set<AZStd::string>& supportedPluginParams = AZStd::unordered_set<AZStd::string>());
 
     //! Check if plugin is supported by using it's filename. The filepath is converted into the filename if necessary.
     //! @param plugin plugin in the parsed SDFormat data

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -53,6 +53,7 @@ namespace ROS2::Utils
     //! always contain at least one element. The back() element of the stack returns the direct model the link is attached to
     //! @return Return true to continue visiting links or false to halt
     using LinkVisitorCallback = AZStd::function<bool(const sdf::Link& link, const ModelStack& modelStack)>;
+    
     //! Visit links from URDF/SDF
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query link
     //! @param visitNestedModelLinks When true recurses to any nested <model> tags of the Model object and invoke visitor on their links as
@@ -88,8 +89,17 @@ namespace ROS2::Utils
     //! @returns mapping from fully qualified joint name(such as "model_name::joint_name") to joint pointer
     AZStd::unordered_map<AZStd::string, const sdf::Joint*> GetAllJoints(const sdf::Model& sdfModel, bool gatherNestedModelJoints = false);
 
+
+    //! Check if there are any joints from URDF/SDF in which the specified link is a child in a sdf::Joint.
+    //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It's used to query joints
+    //! @param linkName Name of link which to query in joint objects ChildName()
+    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
+    //! well
+    //! @returns true if specified link is a child to any joint, false otherwise.
+    bool IsChildLink(const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints = false);
+
     //! Retrieve all joints from URDF/SDF in which the specified link is a child in a sdf::Joint.
-    //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query joints
+    //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It's used to query joints
     //! @param linkName Name of link which to query in joint objects ChildName()
     //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
     //! well

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -89,14 +89,6 @@ namespace ROS2::Utils
     //! @returns mapping from fully qualified joint name(such as "model_name::joint_name") to joint pointer
     AZStd::unordered_map<AZStd::string, const sdf::Joint*> GetAllJoints(const sdf::Model& sdfModel, bool gatherNestedModelJoints = false);
 
-    //! Check if there are any joints from URDF/SDF in which the specified link is a child in a sdf::Joint.
-    //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It's used to query joints
-    //! @param linkName Name of link which to query in joint objects ChildName()
-    //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
-    //! well
-    //! @returns true if specified link is a child to any joint, false otherwise.
-    bool IsChildLink(const sdf::Model& sdfModel, AZStd::string_view linkName, bool gatherNestedModelJoints = false);
-
     //! Retrieve all joints from URDF/SDF in which the specified link is a child in a sdf::Joint.
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It's used to query joints
     //! @param linkName Name of link which to query in joint objects ChildName()

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -90,7 +90,7 @@ namespace ROS2::Utils
     AZStd::unordered_map<AZStd::string, const sdf::Joint*> GetAllJoints(const sdf::Model& sdfModel, bool gatherNestedModelJoints = false);
 
     //! Retrieve all joints from URDF/SDF in which the specified link is a child in a sdf::Joint.
-    //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It's used to query joints
+    //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It is used to query joints
     //! @param linkName Name of link which to query in joint objects ChildName()
     //! @param gatherNestedModelJoints When true recurses to any nested <model> tags of the Model object and also gathers their joints as
     //! well

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -53,7 +53,7 @@ namespace ROS2::Utils
     //! always contain at least one element. The back() element of the stack returns the direct model the link is attached to
     //! @return Return true to continue visiting links or false to halt
     using LinkVisitorCallback = AZStd::function<bool(const sdf::Link& link, const ModelStack& modelStack)>;
-    
+
     //! Visit links from URDF/SDF
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It used to query link
     //! @param visitNestedModelLinks When true recurses to any nested <model> tags of the Model object and invoke visitor on their links as
@@ -88,7 +88,6 @@ namespace ROS2::Utils
     //! well
     //! @returns mapping from fully qualified joint name(such as "model_name::joint_name") to joint pointer
     AZStd::unordered_map<AZStd::string, const sdf::Joint*> GetAllJoints(const sdf::Model& sdfModel, bool gatherNestedModelJoints = false);
-
 
     //! Check if there are any joints from URDF/SDF in which the specified link is a child in a sdf::Joint.
     //! @param sdfModel Model object of SDF document corresponding to the <model> tag. It's used to query joints

--- a/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -231,7 +231,7 @@ namespace ROS2::Utils::SDFormat
     //! @param rootElement pointer to a root Element in parsed XML data that will be a subject to heuristics
     //! @param supportedParams set of predefined parameters that are supported
     //! @param supportedPlugins set of predefined plugins that are supported
-    //! @param supportedPluginParams set of predefined supported plugin params that are supported
+    //! @param supportedPluginParams set of supported plugin params
     //! @returns list of unsupported parameters defined for given element
     AZStd::vector<AZStd::string> GetUnsupportedParams(
         const sdf::ElementPtr& rootElement,

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -44,6 +44,8 @@ set(FILES
     Source/RobotImporter/SDFormat/Hooks/ROS2ImuSensorHook.cpp
     Source/RobotImporter/SDFormat/Hooks/ROS2LidarSensorHook.cpp
     Source/RobotImporter/SDFormat/Hooks/ROS2SkidSteeringModelHook.cpp
+    Source/RobotImporter/SDFormat/Hooks/ROS2JointPoseTrajectoryModelHook.cpp
+    Source/RobotImporter/SDFormat/Hooks/ROS2JointStatePublisherModelHook.cpp
     Source/RobotImporter/SDFormat/ROS2ModelPluginHooks.h
     Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
     Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.h


### PR DESCRIPTION
## What does this PR do?

Adds functionality and fixes some minor bugs in Robot Importer feature:

* Adds GetPluginParams function, extracting parameters from ROS2 and ROS1 plugins, making it easier to read and parse plugins attached to components.
* Components are now imported with correct topic names.
* Frames are imported with correct names and namespaces.
* Adds libgazebo_ros_joint_state_publisher.so and libgazebo_ros_joint_pose_trajectory.so plugins handling.
* ROS1 lidar will be imported with correct update frequency (previously frequency was not imported as for ROS1 it's an element of a plugin which was not supported).
* While importing gnss and imu components, all necessary components will be added to the entity.
* After successful SDF/URDF importing, unsupported plugin parameters will be included in the feedback window.
* Adds JointsManipulationEditorComponent and JointsTrajectoryComponent constructors enabling customizing their publishers.

This PR comes in a set with a documantation update (https://github.com/o3de/o3de.org/pull/2579).

## How was this PR tested?

Tested on variety of urdf and sdf files describing models with defined component namespaces, different topic names and supported plugins.