### PR TITLE
[ROS2] Add support for lidar intensity

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
@@ -88,6 +88,7 @@ namespace ROS2
     {
         Points = (1 << 0), //!< return 3D point coordinates
         Ranges = (1 << 1), //!< return array of distances
+        Intensity = (1 << 2), //!< return intensity data
     };
 
     //! Bitwise operators for RaycastResultFlags
@@ -97,6 +98,7 @@ namespace ROS2
     {
         AZStd::vector<AZ::Vector3> m_points;
         AZStd::vector<float> m_ranges;
+        AZStd::vector<float> m_intensity;
     };
 
     //! Interface class that allows for communication with a single Lidar instance.

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRaycasterBus.h
@@ -88,7 +88,7 @@ namespace ROS2
     {
         Points = (1 << 0), //!< return 3D point coordinates
         Ranges = (1 << 1), //!< return array of distances
-        Intensity = (1 << 2), //!< return intensity data
+        Intensities = (1 << 2), //!< return intensity data
     };
 
     //! Bitwise operators for RaycastResultFlags
@@ -98,7 +98,7 @@ namespace ROS2
     {
         AZStd::vector<AZ::Vector3> m_points;
         AZStd::vector<float> m_ranges;
-        AZStd::vector<float> m_intensity;
+        AZStd::vector<float> m_intensities;
     };
 
     //! Interface class that allows for communication with a single Lidar instance.

--- a/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/LidarRegistrarBus.h
@@ -22,6 +22,7 @@ namespace ROS2
         EntityExclusion         = 1 << 2,
         MaxRangePoints          = 1 << 3,
         PointcloudPublishing    = 1 << 4,
+        Intensity               = 1 << 5,
         All                     = 0b1111111111111111,
     };
 

--- a/Gems/ROS2/Code/Source/Lidar/LidarCore.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarCore.cpp
@@ -77,7 +77,7 @@ namespace ROS2
         RaycastResultFlags requestedFlags = RaycastResultFlags::Ranges | RaycastResultFlags::Points;
         if (m_lidarConfiguration.m_lidarSystemFeatures & LidarSystemFeatures::Intensity)
         {
-            requestedFlags |= RaycastResultFlags::Intensity;
+            requestedFlags |= RaycastResultFlags::Intensities;
         }
 
         LidarRaycasterRequestBus::Event(m_lidarRaycasterId, &LidarRaycasterRequestBus::Events::ConfigureRaycastResultFlags, requestedFlags);

--- a/Gems/ROS2/Code/Source/Lidar/LidarCore.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/LidarCore.cpp
@@ -75,6 +75,10 @@ namespace ROS2
         }
 
         RaycastResultFlags requestedFlags = RaycastResultFlags::Ranges | RaycastResultFlags::Points;
+        if (m_lidarConfiguration.m_lidarSystemFeatures & LidarSystemFeatures::Intensity)
+        {
+            requestedFlags |= RaycastResultFlags::Intensity;
+        }
 
         LidarRaycasterRequestBus::Event(m_lidarRaycasterId, &LidarRaycasterRequestBus::Events::ConfigureRaycastResultFlags, requestedFlags);
 
@@ -161,8 +165,10 @@ namespace ROS2
         return m_lidarRaycasterId;
     }
 
-    RaycastResult LidarCore::PerformRaycast()
+    const RaycastResult& LidarCore::PerformRaycast()
     {
+        static const RaycastResult EmptyResults{};
+
         AZ::Entity* entity = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, m_entityId);
         const auto entityTransform = entity->FindComponent<AzFramework::TransformComponent>();
@@ -172,7 +178,7 @@ namespace ROS2
         if (m_lastScanResults.m_points.empty())
         {
             AZ_TracePrintf("Lidar Sensor Component", "No results from raycast\n");
-            return RaycastResult();
+            return EmptyResults;
         }
         return m_lastScanResults;
     }

--- a/Gems/ROS2/Code/Source/Lidar/LidarCore.h
+++ b/Gems/ROS2/Code/Source/Lidar/LidarCore.h
@@ -37,7 +37,7 @@ namespace ROS2
 
         //! Perform a raycast.
         //! @return Results of the raycast.
-        RaycastResult PerformRaycast();
+        const RaycastResult& PerformRaycast();
         //! Visualize the results of the last performed raycast.
         void VisualizeResults() const;
 

--- a/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2Lidar2DSensorComponent.cpp
@@ -106,7 +106,7 @@ namespace ROS2
 
     void ROS2Lidar2DSensorComponent::FrequencyTick()
     {
-        RaycastResult lastScanResults = m_lidarCore.PerformRaycast();
+        const RaycastResult& lastScanResults = m_lidarCore.PerformRaycast();
 
         if (!m_sensorConfiguration.m_publishingEnabled)
         { // Skip publishing when it is disabled.

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -219,7 +219,9 @@ namespace ROS2
                 ++intensityIt.value();
             }
 
-            ++xIt; ++yIt; ++ zIt;
+            ++xIt;
+            ++yIt;
+            ++zIt;
         }
 
         m_pointCloudPublisher->publish(message);

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -204,12 +204,14 @@ namespace ROS2
             intensityIt = sensor_msgs::PointCloud2Iterator<float>(message, "intensity");
         }
 
+        const auto entityTransform = GetEntity()->FindComponent<AzFramework::TransformComponent>();
+        const auto inverseLidarTM = entityTransform->GetWorldTM().GetInverse();
         for (size_t i = 0; i < results.m_points.size(); ++i)
         {
-            AZ::Vector3 position = results.m_points[i];
-            *xIt = position.GetX();
-            *yIt = position.GetY();
-            *zIt = position.GetZ();
+            const AZ::Vector3 globalPoint = inverseLidarTM.TransformPoint(results.m_points[i]);
+            *xIt = globalPoint.GetX();
+            *yIt = globalPoint.GetY();
+            *zIt = globalPoint.GetZ();
 
             if (isIntensityEnabled)
             {

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -44,6 +44,7 @@ namespace ROS2
     private:
         //////////////////////////////////////////////////////////////////////////
         void FrequencyTick();
+        void PublishRaycastResults(const RaycastResult& results);
 
         bool m_canRaycasterPublish = false;
         std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointCloudPublisher;
@@ -51,5 +52,7 @@ namespace ROS2
         LidarCore m_lidarCore;
 
         LidarId m_lidarRaycasterId;
+
+        AZStd::vector<AZ::u8> m_rosMessageData;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -52,7 +52,5 @@ namespace ROS2
         LidarCore m_lidarCore;
 
         LidarId m_lidarRaycasterId;
-
-        AZStd::vector<AZ::u8> m_rosMessageData;
     };
 } // namespace ROS2


### PR DESCRIPTION
## What does this PR do?

This pr introduces lidar intensity data support for the ROS2 Lidar Sensor Component (does not implement this feature for the ROS2 Lidar 2D Sensor Component) . It also modifies point-cloud publishing as intensity is an optional feature and may not be provided by every lidar implementation (eg. Scene queries). For more information about the intensity capabilities and component support see the [RGL gem intensity support pull request](https://github.com/RobotecAI/o3de-rgl-gem/pull/33).

_**Note:**_ _Due to https://github.com/o3de/o3de-extras/issues/719 and future [instance segmentation](https://github.com/o3de/o3de-extras/pull/713) integration this part of the ROS2 Lidar Sensor will soon have to be updated (see https://github.com/o3de/o3de-extras/issues/736)._

## How was this PR tested?

This feature was tested on Mesh Components with and without the Material Components and on Terrain Components. Since this feature is only supported by the [RGL gem](https://github.com/RobotecAI/o3de-rgl-gem), it was tested with a custom RGL gem test project (and a different closed-source project).
