### PR TITLE
Cherry-pick: fix bug in a spawner component (#725)

### DIFF
--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -227,8 +227,14 @@ namespace ROS2
             PreSpawn(id, view, transform, spawnableName, spawnableNamespace);
         };
 
-        optionalArgs.m_completionCallback = [service_handle, header, ticketName](auto id, auto view)
+        optionalArgs.m_completionCallback = [service_handle, header, ticketName, parentId = GetEntityId()](auto id, auto view)
         {
+            if (!view.empty())
+            {
+                const AZ::Entity* root = *view.begin();
+                auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
+                transformInterface->SetParent(parentId);
+            }
             SpawnEntityResponse response;
             response.success = true;
             response.status_message = ticketName.c_str();
@@ -253,7 +259,6 @@ namespace ROS2
 
         auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
         transformInterface->SetWorldTM(transform);
-        transformInterface->SetParent(GetEntityId());
 
         AZStd::string instanceName = AZStd::string::format("%s_%d", spawnableName.c_str(), m_counter++);
         for (AZ::Entity* entity : view)


### PR DESCRIPTION
## What does this PR do?

This PR cherry-picks the fix that was merged to `stabilization` branch back to the `development` branch. Please refer to #725 for details of the fix.

## How was this PR tested?

The code was built and the object was spawned correctly.
