### PR TITLE
Enable ROS 2 camera pipeline modification

### DIFF
--- a/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
@@ -123,6 +123,7 @@ namespace ROS2
             m_entityId.ToString().c_str());
         AZ::RPI::RenderPipelineDescriptor pipelineDesc;
         pipelineDesc.m_mainViewTagName = "MainCamera";
+        pipelineDesc.m_allowModification = true;
         pipelineDesc.m_name = m_pipelineName;
 
         pipelineDesc.m_rootPassTemplate = GetPipelineTemplateName();


### PR DESCRIPTION
## What does this PR do?

Allows to modify ROS 2 camera pipeline. It enables Diffuse Probe Grid.

## How was this PR tested?

Running level:
https://gist.github.com/michalpelka/e01d0ebe4cbbaf134fa5756839237b0b
![Screenshot from 2024-08-14 12-24-59](https://github.com/user-attachments/assets/f0487b1f-c3b6-4ff1-a970-98771f94096a)


## Problems:
Problems were resolved by https://github.com/o3de/o3de/pull/18254
~~There are multiple warnings in console:~~
```
(PhysX) - Failed to connect to the PhysX Visual Debugger (PVD).
(ROS2SystemComponent) - Enabling realtime clock
Entered game mode
(ROS2FrameComponent) - Setting up Entity6/sensor_frame
(ROS2FrameComponent) - Setting up dynamic transform between parent Entity6/odom and child Entity6/sensor_frame to be published continuously to /tf
(Spawnables) - Entities from new root spawnable 'Root.spawnable' are ready (generation: 0).
(PhysX) - Successfully disconnected from the PhysX Visual Debugger (PVD).
Exited game mode
(PhysX) - Failed to connect to the PhysX Visual Debugger (PVD).
(ROS2SystemComponent) - Enabling realtime clock
Entered game mode
(ROS2FrameComponent) - Setting up Entity6/sensor_frame
(ROS2FrameComponent) - Setting up dynamic transform between parent Entity6/odom and child Entity6/sensor_frame to be published continuously to /tf
(CameraSensor) - Initializing pipeline for Entity6_sensor_frame
(Spawnables) - Entities from new root spawnable 'Root.spawnable' are ready (generation: 0).
[Warning] (ShaderResourceGroupPool) - Attempting to compile SRG 'DiffuseProbeGridPrepare_PassSrg' that's already been queued for compile. Only compile an SRG once per frame.
[Warning] (ShaderResourceGroupPool) - Attempting to compile SRG 'DiffuseProbeGridPrepare_PassSrg' that's already been queued for compile. Only compile an SRG once per frame.
[Warning] (ShaderResourceGroupPool) - Attempting to compile SRG 'DiffuseProbeGridRender_ObjectSrg' that's already been queued for compile. Only compile an SRG once per frame.
[Warning] (ShaderResourceGroupPool) - Attempting to compile SRG 'DiffuseProbeGridPrepare_PassSrg' that's already been queued for compile. Only compile an SRG once per frame.
[Warning] (ShaderResourceGroupPool) - Attempting to compile SRG 'DiffuseProbeGridRender_ObjectSrg' that's already been queued for compile. Only compile an SRG once per frame.
[Warning] (ShaderResourceGroupPool) - Attempting to compile SRG 'DiffuseProbeGridRender_ObjectSrg' that's already been queued for compile. Only compile an SRG once per frame.
(PhysX) - Successfully disconnected from the PhysX Visual Debugger (PVD).
Exited game mode
```