### PR TITLE
Fix non unity build in lidar

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Lidar/RaycastResults.h
+++ b/Gems/ROS2/Code/Include/ROS2/Lidar/RaycastResults.h
@@ -7,7 +7,9 @@
  */
 #pragma once
 
+#include <AzCore/Math/Vector3.h>
 #include <AzCore/std/containers/span.h>
+#include <AzCore/std/containers/vector.h>
 
 namespace ROS2
 {

--- a/Gems/ROS2/Code/Source/Lidar/PointCloudMessageBuilder.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/PointCloudMessageBuilder.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <AzCore/std/string/string.h>
 #include <Lidar/PointCloudMessageBuilder.h>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 


### PR DESCRIPTION
## What does this PR do?

I've added missing includes that prevented non unity builds.

## How was this PR tested?

By compiling an example project.
