### PR TITLE
Fix Multiplayer Component Registration Order

### DIFF
--- a/Templates/Multiplayer/Template/Gem/Source/${Name}SystemComponent.cpp
+++ b/Templates/Multiplayer/Template/Gem/Source/${Name}SystemComponent.cpp
@@ -44,6 +44,8 @@ namespace ${SanitizedCppName}
 
     void ${SanitizedCppName}SystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
+        required.push_back(AZ_CRC_CE("NetworkingService"));
+        required.push_back(AZ_CRC_CE("MultiplayerService"));  // Ensure Multiplayer gem calls RegisterMultiplayerComponents() before this project.
     }
 
     void ${SanitizedCppName}SystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)

--- a/Templates/Multiplayer/Template/Gem/Source/${Name}SystemComponent.cpp
+++ b/Templates/Multiplayer/Template/Gem/Source/${Name}SystemComponent.cpp
@@ -45,7 +45,11 @@ namespace ${SanitizedCppName}
     void ${SanitizedCppName}SystemComponent::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC_CE("NetworkingService"));
-        required.push_back(AZ_CRC_CE("MultiplayerService"));  // Ensure Multiplayer gem calls RegisterMultiplayerComponents() before this project.
+
+        // Ensure Multiplayer gem is a requirement so that MultiplayerSystemComponent calls RegisterMultiplayerComponents before this component activates.
+        // It's important for multiplayer components to be registered in a consistent order so that the server and client
+        //   assign the same component-id for each component.
+        required.push_back(AZ_CRC_CE("MultiplayerService"));
     }
 
     void ${SanitizedCppName}SystemComponent::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)


### PR DESCRIPTION
Ensure Multiplayer gem is a requirement so that MultiplayerSystemComponent calls RegisterMultiplayerComponents before the project component activates.
It's important for multiplayer components to be registered in a consistent order so that the server and client assign the same component-id for each component.

Fixes #767
