### PR TITLE
fix ROS2FrameComponent::UpdateNamespaceConfiguration()

### DIFF
--- a/Gems/ROS2/Code/Source/Frame/NamespaceConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Frame/NamespaceConfiguration.cpp
@@ -82,6 +82,12 @@ namespace ROS2
     {
         m_namespace = ros2Namespace;
         m_namespaceStrategy = strategy;
+
+        if (strategy == NamespaceStrategy::Custom)
+        {
+            m_customNamespace = ros2Namespace;
+        }
+
         UpdateNamespace();
     }
 


### PR DESCRIPTION
## What does this PR do?

This is a cherry-pick of a commit from #771 to fix a **blocker** issue #770 

## How was this PR tested?

The issue was raised on the multirobot setup with `ROS2SpawnerComponent`. `ROS2FleetTemplate` was used as an example - the change in #771 was tested successfully on the template; this PR is just a cherry-pick of the fix (excluding the changes in tests, as the goal is to minimize changes in the `stabilization` branch)


