### PR TITLE
Allow ROS2 Frame Component to be present on Level Entity

### DIFF
--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -115,6 +115,7 @@ namespace ROS2
                 ec->Class<ROS2FrameEditorComponent>("ROS2 Frame", "[ROS2 Frame component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Level"))
                     ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
                     ->Attribute(AZ::Edit::Attributes::Icon, "Editor/Icons/Components/ROS2Frame.svg")
                     ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Editor/Icons/Components/Viewport/ROS2Frame.svg")


### PR DESCRIPTION
## What does this PR do?

This PR allows adding ros2 frame to Level Entity, it allows for simplified level design when adding robots during simulation run. 

## How was this PR tested?

On 2409

1. Created new Level
2. Added ROS2 Frame on level entity
3. added robot to the level
4. Set robot top level tf to `publish tf on`
5. Verified tf tree in rqt-tf-tree