### PR TITLE
Fix FollowingCameraComponent: allow fly camera

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -64,6 +64,7 @@ ly_add_target(
             Gem::Atom_RPI.Public
             Gem::Atom_Feature_Common.Static
             Gem::Atom_Component_DebugCamera.Static
+            Gem::Atom_AtomBridge.Static
             Gem::StartingPointInput
             Gem::PhysX5.Static
             Gem::LmbrCentral.API

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
@@ -81,6 +81,7 @@ namespace ROS2
         float m_rotationOffset = 0.0f; //!< The rotation change from the input.
         float m_opticalAxisTranslation = 0.0f; //!< The zoom change from the input.
         AZ::EntityId m_currentView; //!< Current used view point.
+        bool m_disableCameraMove = false; //!< Disable camera move (used when fly camera is selected).
 
         FollowingCameraConfiguration m_configuration; //!< The configuration of the following camera.
     };


### PR DESCRIPTION
## What does this PR do?

This PR modifies `FollowingCameraComponent` to make it usable with `FlyCameraComponent`. In particular, it disables the keyboard capture in `FollowingCameraComponent`, when the selected camera entity contains `FlyCameraComponent`. That way only one component uses the keyboard captures and only one component changes the camera translation/rotation, making the behavior predictable and usable. 

Additionally, local camera rotation and local translation is reset after changing the camera.

## How was this PR tested?

Entity with `FollowingCameraComponent` was created and few other entities with `FlyCameraComponent` were liked to it. The system works as it should
