### PR TITLE
Cherry-picks for 2409.1 point release

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -64,6 +64,7 @@ ly_add_target(
             Gem::Atom_RPI.Public
             Gem::Atom_Feature_Common.Static
             Gem::Atom_Component_DebugCamera.Static
+            Gem::Atom_AtomBridge.Static
             Gem::StartingPointInput
             Gem::PhysX5.Static
             Gem::LmbrCentral.API

--- a/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
@@ -17,6 +17,7 @@
 #include <Atom/RPI.Public/RenderPipeline.h>
 #include <Atom/RPI.Public/Scene.h>
 #include <AzCore/Math/MatrixUtils.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzFramework/Scene/SceneSystemInterface.h>
 #include <PostProcess/PostProcessFeatureProcessor.h>
@@ -27,6 +28,8 @@ namespace ROS2
 {
     namespace Internal
     {
+        constexpr AZStd::string_view AllowCameraPipelineModificationKey = "/O3DE/ROS2/Camera/AllowPipelineModification";
+
         /// @FormatMappings - contains the mapping from RHI to ROS image encodings. List of supported
         /// ROS image encodings lives in `sensor_msgs/image_encodings.hpp`
         /// We are not including `image_encodings.hpp` since it uses exceptions.
@@ -107,7 +110,18 @@ namespace ROS2
 
     void CameraSensor::SetupPasses()
     {
-        AZ_TracePrintf("CameraSensor", "Initializing pipeline for %s\n", m_cameraSensorDescription.m_cameraName.c_str());
+        bool allowModification = false;
+        auto* registry = AZ::SettingsRegistry::Get();
+        AZ_Assert(registry, "No Registry available");
+        if (registry)
+        {
+            registry->Get(allowModification, Internal::AllowCameraPipelineModificationKey);
+        }
+        AZ_Trace(
+            "CameraSensor",
+            "Initializing pipeline for %s, pipeline modification : %s\n",
+            m_cameraSensorDescription.m_cameraName.c_str(),
+            allowModification ? "yes" : "no");
 
         const AZ::Name viewName = AZ::Name("MainCamera");
         m_view = AZ::RPI::View::CreateView(viewName, AZ::RPI::View::UsageCamera);
@@ -123,7 +137,7 @@ namespace ROS2
             m_entityId.ToString().c_str());
         AZ::RPI::RenderPipelineDescriptor pipelineDesc;
         pipelineDesc.m_mainViewTagName = "MainCamera";
-        pipelineDesc.m_allowModification = true;
+        pipelineDesc.m_allowModification = allowModification;
         pipelineDesc.m_name = m_pipelineName;
 
         pipelineDesc.m_rootPassTemplate = GetPipelineTemplateName();

--- a/Gems/ROS2/Code/Source/Frame/NamespaceConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Frame/NamespaceConfiguration.cpp
@@ -82,6 +82,12 @@ namespace ROS2
     {
         m_namespace = ros2Namespace;
         m_namespaceStrategy = strategy;
+
+        if (strategy == NamespaceStrategy::Custom)
+        {
+            m_customNamespace = ros2Namespace;
+        }
+
         UpdateNamespace();
     }
 

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -115,6 +115,7 @@ namespace ROS2
                 ec->Class<ROS2FrameEditorComponent>("ROS2 Frame", "[ROS2 Frame component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Level"))
                     ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
                     ->Attribute(AZ::Edit::Attributes::Icon, "Editor/Icons/Components/ROS2Frame.svg")
                     ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Editor/Icons/Components/Viewport/ROS2Frame.svg")

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.h
@@ -81,6 +81,7 @@ namespace ROS2
         float m_rotationOffset = 0.0f; //!< The rotation change from the input.
         float m_opticalAxisTranslation = 0.0f; //!< The zoom change from the input.
         AZ::EntityId m_currentView; //!< Current used view point.
+        bool m_disableCameraMove = false; //!< Disable camera move (used when fly camera is selected).
 
         FollowingCameraConfiguration m_configuration; //!< The configuration of the following camera.
     };

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -243,14 +243,8 @@ namespace ROS2
             PreSpawn(id, view, transform, spawnableName, spawnableNamespace);
         };
 
-        optionalArgs.m_completionCallback = [service_handle, header, ticketName, parentId = GetEntityId()](auto id, auto view)
+        optionalArgs.m_completionCallback = [service_handle, header, ticketName](auto id, auto view)
         {
-            if (!view.empty())
-            {
-                const AZ::Entity* root = *view.begin();
-                auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
-                transformInterface->SetParent(parentId);
-            }
             SpawnEntityResponse response;
             response.success = true;
             response.status_message = ticketName.c_str();
@@ -275,6 +269,7 @@ namespace ROS2
 
         auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
         transformInterface->SetWorldTM(transform);
+        transformInterface->SetParent(GetEntityId());
 
         AZStd::string instanceName = AZStd::string::format("%s_%d", spawnableName.c_str(), m_counter++);
         for (AZ::Entity* entity : view)

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ROS2",
-    "version": "3.2.1",
+    "version": "3.1.1",
     "platforms": [
         "Linux"
     ],
@@ -36,5 +36,5 @@
     ],
     "restricted": "ROS2",
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0//ros2-3.2.1-gem.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.1.1-gem.zip"
 }

--- a/Projects/OpenXRTest/project.json
+++ b/Projects/OpenXRTest/project.json
@@ -1,9 +1,9 @@
 {
     "project_name": "OpenXRTest",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "project_id": "{947211d5-689a-437f-8ad7-7f558edcd40a}",
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/openxrtest-1.0.0-project.zip",
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/openxrtest-1.0.1-project.zip",
     "origin": "https://github.com/o3de/o3de-extras",
     "license": "For terms please see the LICENSE*.TXT files at the root of this distribution.",
     "display_name": "OpenXRTest",

--- a/Templates/Multiplayer/template.json
+++ b/Templates/Multiplayer/template.json
@@ -1,5 +1,6 @@
 {
     "template_name": "Multiplayer",
+    "version": "2.0.0",
     "origin": "Open 3D Engine - o3de.org",
     "license": "https://opensource.org/licenses/MIT",
     "display_name": "Multiplayer",
@@ -1472,5 +1473,7 @@
         {
             "dir": "cmake"
         }
-    ]
+    ],
+    "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/multiplayer-2.0.0-template.zip"
 }

--- a/Templates/Ros2FleetRobotTemplate/Template/Registry/ros2.setreg
+++ b/Templates/Ros2FleetRobotTemplate/Template/Registry/ros2.setreg
@@ -1,0 +1,20 @@
+{
+    "O3DE":
+    {
+        "InputSystem":
+        {
+            "Mouse":
+            {
+                "CaptureMouseCursor": false
+            }
+        },
+        "ROS2":
+        {
+            "SteadyClock" : true,
+            "Camera":
+            {
+                "AllowPipelineModification": true
+            }
+        }
+    }
+}

--- a/Templates/Ros2FleetRobotTemplate/template.json
+++ b/Templates/Ros2FleetRobotTemplate/template.json
@@ -152,6 +152,10 @@
             "isTemplated": false
         },
         {
+            "file": "Registry/ros2.setreg",
+            "isTemplated": false
+        },
+        {
             "file": "Resources/GameSDK.ico",
             "isTemplated": false
         },

--- a/Templates/Ros2ProjectTemplate/Template/Registry/ros2.setreg
+++ b/Templates/Ros2ProjectTemplate/Template/Registry/ros2.setreg
@@ -1,0 +1,20 @@
+{
+    "O3DE":
+    {
+        "InputSystem":
+        {
+            "Mouse":
+            {
+                "CaptureMouseCursor": false
+            }
+        },
+        "ROS2":
+        {
+            "SteadyClock" : true,
+            "Camera":
+            {
+                "AllowPipelineModification": false
+            }
+        }
+    }
+}

--- a/Templates/Ros2ProjectTemplate/template.json
+++ b/Templates/Ros2ProjectTemplate/template.json
@@ -1,6 +1,6 @@
 {
     "template_name": "Ros2ProjectTemplate",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "origin": "Open 3D Engine Extras",
     "origin_url": "https://github.com/o3de/o3de-extras",
     "license": "https://github.com/o3de/o3de-extras/tree/development/Templates/Ros2ProjectTemplate/Template/LICENSE.txt",
@@ -557,5 +557,5 @@
         }
     ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2projecttemplate-2.0.0-template.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2projecttemplate-2.0.1-template.zip"
 }

--- a/Templates/Ros2ProjectTemplate/template.json
+++ b/Templates/Ros2ProjectTemplate/template.json
@@ -235,6 +235,10 @@
             "isTemplated": false
         },
         {
+            "file": "Registry/ros2.setreg",
+            "isTemplated": false
+        },
+        {
             "file": "Resources/GameSDK.ico",
             "isTemplated": false
         },

--- a/Templates/Ros2RoboticManipulationTemplate/Template/Registry/ros2.setreg
+++ b/Templates/Ros2RoboticManipulationTemplate/Template/Registry/ros2.setreg
@@ -1,0 +1,20 @@
+{
+    "O3DE":
+    {
+        "InputSystem":
+        {
+            "Mouse":
+            {
+                "CaptureMouseCursor": false
+            }
+        },
+        "ROS2":
+        {
+            "SteadyClock" : true,
+            "Camera":
+            {
+                "AllowPipelineModification": true
+            }
+        }
+    }
+}

--- a/Templates/Ros2RoboticManipulationTemplate/template.json
+++ b/Templates/Ros2RoboticManipulationTemplate/template.json
@@ -619,6 +619,10 @@
             "isTemplated": false
         },
         {
+            "file": "Registry/ros2.setreg",
+            "isTemplated": false
+        },
+        {
             "file": "Resources/GameSDK.ico",
             "isTemplated": false
         },

--- a/repo.json
+++ b/repo.json
@@ -209,7 +209,7 @@
                     "sha256": "aace14afcbe3feda0be0b11cb3610d93ec8e3e55a7b2f185df51ea468e7e7554"
                 },
                 {
-                    "version": "3.2.1",
+                    "version": "3.1.1",
                     "origin_url": "https://robotec.ai",
                     "source_control_uri": "https://github.com/o3de/o3de-extras/development/Gems/ROS2",
                     "compatible_engines": [
@@ -226,8 +226,8 @@
                         "PrimitiveAssets",
                         "StartingPointInput"
                     ],
-                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0//ros2-3.2.1-gem.zip",
-                    "sha256": "9ed6ecb4897fcb38d785ff59dff7c6691a34044df7f7822ea9e4ea54e29d03f9"
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.1.1-gem.zip",
+                    "sha256": "063fea6c2d70a778dcbd92d9b1be2fff36a058d83002f612fcbfa6526b41fcde"
                 }
             ]
         },

--- a/repo.json
+++ b/repo.json
@@ -504,7 +504,6 @@
             "template_name": "Multiplayer",
             "version": "2.0.0",
             "origin": "Open 3D Engine - o3de.org",
-            "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
             "license": "https://opensource.org/licenses/MIT",
             "display_name": "Multiplayer",
             "summary": "A multiplayer project template. Includes a built in network 3rd person player, player spawner, and network filtering example.",
@@ -518,539 +517,655 @@
             "icon_path": "preview.png",
             "copyFiles": [
                 {
-                    "file": "${NameLower}_asset_files.cmake",
+                    "file": ".command_settings",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/BURT.motionset",
+                    "file": ".gitignore",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/BURTActor.fbx",
+                    "file": "AssetBundling/SeedLists/DefaultLevel.seed",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/BURTActor.fbx.assetinfo",
+                    "file": "Assets/Characters/Attachments/Laser_Gun/gun.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/HumanoidCharacter.animgraph",
+                    "file": "Assets/Characters/Attachments/Laser_Gun/gun_gun.material",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Backwards.fbx",
+                    "file": "Assets/Characters/Attachments/Laser_Gun/textures/gun_low_Default_BaseColor.png",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Draw.fbx",
+                    "file": "Assets/Characters/Attachments/Laser_Gun/textures/gun_low_Default_Emissive.png",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Forwards.fbx",
+                    "file": "Assets/Characters/Attachments/Laser_Gun/textures/gun_low_Default_Height.png",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Holster.fbx",
+                    "file": "Assets/Characters/Attachments/Laser_Gun/textures/gun_low_Default_Metallic.png",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Idle.fbx",
+                    "file": "Assets/Characters/Attachments/Laser_Gun/textures/gun_low_Default_Normal.png",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Left_Backwards.fbx",
+                    "file": "Assets/Characters/Attachments/Laser_Gun/textures/gun_low_Default_Roughness.png",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Left_Forwards.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Climbing Ladder.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Right_Backwards.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Climbing Ladder.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Right_Forwards.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Dying.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Run_Backwards.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Dying.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Run_Forwards.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Fall A Land To Run Forward.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Run_Left_Forwards.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Fall A Land To Run Forward.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Run_Right_Forwards.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Fall A Land To Standing Idle 01.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Shoot.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Fall A Land To Standing Idle 01.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/AimStrafe_Shoot.fbx.assetinfo",
+                    "file": "Assets/Characters/Mixamo/Animations/Fall A Loop.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Aim_1D_Level.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Fall A Loop.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Crouch_Idle.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Getting Up.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Crouch_Walk.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Getting Up.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Crouch_Walk_Backwards.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Hit Reaction Pistol Front.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Crouch_Walk_Down.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Hit Reaction Pistol Front.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Crouch_Walk_Down.fbx.assetinfo",
+                    "file": "Assets/Characters/Mixamo/Animations/Hit Reaction Pistol Left.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Crouch_Walk_Up.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Hit Reaction Pistol Left.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Death_Fall_Back.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Idle.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Death_Fall_Forward.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Idle.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Idle.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Jump.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Idle_Alt_A.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Jump.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Idle_To_Run.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Knocked Down.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Idle_To_Run_Down.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Left Strafe Walking.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Idle_To_Run_Left.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Left Strafe Walking.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Idle_To_Run_Right.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Left Strafe.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Idle_To_Run_Up.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Left Strafe.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Idle_To_Walk.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Left Turn 90.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Idle_To_Walk_Down.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Left Turn 90.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Idle_To_Walk_Left.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Left Turn.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Idle_To_Walk_Right.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Left Turn.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Idle_To_Walk_Up.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Opening.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Interact.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Opening.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Interact_In.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Picking Up.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Interact_Out.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Picking Up.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Jump_DoubleJump_Float.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Idle.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Jump_DoubleJump_Land_To_Idle.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Idle.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Jump_DoubleJump_Launch.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Jump 2.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Jump_Fall.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Jump 2.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Jump_Land_Hard.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Jump.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Jump_Land_Medium.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Jump.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Jump_Land_Soft.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Kneel To Stand.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Jump_Running_Land_To_Idle.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Kneel To Stand.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Jump_Running_Launch.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Kneeling Idle.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Jump_Up.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Kneeling Idle.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Run_Left_180.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Recoil.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Run_Left_180_Aim.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Recoil.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Run_Left_90.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Run Arc 2.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Run_Left_90_Aim.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Run Arc 2.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Run_Right_180.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Run Arc.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Run_Right_180_Aim.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Run Arc.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Run_Right_90.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Run Backward Arc 2.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Run_Right_90_Aim.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Run Backward Arc 2.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Walk_Left_180.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Run Backward Arc.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Walk_Left_180_Aim.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Run Backward Arc.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Walk_Left_90.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Run Backward.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Walk_Left_90_Aim.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Run Backward.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Walk_Right_180.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Run.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Walk_Right_180_Aim.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Run.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Walk_Right_90.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Stand To Kneel.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/MotionTurn_Walk_Right_90_Aim.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Stand To Kneel.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Run_To_Idle.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Strafe 2.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Run_To_Idle_Down.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Strafe 2.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Run_To_Idle_Up.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Strafe.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Shoot.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Strafe.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Shoot.fbx.assetinfo",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Walk Arc 2.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Left.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Walk Arc 2.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Right.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Walk Arc.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Run_Forwards 001.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Walk Arc.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Run_Forwards.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Walk Backward Arc 2.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Run_Forwards.fbx.assetinfo",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Walk Backward Arc 2.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Run_Forwards_Down.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Walk Backward Arc.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Run_Forwards_Down.fbx.assetinfo",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Walk Backward Arc.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Run_Forwards_DupA.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Walk Backward.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Run_Forwards_DupB.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Walk Backward.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Run_Forwards_Left_45.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Walk.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Run_Forwards_Right_45.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pistol Walk.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Run_Forwards_Up.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pull Heavy Object.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Run_Forwards_Up.fbx.assetinfo",
+                    "file": "Assets/Characters/Mixamo/Animations/Pull Heavy Object.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Run_Left45.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pushing.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Run_Right45.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Pushing.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_Backwards.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Right Strafe Walking.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_Forwards.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Right Strafe Walking.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_Forwards.fbx.assetinfo",
+                    "file": "Assets/Characters/Mixamo/Animations/Right Strafe.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_Forwards_Down.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Right Strafe.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_Forwards_Down.fbx.assetinfo",
+                    "file": "Assets/Characters/Mixamo/Animations/Right Turn 90.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_Forwards_DupA.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Right Turn 90.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_Forwards_DupB.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Right Turn.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_Forwards_Left_45.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Right Turn.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_Forwards_Right_45.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Running Backward.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_Forwards_Up.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Running Backward.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_Forwards_Up.fbx.assetinfo",
+                    "file": "Assets/Characters/Mixamo/Animations/Running Jump.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_InPlace.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Running Jump.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_InPlace_LeftTransition.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Running.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Strafe_Walk_InPlace_RightTransition.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Stunned.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Take_Damage_Front.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Stunned.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Take_Damage_Front_Additive.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Victory.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Take_Damage_Left.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Victory.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Take_Damage_Left_Additive.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Walking Backwards.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Take_Damage_Rear.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Walking Backwards.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Take_Damage_Rear_Additive.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Walking.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Take_Damage_Right.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/Walking.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Take_Damage_Right_Additive.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/running.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_OnSpot_180_Left.fbx",
+                    "file": "Assets/Characters/Mixamo/Animations/stub",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_OnSpot_180_Right.fbx",
+                    "file": "Assets/Characters/Mixamo/LICENSE.txt",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/YBot.animgraph",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/YBot.emfxworkspace",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/YBot.motionset",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/skins/mixamo_logo.material",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/skins/ybot_body_base.material",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/skins/ybot_head_base.material",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/skins/ybot_joints_base.material",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/test_data/ybot_mesh_test.fbx",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/test_data/ybot_mesh_test_Body_MAT.material",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/test_data/ybot_mesh_test_Head_MAT.material",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/test_data/ybot_mesh_test_Joints_MAT.material",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/test_data/ybot_mesh_test_Left_Arm_MAT.material",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/test_data/ybot_mesh_test_Left_Leg_MAT.material",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/test_data/ybot_mesh_test_Logo_Plate_MAT.material",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/test_data/ybot_mesh_test_Right_Arm_MAT.material",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/test_data/ybot_mesh_test_Right_Leg_MAT.material",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/Alpha_base_Joints_AO.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/Alpha_base_Joints_basecolor.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/Alpha_base_Joints_cavity.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/Alpha_base_Joints_normal.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/Alpha_base_body_ao.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/Alpha_base_body_basecolor.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/Alpha_base_body_cavity.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/Alpha_base_body_normal.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/Alpha_base_head_ao.png",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_OnSpot_90_Left.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/Alpha_base_head_basecolor.png",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_OnSpot_90_Right.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/Alpha_base_head_cavity.png",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_OnSpot_Crouch_180_Left.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/Alpha_base_head_normal.png",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_OnSpot_Crouch_180_Right.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/mixamo_logo_alpha.png",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_OnSpot_Crouch_90_Left.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/mixamo_logo_basecolor.png",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_OnSpot_Crouch_90_Right.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/textures/ps838.tmp",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_Tight_Crouch_Left.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/ybot.fbx",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_Tight_Crouch_Right.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/ybot.fbx.assetinfo",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_Tight_Run_Left.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/ybot_Body_MAT.material",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_Tight_Run_Right.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/ybot_Head_MAT.material",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_Tight_Walk_Left.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/ybot_Joints_MAT.material",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_Tight_Walk_Left_Backwards.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/ybot_Left_Arm_MAT.material",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_Tight_Walk_Right.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/ybot_Left_Leg_MAT.material",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Turn_Tight_Walk_Right_Backwards.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/ybot_Logo_Plate_MAT.material",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Motions/Victory.fbx",
+                    "file": "Assets/Characters/Mixamo/Ybot/ybot_Right_Arm_MAT.material",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Textures/BURT_ddn.tif",
+                    "file": "Assets/Characters/Mixamo/Ybot/ybot_Right_Leg_MAT.material",
                     "isTemplated": false
+                },
+                {
+                    "file": "Assets/Characters/Mixamo/readme.md",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/InputBindings/player.inputbindings",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Prefabs/4x4x4BoxGrid.prefab",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Assets/Prefabs/Player.prefab",
+                    "isTemplated": true
                 },
                 {
-                    "file": "BURT/Textures/BURT_diff.tif",
+                    "file": "Assets/Prefabs/laser_pistol.prefab",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Textures/BURT_emis.tif",
+                    "file": "Assets/UI/BasicHUD/BasicHUD.uicanvas",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/Textures/BURT_spec_02_spec.tif",
+                    "file": "Assets/UI/BasicHUD/Reticle.png",
                     "isTemplated": false
                 },
                 {
-                    "file": "BURT/burtactor.material",
+                    "file": "Assets/UI/BasicHUD/Reticle.sprite",
                     "isTemplated": false
                 },
                 {
@@ -1058,27 +1173,11 @@
                     "isTemplated": true
                 },
                 {
-                    "file": "Config/AtomImageBuilder/Test_Linear_to_Auto.preset",
+                    "file": "CMakePresets.json",
                     "isTemplated": false
                 },
                 {
-                    "file": "Config/AtomImageBuilder/Test_Linear_to_Linear.preset",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Config/AtomImageBuilder/Test_Linear_to_sRGB.preset",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Config/AtomImageBuilder/Test_sRGB_to_Auto.preset",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Config/AtomImageBuilder/Test_sRGB_to_Linear.preset",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Config/AtomImageBuilder/Test_sRGB_to_sRGB.preset",
+                    "file": "Config/default_aws_resource_mappings.json",
                     "isTemplated": false
                 },
                 {
@@ -1086,399 +1185,311 @@
                     "isTemplated": false
                 },
                 {
+                    "file": "Gem/${NameLower}_autogen_files.cmake",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Gem/${NameLower}_client_files.cmake",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Gem/${NameLower}_files.cmake",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/${NameLower}_server_files.cmake",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Gem/${NameLower}_shared_files.cmake",
+                    "isTemplated": true
+                },
+                {
                     "file": "Gem/CMakeLists.txt",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Include/${Name}/${Name}Bus.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Include/${Name}/${Name}TypeIds.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Include/${Name}/GameplayEffectsNotificationBus.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Include/${Name}/NetworkPrefabSpawnerInterface.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Include/${Name}/WeaponNotificationBus.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Platform/Android/${NameLower}_android_files.cmake",
                     "isTemplated": false
                 },
                 {
-                    "file": "Gem/Code/${NameLower}_autogen_files.cmake",
+                    "file": "Gem/Platform/Android/${NameLower}_shared_android_files.cmake",
                     "isTemplated": false
                 },
                 {
-                    "file": "Gem/Code/${NameLower}_files.cmake",
+                    "file": "Gem/Platform/Android/PAL_android.cmake",
                     "isTemplated": true
                 },
                 {
-                    "file": "Gem/Code/${NameLower}_shared_files.cmake",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/CMakeLists.txt",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Include/NetworkPrefabSpawnerInterface.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Platform/Android/${NameLower}_android_files.cmake",
+                    "file": "Gem/Platform/Linux/${NameLower}_linux_files.cmake",
                     "isTemplated": false
                 },
                 {
-                    "file": "Gem/Code/Platform/Linux/${NameLower}_linux_files.cmake",
+                    "file": "Gem/Platform/Linux/${NameLower}_shared_linux_files.cmake",
                     "isTemplated": false
                 },
                 {
-                    "file": "Gem/Code/Platform/Mac/${NameLower}_mac_files.cmake",
+                    "file": "Gem/Platform/Linux/PAL_linux.cmake",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Platform/Mac/${NameLower}_mac_files.cmake",
                     "isTemplated": false
                 },
                 {
-                    "file": "Gem/Code/Platform/Windows/${NameLower}_windows_files.cmake",
+                    "file": "Gem/Platform/Mac/${NameLower}_shared_mac_files.cmake",
                     "isTemplated": false
                 },
                 {
-                    "file": "Gem/Code/Platform/iOS/${NameLower}_ios_files.cmake",
+                    "file": "Gem/Platform/Mac/PAL_mac.cmake",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Platform/Windows/${NameLower}_shared_windows_files.cmake",
                     "isTemplated": false
                 },
                 {
-                    "file": "Gem/Code/Source/${Name}Module.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/${Name}SystemComponent.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/${Name}SystemComponent.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/${Name}Types.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/AutoGen/AnimatedHitVolumesComponent.AutoComponent.xml",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/AutoGen/MultiplayerAutoComponentSchema.xsd",
+                    "file": "Gem/Platform/Windows/${NameLower}_windows_files.cmake",
                     "isTemplated": false
                 },
                 {
-                    "file": "Gem/Code/Source/AutoGen/NetworkAiComponent.AutoComponent.xml",
+                    "file": "Gem/Platform/Windows/PAL_windows.cmake",
                     "isTemplated": true
                 },
                 {
-                    "file": "Gem/Code/Source/AutoGen/NetworkAnimationComponent.AutoComponent.xml",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/AutoGen/NetworkHealthComponent.AutoComponent.xml",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/AutoGen/NetworkPlayerMovementComponent.AutoComponent.xml",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/AutoGen/NetworkPlayerSpawnerComponent.AutoComponent.xml",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/AutoGen/NetworkRandomComponent.AutoComponent.xml",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/AutoGen/NetworkSimplePlayerCameraComponent.AutoComponent.xml",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/AutoGen/NetworkWeaponsComponent.AutoComponent.xml",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/ExampleFilteredEntityComponent.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/ExampleFilteredEntityComponent.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkAiComponent.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkAiComponent.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkAnimationComponent.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkAnimationComponent.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkHealthComponent.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkHealthComponent.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkPlayerMovementComponent.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkPlayerSpawnerComponent.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkPlayerSpawnerComponent.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkRandomComponent.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkRandomComponent.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkSimplePlayerCameraComponent.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkSimplePlayerCameraComponent.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkWeaponsComponent.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkWeaponsComponent.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkPrefabSpawnerComponent.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Components/NetworkPrefabSpawnerComponent.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Spawners/IPlayerSpawner.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Spawners/RoundRobinSpawner.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Spawners/RoundRobinSpawner.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Weapons/BaseWeapon.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Weapons/BaseWeapon.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Weapons/IWeapon.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Weapons/ProjectileWeapon.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Weapons/ProjectileWeapon.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Weapons/SceneQuery.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Weapons/SceneQuery.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Weapons/TraceWeapon.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Weapons/TraceWeapon.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Weapons/WeaponGathers.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Weapons/WeaponGathers.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Weapons/WeaponTypes.cpp",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/Source/Weapons/WeaponTypes.h",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Code/enabled_gems.cmake",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Gem/Resources/GameSDK.ico",
+                    "file": "Gem/Platform/iOS/${NameLower}_ios_files.cmake",
                     "isTemplated": false
                 },
                 {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/Contents.json",
+                    "file": "Gem/Platform/iOS/${NameLower}_shared_ios_files.cmake",
                     "isTemplated": false
                 },
                 {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/iPadAppIcon152x152.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/iPadAppIcon76x76.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/iPadProAppIcon167x167.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/iPadSettingsIcon29x29.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/iPadSettingsIcon58x58.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/iPadSpotlightIcon40x40.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/iPadSpotlightIcon80x80.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/iPhoneAppIcon120x120.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/iPhoneAppIcon180x180.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/iPhoneSettingsIcon58x58.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/iPhoneSettingsIcon87x87.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/iPhoneSpotlightIcon120x120.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset/iPhoneSpotlightIcon80x80.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/Contents.json",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/LaunchImage.launchimage/Contents.json",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage1024x768.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage1536x2048.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage2048x1536.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage768x1024.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/LaunchImage.launchimage/iPhoneLaunchImage640x1136.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Images.xcassets/LaunchImage.launchimage/iPhoneLaunchImage640x960.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Gem/Resources/IOSLauncher/Info.plist",
+                    "file": "Gem/Platform/iOS/PAL_ios.cmake",
                     "isTemplated": true
                 },
                 {
-                    "file": "Gem/Resources/MacLauncher/Images.xcassets/CMakeTestbedAppIcon.appiconset/Contents.json",
-                    "isTemplated": false
+                    "file": "Gem/Registry/assetprocessor_settings.setreg",
+                    "isTemplated": true
                 },
                 {
-                    "file": "Gem/Resources/MacLauncher/Images.xcassets/CMakeTestbedAppIcon.appiconset/icon_128 _2x.png",
-                    "isTemplated": false
+                    "file": "Gem/Source/${Name}Module.cpp",
+                    "isTemplated": true
                 },
                 {
-                    "file": "Gem/Resources/MacLauncher/Images.xcassets/CMakeTestbedAppIcon.appiconset/icon_128.png",
-                    "isTemplated": false
+                    "file": "Gem/Source/${Name}SystemComponent.cpp",
+                    "isTemplated": true
                 },
                 {
-                    "file": "Gem/Resources/MacLauncher/Images.xcassets/CMakeTestbedAppIcon.appiconset/icon_16.png",
-                    "isTemplated": false
+                    "file": "Gem/Source/${Name}SystemComponent.h",
+                    "isTemplated": true
                 },
                 {
-                    "file": "Gem/Resources/MacLauncher/Images.xcassets/CMakeTestbedAppIcon.appiconset/icon_16_2x.png",
-                    "isTemplated": false
+                    "file": "Gem/Source/${Name}Types.h",
+                    "isTemplated": true
                 },
                 {
-                    "file": "Gem/Resources/MacLauncher/Images.xcassets/CMakeTestbedAppIcon.appiconset/icon_256 _2x.png",
-                    "isTemplated": false
+                    "file": "Gem/Source/AutoGen/GameplayEffectsComponent.AutoComponent.xml",
+                    "isTemplated": true
                 },
                 {
-                    "file": "Gem/Resources/MacLauncher/Images.xcassets/CMakeTestbedAppIcon.appiconset/icon_256.png",
-                    "isTemplated": false
+                    "file": "Gem/Source/AutoGen/NetworkAiComponent.AutoComponent.xml",
+                    "isTemplated": true
                 },
                 {
-                    "file": "Gem/Resources/MacLauncher/Images.xcassets/CMakeTestbedAppIcon.appiconset/icon_32.png",
-                    "isTemplated": false
+                    "file": "Gem/Source/AutoGen/NetworkAnimationComponent.AutoComponent.xml",
+                    "isTemplated": true
                 },
                 {
-                    "file": "Gem/Resources/MacLauncher/Images.xcassets/CMakeTestbedAppIcon.appiconset/icon_32_2x.png",
-                    "isTemplated": false
+                    "file": "Gem/Source/AutoGen/NetworkHealthComponent.AutoComponent.xml",
+                    "isTemplated": true
                 },
                 {
-                    "file": "Gem/Resources/MacLauncher/Images.xcassets/CMakeTestbedAppIcon.appiconset/icon_512.png",
-                    "isTemplated": false
+                    "file": "Gem/Source/AutoGen/NetworkPlayerMovementComponent.AutoComponent.xml",
+                    "isTemplated": true
                 },
                 {
-                    "file": "Gem/Resources/MacLauncher/Images.xcassets/CMakeTestbedAppIcon.appiconset/icon_512_2x.png",
-                    "isTemplated": false
+                    "file": "Gem/Source/AutoGen/NetworkRandomComponent.AutoComponent.xml",
+                    "isTemplated": true
                 },
                 {
-                    "file": "Gem/Resources/MacLauncher/Images.xcassets/Contents.json",
-                    "isTemplated": false
+                    "file": "Gem/Source/AutoGen/NetworkSimplePlayerCameraComponent.AutoComponent.xml",
+                    "isTemplated": true
                 },
                 {
-                    "file": "Gem/Resources/MacLauncher/Info.plist",
+                    "file": "Gem/Source/AutoGen/NetworkWeaponsComponent.AutoComponent.xml",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/AutoGen/ScriptingPlayerMovementComponent.AutoComponent.xml",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/AttachPlayerWeaponComponent.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/AttachPlayerWeaponComponent.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/ExampleFilteredEntityComponent.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/ExampleFilteredEntityComponent.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/GameplayEffectsComponent.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/GameplayEffectsComponent.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkAiComponent.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkAiComponent.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkAnimationComponent.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkAnimationComponent.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkHealthComponent.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkHealthComponent.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkPlayerMovementComponent.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkPlayerMovementComponent.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkPrefabSpawnerComponent.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkPrefabSpawnerComponent.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkRandomComponent.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkRandomComponent.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkSimplePlayerCameraComponent.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkSimplePlayerCameraComponent.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkWeaponsComponent.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Components/NetworkWeaponsComponent.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Effects/GameEffect.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Effects/GameEffect.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Weapons/BaseWeapon.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Weapons/BaseWeapon.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Weapons/IWeapon.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Weapons/ProjectileWeapon.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Weapons/ProjectileWeapon.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Weapons/SceneQuery.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Weapons/SceneQuery.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Weapons/TraceWeapon.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Weapons/TraceWeapon.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Weapons/WeaponGathers.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Weapons/WeaponGathers.h",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Weapons/WeaponTypes.cpp",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Gem/Source/Weapons/WeaponTypes.h",
                     "isTemplated": true
                 },
                 {
@@ -1486,79 +1497,11 @@
                     "isTemplated": true
                 },
                 {
-                    "file": "Gem/preview.png",
+                    "file": "Levels/DefaultLevel/DefaultLevel.prefab",
                     "isTemplated": false
                 },
                 {
-                    "file": "InputBindings/player.inputbindings",
-                    "isTemplated": false
-                },
-                {
-                    "file": "LICENSE.txt",
-                    "isTemplated": false
-                },
-                {
-                    "file": "LICENSE_APACHE2.TXT",
-                    "isTemplated": false
-                },
-                {
-                    "file": "LICENSE_MIT.TXT",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Levels/Demo/Demo.prefab",
-                    "isTemplated": true
-                },
-                {
-                    "file": "Levels/Demo/tags.txt",
-                    "isTemplated": false
-                },
-                {
-                    "file": "LightingPresets/greenwich_park_02.lightingconfig.json",
-                    "isTemplated": false
-                },
-                {
-                    "file": "LightingPresets/greenwich_park_02_4k_iblskyboxcm.exr",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Materials/Default/AM_UV_v1_1K_source.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Materials/Default/UVchart_1_basecolor.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Materials/Default/UVchart_2_basecolor.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Materials/Default/UVchart_3_basecolor.png",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Materials/DefaultPBR.material",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Materials/UVs.azsl",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Materials/UVs.material",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Materials/UVs.materialtype",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Materials/UVs.shader",
-                    "isTemplated": false
-                },
-                {
-                    "file": "Objects/cube.fbx",
+                    "file": "Platform/Android/android_project.cmake",
                     "isTemplated": false
                 },
                 {
@@ -1566,23 +1509,247 @@
                     "isTemplated": true
                 },
                 {
-                    "file": "Prefabs/NetworkRigidBodyCube.prefab",
-                    "isTemplated": true
+                    "file": "Platform/Linux/linux_project.cmake",
+                    "isTemplated": false
                 },
                 {
-                    "file": "Prefabs/Player.prefab",
-                    "isTemplated": true
+                    "file": "Platform/Linux/linux_project.json",
+                    "isTemplated": false
                 },
                 {
-                    "file": "Prefabs/PlayerSpawner.prefab",
-                    "isTemplated": true
+                    "file": "Platform/Mac/mac_project.cmake",
+                    "isTemplated": false
                 },
                 {
-                    "file": "Registry/editorpreferences.setreg",
+                    "file": "Platform/Mac/mac_project.json",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Platform/Windows/windows_project.cmake",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Platform/Windows/windows_project.json",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Platform/iOS/ios_project.cmake",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Platform/iOS/ios_project.json",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/Platform/Android/quality.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/Platform/Linux/quality.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/Platform/Mac/quality.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/Platform/Windows/quality.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/Platform/iOS/quality.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/assetprocessor_settings.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/awscoreconfiguration.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/load_level.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/physxdebugconfiguration.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/physxdefaultsceneconfiguration.setreg",
                     "isTemplated": false
                 },
                 {
                     "file": "Registry/physxsystemconfiguration.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/quality.client.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/quality.headless.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/quality.server.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Registry/quality.setreg",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/GameSDK.ico",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/Mac/Images.xcassets/${Name}AppIcon.appiconset/Contents.json",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/Mac/Images.xcassets/${Name}AppIcon.appiconset/icon_128.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/Mac/Images.xcassets/${Name}AppIcon.appiconset/icon_128_2x.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/Mac/Images.xcassets/${Name}AppIcon.appiconset/icon_16.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/Mac/Images.xcassets/${Name}AppIcon.appiconset/icon_16_2x.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/Mac/Images.xcassets/${Name}AppIcon.appiconset/icon_256.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/Mac/Images.xcassets/${Name}AppIcon.appiconset/icon_256_2x.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/Mac/Images.xcassets/${Name}AppIcon.appiconset/icon_32.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/Mac/Images.xcassets/${Name}AppIcon.appiconset/icon_32_2x.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/Mac/Images.xcassets/${Name}AppIcon.appiconset/icon_512.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/Mac/Images.xcassets/${Name}AppIcon.appiconset/icon_512_2x.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/Mac/Images.xcassets/Contents.json",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/Mac/Info.plist",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/Contents.json",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/iPadAppIcon152x152.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/iPadAppIcon76x76.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/iPadProAppIcon167x167.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/iPadSettingsIcon29x29.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/iPadSettingsIcon58x58.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/iPadSpotlightIcon40x40.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/iPadSpotlightIcon80x80.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/iPhoneAppIcon120x120.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/iPhoneAppIcon180x180.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/iPhoneSettingsIcon58x58.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/iPhoneSettingsIcon87x87.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/iPhoneSpotlightIcon120x120.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset/iPhoneSpotlightIcon80x80.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/Contents.json",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/Contents.json",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage1024x768.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage1536x2048.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage2048x1536.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage768x1024.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPhoneLaunchImage640x1136.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPhoneLaunchImage640x960.png",
+                    "isTemplated": false
+                },
+                {
+                    "file": "Resources/Platform/iOS/Info.plist",
+                    "isTemplated": true
+                },
+                {
+                    "file": "Resources/Splash.bmp",
                     "isTemplated": false
                 },
                 {
@@ -1598,11 +1765,7 @@
                     "isTemplated": false
                 },
                 {
-                    "file": "Shaders/CommonVS.azsli",
-                    "isTemplated": false
-                },
-                {
-                    "file": "cmake/CompilerSettings.cmake",
+                    "file": "autoexec.cfg",
                     "isTemplated": false
                 },
                 {
@@ -1610,44 +1773,20 @@
                     "isTemplated": false
                 },
                 {
-                    "file": "cmake/Platform/Linux/CompilerSettings_linux.cmake",
-                    "isTemplated": false
-                },
-                {
                     "file": "editor.cfg",
                     "isTemplated": false
                 },
                 {
+                    "file": "export.bat",
+                    "isTemplated": false
+                },
+                {
+                    "file": "export.sh",
+                    "isTemplated": false
+                },
+                {
                     "file": "game.cfg",
-                    "isTemplated": true
-                },
-                {
-                    "file": "generate_asset_cmake.bat",
-                    "isTemplated": true
-                },
-                {
-                    "file": "launch_client.cfg",
                     "isTemplated": false
-                },
-                {
-                    "file": "launch_client.cmd",
-                    "isTemplated": true
-                },
-                {
-                    "file": "launch_client.sh",
-                    "isTemplated": true
-                },
-                {
-                    "file": "launch_server.cfg",
-                    "isTemplated": false
-                },
-                {
-                    "file": "launch_server.cmd",
-                    "isTemplated": true
-                },
-                {
-                    "file": "launch_server.sh",
-                    "isTemplated": true
                 },
                 {
                     "file": "preview.png",
@@ -1660,109 +1799,109 @@
             ],
             "createDirectories": [
                 {
-                    "dir": "BURT"
+                    "dir": "AssetBundling"
                 },
                 {
-                    "dir": "BURT/Motions"
+                    "dir": "AssetBundling/SeedLists"
                 },
                 {
-                    "dir": "BURT/Textures"
+                    "dir": "Assets"
+                },
+                {
+                    "dir": "Assets/Characters"
+                },
+                {
+                    "dir": "Assets/Characters/Attachments"
+                },
+                {
+                    "dir": "Assets/Characters/Attachments/Laser_Gun"
+                },
+                {
+                    "dir": "Assets/Characters/Attachments/Laser_Gun/textures"
+                },
+                {
+                    "dir": "Assets/Characters/Mixamo"
+                },
+                {
+                    "dir": "Assets/Characters/Mixamo/Animations"
+                },
+                {
+                    "dir": "Assets/Characters/Mixamo/Ybot"
+                },
+                {
+                    "dir": "Assets/Characters/Mixamo/Ybot/skins"
+                },
+                {
+                    "dir": "Assets/Characters/Mixamo/Ybot/test_data"
+                },
+                {
+                    "dir": "Assets/Characters/Mixamo/Ybot/textures"
+                },
+                {
+                    "dir": "Assets/InputBindings"
+                },
+                {
+                    "dir": "Assets/Prefabs"
+                },
+                {
+                    "dir": "Assets/UI"
+                },
+                {
+                    "dir": "Assets/UI/BasicHUD"
                 },
                 {
                     "dir": "Config"
                 },
                 {
-                    "dir": "Config/AtomImageBuilder"
-                },
-                {
                     "dir": "Gem"
                 },
                 {
-                    "dir": "Gem/Code"
+                    "dir": "Gem/Include"
                 },
                 {
-                    "dir": "Gem/Code/Include"
+                    "dir": "Gem/Include/${Name}"
                 },
                 {
-                    "dir": "Gem/Code/Platform"
+                    "dir": "Gem/Platform"
                 },
                 {
-                    "dir": "Gem/Code/Platform/Android"
+                    "dir": "Gem/Platform/Android"
                 },
                 {
-                    "dir": "Gem/Code/Platform/Linux"
+                    "dir": "Gem/Platform/Linux"
                 },
                 {
-                    "dir": "Gem/Code/Platform/Mac"
+                    "dir": "Gem/Platform/Mac"
                 },
                 {
-                    "dir": "Gem/Code/Platform/Windows"
+                    "dir": "Gem/Platform/Windows"
                 },
                 {
-                    "dir": "Gem/Code/Platform/iOS"
+                    "dir": "Gem/Platform/iOS"
                 },
                 {
-                    "dir": "Gem/Code/Source"
+                    "dir": "Gem/Registry"
                 },
                 {
-                    "dir": "Gem/Code/Source/AutoGen"
+                    "dir": "Gem/Source"
                 },
                 {
-                    "dir": "Gem/Code/Source/Components"
+                    "dir": "Gem/Source/AutoGen"
                 },
                 {
-                    "dir": "Gem/Code/Source/Spawners"
+                    "dir": "Gem/Source/Components"
                 },
                 {
-                    "dir": "Gem/Code/Source/Weapons"
+                    "dir": "Gem/Source/Effects"
                 },
                 {
-                    "dir": "Gem/Resources"
-                },
-                {
-                    "dir": "Gem/Resources/IOSLauncher"
-                },
-                {
-                    "dir": "Gem/Resources/IOSLauncher/Images.xcassets"
-                },
-                {
-                    "dir": "Gem/Resources/IOSLauncher/Images.xcassets/${Name}AppIcon.appiconset"
-                },
-                {
-                    "dir": "Gem/Resources/IOSLauncher/Images.xcassets/LaunchImage.launchimage"
-                },
-                {
-                    "dir": "Gem/Resources/MacLauncher"
-                },
-                {
-                    "dir": "Gem/Resources/MacLauncher/Images.xcassets"
-                },
-                {
-                    "dir": "Gem/Resources/MacLauncher/Images.xcassets/CMakeTestbedAppIcon.appiconset"
-                },
-                {
-                    "dir": "InputBindings"
+                    "dir": "Gem/Source/Weapons"
                 },
                 {
                     "dir": "Levels"
                 },
                 {
-                    "dir": "Levels/Demo"
-                },
-                {
-                    "dir": "LightingPresets"
-                },
-                {
-                    "dir": "Materials"
-                },
-                {
-                    "dir": "Materials/Default"
-                },
-                {
-                    "dir": "Materials/decal"
-                },
-                {
-                    "dir": "Objects"
+                    "dir": "Levels/DefaultLevel"
                 },
                 {
                     "dir": "Platform"
@@ -1771,45 +1910,75 @@
                     "dir": "Platform/Android"
                 },
                 {
-                    "dir": "Prefabs"
+                    "dir": "Platform/Linux"
+                },
+                {
+                    "dir": "Platform/Mac"
+                },
+                {
+                    "dir": "Platform/Windows"
+                },
+                {
+                    "dir": "Platform/iOS"
                 },
                 {
                     "dir": "Registry"
                 },
                 {
-                    "dir": "Scripts"
+                    "dir": "Registry/Platform"
                 },
                 {
-                    "dir": "Scripts/build"
+                    "dir": "Registry/Platform/Android"
                 },
                 {
-                    "dir": "Scripts/build/Jenkins"
+                    "dir": "Registry/Platform/Linux"
+                },
+                {
+                    "dir": "Registry/Platform/Mac"
+                },
+                {
+                    "dir": "Registry/Platform/Windows"
+                },
+                {
+                    "dir": "Registry/Platform/iOS"
+                },
+                {
+                    "dir": "Resources"
+                },
+                {
+                    "dir": "Resources/Platform"
+                },
+                {
+                    "dir": "Resources/Platform/Mac"
+                },
+                {
+                    "dir": "Resources/Platform/Mac/Images.xcassets"
+                },
+                {
+                    "dir": "Resources/Platform/Mac/Images.xcassets/${Name}AppIcon.appiconset"
+                },
+                {
+                    "dir": "Resources/Platform/iOS"
+                },
+                {
+                    "dir": "Resources/Platform/iOS/Images.xcassets"
+                },
+                {
+                    "dir": "Resources/Platform/iOS/Images.xcassets/${Name}AppIcon.appiconset"
+                },
+                {
+                    "dir": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage"
                 },
                 {
                     "dir": "ShaderLib"
                 },
                 {
-                    "dir": "Shaders"
-                },
-                {
                     "dir": "cmake"
-                },
-                {
-                    "dir": "cmake/Platform"
-                },
-                {
-                    "dir": "cmake/Platform/Linux"
                 }
             ],
+            "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
             "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/multiplayer-2.0.0-template.zip",
-            "sha256": "4df1e7039ab64e0c531114a969d943635c248e5affc471faf4a710913be3bdf9",
-            "versions_data": [
-                {
-                    "sha256": "5450e61577c310972436f0bc84d89765e176569898713a884ce4620a94f2c23c",
-                    "version": "2.0.0",
-                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/multiplayer-2.0.0-template.zip"
-                }
-            ]
+            "sha256": "f6eaa01c0a66fef0a9fa55e00637ae087f11287f30540ccd479c2988f9e41ab4"
         },
         {
             "template_name": "Ros2FleetRobotTemplate",
@@ -5061,7 +5230,442 @@
                         }
                     ],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2projecttemplate-2.0.0-template.zip",
-                    "sha256": "51bbdcc2b24016a8ec9d005a35fa31139f3fae30c5ae84df54e6b73318b20744"
+                    "sha256": "9d10edb8e3c51358ffcfc7a255af0db34981dafa3a37dd36ba68dda2c56e6866"
+                },
+                {
+                    "version": "2.0.1",
+                    "copyFiles": [
+                        {
+                            "file": ".clang-format",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": ".gitattributes",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": ".gitignore",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "CMakeLists.txt",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "cmake/EngineFinder.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Config/default_aws_resource_mappings.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Config/shader_global_build_options.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/${NameLower}_files.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/${NameLower}_editor_files.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/${NameLower}_shared_files.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/${NameLower}_editor_shared_files.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/CMakeLists.txt",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Include/${Name}/${Name}Bus.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Android/${NameLower}_android_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Android/${NameLower}_shared_android_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Android/PAL_android.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Linux/${NameLower}_linux_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Linux/${NameLower}_shared_linux_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Linux/PAL_linux.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Mac/${NameLower}_mac_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Mac/${NameLower}_shared_mac_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Mac/PAL_mac.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Windows/${NameLower}_shared_windows_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Windows/${NameLower}_windows_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Windows/PAL_windows.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/iOS/${NameLower}_ios_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/iOS/${NameLower}_shared_ios_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/iOS/PAL_ios.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Registry/assetprocessor_settings.setreg",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}Module.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}EditorModule.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}ModuleInterface.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}SystemComponent.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}SystemComponent.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}EditorSystemComponent.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}EditorSystemComponent.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}SampleComponent.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}SampleComponent.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/gem.json",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Levels/DemoLevel/DemoLevel.prefab",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Platform/Android/android_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Android/android_project.json",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Platform/Linux/linux_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Linux/linux_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Mac/mac_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Mac/mac_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Windows/windows_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Windows/windows_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/iOS/ios_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/iOS/ios_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/assetprocessor_settings.setreg",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Registry/awscoreconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/editorpreferences.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/physxsystemconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/sceneassetimporter.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/GameSDK.ico",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/LegacyLogoLauncher.bmp",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_128.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_128_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_16.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_16_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_256.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_256_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_32.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_32_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_512.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_512_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Info.plist",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage1024x768.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage1536x2048.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage2048x1536.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage768x1024.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPhoneLaunchImage640x1136.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPhoneLaunchImage640x960.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadAppIcon152x152.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadAppIcon76x76.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadProAppIcon167x167.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadSettingsIcon29x29.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadSettingsIcon58x58.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadSpotlightIcon40x40.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadSpotlightIcon80x80.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPhoneAppIcon120x120.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPhoneAppIcon180x180.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPhoneSettingsIcon58x58.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPhoneSettingsIcon87x87.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPhoneSpotlightIcon120x120.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPhoneSpotlightIcon80x80.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Info.plist",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "ShaderLib/README.md",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "ShaderLib/scenesrg.srgi",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "ShaderLib/viewsrg.srgi",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "autoexec.cfg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "game.cfg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "preview.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "project.json",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Examples/slam_navigation/launch/config/config.rviz",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/slam_navigation/README.md",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/slam_navigation/launch/config/navigation_params_humble.yaml",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/slam_navigation/launch/config/navigation_params_jazzy.yaml",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/slam_navigation/launch/config/slam_params.yaml",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/slam_navigation/launch/navigation.launch.py",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/slam_navigation/launch/slam.launch.py",
+                            "isTemplated": false
+                        }
+                    ],
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2projecttemplate-2.0.1-template.zip",
+                    "sha256": "c7367b98bd6ee5305eb63e0a256899aa57ee299cb553f4ab2555b8e9fef2100b"
                 }
             ]
         },
@@ -5942,6 +6546,15 @@
                         "OpenXRVk>=1.0.1"
                     ],
                     "version": "1.0.0"
+                },
+                {
+                    "version": "1.0.1",
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/openxrtest-1.0.1-project.zip",
+                    "gem_names": [
+                        "XR>=1.0.1",
+                        "OpenXRVk>=1.0.1"
+                    ],
+                    "sha256": "a08e465949826c204af2a9f32a15b616bf1b81c0cdfde62eb070558b7228312f"
                 }
             ]
         }


### PR DESCRIPTION
## What does this PR do?

This PR cherry-picks commits that should be included in the point release `2409.1`. This includes the following PRs with the following reasoning:
- #769 fixes version numbers of the project templates; it was pushed to the `stabilization/2409` branch **after** the release; it was used to generate the binary packages, but it was missing in the `main` branch
- #774 fixes the blocker issue that made custom namespaces unusable; it was pushed to the `stabilization/2409` branch **after** the release; it was used to generate the binary packages, but it was missing in the `main` branch
- #775 fixes ROS 2 Gem version; it was pushed to the `stabilization/2409` branch **after** the release; it was used to generate the binary packages, but it was missing in the `main` branch
- #772 improves the helper script that can be used when migrating between ROS 2 Gems in 2310.x and 2409.x; the first version of the script incorrectly parsed prefabs overrides; the script does not influence O3DE itself
- #777 enables ROS2 Frame usage within the level entity; this PR can be considered as a feature or a fix of the oversight that existed since 2310.0; it does not influence the codebase or the existing projects/templates
- #778 fixes the bug that was making `FollowingCameraComponent` unusable with `FlyCameraComponent` (the problem existed since 2310.0)
- #781 allows to disable fix from #749 which fixed ROS2 Camera when GlobalIllumination was enabled but broke it when sky atmosphere was enabled; this can be now set with a registry
- revert of #725 : this PR eliminated the warning, but it broke the ROS 2 transforms; after internal discussions with @MateuszWasilewski, @zakmat, and @michalpelka we decided to revert the change and implement a proper fix for the issue triggering warning for the next release; created an issue for that https://github.com/o3de/o3de-extras/issues/783 

**NOTE:** when this PR is merged, there should be one more fix to follow, in which 
- ROS2 Gem version is set to `3.2.2` as discussed on [Discord channel](https://discord.com/channels/805939474655346758/968933327048433724/1301162160315170838)
- patch version of all three ROS 2 templates is bumped after #781 
- `repo.json` file is regenerated to include files added in #781

## How was this PR tested?

ROS2ProjectTemplate was built and tested; more tests with other templates should follow
