### PR TITLE
Added if statement for 'remove' operations in FrameConversion script

### DIFF
--- a/Gems/ROS2/Code/Source/Frame/Conversions/FrameConversion.py
+++ b/Gems/ROS2/Code/Source/Frame/Conversions/FrameConversion.py
@@ -47,6 +47,8 @@ def find_and_replace(data):
                     "m_template/Joint Name"
                 ]):
                     item["path"] = item["path"].replace("m_template", "ROS2FrameConfiguration")
+                if item["op"] == "remove" and "ROS2FrameComponent" in item["path"]:
+                    item["path"] = item["path"].replace("ROS2FrameComponent", "ROS2FrameEditorComponent")
 
             for key, value in item.items():
                 search_for_components(value, foundComponents, insidePatches)


### PR DESCRIPTION
## What does this PR do?

The FrameConversion.py script is very helpful if you need to migrate your project to the 2409 release. However one thing is still missing, even with PR #772 - modifying `remove` operations in the `Patches` section is not handled properly. 
```
                {
                    "op": "remove",
                    "path": "/Entities/Entity_[8678293627970]/Components/ROS2FrameComponent"
                },
 ```

This PR extends the script capabilities - I think that now all cases are now covered.

## How was this PR tested?

By preparing nested prefab with the O3DE 2310, converted prefab with a script and used it with the O3DE 2409.
