### PR TITLE
Fix ROS2 Project Template

### DIFF
--- a/Templates/Ros2ProjectTemplate/Template/Levels/DemoLevel/DemoLevel.prefab
+++ b/Templates/Ros2ProjectTemplate/Template/Levels/DemoLevel/DemoLevel.prefab
@@ -268,7 +268,7 @@
                     "$type": "GenericComponentWrapper",
                     "Id": 2318932367744128274,
                     "m_template": {
-                        "$type": "R2PTSampleComponent",
+                        "$type": "${SanitizedCppName}SampleComponent",
                         "goals": [
                             "Entity_[549827034797]",
                             "Entity_[545532067501]"


### PR DESCRIPTION
## What does this PR do?
This fixes the templated DemoLevel prefab by restoring concrete component name to templated component name

Fixes https://github.com/o3de/o3de-extras/issues/780
## How was this PR tested?
Created a new ROS2 Project from template, Built and opened the editor and open DemoLevel.prefab. Verified warning is no longer there.

