### PR TITLE
Multiplayer Template Monolithic Build Fix

### DIFF
--- a/Templates/Multiplayer/Template/Gem/Source/${Name}Module.cpp
+++ b/Templates/Multiplayer/Template/Gem/Source/${Name}Module.cpp
@@ -43,8 +43,24 @@ namespace ${SanitizedCppName}
     };
 }// namespace ${SanitizedCppName}
 
+#if defined(AZ_MONOLITHIC_BUILD)
+    // Monolithic client
+    #if defined(O3DE_GEM_NAME)
+        AZ_DECLARE_MODULE_CLASS(AZ_JOIN(Gem_, O3DE_GEM_NAME, _Client), ${SanitizedCppName}::${SanitizedCppName}Module)
+    #else
+        AZ_DECLARE_MODULE_CLASS(Gem_${SanitizedCppName}_Client, ${SanitizedCppName}::${SanitizedCppName}Module)
+    #endif
+
+    // Monolithic server
+    #if defined(O3DE_GEM_NAME)
+        AZ_DECLARE_MODULE_CLASS(AZ_JOIN(Gem_, O3DE_GEM_NAME, _Server), ${SanitizedCppName}::${SanitizedCppName}Module)
+    #else
+        AZ_DECLARE_MODULE_CLASS(Gem_${SanitizedCppName}_Server, ${SanitizedCppName}::${SanitizedCppName}Module)
+    #endif
+#endif
+
 #if defined(O3DE_GEM_NAME)
-AZ_DECLARE_MODULE_CLASS(AZ_JOIN(Gem_, O3DE_GEM_NAME), ${SanitizedCppName}::${SanitizedCppName}Module)
+    AZ_DECLARE_MODULE_CLASS(AZ_JOIN(Gem_, O3DE_GEM_NAME), ${SanitizedCppName}::${SanitizedCppName}Module)
 #else
-AZ_DECLARE_MODULE_CLASS(Gem_${SanitizedCppName}, ${SanitizedCppName}::${SanitizedCppName}Module)
+    AZ_DECLARE_MODULE_CLASS(Gem_${SanitizedCppName}, ${SanitizedCppName}::${SanitizedCppName}Module)
 #endif


### PR DESCRIPTION
Adding client/server module gems in order to support monolithic (release export) builds

Fixes #788 

## How was this PR tested?
Created a new game using MultiplayerTemplate, opened ProjectManager and exported for Windows (monolithic enabeled)