### PR TITLE
Fix Gem dependency issue for  projects created from ROS2 templates

### DIFF
--- a/Templates/Ros2FleetRobotTemplate/Template/Gem/gem.json
+++ b/Templates/Ros2FleetRobotTemplate/Template/Gem/gem.json
@@ -21,6 +21,7 @@
     "requirements": "",
     "documentation_url": "",
     "dependencies": [
+        "ROS2>=3.1.0"
     ],
     "compatible_engines": [
         "o3de-sdk>=1.2.0",

--- a/Templates/Ros2FleetRobotTemplate/template.json
+++ b/Templates/Ros2FleetRobotTemplate/template.json
@@ -1,6 +1,6 @@
 {
     "template_name": "Ros2FleetRobotTemplate",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "origin": "Open 3D Engine Extras",
     "origin_url": "https://github.com/o3de/o3de-extras",
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
@@ -493,5 +493,5 @@
             "dir": "Examples/ros2_ws/src/o3de_fleet_nav/test"
         }
     ],
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2fleetrobottemplate-2.0.1-template.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2fleetrobottemplate-2.0.2-template.zip"
 }

--- a/Templates/Ros2ProjectTemplate/Template/Gem/gem.json
+++ b/Templates/Ros2ProjectTemplate/Template/Gem/gem.json
@@ -24,5 +24,6 @@
     ],
     "documentation_url": "",
     "dependencies": [
+        "ROS2>=3.1.0"
     ]
 }

--- a/Templates/Ros2ProjectTemplate/template.json
+++ b/Templates/Ros2ProjectTemplate/template.json
@@ -1,6 +1,6 @@
 {
     "template_name": "Ros2ProjectTemplate",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "origin": "Open 3D Engine Extras",
     "origin_url": "https://github.com/o3de/o3de-extras",
     "license": "https://github.com/o3de/o3de-extras/tree/development/Templates/Ros2ProjectTemplate/Template/LICENSE.txt",
@@ -561,5 +561,5 @@
         }
     ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2projecttemplate-2.0.1-template.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2projecttemplate-2.0.2-template.zip"
 }

--- a/Templates/Ros2RoboticManipulationTemplate/Template/Gem/gem.json
+++ b/Templates/Ros2RoboticManipulationTemplate/Template/Gem/gem.json
@@ -21,10 +21,10 @@
     "requirements": "",
     "documentation_url": "",
     "dependencies": [
+        "ROS2>=3.1.0"
     ],
     "compatible_engines": [
     ],
     "engine_api_dependencies":[
-        "ROS2>=3.1.0"
     ]
 }

--- a/Templates/Ros2RoboticManipulationTemplate/Template/Gem/gem.json
+++ b/Templates/Ros2RoboticManipulationTemplate/Template/Gem/gem.json
@@ -25,5 +25,6 @@
     "compatible_engines": [
     ],
     "engine_api_dependencies":[
+        "ROS2>=3.1.0"
     ]
 }

--- a/Templates/Ros2RoboticManipulationTemplate/template.json
+++ b/Templates/Ros2RoboticManipulationTemplate/template.json
@@ -1,6 +1,6 @@
 {
     "template_name": "Ros2RoboticManipulationTemplate",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "origin": "https://github.com/o3de/o3de-extras",
     "license": "https://github.com/o3de/o3de-extras/tree/development/Templates/Ros2RoboticManipulationTemplate/Template/LICENSE.txt",
     "display_name": "ROS2 Robotic Manipulation",
@@ -834,5 +834,5 @@
         }
     ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2roboticmanipulationtemplate-2.0.0-template.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2roboticmanipulationtemplate-2.0.1-template.zip"
 }


### PR DESCRIPTION
## What does this PR do?
This fixes an issue where the dependency on the ROS2 gem fails whenever you create a project from one of the ROS2 templates and then add or remove additional gems from the project. 

## Root Cause
When you create a new project from one of the ROS2 project templates, the default project Gem is added as the last item in project.json. It is preceded by the default gems for that particular template type, in which case ROS2 is one of the dependencies. The problem is, the CMakeLists.txt for the project gem has a call to `target_depends_on_ros2_packages`, which needs to be loaded before the gem is processed. Since the project gem is always last, the ROS2 gem will always get loaded first. 

But when you add or remove gems, Project Manager will, by default, order the list of enabled gems in alphabetical order. So if your project name comes alphabetically before 'ROS2', the project gem will get processed BEFORE the ROS2 gem, so the cmake function `target_depends_on_ros2_packages` cannot be resolved yet. 

## Fix
Since the project gem relies on `target_depends_on_ros2_packages`, the gem.json definition for the project gem should also have a dependency on the ROS2 gem to ensure that it is processed first. This fixes the template to correct the situation.

**Note** : This will not fix projects created from the previous template. Existing projects will need to have their project gem's  gem.json updated to add ROS2 as a dependency as well.

```
    "dependencies": [
        "ROS2>=3.1.0"
    ]
```
## How was this PR tested?
Create new ROS2 projects and added additional gems and built successfully.

Fixes https://github.com/o3de/o3de/issues/18451 


