### PR TITLE
Remove unused_variable warnings when release mode

### DIFF
--- a/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -656,7 +656,6 @@ namespace ROS2
     {
         const auto filePath = m_robotDescriptionPage->GetModifiedUrdfName();
         const auto& streamData = m_modifiedUrdfWindow->GetUrdfData();
-        bool success = false;
         AZ::IO::FileIOBase* fileIo = AZ::IO::FileIOBase::GetInstance();
         AZ::IO::FixedMaxPathString resolvedPath;
         if (fileIo == nullptr || !fileIo->ResolvePath(filePath.c_str(), resolvedPath.data(), resolvedPath.capacity() + 1))
@@ -667,11 +666,10 @@ namespace ROS2
                 resolvedPath.c_str(),
                 AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY))
         {
-            AZ::IO::SizeType bytesWritten = fileHandle.Write(streamData.data(), streamData.size());
-            success = (bytesWritten == streamData.size());
+            [[maybe_unused]] const AZ::IO::SizeType bytesWritten = fileHandle.Write(streamData.data(), streamData.size());
+            AZ_Warning(
+                "onSaveModifiedUrdfPressed", (bytesWritten == streamData.size()), "Cannot save the output file %s", filePath.c_str());
         }
-
-        AZ_Warning("onSaveModifiedUrdfPressed", success, "Cannot save the output file %s", filePath.c_str());
     }
 
     void RobotImporterWidget::onShowModifiedUrdfPressed()

--- a/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2SkidSteeringModelHook.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/SDFormat/Hooks/ROS2SkidSteeringModelHook.cpp
@@ -103,7 +103,6 @@ namespace ROS2::SDFormat
             if (element->HasElement("wheel_separation") && element->HasElement("wheel_diameter"))
             {
                 // ROS 2 version of either libgazebo_ros_skid_steer_drive.so or libgazebo_ros_diff_drive.so
-                const auto wheelPairs = element->Get<int>("num_wheel_pairs", 1).first;
                 int dataCount = 0;
 
                 auto wheelSeparation = element->GetElement("wheel_separation");
@@ -120,10 +119,9 @@ namespace ROS2::SDFormat
                     }
                     else
                     {
-                        constexpr float epsilon = 0.001f;
                         AZ_Warning(
                             "CreateVehicleConfiguration",
-                            AZ::IsClose(configuration.m_wheelbase, wheelSeparation->Get<float>(), epsilon),
+                            AZ::IsClose(configuration.m_wheelbase, wheelSeparation->Get<float>()),
                             "Different wheel separation distances in one model are not supported.");
                     }
 
@@ -138,6 +136,7 @@ namespace ROS2::SDFormat
                     wheelSeparation = wheelSeparation->GetNextElement("wheel_separation");
                     wheelDiameter = wheelDiameter->GetNextElement("wheel_diameter");
                 }
+                [[maybe_unused]] const auto wheelPairs = element->Get<int>("num_wheel_pairs", 1).first;
                 AZ_Warning(
                     "CreateVehicleConfiguration",
                     wheelPairs == configuration.m_axles.size(),


### PR DESCRIPTION
## What does this PR do?

Some variables in RobotImporter were used only for `AZ_Warning` macro, which is removed in _release_ builds. This was causing _unused_variable_ warnings, leading to a compilation failure. This is fixed now.

## How was this PR tested?

A release build was made.
