### PR TITLE
Fixes following o3de #18405

### DIFF
--- a/Gems/MachineLearning/Code/CMakeLists.txt
+++ b/Gems/MachineLearning/Code/CMakeLists.txt
@@ -102,7 +102,7 @@ ly_add_target(
         PRIVATE
             Gem::${gem_name}.Private.Object
             AZ::AtomCore
-            Gem::Atom_Feature_Common.Static
+            Gem::Atom_Feature_Common.Public
             Gem::ImGui.Static
 )
 

--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -62,7 +62,7 @@ ly_add_target(
             AZ::AzCore
             AZ::AzFramework
             Gem::Atom_RPI.Public
-            Gem::Atom_Feature_Common.Static
+            Gem::Atom_Feature_Common.Public
             Gem::Atom_Component_DebugCamera.Static
             Gem::Atom_AtomBridge.Static
             Gem::StartingPointInput
@@ -97,7 +97,7 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PRIVATE
             Gem::${gem_name}.Static
-            Gem::Atom_Feature_Common.Static
+            Gem::Atom_Feature_Common.Public
 )
 
 # By default, we will specify that the above target ROS2 would be used by
@@ -158,7 +158,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 Gem::${gem_name}.Editor.Static
-                Gem::Atom_Feature_Common.Static
+                Gem::Atom_Feature_Common.Public
     )
 
     # By default, we will specify that the above target ROS2 would be used by

--- a/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
@@ -8,6 +8,7 @@
 #include "CameraSensor.h"
 #include <ROS2/Camera/CameraPostProcessingRequestBus.h>
 
+#include <Atom/Feature/PostProcess/PostProcessFeatureProcessorInterface.h>
 #include <Atom/RPI.Public/Base.h>
 #include <Atom/RPI.Public/FeatureProcessorFactory.h>
 #include <Atom/RPI.Public/Pass/PassFactory.h>
@@ -20,7 +21,6 @@
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzFramework/Scene/SceneSystemInterface.h>
-#include <PostProcess/PostProcessFeatureProcessor.h>
 
 #include <sensor_msgs/distortion_models.hpp>
 
@@ -159,7 +159,7 @@ namespace ROS2
 
         m_pipeline->SetDefaultView(m_view);
         const AZ::RPI::ViewPtr targetView = m_scene->GetDefaultRenderPipeline()->GetDefaultView();
-        if (auto* fp = m_scene->GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessor>())
+        if (auto* fp = m_scene->GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessorInterface>())
         {
             fp->SetViewAlias(m_view, targetView);
         }
@@ -169,7 +169,7 @@ namespace ROS2
     {
         if (m_scene)
         {
-            if (auto* fp = m_scene->GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessor>())
+            if (auto* fp = m_scene->GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessorInterface>())
             {
                 fp->RemoveViewAlias(m_view);
             }

--- a/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
+++ b/Gems/ROS2/Code/Source/RobotImporter/URDF/URDFPrefabMaker.cpp
@@ -10,7 +10,6 @@
 #include "CollidersMaker.h"
 #include "PrefabMakerUtils.h"
 #include <API/EditorAssetSystemAPI.h>
-#include <Atom/Feature/Mesh/MeshFeatureProcessor.h>
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/Math/Transform.h>

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ROS2",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "platforms": [
         "Linux"
     ],
@@ -19,11 +19,11 @@
         "ROS2"
     ],
     "compatible_engines": [
-        "o3de-sdk>=2.3.0",
-        "o3de>=2.3.0"
+        "o3de-sdk>=4.2.0",
+        "o3de>=4.2.0"
     ],
     "icon_path": "preview.png",
-    "requirements": "Requires ROS 2 installation (supported distributions: Humble). Source your workspace before building the Gem",
+    "requirements": "Requires ROS 2 installation (supported distributions: Humble and Jazzy). Source your workspace before building the Gem",
     "documentation_url": "https://docs.o3de.org/docs/user-guide/gems/reference/robotics/ros2/",
     "dependencies": [
         "Atom_RPI",
@@ -36,5 +36,6 @@
     ],
     "restricted": "ROS2",
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0//ros2-3.2.1-gem.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.3.0-gem.zip"
 }
+

--- a/Templates/Ros2ProjectTemplate/Template/Gem/CMakeLists.txt
+++ b/Templates/Ros2ProjectTemplate/Template/Gem/CMakeLists.txt
@@ -125,7 +125,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 ${gem_name}.Editor.Static
-                Gem::Atom_Feature_Common.Public
     )
 
     ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)

--- a/Templates/Ros2ProjectTemplate/Template/Gem/CMakeLists.txt
+++ b/Templates/Ros2ProjectTemplate/Template/Gem/CMakeLists.txt
@@ -125,7 +125,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 ${gem_name}.Editor.Static
-                Gem::Atom_Feature_Common.Static
+                Gem::Atom_Feature_Common.Public
     )
 
     ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem TARGETS Gem::${gem_name}.Editor)

--- a/Templates/Ros2ProjectTemplate/template.json
+++ b/Templates/Ros2ProjectTemplate/template.json
@@ -1,6 +1,6 @@
 {
     "template_name": "Ros2ProjectTemplate",
-    "version": "2.0.2",
+    "version": "2.1.0",
     "origin": "Open 3D Engine Extras",
     "origin_url": "https://github.com/o3de/o3de-extras",
     "license": "https://github.com/o3de/o3de-extras/tree/development/Templates/Ros2ProjectTemplate/Template/LICENSE.txt",
@@ -561,5 +561,6 @@
         }
     ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2projecttemplate-2.0.2-template.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2projecttemplate-2.1.0-template.zip"
 }
+


### PR DESCRIPTION
## What does this PR do?

PR https://github.com/o3de/o3de/pull/18405 changed target names in O3DE Gems, which caused build failures in o3de-extras. This is fixed in this PR.

Additionally:
- _ROS 2 Gem_ version was changed to newer than the last release (new features were added, non-breaking change, hence minor)
- _ROS 2 Gem_ was set to require _development_ version of o3de (it will not build otherwise)
- _Ros2ProjectTemplate_ version was changed to reflect changes in the cmake

## How was this PR tested?

A sample project was built with o3de from `development` branch, 0efe207e34
