### PR TITLE
Add notification bus to spawner

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Spawner/SpawnerBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Spawner/SpawnerBus.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Component/EntityId.h>
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/RTTI/BehaviorContext.h>
@@ -33,5 +34,27 @@ namespace ROS2
         virtual AZStd::unordered_map<AZStd::string, SpawnPointInfo> GetAllSpawnPointInfos() const = 0;
     };
 
+    class SpawnerNotifications : public AZ::EBusTraits
+    {
+    public:
+        AZ_RTTI(SpawnerNotifications, "{0D22B024-48C7-457C-BFFB-D292045B68EC}");
+
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+
+        virtual ~SpawnerNotifications() = default;
+
+        //! Notifies that spawn operation was completed.
+        //! @param spawnableName name of the spawnable that was spawned.
+        //! @param rootEntity root entity of the spawned spawnable.
+        //! @param ticketName name of the ticket that was used to spawn the entity.
+        virtual void OnSpawned(const AZStd::string& spawnableName, const AZ::EntityId& rootEntity, const AZStd::string& ticketName){};
+
+        //! Notifies that despawn operation was completed.
+        //! @param ticketName name of the ticket that was used to despawn the entity.
+        virtual void OnDespawned(const AZStd::string& ticketName){};
+    };
+
     using SpawnerRequestsBus = AZ::EBus<SpawnerRequests>;
+    using SpawnerNotificationBus = AZ::EBus<SpawnerNotifications>;
 } // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Spawner/SpawnerBusHandler.h
+++ b/Gems/ROS2/Code/Include/ROS2/Spawner/SpawnerBusHandler.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "AzCore/RTTI/BehaviorContext.h"
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/EBus/EBus.h>
+#include <ROS2/Spawner/SpawnerBus.h>
+
+namespace ROS2
+{
+    class SpawnerNotificationsBusHandler
+        : public SpawnerNotificationBus::Handler
+        , public AZ::BehaviorEBusHandler
+    {
+    public:
+        AZ_EBUS_BEHAVIOR_BINDER(
+            SpawnerNotificationsBusHandler, "{9EB89664-0BE5-4E89-8E17-01B21073EBB8}", AZ::SystemAllocator, OnSpawned, OnDespawned);
+
+        void OnSpawned(const AZStd::string& spawnableName, const AZ::EntityId& rootEntity, const AZStd::string& ticketName) override
+        {
+            Call(FN_OnSpawned, spawnableName, rootEntity, ticketName);
+        }
+
+        void OnDespawned(const AZStd::string& ticketName) override
+        {
+            Call(FN_OnDespawned, ticketName);
+        }
+    };
+
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -8,6 +8,7 @@
 
 #include "ROS2SpawnerComponent.h"
 #include "Spawner/ROS2SpawnerComponentController.h"
+#include <AzCore/Component/EntityId.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
@@ -18,6 +19,7 @@
 #include <ROS2/Georeference/GeoreferenceBus.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/ROS2GemUtilities.h>
+#include <ROS2/Spawner/SpawnerBus.h>
 #include <ROS2/Utilities/ROS2Conversions.h>
 #include <ROS2/Utilities/ROS2Names.h>
 
@@ -243,18 +245,23 @@ namespace ROS2
             PreSpawn(id, view, transform, spawnableName, spawnableNamespace);
         };
 
-        optionalArgs.m_completionCallback = [service_handle, header, ticketName, parentId = GetEntityId()](auto id, auto view)
+        optionalArgs.m_completionCallback =
+            [service_handle, header, ticketName, spawnableName, parentId = GetEntityId()](auto id, auto view)
         {
+            AZ::EntityId rootEntityId;
             if (!view.empty())
             {
                 const AZ::Entity* root = *view.begin();
                 auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
                 transformInterface->SetParent(parentId);
+                rootEntityId = root->GetId();
             }
             SpawnEntityResponse response;
             response.success = true;
             response.status_message = ticketName.c_str();
             service_handle->send_response(*header, response);
+
+            SpawnerNotificationBus::Broadcast(&SpawnerNotificationBus::Events::OnSpawned, spawnableName, rootEntityId, ticketName);
         };
 
         spawner->SpawnAllEntities(m_tickets.at(ticketName), optionalArgs);
@@ -308,11 +315,13 @@ namespace ROS2
 
         AzFramework::DespawnAllEntitiesOptionalArgs optionalArgs;
 
-        optionalArgs.m_completionCallback = [service_handle, header](auto id)
+        optionalArgs.m_completionCallback = [service_handle, header, deleteName](auto id)
         {
             DeleteEntityResponse response;
             response.success = true;
             service_handle->send_response(*header, response);
+
+            SpawnerNotificationBus::Broadcast(&SpawnerNotificationBus::Events::OnDespawned, deleteName);
         };
 
         spawner->DespawnAllEntities(m_tickets.at(deleteName), optionalArgs);

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -104,7 +104,7 @@ namespace ROS2
 
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
-            behaviorContext->EBus<SpawnerNotificationBus>("SpawnerNotificationBus")->Handler<SpawnerNotificationsBusHandler>();
+            behaviorContext->EBus<SpawnerNotificationBus>("ROS2SpawnerNotificationBus")->Handler<SpawnerNotificationsBusHandler>();
         }
     }
 

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -20,6 +20,7 @@
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/ROS2GemUtilities.h>
 #include <ROS2/Spawner/SpawnerBus.h>
+#include <ROS2/Spawner/SpawnerBusHandler.h>
 #include <ROS2/Utilities/ROS2Conversions.h>
 #include <ROS2/Utilities/ROS2Names.h>
 
@@ -99,6 +100,11 @@ namespace ROS2
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<ROS2SpawnerComponent, ROS2SpawnerComponentBase>()->Version(1);
+        }
+
+        if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<SpawnerNotificationBus>("SpawnerNotificationBus")->Handler<SpawnerNotificationsBusHandler>();
         }
     }
 

--- a/Gems/ROS2/Code/ros2_header_files.cmake
+++ b/Gems/ROS2/Code/ros2_header_files.cmake
@@ -55,6 +55,7 @@ set(FILES
         Include/ROS2/Sensor/SensorConfigurationRequestBus.h
         Include/ROS2/Sensor/SensorHelper.h
         Include/ROS2/Spawner/SpawnerBus.h
+        Include/ROS2/Spawner/SpawnerBusHandler.h
         Include/ROS2/Utilities/Controllers/PidConfiguration.h
         Include/ROS2/Utilities/ROS2Conversions.h
         Include/ROS2/Utilities/ROS2Names.h


### PR DESCRIPTION
## What does this PR do?

This PR adds a bus to the spawner component that notifies other components about spawns.

## How was this PR tested?

By spawning and despawning entities and listening on the bus with a custom component.
