### PR TITLE
Fix: terrain visibility in console mode

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -63,6 +63,7 @@ ly_add_target(
             AZ::AzFramework
             Gem::Atom_RPI.Public
             Gem::Atom_Feature_Common.Public
+            Gem::Atom_RHI.Reflect
             Gem::Atom_Component_DebugCamera.Static
             Gem::Atom_AtomBridge.Static
             Gem::StartingPointInput

--- a/Gems/ROS2/Code/Source/Camera/CameraSensor.h
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensor.h
@@ -15,6 +15,8 @@
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <std_msgs/msg/header.hpp>
+#include <AtomCore/Instance/Instance.h>
+#include <Atom/RPI.Reflect/Image/AttachmentImageAsset.h>
 
 namespace ROS2
 {
@@ -55,6 +57,7 @@ namespace ROS2
         AZ::EntityId m_entityId;
         AZ::RPI::RenderPipelinePtr m_pipeline;
         AZStd::string m_pipelineName;
+        AZ::Data::Instance<AZ::RPI::AttachmentImage> m_brdfTexture;
 
         //! Request a frame from the rendering pipeline
         //! @param cameraPose - current camera pose from which the rendering should take place


### PR DESCRIPTION
## What does this PR do?

This PR fixes terrain rendering in ROS 2 cameras when `-console-mode` is on.

## How was this PR tested?

In custom project with ROS 2 gem anbled. I've put two ROS 2 cameras and terrain in the level. Then build the project and run GameLauncher with `-console-mode` on. Also the Editor output has been tested.

Level: 
[DefaultLevel.zip](https://github.com/user-attachments/files/17979375/DefaultLevel.zip)

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/2d1a1b6c-d6d5-4294-8d72-bf7892b55264) | ![after](https://github.com/user-attachments/assets/67023120-d7bb-45fe-978e-671e442d9a6b) |

Fixes https://github.com/o3de/o3de-extras/issues/792

