### PR TITLE
ROS2 Relative spawning

### DIFF
--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.cpp
@@ -75,6 +75,8 @@ namespace ROS2
                 ->Version(1)
                 ->Field("Editor entity id", &ROS2SpawnerComponentConfig::m_editorEntityId)
                 ->Field("Support WGS", &ROS2SpawnerComponentConfig::m_supportWGS)
+                ->Field("Enable relative spawning", &ROS2SpawnerComponentConfig::m_enableRelativeSpawning)
+                ->Field("Reference coordinate system", &ROS2SpawnerComponentConfig::m_referenceCoordinationSystem)
                 ->Field("Spawnables", &ROS2SpawnerComponentConfig::m_spawnables)
                 ->Field("Default spawn pose", &ROS2SpawnerComponentConfig::m_defaultSpawnPose)
                 ->Field("Service names", &ROS2SpawnerComponentConfig::m_serviceNames)
@@ -86,6 +88,18 @@ namespace ROS2
                 editContext->Class<ROS2SpawnerComponentConfig>("ROS2SpawnerComponentConfig", "Config for ROS2SpawnerComponent")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2SpawnerComponentConfig::m_supportWGS, "Support WGS", "Support for spawning entities using WGS84 coordinate system")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2SpawnerComponentConfig::m_enableRelativeSpawning,
+                        "Enable relative spawning",
+                        "When 'reference_frame' is set to 'relative' then spawns entity in the reference coordinate system")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2SpawnerComponentConfig::m_referenceCoordinationSystem,
+                        "Reference coordinate system",
+                        "Reference coordinate system used for spawning")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ROS2SpawnerComponentConfig::UseReferenceCoordinationSystemVisibility)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2SpawnerComponentConfig::m_spawnables, "Spawnables", "Spawnables")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
@@ -121,6 +135,16 @@ namespace ROS2
     bool ROS2SpawnerComponentController::GetSupportWGS() const
     {
         return m_config.m_supportWGS;
+    }
+
+    bool ROS2SpawnerComponentController::IsRelativeSpawningEnabled() const
+    {
+        return m_config.m_enableRelativeSpawning;
+    }
+
+    AZ::EntityId ROS2SpawnerComponentController::GetReferenceCoordinationSystem() const
+    {
+        return m_config.m_referenceCoordinationSystem;
     }
 
     void ROS2SpawnerComponentController::Reflect(AZ::ReflectContext* context)

--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.h
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponentController.h
@@ -14,6 +14,7 @@
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Memory/Memory_fwd.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/base.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 
@@ -41,6 +42,10 @@ namespace ROS2
         ~ROS2SpawnerComponentConfig() = default;
 
         static void Reflect(AZ::ReflectContext* context);
+        [[nodiscard]] AZ::u32 UseReferenceCoordinationSystemVisibility()
+        {
+            return m_enableRelativeSpawning ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
+        }
 
         AZ::EntityId m_editorEntityId;
         AZ::Transform m_defaultSpawnPose = { AZ::Vector3{ 0, 0, 0 }, AZ::Quaternion{ 0, 0, 0, 1 }, 1.0 };
@@ -48,6 +53,8 @@ namespace ROS2
         ROS2SpawnerServiceNames m_serviceNames;
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables;
         bool m_supportWGS{ true };
+        bool m_enableRelativeSpawning{ false };
+        AZ::EntityId m_referenceCoordinationSystem;
     };
 
     class ROS2SpawnerComponentController : public SpawnerRequestsBus::Handler
@@ -79,6 +86,8 @@ namespace ROS2
         AZ::EntityId GetEditorEntityId() const;
         AZStd::unordered_map<AZStd::string, AZ::Data::Asset<AzFramework::Spawnable>> GetSpawnables() const;
         bool GetSupportWGS() const;
+        bool IsRelativeSpawningEnabled() const;
+        AZ::EntityId GetReferenceCoordinationSystem() const;
 
     private:
         ROS2SpawnerComponentConfig m_config;


### PR DESCRIPTION
## What does this PR do?

Enables spawning entities in an arbitrary coordinate system.

Similar to spawning in WGS coordinate system, enabling the option and setting "relative" in ROS 2 service "reference_frame" spawns entity relatively to the selected coordinate system.

![image](https://github.com/user-attachments/assets/cab14059-fe2b-4a39-a830-3196019787e1)
![image](https://github.com/user-attachments/assets/eb9d58a4-cf64-4c2a-8764-78fbea231b0f)


## How was this PR tested?

1. Spawning with feature off
2. Spawning with feature on/off and with/without reference frame set
3. Checked different positions of reference frame
