### PR TITLE
Use ROS 2 clock for sensor triggering

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Clock/ROS2Clock.h
+++ b/Gems/ROS2/Code/Include/ROS2/Clock/ROS2Clock.h
@@ -21,7 +21,6 @@ namespace ROS2
     //! the /use_sim_time parameter set to true.
     class ROS2Clock
     {
-        static constexpr size_t FramesNumberForStats = 60;
 
     public:
         ROS2Clock();

--- a/Gems/ROS2/Code/Include/ROS2/ROS2Bus.h
+++ b/Gems/ROS2/Code/Include/ROS2/ROS2Bus.h
@@ -64,6 +64,9 @@ namespace ROS2
         //! Obtains a simulation clock that is used across simulation.
         //! @returns constant reference to currently running clock.
         virtual const ROS2Clock& GetSimulationClock() const = 0;
+
+        //! Returns an expected loop time of simulation. It is an estimation from past frames.
+        virtual float GetExpectedSimulationLoopTime() const = 0;
     };
 
     class ROS2BusTraits : public AZ::EBusTraits

--- a/Gems/ROS2/Code/Include/ROS2/Sensor/Events/EventSourceAdapter.h
+++ b/Gems/ROS2/Code/Include/ROS2/Sensor/Events/EventSourceAdapter.h
@@ -180,10 +180,10 @@ namespace ROS2
             {
                 return false;
             }
-
             const float sourceFrequencyEstimation = 1.0f / sourceDeltaTime;
             const float numberOfFrames =
                 m_adaptedFrequency <= sourceFrequencyEstimation ? (sourceFrequencyEstimation / m_adaptedFrequency) : 1.0f;
+            AZ_Printf("EventSourceAdapter", "Number of frames: %f", numberOfFrames);
             m_tickCounter = aznumeric_cast<int>(AZStd::round(numberOfFrames));
             return true;
         }

--- a/Gems/ROS2/Code/Include/ROS2/Sensor/Events/EventSourceAdapter.h
+++ b/Gems/ROS2/Code/Include/ROS2/Sensor/Events/EventSourceAdapter.h
@@ -183,7 +183,6 @@ namespace ROS2
             const float sourceFrequencyEstimation = 1.0f / sourceDeltaTime;
             const float numberOfFrames =
                 m_adaptedFrequency <= sourceFrequencyEstimation ? (sourceFrequencyEstimation / m_adaptedFrequency) : 1.0f;
-            AZ_Printf("EventSourceAdapter", "Number of frames: %f", numberOfFrames);
             m_tickCounter = aznumeric_cast<int>(AZStd::round(numberOfFrames));
             return true;
         }

--- a/Gems/ROS2/Code/Include/ROS2/Sensor/Events/EventSourceAdapter.h
+++ b/Gems/ROS2/Code/Include/ROS2/Sensor/Events/EventSourceAdapter.h
@@ -180,6 +180,7 @@ namespace ROS2
             {
                 return false;
             }
+
             const float sourceFrequencyEstimation = 1.0f / sourceDeltaTime;
             const float numberOfFrames =
                 m_adaptedFrequency <= sourceFrequencyEstimation ? (sourceFrequencyEstimation / m_adaptedFrequency) : 1.0f;

--- a/Gems/ROS2/Code/Include/ROS2/Sensor/Events/PhysicsBasedSource.h
+++ b/Gems/ROS2/Code/Include/ROS2/Sensor/Events/PhysicsBasedSource.h
@@ -11,6 +11,7 @@
 #include <AzCore/EBus/OrderedEvent.h>
 #include <AzFramework/Physics/Common/PhysicsEvents.h>
 #include <AzFramework/Physics/Common/PhysicsTypes.h>
+#include <ROS2/ROS2Bus.h>
 #include <ROS2/Sensor/Events/SensorEventSource.h>
 
 namespace ROS2
@@ -32,5 +33,6 @@ namespace ROS2
 
     private:
         AzPhysics::SceneEvents::OnSceneSimulationFinishHandler m_onSceneSimulationEventHandler; ///< Handler for physics callback.
+        builtin_interfaces::msg::Time m_lastSimulationTime; ///< Last simulation time.
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Include/ROS2/Sensor/Events/TickBasedSource.h
+++ b/Gems/ROS2/Code/Include/ROS2/Sensor/Events/TickBasedSource.h
@@ -11,14 +11,14 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/EBus/Event.h>
 #include <ROS2/Sensor/Events/SensorEventSource.h>
-
+#include <ROS2/ROS2Bus.h>
 namespace ROS2
 {
     //! Class implementing system TickBus (draw calls) as sensor event source. Source event (ROS2::SensorEventSource) is signalled based on
     //! system ticks.
     //! @see ROS2::SensorEventSource
     class TickBasedSource final
-        : public SensorEventSource<AZ::Event, AZ::EventHandler, float, AZ::ScriptTimePoint>
+        : public SensorEventSource<AZ::Event, AZ::EventHandler, float>
         , protected AZ::TickBus::Handler
     {
     public:
@@ -28,10 +28,14 @@ namespace ROS2
         // Overrides of ROS2::SensorEventSource.
         void Start() override;
         void Stop() override;
-        [[nodiscard]] float GetDeltaTime(float deltaTime, AZ::ScriptTimePoint time) const override;
+        [[nodiscard]] float GetDeltaTime(float deltaTime) const override;
 
     private:
         // Override of AZ::TickBus::Handler.
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+
+        builtin_interfaces::msg::Time m_lastTickTimestamp;
+        AZStd::deque<float> m_deltaTimes;
+        constexpr static size_t m_maxDeltaTimes = 100;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Sensor/Events/PhysicsBasedSource.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/Events/PhysicsBasedSource.cpp
@@ -25,7 +25,7 @@ namespace ROS2
     void PhysicsBasedSource::Start()
     {
         m_onSceneSimulationEventHandler.Disconnect();
-        const auto *ros2Interface = ROS2Interface::Get();
+        const auto* ros2Interface = ROS2Interface::Get();
         AZ_Assert(ros2Interface, "ROS2 interface is not initialized.");
 
         m_onSceneSimulationEventHandler = AzPhysics::SceneEvents::OnSceneSimulationFinishHandler(
@@ -33,7 +33,7 @@ namespace ROS2
             {
                 const auto simulationTime = ros2Interface->GetROSTimestamp();
 
-                float deltaSimTime = ROS2Conversions::GetTimeDifference(m_lastSimulationTime, simulationTime);
+                const float deltaSimTime = ROS2Conversions::GetTimeDifference(m_lastSimulationTime, simulationTime);
                 m_sourceEvent.Signal(sceneHandle, deltaSimTime);
                 m_lastSimulationTime = simulationTime;
             });

--- a/Gems/ROS2/Code/Source/Sensor/Events/PhysicsBasedSource.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/Events/PhysicsBasedSource.cpp
@@ -7,6 +7,8 @@
  */
 
 #include <AzFramework/Physics/PhysicsSystem.h>
+
+#include <ROS2/Utilities/ROS2Conversions.h>
 #include <ROS2/Sensor/Events/PhysicsBasedSource.h>
 #include <ROS2/Sensor/SensorConfiguration.h>
 
@@ -23,10 +25,17 @@ namespace ROS2
     void PhysicsBasedSource::Start()
     {
         m_onSceneSimulationEventHandler.Disconnect();
+        const auto *ros2Interface = ROS2Interface::Get();
+        AZ_Assert(ros2Interface, "ROS2 interface is not initialized.");
+
         m_onSceneSimulationEventHandler = AzPhysics::SceneEvents::OnSceneSimulationFinishHandler(
-            [this](AzPhysics::SceneHandle sceneHandle, float deltaTime)
+            [this, ros2Interface](AzPhysics::SceneHandle sceneHandle, float deltaTime)
             {
-                m_sourceEvent.Signal(sceneHandle, deltaTime);
+                const auto simulationTime = ros2Interface->GetROSTimestamp();
+
+                float deltaSimTime = ROS2Conversions::GetTimeDifference(m_lastSimulationTime, simulationTime);
+                m_sourceEvent.Signal(sceneHandle, deltaSimTime);
+                m_lastSimulationTime = simulationTime;
             });
 
         auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();

--- a/Gems/ROS2/Code/Source/Sensor/Events/PhysicsBasedSource.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/Events/PhysicsBasedSource.cpp
@@ -32,9 +32,8 @@ namespace ROS2
             [this, ros2Interface](AzPhysics::SceneHandle sceneHandle, float deltaTime)
             {
                 const auto simulationTime = ros2Interface->GetROSTimestamp();
-
-                const float deltaSimTime = ROS2Conversions::GetTimeDifference(m_lastSimulationTime, simulationTime);
-                m_sourceEvent.Signal(sceneHandle, deltaSimTime);
+                const float deltaSimulationTime = ROS2Conversions::GetTimeDifference(m_lastSimulationTime, simulationTime);
+                m_sourceEvent.Signal(sceneHandle, deltaSimulationTime);
                 m_lastSimulationTime = simulationTime;
             });
 

--- a/Gems/ROS2/Code/Source/Sensor/Events/TickBasedSource.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/Events/TickBasedSource.cpp
@@ -40,8 +40,8 @@ namespace ROS2
     {
         AZ_UNUSED(time);
         AZ_UNUSED(deltaTime);
-        const auto simTimestamp = ROS2Interface::Get()->GetExpectedSimulationLoopTime();
-        m_sourceEvent.Signal(simTimestamp);
+        const auto expectedSimulationLoopTime = ROS2Interface::Get()->GetExpectedSimulationLoopTime();
+        m_sourceEvent.Signal(expectedSimulationLoopTime);
 
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Sensor/Events/TickBasedSource.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/Events/TickBasedSource.cpp
@@ -40,7 +40,7 @@ namespace ROS2
     {
         AZ_UNUSED(time);
         AZ_UNUSED(deltaTime);
-        auto simTimestamp = ROS2Interface::Get()->GetExpectedSimulationLoopTime();
+        const auto simTimestamp = ROS2Interface::Get()->GetExpectedSimulationLoopTime();
         m_sourceEvent.Signal(simTimestamp);
 
     }

--- a/Gems/ROS2/Code/Source/Sensor/Events/TickBasedSource.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/Events/TickBasedSource.cpp
@@ -8,7 +8,9 @@
 
 #include <ROS2/Sensor/Events/TickBasedSource.h>
 #include <ROS2/Sensor/SensorConfiguration.h>
-
+#include <ROS2/ROS2Bus.h>
+#include <ROS2/Utilities/ROS2Conversions.h>
+#include <AzCore/std/numeric.h>
 namespace ROS2
 {
     void TickBasedSource::Reflect(AZ::ReflectContext* context)
@@ -29,13 +31,17 @@ namespace ROS2
         AZ::TickBus::Handler::BusDisconnect();
     }
 
-    float TickBasedSource::GetDeltaTime(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time) const
+    float TickBasedSource::GetDeltaTime(float deltaTime) const
     {
         return deltaTime;
     }
 
     void TickBasedSource::OnTick(float deltaTime, AZ::ScriptTimePoint time)
     {
-        m_sourceEvent.Signal(deltaTime, time);
+        AZ_UNUSED(time);
+        AZ_UNUSED(deltaTime);
+        auto simTimestamp = ROS2Interface::Get()->GetExpectedSimulationLoopTime();
+        m_sourceEvent.Signal(simTimestamp);
+
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
@@ -9,8 +9,8 @@
 
 #include "ROS2SystemComponent.h"
 #include <Lidar/LidarCore.h>
-#include <ROS2/Clock/RealTimeSource.h>
 #include <ROS2/Clock/ROS2TimeSource.h>
+#include <ROS2/Clock/RealTimeSource.h>
 #include <ROS2/Clock/SimulationTimeSource.h>
 #include <ROS2/Communication/PublisherConfiguration.h>
 #include <ROS2/Communication/QoS.h>
@@ -27,12 +27,12 @@
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Time/ITime.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/std/sort.h>
 #include <AzCore/std/string/string_view.h>
 #include <AzFramework/API/ApplicationAPI.h>
 #include <ROS2/Sensor/SensorConfigurationRequestBus.h>
 #include <ROS2/Utilities/ROS2Conversions.h>
-#include <AzCore/std/numeric.h>
-#include <AzCore/std/sort.h>
+
 namespace ROS2
 {
     constexpr AZStd::string_view ClockTypeConfigurationKey = "/O3DE/ROS2/ClockType";
@@ -108,8 +108,8 @@ namespace ROS2
     void ROS2SystemComponent::Init()
     {
         rclcpp::init(0, 0);
-        
-        // handle signals, e.g. via `Ctrl+C` hotkey or `kill` command 
+
+        // handle signals, e.g. via `Ctrl+C` hotkey or `kill` command
         auto handler = [](int sig){
             rclcpp::shutdown(); // shutdown rclcpp
             std::raise(sig); // shutdown o3de
@@ -234,8 +234,8 @@ namespace ROS2
             m_executor->spin_some();
         }
         // Calculate simulation loop time
-        const auto simTimestamp = m_simulationClock->GetROSTimestamp();
-        const float deltaSimTime = ROS2Conversions::GetTimeDifference(m_lastSimulationTime, simTimestamp);
+        const auto simulationTimestamp = m_simulationClock->GetROSTimestamp();
+        const float deltaSimTime = ROS2Conversions::GetTimeDifference(m_lastSimulationTime, simulationTimestamp);
 
         // Filter out the outliers
         m_simulationLoopTimes.push_back(deltaSimTime);
@@ -245,13 +245,13 @@ namespace ROS2
         }
         AZStd::vector<float> frameTimeSorted{ m_simulationLoopTimes.begin(), m_simulationLoopTimes.end() };
         AZStd::sort(frameTimeSorted.begin(), frameTimeSorted.end());
-        m_currentMedian = frameTimeSorted[frameTimeSorted.size() / 2];
+        m_simulationLoopTimeMedian = frameTimeSorted[frameTimeSorted.size() / 2];
 
-        m_lastSimulationTime = simTimestamp;
+        m_lastSimulationTime = simulationTimestamp;
     }
 
     float ROS2SystemComponent::GetExpectedSimulationLoopTime() const
     {
-        return m_currentMedian;
+        return m_simulationLoopTimeMedian;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.cpp
@@ -235,7 +235,7 @@ namespace ROS2
         }
         // Calculate simulation loop time
         const auto simTimestamp = m_simulationClock->GetROSTimestamp();
-        float deltaSimTime = ROS2Conversions::GetTimeDifference(m_lastSimulationTime, simTimestamp);
+        const float deltaSimTime = ROS2Conversions::GetTimeDifference(m_lastSimulationTime, simTimestamp);
 
         // Filter out the outliers
         m_simulationLoopTimes.push_back(deltaSimTime);

--- a/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.h
+++ b/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.h
@@ -93,6 +93,6 @@ namespace ROS2
 
         AZStd::deque<float> m_simulationLoopTimes;
         builtin_interfaces::msg::Time m_lastSimulationTime;
-        float m_currentMedian = 1.f/60.0f;
+        float m_simulationLoopTimeMedian = 1.f / 60.0f;
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.h
+++ b/Gems/ROS2/Code/Source/SystemComponents/ROS2SystemComponent.h
@@ -64,6 +64,7 @@ namespace ROS2
         builtin_interfaces::msg::Time GetROSTimestamp() const override;
         void BroadcastTransform(const geometry_msgs::msg::TransformStamped& t, bool isDynamic) override;
         const ROS2Clock& GetSimulationClock() const override;
+        float GetExpectedSimulationLoopTime() const override;
         //////////////////////////////////////////////////////////////////////////
 
     protected:
@@ -89,5 +90,9 @@ namespace ROS2
         AZStd::unique_ptr<tf2_ros::StaticTransformBroadcaster> m_staticTFBroadcaster;
         AZStd::unique_ptr<ROS2Clock> m_simulationClock;
         NodeChangedEvent m_nodeChangedEvent;
+
+        AZStd::deque<float> m_simulationLoopTimes;
+        builtin_interfaces::msg::Time m_lastSimulationTime;
+        float m_currentMedian = 1.f/60.0f;
     };
 } // namespace ROS2


### PR DESCRIPTION
## What does this PR do?

This PR fixes two minor things in sensors triggering:
- it reintroduced removed by this PR median filter for FPS. It will prevent drops in camera frequency without frame limiter, as explained in #804 .
- it uses selected ROS 2 time source to trigger sensors, what  will resolve #805 

## How was this PR tested?

It was cherry picked against stable and tested in response to #804.
I've used test branch that logs sensor triggers (https://github.com/RobotecAI/o3de-extras/tree/mp/trigger_noted)
And script to visualize : https://gist.github.com/michalpelka/3f2c66f16d20ba714c6389d5cd173032

Without filter:
![NoFiltering](https://github.com/user-attachments/assets/4676f6e6-3693-4d29-bbfd-b0fc98ec56ee)
With filtering
![WithMedianFilter](https://github.com/user-attachments/assets/45577293-bb3c-4444-9b96-02ffe09d24ca)

You can see that triggers fro camera (green dots) are spaced evenly for code using median filter.
**Note** this is minor issue, since it can cause:
- too low frequency use case without frame limiter and request for high FPS ROS 2 camera.
- most simulation are using `\clock` topic so inconsistency in wall time is not that big deal.
