### PR TITLE
Move Joint Tracjectory State to TrajectoryComponent

### DIFF
--- a/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.cpp
@@ -23,16 +23,6 @@ namespace ROS2
             AZStd::bind(&FollowJointTrajectoryActionServer::GoalAcceptedCallback, this, AZStd::placeholders::_1));
     }
 
-    JointsTrajectoryRequests::TrajectoryActionStatus FollowJointTrajectoryActionServer::GetGoalStatus() const
-    {
-        return m_goalStatus;
-    }
-
-    void FollowJointTrajectoryActionServer::SetGoalSuccess()
-    {
-        m_goalStatus = JointsTrajectoryRequests::TrajectoryActionStatus::Succeeded;
-    }
-
     void FollowJointTrajectoryActionServer::CancelGoal(std::shared_ptr<FollowJointTrajectory::Result> result)
     {
         AZ_Assert(m_goalHandle, "Invalid goal handle!");
@@ -50,7 +40,6 @@ namespace ROS2
         {
             AZ_Trace("FollowJointTrajectoryActionServer", "Goal succeeded\n");
             m_goalHandle->succeed(result);
-            m_goalStatus = JointsTrajectoryRequests::TrajectoryActionStatus::Succeeded;
         }
     }
 
@@ -102,7 +91,6 @@ namespace ROS2
             return rclcpp_action::CancelResponse::REJECT;
         }
 
-        m_goalStatus = JointsTrajectoryRequests::TrajectoryActionStatus::Cancelled;
         return rclcpp_action::CancelResponse::ACCEPT;
     }
 
@@ -149,6 +137,5 @@ namespace ROS2
 
         m_goalHandle = goalHandle;
         // m_goalHandle->execute(); // No need to call this, as we are already executing the goal due to ACCEPT_AND_EXECUTE
-        m_goalStatus = JointsTrajectoryRequests::TrajectoryActionStatus::Executing;
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.h
+++ b/Gems/ROS2/Code/Source/Manipulation/FollowJointTrajectoryActionServer.h
@@ -32,16 +32,9 @@ namespace ROS2
         //! server documentation </a>
         FollowJointTrajectoryActionServer(const AZStd::string& actionName, const AZ::EntityId& entityId);
 
-        //! Return trajectory action status.
-        //! @return Status of the trajectory execution.
-        JointsTrajectoryRequests::TrajectoryActionStatus GetGoalStatus() const;
-
         //! Cancel the current goal.
         //! @param result Result to be passed to through action server to the client.
         void CancelGoal(std::shared_ptr<FollowJointTrajectory::Result> result);
-
-        //! Sets the goal status to success
-        void SetGoalSuccess();
 
         //! Report goal success to the action server.
         //! @param result Result which contains success code.
@@ -56,7 +49,6 @@ namespace ROS2
         using TrajectoryActionStatus = JointsTrajectoryRequests::TrajectoryActionStatus;
 
         AZ::EntityId m_entityId;
-        TrajectoryActionStatus m_goalStatus = TrajectoryActionStatus::Idle;
         rclcpp_action::Server<FollowJointTrajectory>::SharedPtr m_actionServer;
         std::shared_ptr<GoalHandle> m_goalHandle;
 

--- a/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsTrajectoryComponent.h
@@ -64,9 +64,9 @@ namespace ROS2
         AZStd::string m_followTrajectoryActionName{ "arm_controller/follow_joint_trajectory" };
         AZStd::unique_ptr<FollowJointTrajectoryActionServer> m_followTrajectoryServer;
         TrajectoryGoal m_trajectoryGoal;
+        TrajectoryActionStatus m_goalStatus = TrajectoryActionStatus::Idle;
         rclcpp::Time m_trajectoryExecutionStartTime;
         ManipulationJoints m_manipulationJoints;
-        bool m_trajectoryInProgress{ false };
         builtin_interfaces::msg::Time m_lastTickTimestamp; //!< ROS 2 Timestamp during last OnTick call
     };
 } // namespace ROS2


### PR DESCRIPTION
## What does this PR do?

This PR fixes state management when calling `JointsTrajectoryRequestBus`
Without this change, method 
```
    class JointsTrajectoryRequests : public AZ::EBusTraits
...
        //! Retrieve current trajectory goal status.
        //! @return Status of trajectory goal.
        virtual TrajectoryActionStatus GetGoalStatus() = 0;
```
Always returns `TrajectoryActionStatus::Idle` because `FollowJointTrajectoryActionServer` never receives any goals. 

This change effectively allows for using `JointsTrajectoryRequestBus` because without it. No movement will occur (cause of broken status in `JointsTrajectoryComponent::FollowTrajectory`)

## How was this PR tested?

`JointsTrajectoryRequestBus` was called in two ways.
1. Directly from cpp code by `JointsTrajectoryRequestBus::EventResult`
2. From ros2 via ros2 action server and `FollowJointTrajectoryActionServer`

Without the change only the second one worked. After the change both calls work as expected.