### PR TITLE
Remove Unused AWS Gem from OpenXRTest

### DIFF
--- a/Projects/OpenXRTest/Gem/enabled_gems.cmake
+++ b/Projects/OpenXRTest/Gem/enabled_gems.cmake
@@ -3,7 +3,6 @@ set(ENABLED_GEMS
     OpenXRTest
     Atom
     AudioSystem
-    AWSCore
     CameraFramework
     DebugDraw
     EditorPythonBindings

--- a/Projects/OpenXRTest/project.json
+++ b/Projects/OpenXRTest/project.json
@@ -1,6 +1,6 @@
 {
     "project_name": "OpenXRTest",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "project_id": "{947211d5-689a-437f-8ad7-7f558edcd40a}",
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/openxrtest-1.0.1-project.zip",


### PR DESCRIPTION
## What does this PR do?
Remove unused AWS core gem from OpenXRTest
Need for Jenkins to build https://github.com/o3de/o3de/pull/18571/

## How was this PR tested?
Built OpenXRTest using a o3de branch without AWS gems
Check AssetProcessor for any failed lua/scriptscanvas assets which may have been using AWS 
Unfortunately, there were a lot of shader/material asset errors and a fatal "RPI System could not initialize" error on Editor startup, but this occurred in vanilla development branch as well as the AWS removal branch