### PR TITLE
Fix bug where joints werent clearing in  JointPositionEditorComponent

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/ROS2GemUtilities.h
+++ b/Gems/ROS2/Code/Include/ROS2/ROS2GemUtilities.h
@@ -22,7 +22,7 @@ namespace ROS2
         //! @param entity pointer to entity
         //! @param typeId type of the component
         //! @returns true if entity has component with given type
-        inline bool CheckIfEntityHasComponentOfType(const AZ::Entity* entity, const AZ::Uuid typeId)
+        inline bool HasComponentOfType(const AZ::Entity* entity, const AZ::Uuid typeId)
         {
             auto components = AZ::EntityUtils::FindDerivedComponents(entity, typeId);
             return !components.empty();

--- a/Gems/ROS2/Code/Include/ROS2/ROS2GemUtilities.h
+++ b/Gems/ROS2/Code/Include/ROS2/ROS2GemUtilities.h
@@ -9,13 +9,25 @@
 
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Component/Entity.h>
+#include <AzCore/Component/EntityUtils.h>
 #ifdef ROS2_EDITOR
 #include <AzToolsFramework/ToolsComponents/GenericComponentWrapper.h>
 #endif
+
 namespace ROS2
 {
     namespace Utils
     {
+        //! Checks whether the entity has a component of the given type
+        //! @param entity pointer to entity
+        //! @param typeId type of the component
+        //! @returns true if entity has component with given type
+        inline bool CheckIfEntityHasComponentOfType(const AZ::Entity* entity, const AZ::Uuid typeId)
+        {
+            auto components = AZ::EntityUtils::FindDerivedComponents(entity, typeId);
+            return !components.empty();
+        }
+
         /// Create component for a given entity in safe way.
         /// @param entityId entity that will own component
         /// @param componentType Uuid of component to create
@@ -26,7 +38,6 @@ namespace ROS2
         /// We should use that that we are not sure if we access eg ROS2FrameComponent in game mode or from Editor
         /// @param entity pointer to entity eg with GetEntity()
         /// @return pointer to component with type T
-
         template<class ComponentType>
         ComponentType* GetGameOrEditorComponent(const AZ::Entity* entity)
         {

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -8,7 +8,6 @@
 
 #include "ROS2FrameSystemComponent.h"
 #include <AzCore/Component/Entity.h>
-#include <AzCore/Component/EntityUtils.h>
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
@@ -68,17 +67,6 @@ namespace ROS2
             // Found the component!
             return component;
         }
-
-        //! Checks whether the entity has a component of the given type
-        //! @param entity pointer to entity
-        //! @param typeId type of the component
-        //! @returns true if entity has component with given type
-        static bool CheckIfEntityHasComponentOfType(const AZ::Entity* entity, const AZ::Uuid typeId)
-        {
-            auto components = AZ::EntityUtils::FindDerivedComponents(entity, typeId);
-            return !components.empty();
-        }
-
     } // namespace Internal
 
     AZ::JsonSerializationResult::Result JsonFrameComponentConfigSerializer::Load(
@@ -160,11 +148,11 @@ namespace ROS2
             // Otherwise it'll be dynamic when it has joints and it's not a fixed joint.
             else
             {
-                const bool hasJoints = Internal::CheckIfEntityHasComponentOfType(
+                const bool hasJoints = Utils::CheckIfEntityHasComponentOfType(
                     m_entity, AZ::Uuid("{B01FD1D2-1D91-438D-874A-BF5EB7E919A8}")); // Physx::JointComponent;
-                const bool hasFixedJoints = Internal::CheckIfEntityHasComponentOfType(
+                const bool hasFixedJoints = Utils::CheckIfEntityHasComponentOfType(
                     m_entity, AZ::Uuid("{02E6C633-8F44-4CEE-AE94-DCB06DE36422}")); // Physx::FixedJointComponent
-                const bool hasArticulations = Internal::CheckIfEntityHasComponentOfType(
+                const bool hasArticulations = Utils::CheckIfEntityHasComponentOfType(
                     m_entity, AZ::Uuid("{48751E98-B35F-4A2F-A908-D9CDD5230264}")); // Physx::ArticulationComponent
                 m_isDynamic = (hasJoints && !hasFixedJoints) || hasArticulations;
             }

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -20,6 +20,9 @@
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/ROS2GemUtilities.h>
 #include <ROS2/Utilities/ROS2Names.h>
+#include <Source/ArticulationLinkComponent.h>
+#include <Source/FixedJointComponent.h>
+#include <Source/JointComponent.h>
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 
@@ -148,12 +151,9 @@ namespace ROS2
             // Otherwise it'll be dynamic when it has joints and it's not a fixed joint.
             else
             {
-                const bool hasJoints = Utils::CheckIfEntityHasComponentOfType(
-                    m_entity, AZ::Uuid("{B01FD1D2-1D91-438D-874A-BF5EB7E919A8}")); // Physx::JointComponent;
-                const bool hasFixedJoints = Utils::CheckIfEntityHasComponentOfType(
-                    m_entity, AZ::Uuid("{02E6C633-8F44-4CEE-AE94-DCB06DE36422}")); // Physx::FixedJointComponent
-                const bool hasArticulations = Utils::CheckIfEntityHasComponentOfType(
-                    m_entity, AZ::Uuid("{48751E98-B35F-4A2F-A908-D9CDD5230264}")); // Physx::ArticulationComponent
+                const bool hasJoints = Utils::HasComponentOfType(m_entity, PhysX::JointComponent::TYPEINFO_Uuid());
+                const bool hasFixedJoints = Utils::HasComponentOfType(m_entity, PhysX::FixedJointComponent::TYPEINFO_Uuid());
+                const bool hasArticulations = Utils::HasComponentOfType(m_entity, PhysX::ArticulationLinkComponent::TYPEINFO_Uuid());
                 m_isDynamic = (hasJoints && !hasFixedJoints) || hasArticulations;
             }
 

--- a/Gems/ROS2/Code/Source/Manipulation/JointUtils.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointUtils.cpp
@@ -9,20 +9,21 @@
 #include "JointUtils.h"
 
 #include <ROS2/ROS2GemUtilities.h>
+#include <Source/EditorArticulationLinkComponent.h>
+#include <Source/EditorBallJointComponent.h>
+#include <Source/EditorFixedJointComponent.h>
+#include <Source/EditorHingeJointComponent.h>
+#include <Source/EditorPrismaticJointComponent.h>
 
-namespace ROS2::Utils
+namespace ROS2::JointUtils
 {
 
-    bool CheckIfEntityHasNonFixedJoints(const AZ::Entity* entity)
+    bool HasNonFixedJoints(const AZ::Entity* entity)
     {
-        const bool hasPrismaticJoints = Utils::CheckIfEntityHasComponentOfType(
-            entity, AZ::Uuid("{607B246E-C2DB-4D43-ABFA-A5A3994867C5}")); // Physx::EditorPrismaticJointComponent
-        const bool hasBallJoints = Utils::CheckIfEntityHasComponentOfType(
-            entity, AZ::Uuid("{3D770685-9271-444D-B8AE-783B652C0986}")); // Physx::EditorBallJointComponent
-        const bool hasHingeJoints = Utils::CheckIfEntityHasComponentOfType(
-            entity, AZ::Uuid("{AF60FD48-4ADC-4C8C-8D3A-A4F7AE63C74D}")); // Physx::EditorHingeJointComponent
-        const bool hasArticulations = Utils::CheckIfEntityHasComponentOfType(
-            entity, AZ::Uuid("{7D23169B-3214-4A32-ABFC-FCCE6E31F2CF}")); // Physx::EditorArticulationLinkComponent
+        const bool hasPrismaticJoints = Utils::HasComponentOfType(entity, PhysX::EditorPrismaticJointComponent::TYPEINFO_Uuid());
+        const bool hasBallJoints = Utils::HasComponentOfType(entity, PhysX::EditorBallJointComponent::TYPEINFO_Uuid());
+        const bool hasHingeJoints = Utils::HasComponentOfType(entity, PhysX::EditorHingeJointComponent::TYPEINFO_Uuid());
+        const bool hasArticulations = Utils::HasComponentOfType(entity, PhysX::EditorArticulationLinkComponent::TYPEINFO_Uuid());
         const bool hasJoints = hasPrismaticJoints || hasBallJoints || hasHingeJoints || hasArticulations;
 
         return hasJoints;

--- a/Gems/ROS2/Code/Source/Manipulation/JointUtils.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointUtils.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "JointUtils.h"
+
+#include <ROS2/ROS2GemUtilities.h>
+
+namespace ROS2::Utils
+{
+
+    bool CheckIfEntityHasNonFixedJoints(const AZ::Entity* entity)
+    {
+        const bool hasPrismaticJoints = Utils::CheckIfEntityHasComponentOfType(
+            entity, AZ::Uuid("{607B246E-C2DB-4D43-ABFA-A5A3994867C5}")); // Physx::EditorPrismaticJointComponent
+        const bool hasBallJoints = Utils::CheckIfEntityHasComponentOfType(
+            entity, AZ::Uuid("{3D770685-9271-444D-B8AE-783B652C0986}")); // Physx::EditorBallJointComponent
+        const bool hasHingeJoints = Utils::CheckIfEntityHasComponentOfType(
+            entity, AZ::Uuid("{AF60FD48-4ADC-4C8C-8D3A-A4F7AE63C74D}")); // Physx::EditorHingeJointComponent
+        const bool hasArticulations = Utils::CheckIfEntityHasComponentOfType(
+            entity, AZ::Uuid("{7D23169B-3214-4A32-ABFC-FCCE6E31F2CF}")); // Physx::EditorArticulationLinkComponent
+        const bool hasJoints = hasPrismaticJoints || hasBallJoints || hasHingeJoints || hasArticulations;
+
+        return hasJoints;
+    }
+} // namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/Manipulation/JointUtils.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointUtils.h
@@ -10,10 +10,10 @@
 
 #include <AzCore/Component/Entity.h>
 
-namespace ROS2::Utils
+namespace ROS2::JointUtils
 {
     //! Check if the entity has any of the non fixed joint or articulation components.
     //! @param entity Entity to check.
     //! @return True if the entity has any of the joint or articulation components.
-    bool CheckIfEntityHasNonFixedJoints(const AZ::Entity* entity);
+    bool HasNonFixedJoints(const AZ::Entity* entity);
 } // namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/Manipulation/JointUtils.h
+++ b/Gems/ROS2/Code/Source/Manipulation/JointUtils.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Entity.h>
+
+namespace ROS2::Utils
+{
+    //! Check if the entity has any of the non fixed joint or articulation components.
+    //! @param entity Entity to check.
+    //! @return True if the entity has any of the joint or articulation components.
+    bool CheckIfEntityHasNonFixedJoints(const AZ::Entity* entity);
+} // namespace ROS2::Utils

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.cpp
@@ -109,7 +109,7 @@ namespace ROS2
                 azrtti_cast<ROS2::ROS2FrameEditorComponent*>(Utils::GetGameOrEditorComponent<ROS2::ROS2FrameEditorComponent>(entity));
             AZ_Assert(frameEditorComponent, "ROS2FrameEditorComponent does not exist!");
 
-            const bool hasNonFixedJoints = Utils::CheckIfEntityHasNonFixedJoints(entity);
+            const bool hasNonFixedJoints = JointUtils::HasNonFixedJoints(entity);
 
             AZStd::string jointName(frameEditorComponent->GetJointName().GetCStr());
             if (!jointName.empty() && hasNonFixedJoints)

--- a/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsManipulationEditorComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "JointsManipulationEditorComponent.h"
+#include "JointUtils.h"
 #include "JointsManipulationComponent.h"
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/TransformBus.h>
@@ -108,8 +109,10 @@ namespace ROS2
                 azrtti_cast<ROS2::ROS2FrameEditorComponent*>(Utils::GetGameOrEditorComponent<ROS2::ROS2FrameEditorComponent>(entity));
             AZ_Assert(frameEditorComponent, "ROS2FrameEditorComponent does not exist!");
 
+            const bool hasNonFixedJoints = Utils::CheckIfEntityHasNonFixedJoints(entity);
+
             AZStd::string jointName(frameEditorComponent->GetJointName().GetCStr());
-            if (!jointName.empty())
+            if (!jointName.empty() && hasNonFixedJoints)
             {
                 m_initialPositions.emplace_back(AZStd::make_pair(jointName, configBackup[jointName]));
             }

--- a/Gems/ROS2/Code/Source/Manipulation/JointsPositionsEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsPositionsEditorComponent.cpp
@@ -9,6 +9,7 @@
 
 #include "JointsPositionsEditorComponent.h"
 #include "JointPositionsSubscriptionHandler.h"
+#include "JointUtils.h"
 #include "JointsPositionsComponent.h"
 
 #include <AzCore/Serialization/EditContext.h>
@@ -83,8 +84,10 @@ namespace ROS2
                 azrtti_cast<ROS2::ROS2FrameEditorComponent*>(Utils::GetGameOrEditorComponent<ROS2::ROS2FrameEditorComponent>(entity));
             AZ_Assert(frameEditorComponent, "ROS2FrameEditorComponent does not exist!");
 
+            const bool hasNonFixedJoints = Utils::CheckIfEntityHasNonFixedJoints(entity);
+
             AZStd::string jointName(frameEditorComponent->GetJointName().GetCStr());
-            if (!jointName.empty())
+            if (!jointName.empty() && hasNonFixedJoints)
             {
                 m_jointNames.emplace_back(jointName);
             }

--- a/Gems/ROS2/Code/Source/Manipulation/JointsPositionsEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsPositionsEditorComponent.cpp
@@ -84,7 +84,7 @@ namespace ROS2
                 azrtti_cast<ROS2::ROS2FrameEditorComponent*>(Utils::GetGameOrEditorComponent<ROS2::ROS2FrameEditorComponent>(entity));
             AZ_Assert(frameEditorComponent, "ROS2FrameEditorComponent does not exist!");
 
-            const bool hasNonFixedJoints = Utils::CheckIfEntityHasNonFixedJoints(entity);
+            const bool hasNonFixedJoints = JointUtils::HasNonFixedJoints(entity);
 
             AZStd::string jointName(frameEditorComponent->GetJointName().GetCStr());
             if (!jointName.empty() && hasNonFixedJoints)

--- a/Gems/ROS2/Code/Source/Manipulation/JointsPositionsEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsPositionsEditorComponent.cpp
@@ -76,6 +76,7 @@ namespace ROS2
 
     AZ::Crc32 JointsPositionsEditorComponent::FindAllJoints()
     {
+        m_jointNames.clear();
         AZStd::function<void(const AZ::Entity* entity)> getAllJointsHierarchy = [&](const AZ::Entity* entity)
         {
             auto* frameEditorComponent =

--- a/Gems/ROS2/Code/ros2_editor_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_files.cmake
@@ -18,6 +18,8 @@ set(FILES
     Source/Manipulation/JointsPositionsEditorComponent.h
     Source/Manipulation/JointsManipulationEditorComponent.cpp
     Source/Manipulation/JointsManipulationEditorComponent.h
+    Source/Manipulation/JointUtils.cpp
+    Source/Manipulation/JointUtils.h
     Source/RobotImporter/FixURDF/FixURDF.cpp
     Source/RobotImporter/FixURDF/FixURDF.h
     Source/RobotImporter/Pages/ModifiedURDFWindow.cpp


### PR DESCRIPTION
## What does this PR do?

Add a vector clear when scanning for joints. In addition a check for joint type was added to prevent adding fix joints. Fixes #812.

## How was this PR tested?

By creating joints and clicking the scan button.
