### PR TITLE
Disable ROS2OdometrySensor for Articulation links

### DIFF
--- a/Gems/ROS2/Code/Source/Odometry/ROS2OdometrySensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Odometry/ROS2OdometrySensorComponent.cpp
@@ -6,10 +6,10 @@
  *
  */
 
+#include "ROS2OdometrySensorComponent.h"
 #include <AzFramework/Physics/PhysicsScene.h>
 #include <AzFramework/Physics/RigidBodyBus.h>
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
-#include "ROS2OdometrySensorComponent.h"
 #include <ROS2/Utilities/ROS2Conversions.h>
 #include <ROS2/Utilities/ROS2Names.h>
 
@@ -53,6 +53,11 @@ namespace ROS2
     {
         required.push_back(AZ_CRC_CE("PhysicsDynamicRigidBodyService"));
         required.push_back(AZ_CRC_CE("ROS2Frame"));
+    }
+
+    void ROS2OdometrySensorComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC("ArticulationLinkService"));
     }
 
     void ROS2OdometrySensorComponent::OnOdometryEvent(AzPhysics::SceneHandle sceneHandle)

--- a/Gems/ROS2/Code/Source/Odometry/ROS2OdometrySensorComponent.h
+++ b/Gems/ROS2/Code/Source/Odometry/ROS2OdometrySensorComponent.h
@@ -10,10 +10,10 @@
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
-#include <nav_msgs/msg/odometry.hpp>
-#include <rclcpp/publisher.hpp>
 #include <ROS2/Sensor/Events/PhysicsBasedSource.h>
 #include <ROS2/Sensor/ROS2SensorComponentBase.h>
+#include <nav_msgs/msg/odometry.hpp>
+#include <rclcpp/publisher.hpp>
 
 namespace ROS2
 {
@@ -21,14 +21,14 @@ namespace ROS2
     //! It constructs and publishes an odometry message, which contains information about vehicle velocity and position in space.
     //! This is a ground truth "sensor", which can be helpful for development and machine learning.
     //! @see <a href="https://index.ros.org/p/nav_msgs/"> nav_msgs package. </a>
-    class ROS2OdometrySensorComponent
-        : public ROS2SensorComponentBase<PhysicsBasedSource>
+    class ROS2OdometrySensorComponent : public ROS2SensorComponentBase<PhysicsBasedSource>
     {
     public:
         AZ_COMPONENT(ROS2OdometrySensorComponent, "{61387448-63AA-4563-AF87-60C72B05B863}", SensorBaseType);
         ROS2OdometrySensorComponent();
         ~ROS2OdometrySensorComponent() = default;
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
         static void Reflect(AZ::ReflectContext* context);
         //////////////////////////////////////////////////////////////////////////
         // Component overrides


### PR DESCRIPTION
## What does this PR do?

This PR prevents user from getting a crash when adding `ROS2OdometrySensor` and `Articulation Link` into the same entity, see #816 

This is a simple fix that adds `Articulation Link` to the incompatible service. `ROS2OdometrySensor` using the link should be implemented as a proper solution to #816

## How was this PR tested?

Tried to add the `Articulation link`. Before (left) and after (right):
![image](https://github.com/user-attachments/assets/ab62b921-be31-483f-96e7-178aa7c6858a)


