### PR TITLE
Fix PostProcessFeatureProcessor view aliasing in ROS2 camera

### DIFF
--- a/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensor.cpp
@@ -158,15 +158,33 @@ namespace ROS2
         m_passHierarchy.push_back("CopyToSwapChain");
 
         m_pipeline->SetDefaultView(m_view);
-        const AZ::RPI::ViewPtr targetView = m_scene->GetDefaultRenderPipeline()->GetDefaultView();
-        if (auto* fp = m_scene->GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessorInterface>())
+        UpdateViewAlias();
+
+        Camera::CameraNotificationBus::Handler::BusConnect();
+    }
+
+    void CameraSensor::OnCameraRemoved(const AZ::EntityId& cameraEntityId)
+    {
+        UpdateViewAlias();
+    }
+
+    void CameraSensor::OnActiveViewChanged(const AZ::EntityId& cameraEntityId)
+    {
+        UpdateViewAlias();
+    }
+
+    void CameraSensor::UpdateViewAlias()
+    {
+        if (auto* fp = m_scene->GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessor>())
         {
+            const AZ::RPI::ViewPtr targetView = m_scene->GetDefaultRenderPipeline()->GetDefaultView();
             fp->SetViewAlias(m_view, targetView);
         }
     }
 
     CameraSensor::~CameraSensor()
     {
+        Camera::CameraNotificationBus::Handler::BusDisconnect();
         if (m_scene)
         {
             if (auto* fp = m_scene->GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessorInterface>())

--- a/Gems/ROS2/Code/Source/Camera/CameraSensor.h
+++ b/Gems/ROS2/Code/Source/Camera/CameraSensor.h
@@ -10,6 +10,7 @@
 #include "CameraPublishers.h"
 #include <Atom/Feature/Utils/FrameCaptureBus.h>
 #include <AzCore/std/containers/span.h>
+#include <AzFramework/Components/CameraBus.h>
 #include <ROS2/ROS2GemUtilities.h>
 #include <rclcpp/publisher.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
@@ -20,7 +21,7 @@ namespace ROS2
 {
     //! Class to create camera sensor using Atom renderer
     //! It creates dedicated rendering pipeline for each camera
-    class CameraSensor
+    class CameraSensor : public Camera::CameraNotificationBus::Handler
     {
     public:
         //! Initializes rendering pipeline for the camera sensor.
@@ -40,6 +41,12 @@ namespace ROS2
         [[nodiscard]] const CameraSensorDescription& GetCameraSensorDescription() const;
 
     private:
+        // CameraNotificationBus overrides
+        void OnCameraRemoved(const AZ::EntityId& cameraEntityId) override;
+        void OnActiveViewChanged(const AZ::EntityId& cameraEntityId) override;
+
+        void UpdateViewAlias();
+
         AZStd::vector<AZStd::string> m_passHierarchy;
         AZ::RPI::ViewPtr m_view;
         AZ::RPI::Scene* m_scene = nullptr;


### PR DESCRIPTION
## What does this PR do?

Currenty the ros2 cameras view was aliased to the main game camera. This enabled the PostProcessFeatureProcessor to works with the ROS2 camera. This aliasing was done during camera activation, but if the main camera was not activated the ROS2 camera aliased to a wrong view (probably the old editor view). To fix this issue I've added the Camera Notification Bus handler to the ROS2 camera. It sets the alias when the main camera view changes.

## How was this PR tested?

By adding a ROS2 camera and fog component and checking if the fog is visible in the topic. I've also verified different this behaviour with different activation orders (1st o3de camera, 2nd ros2 camera and 1st ros2 camera, 2nd o3de camera)
