### PR TITLE
Added registry setting to SteadyClock that allows to disable resettin…

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Clock/SimulationTimeSource.h
+++ b/Gems/ROS2/Code/Include/ROS2/Clock/SimulationTimeSource.h
@@ -36,6 +36,7 @@ namespace ROS2
 
     private:
         double m_elapsed = 0;
+        bool m_resetTimeOnRestart = true;
         AzPhysics::SceneEvents::OnSceneSimulationFinishHandler m_onSceneSimulationEvent;
         AzPhysics::SystemEvents::OnSceneAddedEvent::Handler m_onSceneAdded;
         AzPhysics::SystemEvents::OnSceneRemovedEvent::Handler m_onSceneRemoved;

--- a/Gems/ROS2/Code/Source/Clock/SimulationTimeSource.cpp
+++ b/Gems/ROS2/Code/Source/Clock/SimulationTimeSource.cpp
@@ -6,16 +6,18 @@
  *
  */
 
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/Time/ITime.h>
 #include <ROS2/Clock/SimulationTimeSource.h>
 #include <ROS2/ROS2Bus.h>
-#include <AzCore/Settings/SettingsRegistry.h>
 
 namespace ROS2
 {
-    namespace {
+    namespace
+    {
         constexpr AZStd::string_view ResetTimestampOnLevelReload = "/O3DE/ROS2/SteadyClock/ResetTimestampOnLevelReload";
     }
+
     void SimulationTimeSource::Activate()
     {
         auto* registry = AZ::SettingsRegistry::Get();
@@ -28,7 +30,7 @@ namespace ROS2
         auto* systemInterface = AZ::Interface<AzPhysics::SystemInterface>::Get();
         if (!systemInterface)
         {
-            AZ_Warning("SimulationPhysicalClock", false, "Failed to get AzPhysics::SystemInterface");
+            AZ_Warning("SimulationTimeSource", false, "Failed to get AzPhysics::SystemInterface");
             return;
         }
         m_onSceneSimulationEvent = AzPhysics::SceneEvents::OnSceneSimulationFinishHandler(
@@ -40,14 +42,14 @@ namespace ROS2
         m_onSceneAdded = AzPhysics::SystemEvents::OnSceneAddedEvent::Handler(
             [this](AzPhysics::SceneHandle sceneHandle)
             {
-
                 auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
                 AzPhysics::SceneHandle defaultSceneHandle = sceneInterface->GetSceneHandle(AzPhysics::DefaultPhysicsSceneName);
                 if (sceneHandle == defaultSceneHandle)
                 {
-                    AZ_Printf("SimulationPhysicalClock", "Registering clock to default scene");
+                    AZ_Printf("SimulationTimeSource", "Registering clock to default scene");
                     if (m_resetTimeOnRestart)
                     {
+                        AZ_Printf("SimulationTimeSource", "Reseting clock");
                         m_elapsed = 0.0;
                     }
                     sceneInterface->RegisterSceneSimulationFinishHandler(sceneHandle, m_onSceneSimulationEvent);
@@ -62,7 +64,7 @@ namespace ROS2
                 AzPhysics::SceneHandle defaultSceneHandle = sceneInterface->GetSceneHandle(AzPhysics::DefaultPhysicsSceneName);
                 if (sceneHandle == defaultSceneHandle)
                 {
-                    AZ_Printf("SimulationPhysicalClock", "Removing clock to default scene");
+                    AZ_Printf("SimulationTimeSource", "Removing clock to default scene");
                     m_onSceneSimulationEvent.Disconnect();
                 }
             });


### PR DESCRIPTION
…g the clock when level is reloaded.

This is useful when you want to keep the clock running between level reloads, for example to keep some ROS 2 nodes happy that are running in the background, and you are reload / reset the level.

## What does this PR do?

It is new feature.
It is optional, it does not change default behavior.

## How was this PR tested?

Tested in external project against 2409.1
with registry adjusted:
```
{
    "O3DE":
    {
        "InputSystem":
        {
            "Mouse":
            {
                "CaptureMouseCursor": false
            }
        },
        "ROS2":
        {
            "SteadyClock" : true,
            "SteadyClock":
            {
                "ResetTimestampOnLevelReload": false
            },
            "Camera":
            {
                "AllowPipelineModification": false
            }
        }
    }
}
```
