### PR TITLE
Add service success setting in ROS2SpawnerComponent::GetAvailableSpawnableNames

### DIFF
--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -115,6 +115,7 @@ namespace ROS2
         {
             response->model_names.emplace_back(spawnable.first.c_str());
         }
+        response->success = true;
     }
 
     void ROS2SpawnerComponent::SpawnEntity(


### PR DESCRIPTION
## What does this PR do?

The `/get_available_spawnable_names` service in `ROS2 Spawner` always returned `success=False` in response, while there were no issues in calling the service. This PR adds setting the `success` field to `true` in the appropriate method.

## How was this PR tested?

A scene with ROS2 Spawner was loaded and played in the editor and the service was called:

```
$ ros2 service call /get_available_spawnable_names gazebo_msgs/srv/GetWorldProperties
requester: making request: gazebo_msgs.srv.GetWorldProperties_Request()

response:
gazebo_msgs.srv.GetWorldProperties_Response(sim_time=0.0, model_names=['tomato', 'green_cube', 'apple', 'blue_cube', 'corn', 'toy_box', 'carrot', 'red_cube', 'yellow_cube'], rendering_enabled=False, success=True, status_message='')
```