### PR TITLE
Add service success setting in GetAvailableSpawnableNames

### DIFF
--- a/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
+++ b/Gems/ROS2/Code/Source/Spawner/ROS2SpawnerComponent.cpp
@@ -107,6 +107,7 @@ namespace ROS2
         {
             response->model_names.emplace_back(spawnable.first.c_str());
         }
+        response->success = true;
     }
 
     void ROS2SpawnerComponent::SpawnEntity(


### PR DESCRIPTION
## What does this PR do?

Cherry-pick of the one-liner fix from #828 
The output value was never initialized, hence always returning `false`.

## How was this PR tested?

Tested as in PR #828, this PR was build
