### PR TITLE
Revert ROSBotSample Gem 2.0.2 release

### DIFF
--- a/Gems/RosRobotSample/Assets/ROSbot.prefab
+++ b/Gems/RosRobotSample/Assets/ROSbot.prefab
@@ -1047,7 +1047,7 @@
                     "$type": "EditorFixedJointComponent",
                     "Id": 9934662879286617893,
                     "Configuration": {
-                        "Parent Entity": "Entity_[7507839849146]",
+                        "Parent Entity": "",
                         "Child Entity": "Entity_[7499249914554]"
                     }
                 }

--- a/Gems/RosRobotSample/gem.json
+++ b/Gems/RosRobotSample/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "RosRobotSample",
-    "version": "2.0.2",
+    "version": "2.0.1",
     "display_name": "ROS Robot Sample",
     "license": "Apache-2.0 or MIT",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -29,5 +29,5 @@
     ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "restricted": "",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/rosrobotsample-2.0.2-gem.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/rosrobotsample-2.0.1-gem.zip"
 }

--- a/repo.json
+++ b/repo.json
@@ -356,22 +356,6 @@
                     ],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/rosrobotsample-2.0.1-gem.zip",
                     "sha256": "a4ff12f401cd24d01e68c2058da5312bc1567c72fc26389593ec2e36bdfd3858"
-                },
-                {
-                    "version": "2.0.2",
-                    "origin": "RobotecAI",
-                    "origin_url": "https://robotec.ai",
-                    "summary": "Husarion ROSbot XL robot assets.",
-                    "requirements": "Requires ROS 2 Gem",
-                    "dependencies": [
-                        "ROS2>=3.1.0"
-                    ],
-                    "compatible_engines": [
-                        "o3de-sdk>=2.3.0",
-                        "o3de>=2.3.0"
-                    ],
-                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/rosrobotsample-2.0.2-gem.zip",
-                    "sha256": "99f308ffb2c8d4a96da188ee08f8834abdf27b5c09f372f3965fc39543881a93"
                 }
             ]
         },


### PR DESCRIPTION
## What does this PR do?

This PR reverts the change introduced in `ROSBotSample` Gem introduced in #831 which fixed the `cover_link` entity. Besides fixing the `cover_link` entity, the change introduces other problems. After some internal `sig-simulation` conversations, the decision was to revert it. It is better to have an incorrect fixed joint than a stationary robot.

## How was this PR tested?

`git diff ` was used to check if the change in the Gem was reverted and if the change in `repo.json` was correctly reverted.
