### PR TITLE
Adjusted cmake in asset-only gems using the newest asset-only template

### DIFF
--- a/Gems/RosRobotSample/CMakeLists.txt
+++ b/Gems/RosRobotSample/CMakeLists.txt
@@ -3,12 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-# Query the gem name from the gem.json file if possible
-# otherwise fallback to using RosRobotSample
-o3de_find_ancestor_gem_root(gem_root_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
-if (NOT gem_name)
-    set(gem_name "RosRobotSample")
-endif()
+o3de_gem_setup("RosRobotSample")
 
 # This indicates to the Builders applications(AssetProcessor, AssetBuilder, AssetBundler)
 # that the gem should be added to the "cmake_dependencies.<project>.assetbuilder.setreg"

--- a/Gems/WarehouseAssets/CMakeLists.txt
+++ b/Gems/WarehouseAssets/CMakeLists.txt
@@ -1,15 +1,20 @@
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
-# Query the gem name from the gem.json file if possible
-# otherwise fallback to using WarehouseSample
-o3de_find_ancestor_gem_root(gem_root_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
-if (NOT gem_name)
-    set(gem_name "WarehouseAssets")
-endif()
+o3de_gem_setup("WarehouseAssets")
 
-# This will export the path to the directory containing the gem.json
-# to the "SourcePaths" entry within the "cmake_dependencies.<project>.assetbuilder.setreg"
-# which is generated when cmake is run
-# This path is the gem root directory
+# This indicates to the Builders applications(AssetProcessor, AssetBuilder, AssetBundler)
+# that the gem should be added to the "cmake_dependencies.<project>.assetbuilder.setreg"
+# which is generated when cmake configure occurs.
+# Also tooling applications such as the Editor needs the CMake alias
+# to see the gem as active
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem)
+    ly_create_alias(NAME ${gem_name}.Tools NAMESPACE Gem)
+
+    # Add in CMake dependencies for each gem dependency listed in this gem's gem.json file
+    # for the Tools and Builders gem variants
+    o3de_add_variant_dependencies_for_gem_dependencies(GEM_NAME ${gem_name} VARIANTS Tools Builders)
 endif()

--- a/Gems/WarehouseSample/CMakeLists.txt
+++ b/Gems/WarehouseSample/CMakeLists.txt
@@ -1,15 +1,20 @@
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
-# Query the gem name from the gem.json file if possible
-# otherwise fallback to using WarehouseSample
-o3de_find_ancestor_gem_root(gem_root_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
-if (NOT gem_name)
-    set(gem_name "WarehouseSample")
-endif()
+o3de_gem_setup("WarehouseSample")
 
-# This will export the path to the directory containing the gem.json
-# to the "SourcePaths" entry within the "cmake_dependencies.<project>.assetbuilder.setreg"
-# which is generated when cmake is run
-# This path is the gem root directory
+# This indicates to the Builders applications(AssetProcessor, AssetBuilder, AssetBundler)
+# that the gem should be added to the "cmake_dependencies.<project>.assetbuilder.setreg"
+# which is generated when cmake configure occurs.
+# Also tooling applications such as the Editor needs the CMake alias
+# to see the gem as active
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem)
+    ly_create_alias(NAME ${gem_name}.Tools NAMESPACE Gem)
+
+    # Add in CMake dependencies for each gem dependency listed in this gem's gem.json file
+    # for the Tools and Builders gem variants
+    o3de_add_variant_dependencies_for_gem_dependencies(GEM_NAME ${gem_name} VARIANTS Tools Builders)
 endif()


### PR DESCRIPTION
## What does this PR do?

It resolved issue that I could not reference textures from other gems using e.g., ` "baseColor.textureMap": "@gemroot:WarehouseAssets@/Assets/assets/Warehouse/Textures/WarehouseBoxes/WarehouseBoxesBaseMap.png",`

## How was this PR tested?

I've build project with changed gem updated.
