### PR TITLE
Add gripper's initial position setting in FingerGripperComponent

### DIFF
--- a/Gems/ROS2/Code/Source/Gripper/FingerGripperComponent.cpp
+++ b/Gems/ROS2/Code/Source/Gripper/FingerGripperComponent.cpp
@@ -57,7 +57,8 @@ namespace ROS2
                 ->Field("VelocityEpsilon", &FingerGripperComponent::m_velocityEpsilon)
                 ->Field("DistanceEpsilon", &FingerGripperComponent::m_goalTolerance)
                 ->Field("StallTime", &FingerGripperComponent::m_stallTime)
-                ->Version(1);
+                ->Field("InitialPosition", &FingerGripperComponent::m_initialPosition)
+                ->Version(2);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
@@ -81,7 +82,12 @@ namespace ROS2
                         AZ::Edit::UIHandlers::Default,
                         &FingerGripperComponent::m_stallTime,
                         "Stall Time",
-                        "The time to wait before considering the gripper as stalled.");
+                        "The time to wait before considering the gripper as stalled.")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &FingerGripperComponent::m_initialPosition,
+                        "Initial Position",
+                        "The initial position of the gripper.");
             }
         }
     }
@@ -179,7 +185,7 @@ namespace ROS2
     {
         m_grippingInProgress = false;
         m_cancelled = true;
-        SetPosition(0.0f, AZStd::numeric_limits<float>::infinity());
+        SetPosition(m_initialPosition, AZStd::numeric_limits<float>::infinity());
         return AZ::Success();
     }
 
@@ -268,7 +274,7 @@ namespace ROS2
         {
             m_initialised = true;
             GetFingerJoints();
-            SetPosition(0.0f, AZStd::numeric_limits<float>::infinity());
+            SetPosition(m_initialPosition, AZStd::numeric_limits<float>::infinity());
         }
 
         if (IsGripperVelocity0())

--- a/Gems/ROS2/Code/Source/Gripper/FingerGripperComponent.cpp
+++ b/Gems/ROS2/Code/Source/Gripper/FingerGripperComponent.cpp
@@ -87,7 +87,7 @@ namespace ROS2
                         AZ::Edit::UIHandlers::Default,
                         &FingerGripperComponent::m_initialPosition,
                         "Initial Position",
-                        "The initial position of the gripper.");
+                        "The initial position of the gripper in units of the gripper's joints (meters if prismatic, radians if revolute).");
             }
         }
     }

--- a/Gems/ROS2/Code/Source/Gripper/FingerGripperComponent.h
+++ b/Gems/ROS2/Code/Source/Gripper/FingerGripperComponent.h
@@ -80,5 +80,6 @@ namespace ROS2
         float m_velocityEpsilon{ 0.01f }; //!< The epsilon value used to determine whether the gripper is moving
         float m_goalTolerance{ 0.001f }; //!< The epsilon value used to determine whether the gripper reached it's goal
         float m_stallTime{ 0.1f }; //!< The time in seconds to wait before determining the gripper is stalled
+        float m_initialPosition{ 0.0f };
     };
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Gripper/FingerGripperComponent.h
+++ b/Gems/ROS2/Code/Source/Gripper/FingerGripperComponent.h
@@ -80,6 +80,6 @@ namespace ROS2
         float m_velocityEpsilon{ 0.01f }; //!< The epsilon value used to determine whether the gripper is moving
         float m_goalTolerance{ 0.001f }; //!< The epsilon value used to determine whether the gripper reached it's goal
         float m_stallTime{ 0.1f }; //!< The time in seconds to wait before determining the gripper is stalled
-        float m_initialPosition{ 0.0f };
+        float m_initialPosition{ 0.0f }; //!< The initial position of the gripper in units of the gripper's joints
     };
 } // namespace ROS2


### PR DESCRIPTION
## What does this PR do?

This PR adds an editor field allowing to change the initial position of the gripper in the FingerGripperComponent, which was previously hardcoded as `0.0f`. This would cause issues if the controller made a small error and set the position to a negative value close to zero - when trying to execute any trajectory using moveit, it would complain about it with the following error and reject to execute it:
![image](https://github.com/user-attachments/assets/f7dcbff3-a7ed-486b-b8b0-112beccbd758)

![image](https://github.com/user-attachments/assets/2f9c2155-271b-478f-8c7e-0307dcf282ff)


## How was this PR tested?
In the ROS2 Robotic Manipulation template, in the Finger Gripper Component of the manipulator, various values were put into the "initial position" field and the gripper was put in those positions correctly when starting game mode.
![image](https://github.com/user-attachments/assets/cf90f855-5334-4501-a397-6483b212e051)

![image](https://github.com/user-attachments/assets/2c81d3bd-63e6-4df1-95e1-c5ae157aa4bc)
![image](https://github.com/user-attachments/assets/056e7d9d-2e2a-4e28-965e-f2e7e38e2719)
![image](https://github.com/user-attachments/assets/f9ec368d-fd8c-420d-aba2-d23c50898ac2)
