### PR TITLE
Small fixes for Gems

### DIFF
--- a/Gems/ProteusRobot/CMakeLists.txt
+++ b/Gems/ProteusRobot/CMakeLists.txt
@@ -3,12 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-# Query the gem name from the gem.json file if possible
-# otherwise fallback to using ProteusRobot
-o3de_find_ancestor_gem_root(gem_root_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
-if (NOT gem_name)
-    set(gem_name "ProteusRobot")
-endif()
+o3de_gem_setup("ProteusRobot")
 
 # This indicates to the Builders applications(AssetProcessor, AssetBuilder, AssetBundler)
 # that the gem should be added to the "cmake_dependencies.<project>.assetbuilder.setreg"

--- a/Gems/ProteusRobot/gem.json
+++ b/Gems/ProteusRobot/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ProteusRobot",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "display_name": "Proteus Robot",
     "license": "Apache-2.0 or MIT",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -15,21 +15,20 @@
         "ProteusRobot"
     ],
     "platforms": [
-        ""
+        "Linux"
     ],
     "icon_path": "preview.png",
     "requirements": "Requires ROS 2 Gem",
-    "documentation_url": "https://www.o3de.org/docs/user-guide/interactivity/robotics/project-configuration/#ros-2-project-templates",
+    "documentation_url": "",
     "dependencies": [
         "ROS2>=3.1.0"
     ],
-    "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "compatible_engines": [
         "o3de-sdk>=2.3.0",
         "o3de>=2.3.0"
     ],
+    "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "engine_api_dependencies": [],
     "restricted": "ProteusRobot",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/proteusrobot-2.0.0-gem.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/proteusrobot-2.1.0-gem.zip"
 }
-

--- a/Gems/RosRobotSample/Assets/ROSBot_slamtec.prefab
+++ b/Gems/RosRobotSample/Assets/ROSBot_slamtec.prefab
@@ -27,7 +27,7 @@
                 "$type": "EditorEntitySortComponent",
                 "Id": 615377764463113571,
                 "Child Entity Order": [
-                    ""
+                    "Entity_[2903754359265]"
                 ]
             },
             "Component_[6825265907510842117]": {
@@ -49,203 +49,58 @@
             }
         }
     },
+    "Entities": {
+        "Entity_[2903754359265]": {
+            "Id": "Entity_[2903754359265]",
+            "Name": "rosbot_xl",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10750615380987209797
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3634755607960602743
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1820745215303074243,
+                    "Child Entity Order": [
+                        "Instance_[3732164110801]/ContainerEntity"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 18363598070632634725
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10830872446621478077
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17669973974886378772
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 10573047347709242649
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13933101236206376606
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15110202460887678142,
+                    "Parent Entity": "ContainerEntity"
+                }
+            }
+        }
+    },
     "Instances": {
         "Instance_[3732164110801]": {
             "Source": "ROSbot.prefab",
             "Patches": [
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/Component_[1258474389347419349]/Parent Entity",
-                    "value": "../ContainerEntity"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[7499249914554]/Components/Component_[1770764664089996465]/Child Entity Order/0",
-                    "value": "Entity_[5429730984677]"
-                },
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[5434025951973]",
-                    "value": {
-                        "Id": "Entity_[5434025951973]",
-                        "Name": "slamtec_rplidar_s1_link_visual",
-                        "Components": {
-                            "Component_[13558631120334703172]": {
-                                "$type": "EditorInspectorComponent",
-                                "Id": 13558631120334703172,
-                                "ComponentOrderEntryArray": []
-                            },
-                            "Component_[15937921940637916859]": {
-                                "$type": "EditorEntitySortComponent",
-                                "Id": 15937921940637916859,
-                                "Child Entity Order": []
-                            },
-                            "Component_[16880687897144235879]": {
-                                "$type": "EditorVisibilityComponent",
-                                "Id": 16880687897144235879,
-                                "VisibilityFlag": true
-                            },
-                            "Component_[17782893825045371782]": {
-                                "$type": "EditorPendingCompositionComponent",
-                                "Id": 17782893825045371782,
-                                "PendingComponents": []
-                            },
-                            "Component_[2514902925827828913]": {
-                                "$type": "EditorDisabledCompositionComponent",
-                                "Id": 2514902925827828913,
-                                "DisabledComponents": []
-                            },
-                            "Component_[2561471299578768190]": {
-                                "$type": "EditorOnlyEntityComponent",
-                                "Id": 2561471299578768190,
-                                "IsEditorOnly": false
-                            },
-                            "Component_[2663517450077638093]": {
-                                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                                "Id": 2663517450077638093,
-                                "Parent Entity": "Entity_[5429730984677]",
-                                "Transform Data": {
-                                    "Translate": [
-                                        0.0,
-                                        0.0,
-                                        0.0
-                                    ],
-                                    "Rotate": [
-                                        0.0,
-                                        0.0,
-                                        0.0
-                                    ],
-                                    "Scale": [
-                                        1.0,
-                                        1.0,
-                                        1.0
-                                    ],
-                                    "Locked": false,
-                                    "UniformScale": 1.0
-                                },
-                                "Parent Activation Transform Mode": 0,
-                                "IsStatic": false,
-                                "InterpolatePosition": 0,
-                                "InterpolateRotation": 0
-                            },
-                            "Component_[3265076674777361038]": {
-                                "$type": "EditorLockComponent",
-                                "Id": 3265076674777361038,
-                                "Locked": false
-                            },
-                            "Component_[6586089230771174257]": {
-                                "$type": "EditorMaterialComponent",
-                                "Id": 6586089230771174257,
-                                "Controller": {
-                                    "Configuration": {
-                                        "materials": [
-                                            {
-                                                "Key": {
-                                                    "lodIndex": 18446744073709551615,
-                                                    "materialSlotStableId": 1311805850
-                                                },
-                                                "Value": {
-                                                    "MaterialAsset": {
-                                                        "assetId": {
-                                                            "guid": "{6F8ACA28-0900-5937-A365-FFED5F372998}",
-                                                            "subId": 0
-                                                        },
-                                                        "loadBehavior": "QueueLoad",
-                                                        "assetHint": ""
-                                                    },
-                                                    "PropertyOverrides": [],
-                                                    "ModelUvOverrides": []
-                                                }
-                                            },
-                                            {
-                                                "Key": {
-                                                    "lodIndex": 18446744073709551615,
-                                                    "materialSlotStableId": 3117107120
-                                                },
-                                                "Value": {
-                                                    "MaterialAsset": {
-                                                        "assetId": {
-                                                            "guid": "{B8C827B6-2493-58DC-ADDC-8B721E34DA55}",
-                                                            "subId": 0
-                                                        },
-                                                        "loadBehavior": "QueueLoad",
-                                                        "assetHint": ""
-                                                    },
-                                                    "PropertyOverrides": [],
-                                                    "ModelUvOverrides": []
-                                                }
-                                            },
-                                            {
-                                                "Key": {
-                                                    "lodIndex": 18446744073709551615,
-                                                    "materialSlotStableId": 4154092942
-                                                },
-                                                "Value": {
-                                                    "MaterialAsset": {
-                                                        "assetId": {
-                                                            "guid": "{DBB9C83E-9304-504B-8428-769E3AC42221}",
-                                                            "subId": 0
-                                                        },
-                                                        "loadBehavior": "QueueLoad",
-                                                        "assetHint": ""
-                                                    },
-                                                    "PropertyOverrides": [],
-                                                    "ModelUvOverrides": []
-                                                }
-                                            }
-                                        ]
-                                    }
-                                },
-                                "materialSlotsByLodEnabled": false
-                            },
-                            "Component_[780474675560340036]": {
-                                "$type": "EditorEntityIconComponent",
-                                "Id": 780474675560340036,
-                                "EntityIconAssetId": {
-                                    "guid": "{00000000-0000-0000-0000-000000000000}",
-                                    "subId": 0
-                                }
-                            },
-                            "Component_[9753263690525804004]": {
-                                "$type": "AZ::Render::EditorMeshComponent",
-                                "Id": 9753263690525804004,
-                                "Controller": {
-                                    "Configuration": {
-                                        "ModelAsset": {
-                                            "assetId": {
-                                                "guid": "{45977802-63D1-54D0-AAA3-FF63FEE5F690}",
-                                                "subId": 282870366
-                                            },
-                                            "loadBehavior": "QueueLoad",
-                                            "assetHint": "robot/ros_components_description/meshes/slamtec_rplidar_s1.azmodel"
-                                        },
-                                        "SortKey": 0,
-                                        "ExcludeFromReflectionCubeMaps": false,
-                                        "UseForwardPassIBLSpecular": false,
-                                        "IsRayTracingEnabled": true,
-                                        "IsAlwaysDynamic": false,
-                                        "LodType": 0,
-                                        "LodOverride": 0,
-                                        "MinimumScreenCoverage": 0.0009259259095415472,
-                                        "QualityDecayRate": 0.5
-                                    }
-                                },
-                                "meshStats": {}
-                            }
-                        },
-                        "IsRuntimeActive": true
-                    }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[7507839849146]/Components/Component_[1153232506834696450]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
-                    "value": "robot/rosbot_xl_description/meshes/body_colision.stl.pxmesh"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[7507839849146]/Components/Component_[1153232506834696450]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
-                    "value": "robot/rosbot_xl_description/meshes/body_colision.stl.pxmesh"
-                },
                 {
                     "op": "add",
                     "path": "/Entities/Entity_[5429730984677]",
@@ -665,6 +520,19 @@
                                 "Id": 17880429133386895196,
                                 "VisibilityFlag": true
                             },
+                            "ROS2FrameEditorComponent": {
+                                "$type": "ROS2FrameEditorComponent",
+                                "Id": 8120896383852689752,
+                                "ROS2FrameConfiguration": {
+                                    "Namespace Configuration": {
+                                        "Namespace Strategy": 0,
+                                        "Namespace": ""
+                                    },
+                                    "Frame Name": "slamtec_rplidar_s1_link",
+                                    "Joint Name": "cover_to_slamtec_rplidar_s1_joint",
+                                    "Publish Transform": true
+                                }
+                            },
                             "TransformComponent": {
                                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                                 "Id": 9692259687288593691,
@@ -692,20 +560,6 @@
                                 "IsStatic": false,
                                 "InterpolatePosition": 0,
                                 "InterpolateRotation": 0
-                            },
-                            "ROS2FrameEditorComponent": {
-                                "$type": "ROS2FrameEditorComponent",
-                                "Id": 8120896383852689752,
-                                "ROS2FrameConfiguration": {
-                                    "Id": 0,
-                                    "Namespace Configuration": {
-                                        "Namespace Strategy": 0,
-                                        "Namespace": ""
-                                    },
-                                    "Frame Name": "slamtec_rplidar_s1_link",
-                                    "Joint Name": "cover_to_slamtec_rplidar_s1_joint",
-                                    "Publish Transform": true
-                                }
                             }
                         },
                         "IsRuntimeActive": true
@@ -761,6 +615,19 @@
                                 "Id": 9118740895747240865,
                                 "VisibilityFlag": true
                             },
+                            "ROS2FrameEditorComponent": {
+                                "$type": "ROS2FrameEditorComponent",
+                                "Id": 12598642067614797199,
+                                "ROS2FrameConfiguration": {
+                                    "Namespace Configuration": {
+                                        "Namespace Strategy": 0,
+                                        "Namespace": ""
+                                    },
+                                    "Frame Name": "laser",
+                                    "Joint Name": "",
+                                    "Publish Transform": true
+                                }
+                            },
                             "ROS2Lidar2DSensorComponent_2": {
                                 "$type": "GenericComponentWrapper",
                                 "Id": 15951162260593853297,
@@ -789,14 +656,26 @@
                                             "lidarImplementation": "Scene Queries",
                                             "LidarParameters": {
                                                 "Name": "Slamtec RPLIDAR S1",
+                                                "Layers": 1,
                                                 "Points per layer": 921,
+                                                "Min horizontal angle": -180.0,
+                                                "Max horizontal angle": 180.0,
+                                                "Min vertical angle": 0.0,
+                                                "Max vertical angle": 0.0,
                                                 "Min range": 0.10000000149011612,
-                                                "Max range": 40.0
+                                                "Max range": 40.0,
+                                                "Enable Noise": true,
+                                                "Noise Parameters": {
+                                                    "Angular noise standard deviation": 0.0,
+                                                    "Distance noise standard deviation base": 0.019999999552965164,
+                                                    "Distance noise standard deviation slope": 0.0010000000474974513
+                                                }
                                             },
                                             "IgnoredLayerIndices": [
                                                 1
                                             ],
                                             "ExcludedEntities": [],
+                                            "IsSegmentationEnabled": false,
                                             "PointsAtMax": false
                                         }
                                     }
@@ -829,20 +708,194 @@
                                 "IsStatic": false,
                                 "InterpolatePosition": 0,
                                 "InterpolateRotation": 0
+                            }
+                        },
+                        "IsRuntimeActive": true
+                    }
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[1258474389347419349]/Parent Entity",
+                    "value": "../Entity_[2903754359265]"
+                },
+                {
+                    "op": "add",
+                    "path": "/Entities/Entity_[5434025951973]",
+                    "value": {
+                        "Id": "Entity_[5434025951973]",
+                        "Name": "slamtec_rplidar_s1_link_visual",
+                        "Components": {
+                            "Component_[13558631120334703172]": {
+                                "$type": "EditorInspectorComponent",
+                                "Id": 13558631120334703172,
+                                "ComponentOrderEntryArray": []
                             },
-                            "ROS2FrameEditorComponent": {
-                                "$type": "ROS2FrameEditorComponent",
-                                "Id": 12598642067614797199,
-                                "ROS2FrameConfiguration": {
-                                    "Id": 0,
-                                    "Namespace Configuration": {
-                                        "Namespace Strategy": 0,
-                                        "Namespace": ""
-                                    },
-                                    "Frame Name": "laser",
-                                    "Joint Name": "",
-                                    "Publish Transform": true
+                            "Component_[15937921940637916859]": {
+                                "$type": "EditorEntitySortComponent",
+                                "Id": 15937921940637916859,
+                                "Child Entity Order": []
+                            },
+                            "Component_[16880687897144235879]": {
+                                "$type": "EditorVisibilityComponent",
+                                "Id": 16880687897144235879,
+                                "VisibilityFlag": true
+                            },
+                            "Component_[17782893825045371782]": {
+                                "$type": "EditorPendingCompositionComponent",
+                                "Id": 17782893825045371782,
+                                "PendingComponents": []
+                            },
+                            "Component_[2514902925827828913]": {
+                                "$type": "EditorDisabledCompositionComponent",
+                                "Id": 2514902925827828913,
+                                "DisabledComponents": []
+                            },
+                            "Component_[2561471299578768190]": {
+                                "$type": "EditorOnlyEntityComponent",
+                                "Id": 2561471299578768190,
+                                "IsEditorOnly": false
+                            },
+                            "Component_[2663517450077638093]": {
+                                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                                "Id": 2663517450077638093,
+                                "Parent Entity": "Entity_[5429730984677]",
+                                "Transform Data": {
+                                    "Translate": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "Rotate": [
+                                        0.0,
+                                        0.0,
+                                        0.0
+                                    ],
+                                    "Scale": [
+                                        1.0,
+                                        1.0,
+                                        1.0
+                                    ],
+                                    "Locked": false,
+                                    "UniformScale": 1.0
+                                },
+                                "Parent Activation Transform Mode": 0,
+                                "IsStatic": false,
+                                "InterpolatePosition": 0,
+                                "InterpolateRotation": 0
+                            },
+                            "Component_[3265076674777361038]": {
+                                "$type": "EditorLockComponent",
+                                "Id": 3265076674777361038,
+                                "Locked": false
+                            },
+                            "Component_[6586089230771174257]": {
+                                "$type": "EditorMaterialComponent",
+                                "Id": 6586089230771174257,
+                                "Controller": {
+                                    "Configuration": {
+                                        "materials": [
+                                            {
+                                                "Key": {
+                                                    "lodIndex": 18446744073709551615,
+                                                    "materialSlotStableId": 1311805850
+                                                },
+                                                "Value": {
+                                                    "MaterialAsset": {
+                                                        "assetId": {
+                                                            "guid": "{6F8ACA28-0900-5937-A365-FFED5F372998}",
+                                                            "subId": 0
+                                                        },
+                                                        "loadBehavior": "QueueLoad",
+                                                        "assetHint": "robot/ros_components_description/meshes/slamtec_rplidar_s1_black.azmaterial"
+                                                    },
+                                                    "PropertyOverrides": [],
+                                                    "ModelUvOverrides": []
+                                                }
+                                            },
+                                            {
+                                                "Key": {
+                                                    "lodIndex": 18446744073709551615,
+                                                    "materialSlotStableId": 3117107120
+                                                },
+                                                "Value": {
+                                                    "MaterialAsset": {
+                                                        "assetId": {
+                                                            "guid": "{B8C827B6-2493-58DC-ADDC-8B721E34DA55}",
+                                                            "subId": 0
+                                                        },
+                                                        "loadBehavior": "QueueLoad",
+                                                        "assetHint": "robot/ros_components_description/meshes/slamtec_rplidar_s1_gray.azmaterial"
+                                                    },
+                                                    "PropertyOverrides": [],
+                                                    "ModelUvOverrides": []
+                                                }
+                                            },
+                                            {
+                                                "Key": {
+                                                    "lodIndex": 18446744073709551615,
+                                                    "materialSlotStableId": 4154092942
+                                                },
+                                                "Value": {
+                                                    "MaterialAsset": {
+                                                        "assetId": {
+                                                            "guid": "{DBB9C83E-9304-504B-8428-769E3AC42221}",
+                                                            "subId": 0
+                                                        },
+                                                        "loadBehavior": "QueueLoad",
+                                                        "assetHint": "robot/ros_components_description/meshes/slamtec_rplidar_s1_white.azmaterial"
+                                                    },
+                                                    "PropertyOverrides": [],
+                                                    "ModelUvOverrides": []
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "materialSlotsByLodEnabled": false
+                            },
+                            "Component_[780474675560340036]": {
+                                "$type": "EditorEntityIconComponent",
+                                "Id": 780474675560340036,
+                                "EntityIconAssetId": {
+                                    "guid": "{00000000-0000-0000-0000-000000000000}",
+                                    "subId": 0
                                 }
+                            },
+                            "Component_[9753263690525804004]": {
+                                "$type": "AZ::Render::EditorMeshComponent",
+                                "Id": 9753263690525804004,
+                                "Controller": {
+                                    "Configuration": {
+                                        "ModelAsset": {
+                                            "assetId": {
+                                                "guid": "{45977802-63D1-54D0-AAA3-FF63FEE5F690}",
+                                                "subId": 282870366
+                                            },
+                                            "loadBehavior": "QueueLoad",
+                                            "assetHint": "robot/ros_components_description/meshes/slamtec_rplidar_s1.dae.azmodel"
+                                        },
+                                        "SortKey": 0,
+                                        "ExcludeFromReflectionCubeMaps": false,
+                                        "UseForwardPassIBLSpecular": false,
+                                        "IsRayTracingEnabled": true,
+                                        "IsAlwaysDynamic": false,
+                                        "SupportRayIntersection": false,
+                                        "LodType": 0,
+                                        "LodOverride": 0,
+                                        "MinimumScreenCoverage": 0.0009259259095415473,
+                                        "QualityDecayRate": 0.5,
+                                        "LightingChannelConfig": {
+                                            "lightingChannelFlags": [
+                                                true,
+                                                false,
+                                                false,
+                                                false,
+                                                false
+                                            ]
+                                        }
+                                    }
+                                },
+                                "meshStats": {}
                             }
                         },
                         "IsRuntimeActive": true

--- a/Gems/RosRobotSample/Assets/ROSbot.prefab
+++ b/Gems/RosRobotSample/Assets/ROSbot.prefab
@@ -486,7 +486,7 @@
                     "$type": "EditorFixedJointComponent",
                     "Id": 11310786217061747012,
                     "Configuration": {
-                        "Parent Entity": "",
+                        "Parent Entity": "Entity_[7507839849146]",
                         "Child Entity": "Entity_[7482070045370]"
                     }
                 },
@@ -498,8 +498,7 @@
                     "$type": "EditorRigidBodyComponent",
                     "Id": 12432694652345033923,
                     "Configuration": {
-                        "entityId": "",
-                        "Kinematic": true
+                        "entityId": ""
                     }
                 },
                 "Component_[12817635789820242289]": {
@@ -1027,14 +1026,6 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 17859749258720088518
                 },
-                "Component_[3303670314104435058]": {
-                    "$type": "EditorRigidBodyComponent",
-                    "Id": 3303670314104435058,
-                    "Configuration": {
-                        "entityId": "",
-                        "Kinematic": true
-                    }
-                },
                 "Component_[5503518763347768805]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 5503518763347768805
@@ -1042,14 +1033,6 @@
                 "Component_[8747820045819434329]": {
                     "$type": "EditorLockComponent",
                     "Id": 8747820045819434329
-                },
-                "Component_[9934662879286617893]": {
-                    "$type": "EditorFixedJointComponent",
-                    "Id": 9934662879286617893,
-                    "Configuration": {
-                        "Parent Entity": "",
-                        "Child Entity": "Entity_[7499249914554]"
-                    }
                 }
             }
         },

--- a/Gems/RosRobotSample/Assets/ROSbot_velodyne.prefab
+++ b/Gems/RosRobotSample/Assets/ROSbot_velodyne.prefab
@@ -24,7 +24,7 @@
                 "$type": "EditorEntitySortComponent",
                 "Id": 3608898425222506107,
                 "Child Entity Order": [
-                    "Instance_[812111036889]/ContainerEntity"
+                    "Entity_[465452541274]"
                 ]
             },
             "Component_[5327346244572264003]": {
@@ -49,15 +49,58 @@
             }
         }
     },
+    "Entities": {
+        "Entity_[465452541274]": {
+            "Id": "Entity_[465452541274]",
+            "Name": "rosbot_xl",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2383491808723318171
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 18108304331946507488
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 18162337217067356831,
+                    "Child Entity Order": [
+                        "Instance_[812111036889]/ContainerEntity"
+                    ]
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5225736643448429803
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11117548785735244679
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4526456886531647600
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 3703178989277381678
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6702016649435686463
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 13117328618696151745,
+                    "Parent Entity": "ContainerEntity"
+                }
+            }
+        }
+    },
     "Instances": {
         "Instance_[812111036889]": {
             "Source": "ROSbot.prefab",
             "Patches": [
-                {
-                    "op": "add",
-                    "path": "/Entities/Entity_[7499249914554]/Components/Component_[1770764664089996465]/Child Entity Order/0",
-                    "value": "Entity_[4501487944153]"
-                },
                 {
                     "op": "add",
                     "path": "/Entities/Entity_[4501487944153]",
@@ -239,7 +282,7 @@
                                     "Breakable": false,
                                     "Maximum Force": 1.0,
                                     "Maximum Torque": 1.0,
-                                    "Display Debug": 1,
+                                    "Display Debug": "Selected",
                                     "Select Lead on Snap": true,
                                     "Self Collide": false
                                 },
@@ -344,6 +387,19 @@
                                 "Id": 17997022775023708009,
                                 "VisibilityFlag": true
                             },
+                            "ROS2FrameEditorComponent": {
+                                "$type": "ROS2FrameEditorComponent",
+                                "Id": 88600217186346884,
+                                "ROS2FrameConfiguration": {
+                                    "Namespace Configuration": {
+                                        "Namespace Strategy": 0,
+                                        "Namespace": ""
+                                    },
+                                    "Frame Name": "velodyne_puck_link",
+                                    "Joint Name": "",
+                                    "Publish Transform": true
+                                }
+                            },
                             "TransformComponent": {
                                 "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                                 "Id": 285955374135339063,
@@ -371,29 +427,10 @@
                                 "IsStatic": false,
                                 "InterpolatePosition": 0,
                                 "InterpolateRotation": 0
-                            },
-                            "ROS2FrameEditorComponent": {
-                                "$type": "ROS2FrameEditorComponent",
-                                "Id": 88600217186346884,
-                                "ROS2FrameConfiguration": {
-                                    "Id": 0,
-                                    "Namespace Configuration": {
-                                        "Namespace Strategy": 0,
-                                        "Namespace": ""
-                                    },
-                                    "Frame Name": "velodyne_puck_link",
-                                    "Joint Name": "",
-                                    "Publish Transform": true
-                                }
                             }
                         },
                         "IsRuntimeActive": true
                     }
-                },
-                {
-                    "op": "replace",
-                    "path": "/ContainerEntity/Components/Component_[1258474389347419349]/Parent Entity",
-                    "value": "../ContainerEntity"
                 },
                 {
                     "op": "add",
@@ -466,7 +503,7 @@
                                                             "subId": 0
                                                         },
                                                         "loadBehavior": "QueueLoad",
-                                                        "assetHint": ""
+                                                        "assetHint": "robot/ros_components_description/meshes/velodyne_puck_blue.azmaterial"
                                                     },
                                                     "PropertyOverrides": [],
                                                     "ModelUvOverrides": []
@@ -544,17 +581,27 @@
                                                 "subId": 274760714
                                             },
                                             "loadBehavior": "QueueLoad",
-                                            "assetHint": "robot/ros_components_description/meshes/velodyne_puck.azmodel"
+                                            "assetHint": "robot/ros_components_description/meshes/velodyne_puck.dae.azmodel"
                                         },
                                         "SortKey": 0,
                                         "ExcludeFromReflectionCubeMaps": false,
                                         "UseForwardPassIBLSpecular": false,
                                         "IsRayTracingEnabled": true,
                                         "IsAlwaysDynamic": false,
+                                        "SupportRayIntersection": false,
                                         "LodType": 0,
                                         "LodOverride": 0,
                                         "MinimumScreenCoverage": 0.0009259000071324408,
-                                        "QualityDecayRate": 0.5
+                                        "QualityDecayRate": 0.5,
+                                        "LightingChannelConfig": {
+                                            "lightingChannelFlags": [
+                                                true,
+                                                false,
+                                                false,
+                                                false,
+                                                false
+                                            ]
+                                        }
                                     }
                                 },
                                 "meshStats": {}
@@ -567,16 +614,6 @@
                         },
                         "IsRuntimeActive": true
                     }
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[7507839849146]/Components/Component_[1153232506834696450]/ShapeConfiguration/PhysicsAsset/Asset/assetHint",
-                    "value": "robot/rosbot_xl_description/meshes/body_colision.stl.pxmesh"
-                },
-                {
-                    "op": "replace",
-                    "path": "/Entities/Entity_[7507839849146]/Components/Component_[1153232506834696450]/ShapeConfiguration/PhysicsAsset/Configuration/PhysicsAsset/assetHint",
-                    "value": "robot/rosbot_xl_description/meshes/body_colision.stl.pxmesh"
                 },
                 {
                     "op": "add",
@@ -628,6 +665,19 @@
                                 "Id": 6095707461105765349,
                                 "VisibilityFlag": true
                             },
+                            "ROS2FrameEditorComponent": {
+                                "$type": "ROS2FrameEditorComponent",
+                                "Id": 14365734668344824407,
+                                "ROS2FrameConfiguration": {
+                                    "Namespace Configuration": {
+                                        "Namespace Strategy": 0,
+                                        "Namespace": ""
+                                    },
+                                    "Frame Name": "velodyne",
+                                    "Joint Name": "",
+                                    "Publish Transform": true
+                                }
+                            },
                             "ROS2LidarSensorComponent_2": {
                                 "$type": "GenericComponentWrapper",
                                 "Id": 14130657555606726475,
@@ -658,17 +708,24 @@
                                                 "Name": "Velodyne Puck (VLP-16)",
                                                 "Layers": 16,
                                                 "Points per layer": 1800,
+                                                "Min horizontal angle": -180.0,
+                                                "Max horizontal angle": 180.0,
                                                 "Min vertical angle": 15.0,
                                                 "Max vertical angle": -15.0,
+                                                "Min range": 0.0,
+                                                "Max range": 100.0,
                                                 "Enable Noise": true,
                                                 "Noise Parameters": {
-                                                    "Distance noise standard deviation base": 0.029999999329447746
+                                                    "Angular noise standard deviation": 0.0,
+                                                    "Distance noise standard deviation base": 0.029999999329447746,
+                                                    "Distance noise standard deviation slope": 0.0010000000474974513
                                                 }
                                             },
                                             "IgnoredLayerIndices": [
                                                 1
                                             ],
                                             "ExcludedEntities": [],
+                                            "IsSegmentationEnabled": false,
                                             "PointsAtMax": false
                                         }
                                     }
@@ -701,24 +758,15 @@
                                 "IsStatic": false,
                                 "InterpolatePosition": 0,
                                 "InterpolateRotation": 0
-                            },
-                            "ROS2FrameEditorComponent": {
-                                "$type": "ROS2FrameEditorComponent",
-                                "Id": 14365734668344824407,
-                                "ROS2FrameConfiguration": {
-                                    "Id": 0,
-                                    "Namespace Configuration": {
-                                        "Namespace Strategy": 0,
-                                        "Namespace": ""
-                                    },
-                                    "Frame Name": "velodyne",
-                                    "Joint Name": "",
-                                    "Publish Transform": true
-                                }
                             }
                         },
                         "IsRuntimeActive": true
                     }
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[1258474389347419349]/Parent Entity",
+                    "value": "../Entity_[465452541274]"
                 }
             ]
         }

--- a/Gems/RosRobotSample/CMakeLists.txt
+++ b/Gems/RosRobotSample/CMakeLists.txt
@@ -3,12 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-# Query the gem name from the gem.json file if possible
-# otherwise fallback to using RosRobotSample
-o3de_find_ancestor_gem_root(gem_root_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
-if (NOT gem_name)
-    set(gem_name "RosRobotSample")
-endif()
+o3de_gem_setup("RosRobotSample")
 
 # This indicates to the Builders applications(AssetProcessor, AssetBuilder, AssetBundler)
 # that the gem should be added to the "cmake_dependencies.<project>.assetbuilder.setreg"

--- a/Gems/RosRobotSample/gem.json
+++ b/Gems/RosRobotSample/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "RosRobotSample",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "display_name": "ROS Robot Sample",
     "license": "Apache-2.0 or MIT",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -29,5 +29,5 @@
     ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "restricted": "",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/rosrobotsample-2.0.1-gem.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/rosrobotsample-2.1.0-gem.zip"
 }

--- a/Gems/WarehouseAssets/CMakeLists.txt
+++ b/Gems/WarehouseAssets/CMakeLists.txt
@@ -1,15 +1,20 @@
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
-# Query the gem name from the gem.json file if possible
-# otherwise fallback to using WarehouseSample
-o3de_find_ancestor_gem_root(gem_root_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
-if (NOT gem_name)
-    set(gem_name "WarehouseAssets")
-endif()
+o3de_gem_setup("WarehouseAssets")
 
-# This will export the path to the directory containing the gem.json
-# to the "SourcePaths" entry within the "cmake_dependencies.<project>.assetbuilder.setreg"
-# which is generated when cmake is run
-# This path is the gem root directory
+# This indicates to the Builders applications(AssetProcessor, AssetBuilder, AssetBundler)
+# that the gem should be added to the "cmake_dependencies.<project>.assetbuilder.setreg"
+# which is generated when cmake configure occurs.
+# Also tooling applications such as the Editor needs the CMake alias
+# to see the gem as active
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem)
+    ly_create_alias(NAME ${gem_name}.Tools NAMESPACE Gem)
+
+    # Add in CMake dependencies for each gem dependency listed in this gem's gem.json file
+    # for the Tools and Builders gem variants
+    o3de_add_variant_dependencies_for_gem_dependencies(GEM_NAME ${gem_name} VARIANTS Tools Builders)
 endif()

--- a/Gems/WarehouseAssets/gem.json
+++ b/Gems/WarehouseAssets/gem.json
@@ -1,10 +1,11 @@
 {
     "gem_name": "WarehouseAssets",
+    "version": "1.1.0",
     "display_name": "WarehouseAssets",
     "license": "Apache-2.0 or MIT",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
-    "origin": "The name of the originator or creator",
-    "origin_url": "https://github.com/o3de/o3de-extras/tree/main/Gems/WarehouseAssets",
+    "origin": "RobotecAI",
+    "origin_url": "https://robotec.ai",
     "type": "Asset",
     "summary": "A set of prefabs and assets to build large warehouse scenes.",
     "canonical_tags": [
@@ -20,13 +21,11 @@
     "requirements": "",
     "documentation_url": "",
     "dependencies": [],
-    "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "compatible_engines": [
         "o3de-sdk>=1.2.0",
         "o3de>=1.2.0"
     ],
-    "engine_api_dependencies": [],
+    "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "restricted": "",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehouseassets-1.0.0-gem.zip",
-    "version": "1.0.0"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehouseassets-1.1.0-gem.zip"
 }

--- a/Gems/WarehouseSample/Assets/O3DEScene/Prefabs/Warehouse.prefab
+++ b/Gems/WarehouseSample/Assets/O3DEScene/Prefabs/Warehouse.prefab
@@ -1531,7 +1531,7 @@
                                     "guid": "{2B484CB6-8011-5B56-B194-7B3110DA7629}",
                                     "subId": 280202236
                                 },
-                                "assetHint": "o3descene/warehouse.azmodel"
+                                "assetHint": "o3descene/warehouse.fbx.azmodel"
                             }
                         }
                     }
@@ -1746,7 +1746,7 @@
                                     "guid": "{2B484CB6-8011-5B56-B194-7B3110DA7629}",
                                     "subId": 2755884180
                                 },
-                                "assetHint": "o3descene/warehouse.pxmesh"
+                                "assetHint": "o3descene/warehouse.fbx.pxmesh"
                             },
                             "Configuration": {
                                 "PhysicsAsset": {
@@ -1755,7 +1755,7 @@
                                         "subId": 2755884180
                                     },
                                     "loadBehavior": "QueueLoad",
-                                    "assetHint": "o3descene/warehouse.pxmesh"
+                                    "assetHint": "o3descene/warehouse.fbx.pxmesh"
                                 }
                             }
                         }

--- a/Gems/WarehouseSample/CMakeLists.txt
+++ b/Gems/WarehouseSample/CMakeLists.txt
@@ -1,15 +1,20 @@
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 
-# Query the gem name from the gem.json file if possible
-# otherwise fallback to using WarehouseSample
-o3de_find_ancestor_gem_root(gem_root_path gem_name "${CMAKE_CURRENT_SOURCE_DIR}")
-if (NOT gem_name)
-    set(gem_name "WarehouseSample")
-endif()
+o3de_gem_setup("WarehouseSample")
 
-# This will export the path to the directory containing the gem.json
-# to the "SourcePaths" entry within the "cmake_dependencies.<project>.assetbuilder.setreg"
-# which is generated when cmake is run
-# This path is the gem root directory
+# This indicates to the Builders applications(AssetProcessor, AssetBuilder, AssetBundler)
+# that the gem should be added to the "cmake_dependencies.<project>.assetbuilder.setreg"
+# which is generated when cmake configure occurs.
+# Also tooling applications such as the Editor needs the CMake alias
+# to see the gem as active
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_create_alias(NAME ${gem_name}.Builders NAMESPACE Gem)
+    ly_create_alias(NAME ${gem_name}.Tools NAMESPACE Gem)
+
+    # Add in CMake dependencies for each gem dependency listed in this gem's gem.json file
+    # for the Tools and Builders gem variants
+    o3de_add_variant_dependencies_for_gem_dependencies(GEM_NAME ${gem_name} VARIANTS Tools Builders)
 endif()

--- a/Gems/WarehouseSample/gem.json
+++ b/Gems/WarehouseSample/gem.json
@@ -1,5 +1,6 @@
 {
     "gem_name": "WarehouseSample",
+    "version": "1.0.1",
     "display_name": "WarehouseSample",
     "license": "Apache-2.0 or MIT",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -26,6 +27,5 @@
         "o3de>=1.2.0"
     ],
     "restricted": "",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehousesample-1.0.0-gem.zip",
-    "version": "1.0.0"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehousesample-1.0.1-gem.zip"
 }

--- a/Gems/WarehouseSample/gem.json
+++ b/Gems/WarehouseSample/gem.json
@@ -1,13 +1,13 @@
 {
     "gem_name": "WarehouseSample",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "display_name": "WarehouseSample",
     "license": "Apache-2.0 or MIT",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
     "origin": "RobotecAI",
     "origin_url": "https://robotec.ai",
     "type": "Asset",
-    "summary": "This Gem contains a Warehouse sample scene",
+    "summary": "This Gem contains a Warehouse sample assets.",
     "canonical_tags": [
         "Gem"
     ],
@@ -21,11 +21,11 @@
     "requirements": "",
     "documentation_url": "",
     "dependencies": [],
-    "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "compatible_engines": [
         "o3de-sdk>=1.2.0",
         "o3de>=1.2.0"
     ],
+    "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "restricted": "",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehousesample-1.0.1-gem.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehousesample-1.1.0-gem.zip"
 }


### PR DESCRIPTION
## What does this PR do?

This PR fixes multiple small issues found when testing simulation Gems before the `2409.2` point release, please see #822 for details.
- `cover_link` entity in `ROSbot` prefabs in `RosRobotSample` Gem are now linked to the `body_link` entity, which makes them move correctly
- meshes in prefabs in `RosRobotSample` Gem are now correctly defined in _assethints_ (hence some overrides could have been removed)
- meshes in prefabs in `WarehouseSample` Gem are now correctly defined in _assethints_
- `CMakeLists.txt` files of asset-only simulation Gems were regenerated using O3DE 2410.x to ensure there are no problems with linking (see #837 for details)

## How was this PR tested?

`ROS2ProjectTemplate` was built with the newest version of Gems and tested.
Tested using #841  against O3DE `9b8d468f64` _stabilization/25050_
