### PR TITLE
Fix of three minor bugs in Articulations in ROS 2 gem:

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameEditorComponent.h
@@ -74,6 +74,10 @@ namespace ROS2
         AZ::EntityId GetFrameParent() const override;
         AZStd::set<AZ::EntityId> GetFrameChildren() const override;
 
+
+        //! Get the configuration of this component.
+        ROS2FrameConfiguration GetConfiguration() const;
+
     private:
         AZ::Crc32 OnFrameConfigurationChange();
 

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -177,4 +177,9 @@ namespace ROS2
         gameEntity->CreateComponent<ROS2FrameComponent>(m_configuration);
     }
 
+    ROS2FrameConfiguration ROS2FrameEditorComponent::GetConfiguration() const
+    {
+        return m_configuration;
+    }
+
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Manipulation/JointsPositionsEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Manipulation/JointsPositionsEditorComponent.cpp
@@ -15,6 +15,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 #include <ROS2/Frame/ROS2FrameEditorComponent.h>
 #include <ROS2/Manipulation/JointsManipulationRequests.h>
@@ -25,7 +26,7 @@ namespace ROS2
     JointsPositionsEditorComponent::JointsPositionsEditorComponent()
     {
         m_topicConfiguration.m_type = "std_msgs::msg::Float64MultiArray";
-        m_topicConfiguration.m_topic = "/position_controller/commands";
+        m_topicConfiguration.m_topic = "position_controller/commands";
     }
 
     void JointsPositionsEditorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
@@ -77,6 +78,7 @@ namespace ROS2
 
     AZ::Crc32 JointsPositionsEditorComponent::FindAllJoints()
     {
+        AzToolsFramework::ScopedUndoBatch undo("FindAllJoints");
         m_jointNames.clear();
         AZStd::function<void(const AZ::Entity* entity)> getAllJointsHierarchy = [&](const AZ::Entity* entity)
         {
@@ -86,7 +88,7 @@ namespace ROS2
 
             const bool hasNonFixedJoints = JointUtils::HasNonFixedJoints(entity);
 
-            AZStd::string jointName(frameEditorComponent->GetJointName().GetCStr());
+            const AZStd::string jointName(frameEditorComponent->GetJointName().GetCStr());
             if (!jointName.empty() && hasNonFixedJoints)
             {
                 m_jointNames.emplace_back(jointName);
@@ -97,14 +99,15 @@ namespace ROS2
             {
                 for (const auto& entityId : childrenEntityIds)
                 {
-                    AZ::Entity* entity = nullptr;
-                    AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationBus::Events::FindEntity, entityId);
-                    getAllJointsHierarchy(entity);
+                    AZ::Entity* childEntity = nullptr;
+                    AZ::ComponentApplicationBus::BroadcastResult(childEntity, &AZ::ComponentApplicationBus::Events::FindEntity, entityId);
+                    AZ_Assert(childEntity, "Entity not found!");
+                    getAllJointsHierarchy(childEntity);
                 }
             }
         };
         getAllJointsHierarchy(GetEntity());
-
+        undo.MarkEntityDirty(GetEntity()->GetId());
         return AZ::Edit::PropertyRefreshLevels::EntireTree;
     }
 


### PR DESCRIPTION
## What does this PR do?

This PR  fixes few issues with articulation in ROS 2:
  - Invalid default for topic name for JointsPositionsEditorComponent
  - "Find all values" button gives correct values for : JointsManipulationEditorComponent, JointsPositionsEditorComponent
  - Add undo batch to trigger prefab modification.

## How was this PR tested?

- I've created articulation from scratch
- Added JointsManipulationEditorComponent and JointsPositionsEditorComponent
- Clicked "Find all values" for both components
- Saved prefab
- tested two components.
