### PR TITLE
Fix Georeferencing rename

### DIFF
--- a/Gems/LevelGeoreferencing/CMakeLists.txt
+++ b/Gems/LevelGeoreferencing/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-o3de_gem_setup("Georeferencing")
+o3de_gem_setup("LevelGeoreferencing")
 
 ly_add_external_target_path(${CMAKE_CURRENT_SOURCE_DIR}/3rdParty)
 

--- a/Gems/LevelGeoreferencing/Registry/assetprocessor_settings.setreg
+++ b/Gems/LevelGeoreferencing/Registry/assetprocessor_settings.setreg
@@ -3,12 +3,12 @@
         "AssetProcessor": {
             "Settings": {
                 "ScanFolder Georeferencing/Assets": {
-                    "watch": "@GEMROOT:Georeferencing@/Assets",
+                    "watch": "@GEMROOT:LevelGeoreferencing@/Assets",
                     "recursive": 1,
                     "order": 101
                 },
                 "ScanFolder Georeferencing/Registry": {
-                    "watch": "@GEMROOT:Georeferencing@/Registry",
+                    "watch": "@GEMROOT:LevelGeoreferencing@/Registry",
                     "recursive": 1,
                     "order": 102
                 }

--- a/Gems/LevelGeoreferencing/gem.json
+++ b/Gems/LevelGeoreferencing/gem.json
@@ -12,7 +12,7 @@
         "Gem"
     ],
     "user_tags": [
-        "Georeferencing"
+        "Georeferencing", "LevelGeoreferencing"
     ],
     "platforms": [
         ""
@@ -24,5 +24,5 @@
     "repo_uri": "",
     "compatible_engines": [],
     "engine_api_dependencies": [],
-    "restricted": "Georeferencing"
+    "restricted": "LevelGeoreferencing"
 }


### PR DESCRIPTION
## What does this PR do?

The `LevelGeoreferencing` Gem was first created as `Georeferencing` Gem and renamed afterward, but not all names were changed. This resulted in a warning printed in all projects using this Gem:

```
[Warning] (LocalFileIO::ResolveAlias) - Failed to resolve an alias: @GEMROOT:Georeferencing@/Assets
[Warning] (LocalFileIO::ResolveAlias) - Failed to resolve an alias: @GEMROOT:Georeferencing@/Registry
[Warning] (AssetDatabase) - Load time threshold exceeded: LoadAssetData call for translationassets/types/ondemandreflectedtypes.names took 162 ms to load 4010690 bytes (  0.0000 KB/s)
```

This warning was fixed by adding missing renames.

## How was this PR tested?

The project was built and no warning message can be seen. 
Tested against O3DE `9b8d468f64` _stabilization/25050_
