### PR TITLE
The `ROS2CameraSensorComponent` was reflected twice

### DIFF
--- a/Gems/ROS2/Code/Source/ROS2ModuleInterface.h
+++ b/Gems/ROS2/Code/Source/ROS2ModuleInterface.h
@@ -74,7 +74,6 @@ namespace ROS2
                     ROS2WheelOdometryComponent::CreateDescriptor(),
                     ROS2FrameComponent::CreateDescriptor(),
                     ROS2RobotControlComponent::CreateDescriptor(),
-                    ROS2CameraSensorComponent::CreateDescriptor(),
                     ROS2ImageEncodingConversionComponent::CreateDescriptor(),
                     AckermannControlComponent::CreateDescriptor(),
                     RigidBodyTwistControlComponent::CreateDescriptor(),


### PR DESCRIPTION
## What does this PR do?

Fixes double-free style error in ROS 2 Gem.
This is imprtant since:
- prevent unloaind of ROS2 Gem in gem test environment,
- It triggered UB on app exit.

This bug-fix part of other PR (to development):
https://github.com/o3de/o3de-extras/pull/852
## How was this PR tested?

I've fixed issue working on on other branch - it allowed to load and unload ROS 2 in test environment. 

It closes without any breakpoints, asserts, errors with '-rhi=null'.

**Note**
Built application still experience UB from Vulkan, this PR won't fix it.
```
System: Trace::Assert
 /home/michalpelka/github_develop/o3de/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h(142): (130870476277312) 'void AZ::Vulkan::AssertSuccess(VkResult)'
System: ASSERT: Vulkan API method failed: Device lost
System: ------------------------------------------------
System:  -- error: unable to obtain symbol name for this frame
System:  -- error: unable to obtain symbol name for this frame
System:  -- error: unable to obtain symbol name for this frame
System:  -- error: unable to obtain symbol name for this frame
System:  -- error: unable to obtain symbol name for this frame
System:  -- error: unable to obtain symbol name for this frame
System: pthread_condattr_setpshared (+0x513) [0x770726294ac3]
System: __xmknodat (+0x230) [0x770726326850]
System: ==================================================================
System: ====Assert added to ignore list by spec and verbosity setting.====
InstanceDatabase: 
==================================================================

```