### PR TITLE
Added `get_simulation_features` to SimulationInterfaces and SimulationInterfacesROS2

### DIFF
--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationFeatures.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationFeatures.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/base.h>
+namespace SimulationInterfaces
+{
+
+    //! Simulation Features copied from the simulation_interfaces
+    //! to avoid ros2 dependency
+    //! @see https://github.com/ros-simulation/simulation_interfaces/blob/main/msg/SimulatorFeatures.msg
+    enum class SimulationFeatures : AZ::u8
+    {
+        SPAWNING = 0,
+        DELETING = 1,
+        NAMED_POSES = 2,
+        POSE_BOUNDS = 3,
+        ENTITY_TAGS = 4,
+        ENTITY_BOUNDS = 5,
+        ENTITY_BOUNDS_BOX = 6,
+        ENTITY_BOUNDS_CONVEX = 7,
+        ENTITY_CATEGORIES = 8,
+        SPAWNING_RESOURCE_STRING = 9,
+        ENTITY_STATE_GETTING = 10,
+        ENTITY_STATE_SETTING = 11,
+        ENTITY_INFO_GETTING = 12,
+        ENTITY_INFO_SETTING = 13,
+        SPAWNABLES = 14,
+        SIMULATION_RESET = 20,
+        SIMULATION_RESET_TIME = 21,
+        SIMULATION_RESET_STATE = 22,
+        SIMULATION_RESET_SPAWNED = 23,
+        SIMULATION_STATE_GETTING = 24,
+        SIMULATION_STATE_SETTING = 25,
+        SIMULATION_STATE_PAUSE = 26,
+        STEP_SIMULATION_SINGLE = 31,
+        STEP_SIMULATION_MULTIPLE = 32,
+        STEP_SIMULATION_ACTION = 33
+    };
+} // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationFeaturesAggregatorRequestBus.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationFeaturesAggregatorRequestBus.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <SimulationInterfaces/SimulationInterfacesTypeIds.h>
+
+#include "SimulationFeatures.h"
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzFramework/Physics/ShapeConfiguration.h>
+
+namespace SimulationInterfaces
+{
+
+    class SimulationFeaturesAggregatorRequests
+    {
+    public:
+        AZ_RTTI(SimulationFeaturesAggregatorRequests, SimulationFeaturesAggregatorRequestsTypeId);
+        virtual ~SimulationFeaturesAggregatorRequests() = default;
+
+        //! Registers simulation features defined by caller
+        virtual void AddSimulationFeatures(AZStd::unordered_set<SimulationFeatures> features) = 0;
+
+        //! Returns features available in the simulator, list follows definitions at
+        //! @see https://github.com/ros-simulation/simulation_interfaces/blob/main/msg/SimulatorFeatures.msg
+        virtual AZStd::unordered_set<SimulationFeatures> GetSimulationFeatures() = 0;
+    };
+
+    class SimulationFeaturesAggregatorRequestBusTraits : public AZ::EBusTraits
+    {
+    public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        //////////////////////////////////////////////////////////////////////////
+    };
+
+    using SimulationFeaturesAggregatorRequestBus =
+        AZ::EBus<SimulationFeaturesAggregatorRequests, SimulationFeaturesAggregatorRequestBusTraits>;
+    using SimulationFeaturesAggregatorRequestBusInterface = AZ::Interface<SimulationFeaturesAggregatorRequests>;
+
+} // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationInterfacesTypeIds.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationInterfacesTypeIds.h
@@ -17,6 +17,9 @@ namespace SimulationInterfaces
     inline constexpr const char* SimulationManagerTypeId = "{5BB34EB0-1263-4DA1-A35C-CE613A088F4B}";
     inline constexpr const char* SimulationManagerEditorTypeId = "{2CC8D67B-CFD3-4E89-AAF0-8935640B51C1}";
 
+    inline constexpr const char* SimulationFeaturesAggregatorTypeId = "{5c5ae765-1776-4ba0-8e32-b66c8f4edafe}";
+    inline constexpr const char* SimulationFeaturesAggregatorEditorTypeId = "{504a86ef-df0a-45ec-b69d-315ff4ec8121}";
+
     // Module derived classes TypeIds
     inline constexpr const char* SimulationInterfacesModuleInterfaceTypeId = "{675797BF-E5D5-438A-BF86-4B4554F09CEF}";
     inline constexpr const char* SimulationInterfacesModuleTypeId = "{8D6741FD-3105-4CB0-9700-152123B6D135}";
@@ -27,5 +30,6 @@ namespace SimulationInterfaces
     // Interface TypeIds
     inline constexpr const char* SimulationInterfacesRequestsTypeId = "{6818E5E3-BBF5-41BD-96BB-7AF57CCC7528}";
     inline constexpr const char* SimulationManagerRequestsTypeId = "{056477BA-8153-4901-9401-0146A5E3E9ED}";
+    inline constexpr const char* SimulationFeaturesAggregatorRequestsTypeId = "{099fd08b-b0e2-4705-9c35-cc09c8e45076}";
 
 } // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationFeaturesAggregator.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationFeaturesAggregator.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SimulationFeaturesAggregator.h"
+
+#include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Physics/PhysicsSystem.h>
+#include <SimulationInterfaces/SimulationInterfacesTypeIds.h>
+
+namespace SimulationInterfaces
+{
+
+    AZ_COMPONENT_IMPL(SimulationFeaturesAggregator, "SimulationFeaturesAggregator", SimulationFeaturesAggregatorTypeId);
+
+    void SimulationFeaturesAggregator::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<SimulationFeaturesAggregator, AZ::Component>()->Version(0);
+        }
+    }
+
+    void SimulationFeaturesAggregator::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        provided.push_back(AZ_CRC_CE("SimulationFeaturesAggregator"));
+    }
+
+    void SimulationFeaturesAggregator::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("SimulationFeaturesAggregator"));
+    }
+
+    void SimulationFeaturesAggregator::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+    }
+
+    void SimulationFeaturesAggregator::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+    }
+
+    SimulationFeaturesAggregator::SimulationFeaturesAggregator()
+    {
+        if (SimulationFeaturesAggregatorRequestBusInterface::Get() == nullptr)
+        {
+            SimulationFeaturesAggregatorRequestBusInterface::Register(this);
+        }
+    }
+
+    SimulationFeaturesAggregator::~SimulationFeaturesAggregator()
+    {
+        if (SimulationFeaturesAggregatorRequestBusInterface::Get() == this)
+        {
+            SimulationFeaturesAggregatorRequestBusInterface::Unregister(this);
+        }
+    }
+
+    void SimulationFeaturesAggregator::Init()
+    {
+    }
+
+    void SimulationFeaturesAggregator::Activate()
+    {
+        SimulationFeaturesAggregatorRequestBus::Handler::BusConnect();
+    }
+
+    void SimulationFeaturesAggregator::Deactivate()
+    {
+        SimulationFeaturesAggregatorRequestBus::Handler::BusDisconnect();
+    }
+
+    void SimulationFeaturesAggregator::AddSimulationFeatures(AZStd::unordered_set<SimulationFeatures> features)
+    {
+        m_registeredFeatures.insert(features.begin(), features.end());
+    }
+    AZStd::unordered_set<SimulationFeatures> SimulationFeaturesAggregator::GetSimulationFeatures()
+    {
+        return m_registeredFeatures;
+    }
+
+} // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationFeaturesAggregator.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationFeaturesAggregator.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzCore/Script/ScriptTimePoint.h>
+#include <AzFramework/Entity/EntityContextBus.h>
+#include <AzFramework/Physics/PhysicsScene.h>
+#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+#include <SimulationInterfaces/SimulationEntityManagerRequestBus.h>
+#include <SimulationInterfaces/SimulationFeaturesAggregatorRequestBus.h>
+#include <SimulationInterfaces/SimulationMangerRequestBus.h>
+namespace SimulationInterfaces
+{
+    class SimulationFeaturesAggregator
+        : public AZ::Component
+        , protected SimulationFeaturesAggregatorRequestBus::Handler
+    {
+    public:
+        AZ_COMPONENT_DECL(SimulationFeaturesAggregator);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+        SimulationFeaturesAggregator();
+        ~SimulationFeaturesAggregator();
+
+        // AZ::Component
+        void Init() override;
+        void Activate() override;
+        void Deactivate() override;
+
+    protected:
+        // SimulationFeaturesAggregatorRequestBus overrides
+        void AddSimulationFeatures(AZStd::unordered_set<SimulationFeatures> features) override;
+        AZStd::unordered_set<SimulationFeatures> GetSimulationFeatures() override;
+
+    private:
+        AZStd::unordered_set<SimulationFeatures> m_registeredFeatures;
+    };
+} // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.cpp
@@ -7,10 +7,12 @@
  */
 
 #include "SimulationManager.h"
+#include "SimulationInterfaces/SimulationFeatures.h"
 
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
+#include <SimulationInterfaces/SimulationFeaturesAggregatorRequestBus.h>
 #include <SimulationInterfaces/SimulationInterfacesTypeIds.h>
 
 namespace SimulationInterfaces
@@ -39,10 +41,12 @@ namespace SimulationInterfaces
     void SimulationManager::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC_CE("PhysicsService"));
+        required.push_back(AZ_CRC_CE("SimulationFeaturesAggregator"));
     }
 
     void SimulationManager::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
     {
+        dependent.push_back(AZ_CRC_CE("SimulationFeaturesAggregator"));
     }
 
     SimulationManager::SimulationManager()
@@ -68,6 +72,12 @@ namespace SimulationInterfaces
     void SimulationManager::Activate()
     {
         SimulationManagerRequestBus::Handler::BusConnect();
+        SimulationFeaturesAggregatorRequestBus::Broadcast(
+            &SimulationFeaturesAggregatorRequests::AddSimulationFeatures,
+            AZStd::unordered_set<SimulationFeatures>{ SimulationFeatures::SIMULATION_STATE_PAUSE,
+                                                      SimulationFeatures::STEP_SIMULATION_SINGLE,
+                                                      SimulationFeatures::STEP_SIMULATION_MULTIPLE,
+                                                      SimulationFeatures::STEP_SIMULATION_ACTION });
     }
 
     void SimulationManager::Deactivate()

--- a/Gems/SimulationInterfaces/Code/Source/SimulationInterfacesModuleInterface.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/SimulationInterfacesModuleInterface.cpp
@@ -11,7 +11,8 @@
 
 #include <SimulationInterfaces/SimulationInterfacesTypeIds.h>
 
-#include <Clients/SimulationManager.h>
+#include "Clients/SimulationFeaturesAggregator.h"
+#include "Clients/SimulationManager.h"
 #include <Clients/SimulationEntitiesManager.h>
 
 namespace SimulationInterfaces
@@ -28,6 +29,7 @@ namespace SimulationInterfaces
             {
                 SimulationEntitiesManager::CreateDescriptor(),
                 SimulationManager::CreateDescriptor(),
+                SimulationFeaturesAggregator::CreateDescriptor(),
             });
     }
 
@@ -36,6 +38,7 @@ namespace SimulationInterfaces
         return AZ::ComponentTypeList{
             azrtti_typeid<SimulationEntitiesManager>(),
             azrtti_typeid<SimulationManager>(),
+            azrtti_typeid<SimulationFeaturesAggregator>(),
         };
     }
 } // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Tools/SimulationEntitiesManagerEditor.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Tools/SimulationEntitiesManagerEditor.cpp
@@ -43,11 +43,13 @@ namespace SimulationInterfaces
     void SimulationEntitiesManagerEditor::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         BaseSystemComponent::GetRequiredServices(required);
+        required.push_back(AZ_CRC_CE("SimulationFeaturesAggregatorEditorService"));
     }
 
     void SimulationEntitiesManagerEditor::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
     {
         BaseSystemComponent::GetDependentServices(dependent);
+        dependent.push_back(AZ_CRC_CE("SimulationFeaturesAggregatorEditorService"));
     }
 
     void SimulationEntitiesManagerEditor::Activate()

--- a/Gems/SimulationInterfaces/Code/Source/Tools/SimulationFeaturesAggregatorEditor.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Tools/SimulationFeaturesAggregatorEditor.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SimulationFeaturesAggregatorEditor.h"
+#include <AzCore/Serialization/SerializeContext.h>
+
+#include <SimulationInterfaces/SimulationInterfacesTypeIds.h>
+
+namespace SimulationInterfaces
+{
+    AZ_COMPONENT_IMPL(
+        SimulationFeaturesAggregatorEditor, "SimulationMangerEditor", SimulationFeaturesAggregatorEditorTypeId, BaseSystemComponent);
+
+    void SimulationFeaturesAggregatorEditor::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<SimulationFeaturesAggregatorEditor, SimulationFeaturesAggregator>()->Version(0);
+        }
+    }
+
+    SimulationFeaturesAggregatorEditor::SimulationFeaturesAggregatorEditor() = default;
+
+    SimulationFeaturesAggregatorEditor::~SimulationFeaturesAggregatorEditor() = default;
+
+    void SimulationFeaturesAggregatorEditor::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    {
+        BaseSystemComponent::GetProvidedServices(provided);
+        provided.push_back(AZ_CRC_CE("SimulationFeaturesAggregatorEditorService"));
+    }
+
+    void SimulationFeaturesAggregatorEditor::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        BaseSystemComponent::GetIncompatibleServices(incompatible);
+        incompatible.push_back(AZ_CRC_CE("SimulationFeaturesAggregatorEditorService"));
+    }
+
+    void SimulationFeaturesAggregatorEditor::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        BaseSystemComponent::GetRequiredServices(required);
+    }
+
+    void SimulationFeaturesAggregatorEditor::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
+    {
+        BaseSystemComponent::GetDependentServices(dependent);
+    }
+    void SimulationFeaturesAggregatorEditor::Init()
+    {
+        BaseSystemComponent::Init();
+    }
+
+    void SimulationFeaturesAggregatorEditor::Activate()
+    {
+        BaseSystemComponent::Activate();
+        AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
+    }
+
+    void SimulationFeaturesAggregatorEditor::Deactivate()
+    {
+        AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect();
+        BaseSystemComponent::Deactivate();
+    }
+
+} // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Tools/SimulationFeaturesAggregatorEditor.h
+++ b/Gems/SimulationInterfaces/Code/Source/Tools/SimulationFeaturesAggregatorEditor.h
@@ -10,26 +10,24 @@
 
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 
-#include <AzToolsFramework/Entity/EditorEntityContextBus.h>
-#include <Clients/SimulationInterfacesROS2SystemComponent.h>
-#include <ROS2/ROS2Bus.h>
+#include <Clients/SimulationFeaturesAggregator.h>
 
-namespace SimulationInterfacesROS2
+namespace SimulationInterfaces
 {
-    /// System component for SimulationInterfacesROS2 editor
-    class SimulationInterfacesROS2EditorSystemComponent
-        : public SimulationInterfacesROS2SystemComponent
+    /// System component for SimulationInterfaces editor
+    class SimulationFeaturesAggregatorEditor
+        : public SimulationFeaturesAggregator
         , protected AzToolsFramework::EditorEvents::Bus::Handler
     {
-        using BaseSystemComponent = SimulationInterfacesROS2SystemComponent;
+        using BaseSystemComponent = SimulationFeaturesAggregator;
 
     public:
-        AZ_COMPONENT_DECL(SimulationInterfacesROS2EditorSystemComponent);
+        AZ_COMPONENT_DECL(SimulationFeaturesAggregatorEditor);
 
         static void Reflect(AZ::ReflectContext* context);
 
-        SimulationInterfacesROS2EditorSystemComponent();
-        ~SimulationInterfacesROS2EditorSystemComponent();
+        SimulationFeaturesAggregatorEditor();
+        ~SimulationFeaturesAggregatorEditor();
 
     private:
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
@@ -38,10 +36,8 @@ namespace SimulationInterfacesROS2
         static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
 
         // AZ::Component
+        void Init() override;
         void Activate() override;
         void Deactivate() override;
-
-        bool m_systemComponentActivated = false;
-        ROS2::ROS2Requests::NodeChangedEvent::Handler m_nodeHandler;
     };
-} // namespace SimulationInterfacesROS2
+} // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Tools/SimulationInterfacesEditorModule.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Tools/SimulationInterfacesEditorModule.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "SimulationEntitiesManagerEditor.h"
+#include "SimulationFeaturesAggregatorEditor.h"
 #include "SimulationManagerEditor.h"
 #include <SimulationInterfaces/SimulationInterfacesTypeIds.h>
 #include <SimulationInterfacesModuleInterface.h>
@@ -25,6 +26,7 @@ namespace SimulationInterfaces
                 {
                     SimulationEntitiesManagerEditor::CreateDescriptor(),
                     SimulationManagerEditor::CreateDescriptor(),
+                    SimulationFeaturesAggregatorEditor::CreateDescriptor(),
                 });
         }
 
@@ -36,6 +38,7 @@ namespace SimulationInterfaces
         {
             return AZ::ComponentTypeList{
                 azrtti_typeid<SimulationEntitiesManagerEditor>(),
+                azrtti_typeid<SimulationFeaturesAggregatorEditor>(),
             };
         }
     };

--- a/Gems/SimulationInterfaces/Code/Source/Tools/SimulationManagerEditor.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Tools/SimulationManagerEditor.cpp
@@ -42,11 +42,13 @@ namespace SimulationInterfaces
     void SimulationManagerEditor::GetRequiredServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         BaseSystemComponent::GetRequiredServices(required);
+        required.push_back(AZ_CRC_CE("SimulationFeaturesAggregatorEditorService"));
     }
 
     void SimulationManagerEditor::GetDependentServices([[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& dependent)
     {
         BaseSystemComponent::GetDependentServices(dependent);
+        dependent.push_back(AZ_CRC_CE("SimulationFeaturesAggregatorEditorService"));
     }
     void SimulationManagerEditor::Init()
     {

--- a/Gems/SimulationInterfaces/Code/simulationinterfaces_api_files.cmake
+++ b/Gems/SimulationInterfaces/Code/simulationinterfaces_api_files.cmake
@@ -10,4 +10,6 @@ set(FILES
     Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
     Include/SimulationInterfaces/SimulationInterfacesTypeIds.h
     Include/SimulationInterfaces/SimulationMangerRequestBus.h
+    Include/SimulationInterfaces/SimulationFeaturesAggregatorRequestBus.h
+    Include/SimulationInterfaces/SimulationFeatures.h
 )

--- a/Gems/SimulationInterfaces/Code/simulationinterfaces_editor_private_files.cmake
+++ b/Gems/SimulationInterfaces/Code/simulationinterfaces_editor_private_files.cmake
@@ -9,4 +9,6 @@ set(FILES
         Source/Tools/SimulationManagerEditor.h
         Source/Tools/SimulationEntitiesManagerEditor.cpp
         Source/Tools/SimulationEntitiesManagerEditor.h
+        Source/Tools/SimulationFeaturesAggregatorEditor.cpp
+        Source/Tools/SimulationFeaturesAggregatorEditor.h
 )

--- a/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
+++ b/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
@@ -13,4 +13,6 @@ set(FILES
     Source/Clients/SimulationEntitiesManager.h
     Source/Clients/CommonUtilities.cpp
     Source/Clients/CommonUtilities.h
+    Source/Clients/SimulationFeaturesAggregator.cpp
+    Source/Clients/SimulationFeaturesAggregator.h
 )

--- a/Gems/SimulationInterfacesROS2/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfacesROS2/Code/CMakeLists.txt
@@ -139,6 +139,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
+                Gem::ROS2.API
                 ${gem_name}.Private.Object
     )
 

--- a/Gems/SimulationInterfacesROS2/Code/Include/SimulationInterfacesROS2/SimulationInterfacesROS2RequestBus.h
+++ b/Gems/SimulationInterfacesROS2/Code/Include/SimulationInterfacesROS2/SimulationInterfacesROS2RequestBus.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <SimulationInterfacesROS2/SimulationInterfacesROS2TypeIds.h>
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/std/containers/unordered_set.h>
+
+namespace SimulationInterfacesROS2
+{
+    class SimulationInterfacesROS2Requests
+    {
+    public:
+        AZ_RTTI(SimulationInterfacesROS2Requests, SimulationInterfacesROS2RequestBusTypeId);
+        virtual ~SimulationInterfacesROS2Requests() = default;
+
+        //! Returns set of simulation features available in SimulationInterfacesROS2 Gem
+        //! SimulationFeatures follows definition available at:
+        //! @see https://github.com/ros-simulation/simulation_interfaces/blob/main/msg/SimulatorFeatures.msg
+        virtual AZStd::unordered_set<AZ::u8> GetSimulationFeatures() = 0;
+    };
+
+    class SimulationInterfacesROS2RequestBusTraits : public AZ::EBusTraits
+    {
+    public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        //////////////////////////////////////////////////////////////////////////
+    };
+
+    using SimulationInterfacesROS2RequestBus = AZ::EBus<SimulationInterfacesROS2Requests, SimulationInterfacesROS2RequestBusTraits>;
+    using SimulationInterfacesROS2RequestBusInterface = AZ::Interface<SimulationInterfacesROS2Requests>;
+
+} // namespace SimulationInterfacesROS2

--- a/Gems/SimulationInterfacesROS2/Code/Include/SimulationInterfacesROS2/SimulationInterfacesROS2TypeIds.h
+++ b/Gems/SimulationInterfacesROS2/Code/Include/SimulationInterfacesROS2/SimulationInterfacesROS2TypeIds.h
@@ -20,4 +20,7 @@ namespace SimulationInterfacesROS2
     // The Editor Module by default is mutually exclusive with the Client Module
     // so they use the Same TypeId
     inline constexpr const char* SimulationInterfacesROS2EditorModuleTypeId = SimulationInterfacesROS2ModuleTypeId;
+
+    // API TypeIds
+    inline constexpr const char* SimulationInterfacesROS2RequestBusTypeId = "{00d08870-e329-4bd7-bb8c-f67fe369de92}";
 } // namespace SimulationInterfacesROS2

--- a/Gems/SimulationInterfacesROS2/Code/Source/Clients/SimulationInterfacesROS2SystemComponent.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Clients/SimulationInterfacesROS2SystemComponent.cpp
@@ -60,6 +60,7 @@ namespace SimulationInterfacesROS2
     void SimulationInterfacesROS2SystemComponent::GetRequiredServices(
         [[maybe_unused]] AZ::ComponentDescriptor::DependencyArrayType& required)
     {
+        required.push_back(AZ_CRC_CE("ROS2Service"));
     }
 
     void SimulationInterfacesROS2SystemComponent::GetDependentServices(

--- a/Gems/SimulationInterfacesROS2/Code/Source/Clients/SimulationInterfacesROS2SystemComponent.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Clients/SimulationInterfacesROS2SystemComponent.cpp
@@ -9,15 +9,33 @@
 #include "SimulationInterfacesROS2SystemComponent.h"
 #include "SimulationInterfacesROS2/SimulationInterfacesROS2RequestBus.h"
 #include "Utils/ServicesConfig.h"
+#include <AzCore/std/string/string.h>
 
 #include <ROS2/ROS2Bus.h>
 #include <SimulationInterfacesROS2/SimulationInterfacesROS2TypeIds.h>
 
+#include "Utils/RegistryUtils.h"
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 
 namespace SimulationInterfacesROS2
 {
+
+    namespace
+    {
+        template<typename T>
+        void RegisterInterface(
+            AZStd::unordered_map<AZStd::string, AZStd::shared_ptr<ROS2HandlerBase>>& interfacesMap,
+            rclcpp::Node::SharedPtr ros2Node,
+            AZStd::string serviceType,
+            AZStd::string defaultName)
+        {
+            // add all known/implemented interfaces
+            auto serviceName = RegistryUtilities::GetServiceName(serviceType);
+            interfacesMap[serviceType] = AZStd::make_shared<T>(ros2Node, serviceName.empty() ? defaultName : serviceName);
+        };
+    } // namespace
+
     AZ_COMPONENT_IMPL(
         SimulationInterfacesROS2SystemComponent, "SimulationInterfacesROS2SystemComponent", SimulationInterfacesROS2SystemComponentTypeId);
 
@@ -59,30 +77,36 @@ namespace SimulationInterfacesROS2
 
         rclcpp::Node::SharedPtr ros2Node = rclcpp::Node::SharedPtr(ROS2::ROS2Interface::Get()->GetNode());
         AZ_Assert(ros2Node, "ROS2 node is not available.");
-        // add all known/implemented interfaces
-        m_availableRos2Interface[DeleteEntityService] =
-            AZStd::make_shared<DeleteEntityServiceHandler>(ros2Node, DeleteEntityServiceDefaultName);
 
-        m_availableRos2Interface[GetEntitiesService] =
-            AZStd::make_shared<GetEntitiesServiceHandler>(ros2Node, GetEntitiesServiceDefaultName);
+        RegisterInterface<DeleteEntityServiceHandler>(
+            m_availableRos2Interface, ros2Node, AZStd::string(DeleteEntityService), AZStd::string(DeleteEntityServiceDefaultName));
 
-        m_availableRos2Interface[GetEntitiesStatesService] =
-            AZStd::make_shared<GetEntitiesStatesServiceHandler>(ros2Node, GetEntitiesStatesServiceDefaultName);
+        RegisterInterface<GetEntitiesServiceHandler>(
+            m_availableRos2Interface, ros2Node, AZStd::string(GetEntitiesService), AZStd::string(GetEntitiesServiceDefaultName));
 
-        m_availableRos2Interface[GetEntityStateService] =
-            AZStd::make_shared<GetEntityStateServiceHandler>(ros2Node, GetEntityStateServiceDefaultName);
+        RegisterInterface<GetEntitiesStatesServiceHandler>(
+            m_availableRos2Interface,
+            ros2Node,
+            AZStd::string(GetEntitiesStatesService),
+            AZStd::string(GetEntitiesStatesServiceDefaultName));
 
-        m_availableRos2Interface[GetSpawnablesService] =
-            AZStd::make_shared<GetSpawnablesServiceHandler>(ros2Node, GetSpawnablesServiceDefaultName);
+        RegisterInterface<GetEntityStateServiceHandler>(
+            m_availableRos2Interface, ros2Node, AZStd::string(GetEntityStateService), AZStd::string(GetEntityStateServiceDefaultName));
 
-        m_availableRos2Interface[SetEntityStateService] =
-            AZStd::make_shared<SetEntityStateServiceHandler>(ros2Node, SetEntityStateServiceDefaultName);
+        RegisterInterface<GetSpawnablesServiceHandler>(
+            m_availableRos2Interface, ros2Node, AZStd::string(GetSpawnablesService), AZStd::string(GetSpawnablesServiceDefaultName));
 
-        m_availableRos2Interface[SpawnEntityService] =
-            AZStd::make_shared<SpawnEntityServiceHandler>(ros2Node, SpawnEntityServiceDefaultName);
+        RegisterInterface<SetEntityStateServiceHandler>(
+            m_availableRos2Interface, ros2Node, AZStd::string(SetEntityStateService), AZStd::string(SetEntityStateServiceDefaultName));
 
-        m_availableRos2Interface[GetSimulationFeaturesService] =
-            AZStd::make_shared<GetSimulationFeaturesServiceHandler>(ros2Node, GetSimulationFeaturesServiceDefaultName);
+        RegisterInterface<SpawnEntityServiceHandler>(
+            m_availableRos2Interface, ros2Node, AZStd::string(SpawnEntityService), AZStd::string(SpawnEntityServiceDefaultName));
+
+        RegisterInterface<GetSimulationFeaturesServiceHandler>(
+            m_availableRos2Interface,
+            ros2Node,
+            AZStd::string(GetSimulationFeaturesService),
+            AZStd::string(GetSimulationFeaturesServiceDefaultName));
     }
 
     void SimulationInterfacesROS2SystemComponent::Deactivate()

--- a/Gems/SimulationInterfacesROS2/Code/Source/Clients/SimulationInterfacesROS2SystemComponent.h
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Clients/SimulationInterfacesROS2SystemComponent.h
@@ -11,20 +11,29 @@
 #include <AzCore/Component/Component.h>
 #include <AzFramework/API/ApplicationAPI.h>
 
+#include "AzCore/std/smart_ptr/shared_ptr.h"
 #include "Services/DeleteEntityServiceHandler.h"
 #include "Services/GetEntitiesServiceHandler.h"
 #include "Services/GetEntitiesStatesServiceHandler.h"
 #include "Services/GetEntityStateServiceHandler.h"
+#include "Services/GetSimulationFeaturesServiceHandler.h"
 #include "Services/GetSpawnablesServiceHandler.h"
+#include "Services/ROS2HandlerBaseClass.h"
 #include "Services/SetEntityStateServiceHandler.h"
 #include "Services/SpawnEntityServiceHandler.h"
+#include "SimulationInterfacesROS2/SimulationInterfacesROS2RequestBus.h"
 #include "Utils/ServicesConfig.h"
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/optional.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/string/string.h>
 
 namespace SimulationInterfacesROS2
 {
     class SimulationInterfacesROS2SystemComponent
         : public AZ::Component
         , public AzFramework::LevelSystemLifecycleNotificationBus::Handler
+        , public SimulationInterfacesROS2RequestBus::Handler
     {
     public:
         AZ_COMPONENT_DECL(SimulationInterfacesROS2SystemComponent);
@@ -45,18 +54,14 @@ namespace SimulationInterfacesROS2
         void Activate() override;
         void Deactivate() override;
 
+        AZStd::unordered_set<AZ::u8> GetSimulationFeatures() override;
+
     private:
         // LevelSystemLifecycleNotificationBus::Handler overrides
         void OnLoadingComplete([[maybe_unused]] const char* levelName) override;
         void OnUnloadComplete([[maybe_unused]] const char* levelName) override;
 
-        AZStd::optional<DeleteEntityServiceHandler> m_deleteEntityServiceHandler;
-        AZStd::optional<GetEntitiesServiceHandler> m_getEntitiesServiceHandler;
-        AZStd::optional<GetEntitiesStatesServiceHandler> m_getEntitiesStatesServiceHandler;
-        AZStd::optional<GetEntityStateServiceHandler> m_getEntityStateServiceHandler;
-        AZStd::optional<GetSpawnablesServiceHandler> m_getSpawnablesServiceHandler;
-        AZStd::optional<SetEntityStateServiceHandler> m_setEntityStateServiceHandler;
-        AZStd::optional<SpawnEntityServiceHandler> m_spawnEntityServiceHandler;
+        AZStd::unordered_map<AZStd::string, AZStd::shared_ptr<ROS2HandlerBase>> m_availableRos2Interface;
     };
 
 } // namespace SimulationInterfacesROS2

--- a/Gems/SimulationInterfacesROS2/Code/Source/Clients/SimulationInterfacesROS2SystemComponent.h
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Clients/SimulationInterfacesROS2SystemComponent.h
@@ -11,7 +11,6 @@
 #include <AzCore/Component/Component.h>
 #include <AzFramework/API/ApplicationAPI.h>
 
-#include "AzCore/std/smart_ptr/shared_ptr.h"
 #include "Services/DeleteEntityServiceHandler.h"
 #include "Services/GetEntitiesServiceHandler.h"
 #include "Services/GetEntitiesStatesServiceHandler.h"
@@ -32,7 +31,6 @@ namespace SimulationInterfacesROS2
 {
     class SimulationInterfacesROS2SystemComponent
         : public AZ::Component
-        , public AzFramework::LevelSystemLifecycleNotificationBus::Handler
         , public SimulationInterfacesROS2RequestBus::Handler
     {
     public:
@@ -54,13 +52,10 @@ namespace SimulationInterfacesROS2
         void Activate() override;
         void Deactivate() override;
 
+        // SimulationInterfacesROS2RequestBus override
         AZStd::unordered_set<AZ::u8> GetSimulationFeatures() override;
 
     private:
-        // LevelSystemLifecycleNotificationBus::Handler overrides
-        void OnLoadingComplete([[maybe_unused]] const char* levelName) override;
-        void OnUnloadComplete([[maybe_unused]] const char* levelName) override;
-
         AZStd::unordered_map<AZStd::string, AZStd::shared_ptr<ROS2HandlerBase>> m_availableRos2Interface;
     };
 

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/DeleteEntityServiceHandler.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/DeleteEntityServiceHandler.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "DeleteEntityServiceHandler.h"
+#include "AzCore/Debug/Trace.h"
 #include <AzCore/std/string/string.h>
 #include <SimulationInterfaces/SimulationEntityManagerRequestBus.h>
 
@@ -30,6 +31,10 @@ namespace SimulationInterfacesROS2
         {
             m_deleteEntityService.reset();
         }
+    }
+    AZStd::unordered_set<AZ::u8> DeleteEntityServiceHandler::GetProvidedFeatures()
+    {
+        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::DELETING };
     }
 
     void DeleteEntityServiceHandler::HandleServiceRequest(

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/DeleteEntityServiceHandler.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/DeleteEntityServiceHandler.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "DeleteEntityServiceHandler.h"
-#include "AzCore/Debug/Trace.h"
 #include <AzCore/std/string/string.h>
 #include <SimulationInterfaces/SimulationEntityManagerRequestBus.h>
 

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/DeleteEntityServiceHandler.h
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/DeleteEntityServiceHandler.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Services/ROS2HandlerBaseClass.h"
 #include <AzCore/std/string/string_view.h>
 #include <rclcpp/rclcpp.hpp>
 #include <simulation_interfaces/srv/delete_entity.hpp>
@@ -15,7 +16,7 @@
 namespace SimulationInterfacesROS2
 {
 
-    class DeleteEntityServiceHandler
+    class DeleteEntityServiceHandler : public ROS2HandlerBase
     {
     public:
         using ServiceType = simulation_interfaces::srv::DeleteEntity;
@@ -26,7 +27,7 @@ namespace SimulationInterfacesROS2
         DeleteEntityServiceHandler() = delete;
         DeleteEntityServiceHandler(rclcpp::Node::SharedPtr& node, AZStd::string_view serviceName);
         ~DeleteEntityServiceHandler();
-
+        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
         void HandleServiceRequest(
             const ServiceHandle service_handle, const std::shared_ptr<rmw_request_id_t> header, const std::shared_ptr<Request> request);
 

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/GetEntitiesServiceHandler.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/GetEntitiesServiceHandler.cpp
@@ -32,6 +32,14 @@ namespace SimulationInterfacesROS2
         }
     }
 
+    AZStd::unordered_set<AZ::u8> GetEntitiesServiceHandler::GetProvidedFeatures()
+    {
+        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::ENTITY_TAGS,
+                                             SimulationFeatures::ENTITY_BOUNDS_BOX,
+                                             SimulationFeatures::ENTITY_BOUNDS_CONVEX,
+                                             SimulationFeatures::ENTITY_CATEGORIES };
+    }
+
     GetEntitiesServiceHandler::Response GetEntitiesServiceHandler::HandleServiceRequest(const Request& request)
     {
         AZ::Outcome<SimulationInterfaces::EntityNameList, SimulationInterfaces::FailedResult> outcome;

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/GetEntitiesStatesServiceHandler.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/GetEntitiesStatesServiceHandler.cpp
@@ -34,6 +34,15 @@ namespace SimulationInterfacesROS2
         }
     }
 
+    AZStd::unordered_set<AZ::u8> GetEntitiesStatesServiceHandler::GetProvidedFeatures()
+    {
+        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::ENTITY_TAGS,
+                                             SimulationFeatures::ENTITY_BOUNDS_BOX,
+                                             SimulationFeatures::ENTITY_BOUNDS_CONVEX,
+                                             SimulationFeatures::ENTITY_CATEGORIES,
+                                             SimulationFeatures::ENTITY_STATE_GETTING };
+    }
+
     GetEntitiesStatesServiceHandler::Response GetEntitiesStatesServiceHandler::HandleServiceRequest(const Request& request)
     {
         AZ::Outcome<SimulationInterfaces::MultipleEntitiesStates, SimulationInterfaces::FailedResult> outcome;

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/GetEntitiesStatesServiceHandler.h
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/GetEntitiesStatesServiceHandler.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Services/ROS2HandlerBaseClass.h"
 #include <AzCore/std/string/string_view.h>
 #include <rclcpp/rclcpp.hpp>
 #include <simulation_interfaces/srv/get_entities_states.hpp>
@@ -15,7 +16,7 @@
 namespace SimulationInterfacesROS2
 {
 
-    class GetEntitiesStatesServiceHandler
+    class GetEntitiesStatesServiceHandler : public ROS2HandlerBase
     {
     public:
         using ServiceType = simulation_interfaces::srv::GetEntitiesStates;
@@ -25,7 +26,7 @@ namespace SimulationInterfacesROS2
         GetEntitiesStatesServiceHandler() = delete;
         GetEntitiesStatesServiceHandler(rclcpp::Node::SharedPtr& node, AZStd::string_view serviceName);
         ~GetEntitiesStatesServiceHandler();
-
+        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
         Response HandleServiceRequest(const Request& request);
 
     private:

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/GetEntityStateServiceHandler.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/GetEntityStateServiceHandler.cpp
@@ -34,6 +34,11 @@ namespace SimulationInterfacesROS2
         }
     }
 
+    AZStd::unordered_set<AZ::u8> GetEntityStateServiceHandler::GetProvidedFeatures()
+    {
+        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::ENTITY_STATE_GETTING };
+    }
+
     GetEntityStateServiceHandler::Response GetEntityStateServiceHandler::HandleServiceRequest(const Request& request)
     {
         AZStd::string entityName = request.entity.c_str();

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/GetEntityStateServiceHandler.h
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/GetEntityStateServiceHandler.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Services/ROS2HandlerBaseClass.h"
 #include <AzCore/std/string/string_view.h>
 #include <rclcpp/rclcpp.hpp>
 #include <simulation_interfaces/srv/get_entity_state.hpp>
@@ -15,7 +16,7 @@
 namespace SimulationInterfacesROS2
 {
 
-    class GetEntityStateServiceHandler
+    class GetEntityStateServiceHandler : public ROS2HandlerBase
     {
     public:
         using ServiceType = simulation_interfaces::srv::GetEntityState;
@@ -25,7 +26,7 @@ namespace SimulationInterfacesROS2
         GetEntityStateServiceHandler() = delete;
         GetEntityStateServiceHandler(rclcpp::Node::SharedPtr& node, AZStd::string_view serviceName);
         ~GetEntityStateServiceHandler();
-
+        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
         Response HandleServiceRequest(const Request& request);
 
     private:

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/GetSimulationFeaturesServiceHandler.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/GetSimulationFeaturesServiceHandler.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "GetSimulationFeaturesServiceHandler.h"
+#include "SimulationInterfacesROS2/SimulationInterfacesROS2RequestBus.h"
+#include <AzCore/base.h>
+#include <AzCore/std/containers/unordered_set.h>
+
+namespace SimulationInterfacesROS2
+{
+
+    GetSimulationFeaturesServiceHandler::GetSimulationFeaturesServiceHandler(rclcpp::Node::SharedPtr& node, AZStd::string_view serviceName)
+    {
+        const std::string serviceNameStr(std::string_view(serviceName.data(), serviceName.size()));
+        m_getSimulationFeaturesService = node->create_service<ServiceType>(
+            serviceNameStr,
+            [this](const Request::SharedPtr request, Response::SharedPtr response)
+            {
+                *response = HandleServiceRequest(*request);
+            });
+    }
+
+    GetSimulationFeaturesServiceHandler::~GetSimulationFeaturesServiceHandler()
+    {
+        if (m_getSimulationFeaturesService)
+        {
+            m_getSimulationFeaturesService.reset();
+        }
+    }
+
+    AZStd::unordered_set<AZ::u8> GetSimulationFeaturesServiceHandler::GetProvidedFeatures()
+    {
+        // standard doesn't define specific feature id for this service
+        return AZStd::unordered_set<AZ::u8>{};
+    }
+
+    GetSimulationFeaturesServiceHandler::Response GetSimulationFeaturesServiceHandler::HandleServiceRequest(const Request& request)
+    {
+        // call bus to get simulation features in SimulationInterfacesROS2 Gem side
+        AZStd::unordered_set<AZ::u8> ros2Interfaces;
+        SimulationInterfacesROS2RequestBus::BroadcastResult(ros2Interfaces, &SimulationInterfacesROS2Requests::GetSimulationFeatures);
+        // call bus to get simulation features on SimulationInterfaces Gem  side
+
+        // create common features and return it;
+
+        Response response;
+        response.features.features.insert(response.features.features.end(), ros2Interfaces.begin(), ros2Interfaces.end());
+        return response;
+    }
+} // namespace SimulationInterfacesROS2

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/GetSimulationFeaturesServiceHandler.h
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/GetSimulationFeaturesServiceHandler.h
@@ -7,30 +7,31 @@
  */
 
 #pragma once
-
 #include "Services/ROS2HandlerBaseClass.h"
 #include <AzCore/std/string/string_view.h>
 #include <rclcpp/rclcpp.hpp>
-#include <simulation_interfaces/srv/get_entities.hpp>
+#include <simulation_interfaces/srv/delete_entity.hpp>
+#include <simulation_interfaces/srv/detail/get_simulator_features__struct.hpp>
 
 namespace SimulationInterfacesROS2
 {
 
-    class GetEntitiesServiceHandler : public ROS2HandlerBase
+    class GetSimulationFeaturesServiceHandler : public ROS2HandlerBase
     {
     public:
-        using ServiceType = simulation_interfaces::srv::GetEntities;
+        using ServiceType = simulation_interfaces::srv::GetSimulatorFeatures;
         using Request = ServiceType::Request;
         using Response = ServiceType::Response;
+        using ServiceHandle = std::shared_ptr<rclcpp::Service<ServiceType>>;
 
-        GetEntitiesServiceHandler() = delete;
-        GetEntitiesServiceHandler(rclcpp::Node::SharedPtr& node, AZStd::string_view serviceName);
-        ~GetEntitiesServiceHandler();
+        GetSimulationFeaturesServiceHandler() = delete;
+        GetSimulationFeaturesServiceHandler(rclcpp::Node::SharedPtr& node, AZStd::string_view serviceName);
+        ~GetSimulationFeaturesServiceHandler();
         AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
         Response HandleServiceRequest(const Request& request);
 
     private:
-        rclcpp::Service<ServiceType>::SharedPtr m_getEntitiesService;
+        rclcpp::Service<ServiceType>::SharedPtr m_getSimulationFeaturesService;
     };
 
 } // namespace SimulationInterfacesROS2

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/GetSpawnablesServiceHandler.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/GetSpawnablesServiceHandler.cpp
@@ -30,6 +30,11 @@ namespace SimulationInterfacesROS2
         }
     }
 
+    AZStd::unordered_set<AZ::u8> GetSpawnablesServiceHandler::GetProvidedFeatures()
+    {
+        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::SPAWNABLES };
+    }
+
     GetSpawnablesServiceHandler::Response GetSpawnablesServiceHandler::HandleServiceRequest(const Request& request)
     {
         AZ::Outcome<SimulationInterfaces::SpawnableList, SimulationInterfaces::FailedResult> outcome;

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/GetSpawnablesServiceHandler.h
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/GetSpawnablesServiceHandler.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Services/ROS2HandlerBaseClass.h"
 #include <AzCore/std/string/string_view.h>
 #include <rclcpp/rclcpp.hpp>
 #include <simulation_interfaces/srv/get_spawnables.hpp>
@@ -15,7 +16,7 @@
 namespace SimulationInterfacesROS2
 {
 
-    class GetSpawnablesServiceHandler
+    class GetSpawnablesServiceHandler : public ROS2HandlerBase
     {
     public:
         using ServiceType = simulation_interfaces::srv::GetSpawnables;
@@ -25,7 +26,7 @@ namespace SimulationInterfacesROS2
         GetSpawnablesServiceHandler() = delete;
         GetSpawnablesServiceHandler(rclcpp::Node::SharedPtr& node, AZStd::string_view serviceName);
         ~GetSpawnablesServiceHandler();
-
+        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
         Response HandleServiceRequest(const Request& request);
 
     private:

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/ROS2HandlerBaseClass.h
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/ROS2HandlerBaseClass.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/containers/unordered_set.h>
+#include <simulation_interfaces/msg/simulator_features.hpp>
+namespace SimulationInterfacesROS2
+{
+    //! base for each ros2 handler, forces declaration of features provided by the handler
+    //! combined informations along all ROS 2 handlers gives information about simulation features
+    //! @see https://github.com/ros-simulation/simulation_interfaces/blob/main/msg/SimulatorFeatures.msg
+    using SimulationFeatures = simulation_interfaces::msg::SimulatorFeatures;
+    class ROS2HandlerBase
+    {
+    public:
+        virtual ~ROS2HandlerBase() = default;
+
+        //! return features id defined by the handler, ids must follow the definition inside standard:
+        //! @see https://github.com/ros-simulation/simulation_interfaces/blob/main/msg/SimulatorFeatures.msg
+        virtual AZStd::unordered_set<AZ::u8> GetProvidedFeatures()
+        {
+            return {};
+        };
+    };
+} // namespace SimulationInterfacesROS2

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/SetEntityStateServiceHandler.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/SetEntityStateServiceHandler.cpp
@@ -31,6 +31,11 @@ namespace SimulationInterfacesROS2
         }
     }
 
+    AZStd::unordered_set<AZ::u8> SetEntityStateServiceHandler::GetProvidedFeatures()
+    {
+        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::ENTITY_STATE_SETTING };
+    }
+
     SetEntityStateServiceHandler::Response SetEntityStateServiceHandler::HandleServiceRequest(const Request& request)
     {
         AZ::Outcome<void, SimulationInterfaces::FailedResult> outcome;

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/SetEntityStateServiceHandler.h
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/SetEntityStateServiceHandler.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Services/ROS2HandlerBaseClass.h"
 #include <AzCore/std/string/string_view.h>
 #include <rclcpp/rclcpp.hpp>
 #include <simulation_interfaces/srv/set_entity_state.hpp>
@@ -15,7 +16,7 @@
 namespace SimulationInterfacesROS2
 {
 
-    class SetEntityStateServiceHandler
+    class SetEntityStateServiceHandler : public ROS2HandlerBase
     {
     public:
         using ServiceType = simulation_interfaces::srv::SetEntityState;
@@ -25,7 +26,7 @@ namespace SimulationInterfacesROS2
         SetEntityStateServiceHandler() = delete;
         SetEntityStateServiceHandler(rclcpp::Node::SharedPtr& node, AZStd::string_view serviceName);
         ~SetEntityStateServiceHandler();
-
+        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
         Response HandleServiceRequest(const Request& request);
 
     private:

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/SpawnEntityServiceHandler.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/SpawnEntityServiceHandler.cpp
@@ -34,6 +34,11 @@ namespace SimulationInterfacesROS2
         }
     }
 
+    AZStd::unordered_set<AZ::u8> SpawnEntityServiceHandler::GetProvidedFeatures()
+    {
+        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::SPAWNING };
+    }
+
     void SpawnEntityServiceHandler::HandleServiceRequest(
         const ServiceHandle service_handle, const std::shared_ptr<rmw_request_id_t> header, const std::shared_ptr<Request> request)
     {

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/SpawnEntityServiceHandler.h
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/SpawnEntityServiceHandler.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Services/ROS2HandlerBaseClass.h"
 #include <AzCore/std/string/string_view.h>
 #include <rclcpp/rclcpp.hpp>
 #include <simulation_interfaces/srv/spawn_entity.hpp>
@@ -15,7 +16,7 @@
 namespace SimulationInterfacesROS2
 {
 
-    class SpawnEntityServiceHandler
+    class SpawnEntityServiceHandler : public ROS2HandlerBase
     {
     public:
         using ServiceType = simulation_interfaces::srv::SpawnEntity;
@@ -26,7 +27,7 @@ namespace SimulationInterfacesROS2
         SpawnEntityServiceHandler() = delete;
         SpawnEntityServiceHandler(rclcpp::Node::SharedPtr& node, AZStd::string_view serviceName);
         ~SpawnEntityServiceHandler();
-
+        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
         void HandleServiceRequest(
             const ServiceHandle service_handle, const std::shared_ptr<rmw_request_id_t> header, const std::shared_ptr<Request> request);
 

--- a/Gems/SimulationInterfacesROS2/Code/Source/Utils/RegistryUtils.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Utils/RegistryUtils.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "RegistryUtils.h"
+#include <AzCore/IO/Path/Path.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+
+namespace SimulationInterfacesROS2::RegistryUtilities
+{
+    AZStd::string GetServiceName(AZStd::string serviceType)
+    {
+        AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get();
+        AZ_Assert(settingsRegistry, "Settings Registry is not available");
+        AZStd::string output = "";
+        AZ::IO::Path setRegPath = AZ::IO::Path(RegistryPrefix) / AZ::IO::Path(serviceType);
+        settingsRegistry->Get(output, setRegPath.String());
+        return output;
+    }
+} // namespace SimulationInterfacesROS2::RegistryUtilities

--- a/Gems/SimulationInterfacesROS2/Code/Source/Utils/RegistryUtils.h
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Utils/RegistryUtils.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/string/string.h>
+
+namespace SimulationInterfacesROS2::RegistryUtilities
+{
+    // prefix for settings registry related to ros2 topics names
+    inline constexpr const char* RegistryPrefix = "/SimulationInterfacesROS2";
+
+    //! Gets name of the service with defined type form settings registry
+    //! @return string with service name, if setting registry doesn't exits returns empty string
+    [[nodiscard]] AZStd::string GetServiceName(AZStd::string serviceType);
+} // namespace SimulationInterfacesROS2::RegistryUtilities

--- a/Gems/SimulationInterfacesROS2/Code/Source/Utils/ServicesConfig.h
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Utils/ServicesConfig.h
@@ -10,11 +10,20 @@
 
 namespace SimulationInterfacesROS2
 {
-    inline constexpr const char* DeleteEntityServiceName = "delete_entity";
-    inline constexpr const char* GetEntitiesServiceName = "get_entities";
-    inline constexpr const char* GetEntitiesStatesServiceName = "get_entities_states";
-    inline constexpr const char* GetEntityStateServiceName = "get_entity_state";
-    inline constexpr const char* GetSpawnablesServiceName = "get_spawnables";
-    inline constexpr const char* SetEntityStateServiceName = "set_entity_state";
-    inline constexpr const char* SpawnEntityServiceName = "spawn_entity";
+    inline constexpr const char* DeleteEntityService = "DeleteEntity";
+    inline constexpr const char* DeleteEntityServiceDefaultName = "delete_entity";
+    inline constexpr const char* GetEntitiesService = "GetEntities";
+    inline constexpr const char* GetEntitiesServiceDefaultName = "get_entities";
+    inline constexpr const char* GetEntitiesStatesService = "GetEntitiesStates";
+    inline constexpr const char* GetEntitiesStatesServiceDefaultName = "get_entities_states";
+    inline constexpr const char* GetEntityStateService = "GetEntity";
+    inline constexpr const char* GetEntityStateServiceDefaultName = "get_entity_state";
+    inline constexpr const char* GetSpawnablesService = "GetSpawnables";
+    inline constexpr const char* GetSpawnablesServiceDefaultName = "get_spawnables";
+    inline constexpr const char* SetEntityStateService = "SetEntityState";
+    inline constexpr const char* SetEntityStateServiceDefaultName = "set_entity_state";
+    inline constexpr const char* SpawnEntityService = "SpawnEntity";
+    inline constexpr const char* SpawnEntityServiceDefaultName = "spawn_entity";
+    inline constexpr const char* GetSimulationFeaturesService = "GetSimulationFeatures";
+    inline constexpr const char* GetSimulationFeaturesServiceDefaultName = "get_simulation_features";
 } // namespace SimulationInterfacesROS2

--- a/Gems/SimulationInterfacesROS2/Code/simulationinterfacesros2_private_files.cmake
+++ b/Gems/SimulationInterfacesROS2/Code/simulationinterfacesros2_private_files.cmake
@@ -25,6 +25,8 @@ set(FILES
     Source/Services/SpawnEntityServiceHandler.h
     Source/Services/GetSimulationFeaturesServiceHandler.cpp
     Source/Services/GetSimulationFeaturesServiceHandler.h
+    Source/Utils/RegistryUtils.cpp
+    Source/Utils/RegistryUtils.h
     Source/Utils/ServicesConfig.h
     Source/Utils/Utils.h    
 )

--- a/Gems/SimulationInterfacesROS2/Code/simulationinterfacesros2_private_files.cmake
+++ b/Gems/SimulationInterfacesROS2/Code/simulationinterfacesros2_private_files.cmake
@@ -4,6 +4,7 @@ set(FILES
     Source/SimulationInterfacesROS2ModuleInterface.h
     Source/Clients/SimulationInterfacesROS2SystemComponent.cpp
     Source/Clients/SimulationInterfacesROS2SystemComponent.h
+    Source/Services/ROS2HandlerBaseClass.h
     Source/Services/GetEntitiesServiceHandler.cpp
     Source/Services/GetEntitiesServiceHandler.h
     Source/Services/DeleteEntityServiceHandler.cpp
@@ -22,6 +23,8 @@ set(FILES
     Source/Services/GetSpawnablesServiceHandler.h
     Source/Services/SpawnEntityServiceHandler.cpp
     Source/Services/SpawnEntityServiceHandler.h
+    Source/Services/GetSimulationFeaturesServiceHandler.cpp
+    Source/Services/GetSimulationFeaturesServiceHandler.h
     Source/Utils/ServicesConfig.h
-    Source/Utils/Utils.h
+    Source/Utils/Utils.h    
 )


### PR DESCRIPTION
## What does this PR do?
This adds `get_simulation_features` service, which is part of the simulation_interfaces standard
https://github.com/ros-simulation/simulation_interfaces

PR fixes also lack of ROS 2 services in the Editor game mode and allows modification of their names via settings registry

## How was this PR tested?
Testing was performed using terminal calls to newly created ROS 2 service