### PR TITLE
Add allow renaming option to Simulation Interface spawner

### DIFF
--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
@@ -91,7 +91,7 @@ namespace SimulationInterfaces
             const AZStd::string& uri,
             const AZStd::string& entityNamespace,
             const AZ::Transform& initialPose,
-            bool allowRename,
+            const bool allowRename,
             SpawnCompletedCb completedCb) = 0;
     };
 

--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
@@ -86,12 +86,12 @@ namespace SimulationInterfaces
 
         //! Callback for when an entity has been spawned and registered. The string is the name of the entity in the simulation interface.
         //! Note : The names is empty, if the entity could not be registered (e.g. prefab has no simulated entities)
-
         virtual void SpawnEntity(
             const AZStd::string& name,
             const AZStd::string& uri,
             const AZStd::string& entityNamespace,
             const AZ::Transform& initialPose,
+            bool allowRename,
             SpawnCompletedCb completedCb) = 0;
     };
 

--- a/Gems/SimulationInterfaces/Code/Source/Clients/ConsoleCommands.inl
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/ConsoleCommands.inl
@@ -221,7 +221,7 @@ namespace SimulationInterfacesCommands
             AZ_Printf("SimulationInterfacesConsole", "Entity spawned and registered : %s\n", result.GetValue().c_str());
 
         };
-        SimulationEntityManagerRequestBus::Broadcast(&SimulationEntityManagerRequestBus::Events::SpawnEntity, name, uri, entityNamespace, initialPose, completedCb);
+        SimulationEntityManagerRequestBus::Broadcast(&SimulationEntityManagerRequestBus::Events::SpawnEntity, name, uri, entityNamespace, initialPose, true, completedCb);
         AZ_Printf("SimulationInterfacesConsole", "simulationinterface_Spawn %s %s\n", name.c_str(), uri.c_str());
     }
 

--- a/Gems/SimulationInterfaces/Code/Source/Clients/ConsoleCommands.inl
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/ConsoleCommands.inl
@@ -221,7 +221,8 @@ namespace SimulationInterfacesCommands
             AZ_Printf("SimulationInterfacesConsole", "Entity spawned and registered : %s\n", result.GetValue().c_str());
 
         };
-        SimulationEntityManagerRequestBus::Broadcast(&SimulationEntityManagerRequestBus::Events::SpawnEntity, name, uri, entityNamespace, initialPose, true, completedCb);
+        constexpr bool allowRename = true;
+        SimulationEntityManagerRequestBus::Broadcast(&SimulationEntityManagerRequestBus::Events::SpawnEntity, name, uri, entityNamespace, initialPose, allowRename, completedCb);
         AZ_Printf("SimulationInterfacesConsole", "simulationinterface_Spawn %s %s\n", name.c_str(), uri.c_str());
     }
 

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -541,7 +541,7 @@ namespace SimulationInterfaces
         const AZStd::string& uri,
         const AZStd::string& entityNamespace,
         const AZ::Transform& initialPose,
-        bool allowRename,
+        const bool allowRename,
         SpawnCompletedCb completedCb)
     {
 
@@ -611,13 +611,6 @@ namespace SimulationInterfaces
             if (transformInterface)
             {
                 transformInterface->SetWorldTM(initialPose);
-            }
-
-            if (!entityNamespace.empty())
-            {
-                // TODO: Mpelka set ROS 2 namespace here
-                AZ_Error("SimulationInterfaces", false, "ROS 2 namespace is not implemented yet in spawning");
-                return;
             }
         };
         optionalArgs.m_completionCallback =

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
@@ -48,7 +48,7 @@ namespace SimulationInterfaces
             const AZStd::string& uri,
             const AZStd::string& entityNamespace,
             const AZ::Transform& initialPose,
-            bool allowRename,
+            const bool allowRename,
             SpawnCompletedCb completedCb) override;
 
         // AZ::Component interface implementation

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
@@ -48,6 +48,7 @@ namespace SimulationInterfaces
             const AZStd::string& uri,
             const AZStd::string& entityNamespace,
             const AZ::Transform& initialPose,
+            bool allowRename,
             SpawnCompletedCb completedCb) override;
 
         // AZ::Component interface implementation

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/SimulationIterfaceAppTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/SimulationIterfaceAppTest.cpp
@@ -67,11 +67,21 @@ namespace UnitTest
         };
 
         SimulationEntityManagerRequestBus::Broadcast(
-            &SimulationEntityManagerRequestBus::Events::SpawnEntity, entityName, uri, entityNamespace, initialPose, completedCb);
-
+            &SimulationEntityManagerRequestBus::Events::SpawnEntity, entityName, uri, entityNamespace, initialPose, false, completedCb);
         // entities are spawned asynchronously, so we need to tick the app to let the entity be spawned
         TickApp(100);
         EXPECT_TRUE(completed);
+
+        // try to spawn entity with the same name, expect failure
+        AZStd::atomic_bool completed2 = false;
+        SpawnCompletedCb failedSpawnCompletedCb = [&](const AZ::Outcome<AZStd::string, FailedResult>& result)
+        {
+            EXPECT_FALSE(result.IsSuccess());
+            completed2 = true;
+        };
+        SimulationEntityManagerRequestBus::Broadcast(
+            &SimulationEntityManagerRequestBus::Events::SpawnEntity, entityName, uri, entityNamespace, initialPose, false, failedSpawnCompletedCb);
+        EXPECT_TRUE(completed2);
 
         // list simulation entities
         AZ::Outcome<EntityNameList, FailedResult> entitiesResult;

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/SimulationIterfaceAppTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/SimulationIterfaceAppTest.cpp
@@ -66,8 +66,9 @@ namespace UnitTest
             completed = true;
         };
 
+        constexpr bool allowRename = false;
         SimulationEntityManagerRequestBus::Broadcast(
-            &SimulationEntityManagerRequestBus::Events::SpawnEntity, entityName, uri, entityNamespace, initialPose, false, completedCb);
+            &SimulationEntityManagerRequestBus::Events::SpawnEntity, entityName, uri, entityNamespace, initialPose, allowRename, completedCb);
         // entities are spawned asynchronously, so we need to tick the app to let the entity be spawned
         TickApp(100);
         EXPECT_TRUE(completed);
@@ -80,7 +81,7 @@ namespace UnitTest
             completed2 = true;
         };
         SimulationEntityManagerRequestBus::Broadcast(
-            &SimulationEntityManagerRequestBus::Events::SpawnEntity, entityName, uri, entityNamespace, initialPose, false, failedSpawnCompletedCb);
+            &SimulationEntityManagerRequestBus::Events::SpawnEntity, entityName, uri, entityNamespace, initialPose, allowRename, failedSpawnCompletedCb);
         EXPECT_TRUE(completed2);
 
         // list simulation entities

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/SpawnEntityServiceHandler.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/SpawnEntityServiceHandler.cpp
@@ -29,13 +29,13 @@ namespace SimulationInterfacesROS2
         const AZStd::string_view uri{ request.uri.c_str(), request.uri.size() };
         const AZStd::string_view entityNamespace{ request.entity_namespace.c_str(), request.entity_namespace.size() };
         const AZ::Transform initialPose = ROS2::ROS2Conversions::FromROS2Pose(request.initial_pose.pose);
-
         SimulationInterfaces::SimulationEntityManagerRequestBus::Broadcast(
             &SimulationInterfaces::SimulationEntityManagerRequests::SpawnEntity,
             name,
             uri,
             entityNamespace,
             initialPose,
+            request.allow_renaming,
             [this](const AZ::Outcome<AZStd::string, SimulationInterfaces::FailedResult>& outcome)
             {
                 Response response;

--- a/Gems/SimulationInterfacesROS2/Code/Tests/Tools/Mocks/SimulationEntityManagerMock.h
+++ b/Gems/SimulationInterfacesROS2/Code/Tests/Tools/Mocks/SimulationEntityManagerMock.h
@@ -25,7 +25,7 @@ namespace UnitTest
         MOCK_METHOD0(GetSpawnables, AZ::Outcome<SpawnableList, FailedResult>());
         MOCK_METHOD6(
             SpawnEntity,
-            void(const AZStd::string& name, const AZStd::string& uri, const AZStd::string& entityNamespace, const AZ::Transform& initialPose, bool allowRename, SpawnCompletedCb completedCb));
+            void(const AZStd::string& name, const AZStd::string& uri, const AZStd::string& entityNamespace, const AZ::Transform& initialPose, const bool allowRename, SpawnCompletedCb completedCb));
 
     };
 }

--- a/Gems/SimulationInterfacesROS2/Code/Tests/Tools/Mocks/SimulationEntityManagerMock.h
+++ b/Gems/SimulationInterfacesROS2/Code/Tests/Tools/Mocks/SimulationEntityManagerMock.h
@@ -23,9 +23,9 @@ namespace UnitTest
         MOCK_METHOD2(SetEntityState, AZ::Outcome<void, FailedResult>(const AZStd::string& name, const EntityState& state));
         MOCK_METHOD2(DeleteEntity, void(const AZStd::string& name, DeletionCompletedCb completedCb));
         MOCK_METHOD0(GetSpawnables, AZ::Outcome<SpawnableList, FailedResult>());
-        MOCK_METHOD5(
+        MOCK_METHOD6(
             SpawnEntity,
-            void(const AZStd::string& name, const AZStd::string& uri, const AZStd::string& entityNamespace, const AZ::Transform& initialPose, SpawnCompletedCb completedCb));
+            void(const AZStd::string& name, const AZStd::string& uri, const AZStd::string& entityNamespace, const AZ::Transform& initialPose, bool allowRename, SpawnCompletedCb completedCb));
 
     };
 }


### PR DESCRIPTION
## What does this PR do?

Add option allow renaming to spawn service

## How was this PR tested?

Added integration test scenario,
Manual tests with https://github.com/michalpelka/q_simulation_interfaces
![image](https://github.com/user-attachments/assets/b03a46d5-bd07-4d80-97c1-e787e93b0283)
