### PR TITLE
[Simulation Interfaces] Adjust error code type - ROS2 way, setting frames

### DIFF
--- a/Gems/SimulationInterfaces/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfaces/Code/CMakeLists.txt
@@ -55,6 +55,8 @@ ly_add_target(
         PUBLIC
             AZ::AzCore
             AZ::AzFramework
+        PRIVATE
+            Gem::ROS2.Static
 )
 target_depends_on_ros2_packages(${gem_name}.Private.Object simulation_interfaces)
 

--- a/Gems/SimulationInterfaces/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfaces/Code/CMakeLists.txt
@@ -56,6 +56,7 @@ ly_add_target(
             AZ::AzCore
             AZ::AzFramework
 )
+target_depends_on_ros2_packages(${gem_name}.Private.Object simulation_interfaces)
 
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface
 ly_add_target(

--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/Result.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/Result.h
@@ -14,23 +14,7 @@ namespace SimulationInterfaces
     //! Result codes to be used in the Result message
     //!  @see <a href="https://github.com/ros-simulation/simulation_interfaces/blob/main/msg/Result.msg">Result.msg</a>
     using ErrorCodeValue = uint8_t;
-    namespace ErrorCode
-    {
-        constexpr ErrorCodeValue RESULT_FEATURE_UNSUPPORTED = 0;
-        constexpr ErrorCodeValue RESULT_OK = 1;
-        constexpr ErrorCodeValue RESULT_NOT_FOUND = 2;
-        constexpr ErrorCodeValue RESULT_INCORRECT_STATE = 3;
-        constexpr ErrorCodeValue RESULT_OPERATION_FAILED = 4;
 
-        inline bool IsSuccess(ErrorCodeValue v)
-        {
-            return v == RESULT_OK;
-        }
-        inline bool IsMessageSpecific(ErrorCodeValue v)
-        {
-            return v > 100;
-        }
-    }; // namespace ErrorCode
     //! A message type to represent the result of a failed operation
     struct FailedResult
     {

--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/Result.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/Result.h
@@ -13,24 +13,34 @@ namespace SimulationInterfaces
 {
     //! Result codes to be used in the Result message
     //!  @see <a href="https://github.com/ros-simulation/simulation_interfaces/blob/main/msg/Result.msg">Result.msg</a>
-    enum class ErrorCode
+    using ErrorCodeValue = uint8_t;
+    namespace ErrorCode
     {
-        RESULT_FEATURE_UNSUPPORTED = 0,
-        RESULT_NOT_FOUND = 2,
-        RESULT_INCORRECT_STATE = 3,
-        RESULT_OPERATION_FAILED = 4
-    };
+        constexpr ErrorCodeValue RESULT_FEATURE_UNSUPPORTED = 0;
+        constexpr ErrorCodeValue RESULT_OK = 1;
+        constexpr ErrorCodeValue RESULT_NOT_FOUND = 2;
+        constexpr ErrorCodeValue RESULT_INCORRECT_STATE = 3;
+        constexpr ErrorCodeValue RESULT_OPERATION_FAILED = 4;
 
+        inline bool IsSuccess(ErrorCodeValue v)
+        {
+            return v == RESULT_OK;
+        }
+        inline bool IsMessageSpecific(ErrorCodeValue v)
+        {
+            return v > 100;
+        }
+    }; // namespace ErrorCode
     //! A message type to represent the result of a failed operation
     struct FailedResult
     {
         FailedResult() = default;
-        FailedResult(ErrorCode error_code, const AZStd::string& error_string)
+        FailedResult(ErrorCodeValue error_code, const AZStd::string& error_string)
             : error_code(error_code)
             , error_string(error_string)
         {
         }
-        ErrorCode error_code;
+        ErrorCodeValue error_code;
         AZStd::string error_string;
     };
 } // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -30,6 +30,9 @@
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 
+#include <simulation_interfaces/msg/result.hpp>
+#include <simulation_interfaces/srv/spawn_entity.hpp>
+
 namespace SimulationInterfaces
 {
     void SetRigidBodyVelocities(AzPhysics::RigidBody* rigidBody, const EntityState& state)
@@ -277,7 +280,7 @@ namespace SimulationInterfaces
         if (!filter.m_tags_filter.m_tags.empty())
         {
             AZ_Warning("SimulationInterfaces", false, "Tags filter is not implemented yet");
-            return AZ::Failure(FailedResult(ErrorCode::RESULT_FEATURE_UNSUPPORTED, "Tags filter is not implemented yet"));
+            return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, "Tags filter is not implemented yet"));
         }
 
         const bool reFilter = !filter.m_filter.empty();
@@ -304,7 +307,7 @@ namespace SimulationInterfaces
 
             if (m_physicsScenesHandle == AzPhysics::InvalidSceneHandle)
             {
-                return AZ::Failure(FailedResult(ErrorCode::RESULT_OPERATION_FAILED, "Physics scene interface is not available."));
+                return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, "Physics scene interface is not available."));
             }
 
             AzPhysics::OverlapRequest request;
@@ -331,7 +334,7 @@ namespace SimulationInterfaces
             if (!regex.Valid())
             {
                 AZ_Warning("SimulationInterfaces", false, "Invalid regex filter");
-                return AZ::Failure(FailedResult(ErrorCode::RESULT_NOT_FOUND, "Invalid regex filter"));
+                return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_NOT_FOUND, "Invalid regex filter"));
             }
             AZStd::ranges::copy_if(
                 prefilteredEntities,
@@ -350,7 +353,7 @@ namespace SimulationInterfaces
         if (findIt == m_simulatedEntityToEntityIdMap.end())
         {
             AZ_Warning("SimulationInterfaces", findIt != m_simulatedEntityToEntityIdMap.end(), "Entity %s not found", name.c_str());
-            return AZ::Failure(FailedResult(ErrorCode::RESULT_NOT_FOUND, "Entity not found"));
+            return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_NOT_FOUND, "Entity not found"));
         }
         EntityState entityState{};
         const AZ::EntityId entityId = findIt->second;
@@ -376,7 +379,7 @@ namespace SimulationInterfaces
         if (!filter.m_tags_filter.m_tags.empty())
         {
             AZ_Warning("SimulationInterfaces", false, "Tags filter is not implemented yet");
-            return AZ::Failure(FailedResult(ErrorCode::RESULT_FEATURE_UNSUPPORTED, "Tags filter is not implemented yet"));
+            return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, "Tags filter is not implemented yet"));
         }
         MultipleEntitiesStates entitiesStates;
         const auto& entities = GetEntities(filter);
@@ -402,7 +405,7 @@ namespace SimulationInterfaces
         if (findIt == m_simulatedEntityToEntityIdMap.end())
         {
             AZ_Warning("SimulationInterfaces", false, "Entity %s not found", name.c_str());
-            return AZ::Failure(FailedResult(ErrorCode::RESULT_NOT_FOUND, "Entity not found"));
+            return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_NOT_FOUND, "Entity not found"));
         }
 
         const AZ::EntityId entityId = findIt->second;
@@ -454,7 +457,7 @@ namespace SimulationInterfaces
 
         if (findIt == m_simulatedEntityToEntityIdMap.end())
         {
-            completedCb(AZ::Failure(FailedResult(ErrorCode::RESULT_NOT_FOUND, "Entity not found")));
+            completedCb(AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_NOT_FOUND, "Entity not found")));
             return;
         }
 
@@ -467,7 +470,7 @@ namespace SimulationInterfaces
         if (entity == nullptr)
         {
             AZ_Error("SimulationInterfaces", false, "Entity %s (%s) not found", name.c_str(), entityId.ToString().c_str());
-            completedCb(AZ::Failure(FailedResult(ErrorCode::RESULT_NOT_FOUND, "Entity not found")));
+            completedCb(AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_NOT_FOUND, "Entity not found")));
             return;
         }
         // check if entity is spawned by this component
@@ -493,7 +496,7 @@ namespace SimulationInterfaces
         else
         {
             const auto msg = AZStd::string::format("Entity %s was not spawned by this component, wont delete it", name.c_str());
-            completedCb(AZ::Failure(FailedResult(ErrorCode::RESULT_OPERATION_FAILED, msg)));
+            completedCb(AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, msg)));
         }
 #ifdef POTENTIALY_UNSAFE
         if (findIt != m_simulatedEntityToEntityIdMap.end())
@@ -585,7 +588,7 @@ namespace SimulationInterfaces
         if (!spawnableAsset)
         {
             const auto msg = AZStd::string::format("Spawnable asset %s not found", uri.c_str());
-            completedCb(AZ::Failure(FailedResult(ErrorCode::RESULT_NOT_FOUND, msg)));
+            completedCb(AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_NOT_FOUND, msg)));
             return;
         }
 

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -548,22 +548,35 @@ namespace SimulationInterfaces
         SpawnCompletedCb completedCb)
     {
 
+
         if (!allowRename)
         {
             // If API user does not allow renaming, check if name is unique
             if (m_simulatedEntityToEntityIdMap.contains(name))
             {
                 const auto msg = AZStd::string::format("Entity name %s is not unique", name.c_str());
-                completedCb(AZ::Failure(FailedResult(ErrorCode::RESULT_INCORRECT_STATE, msg)));
+                completedCb(AZ::Failure(FailedResult(simulation_interfaces::srv::SpawnEntity::Response::NAME_NOT_UNIQUE, msg)));
                 return;
             }
+            if (name.empty())
+            {
+                const auto msg = AZStd::string::format("Entity name is empty");
+                completedCb(AZ::Failure(FailedResult(simulation_interfaces::srv::SpawnEntity::Response::NAME_INVALID, msg)));
+                return;
+            }
+        }
+        if (!initialPose.IsOrthogonal())
+        {
+            AZ_Warning("SimulationInterfaces", false, "Initial pose is not orthogonal");
+            completedCb(AZ::Failure(FailedResult(simulation_interfaces::srv::SpawnEntity::Response::INVALID_POSE, "Initial pose is not orthogonal"))); //  INVALID_POSE
+            return;
         }
 
         if (!entityNamespace.empty())
         {
             // TODO: Mpelka - remove this error when ROS 2 namespace is implemented
             AZ_Error("SimulationInterfaces", false, "ROS 2 namespace is not implemented yet in spawning");
-            completedCb(AZ::Failure(FailedResult(ErrorCode::RESULT_NOT_FOUND, "This feature is not implemented yet in spawning entities")));
+            completedCb(AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_NOT_FOUND, "This feature is not implemented yet in spawning entities")));
             return;
         }
 

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -32,7 +32,7 @@
 
 #include <simulation_interfaces/msg/result.hpp>
 #include <simulation_interfaces/srv/spawn_entity.hpp>
-
+#include <ROS2/Frame/ROS2FrameComponent.h>
 namespace SimulationInterfaces
 {
     void SetRigidBodyVelocities(AzPhysics::RigidBody* rigidBody, const EntityState& state)
@@ -572,13 +572,13 @@ namespace SimulationInterfaces
             return;
         }
 
-        if (!entityNamespace.empty())
-        {
-            // TODO: Mpelka - remove this error when ROS 2 namespace is implemented
-            AZ_Error("SimulationInterfaces", false, "ROS 2 namespace is not implemented yet in spawning");
-            completedCb(AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_NOT_FOUND, "This feature is not implemented yet in spawning entities")));
-            return;
-        }
+//        if (!entityNamespace.empty())
+//        {
+//            // TODO: Mpelka - remove this error when ROS 2 namespace is implemented
+//            AZ_Error("SimulationInterfaces", false, "ROS 2 namespace is not implemented yet in spawning");
+//            completedCb(AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_NOT_FOUND, "This feature is not implemented yet in spawning entities")));
+//            return;
+//        }
 
         // get rel path from uri
         const AZStd::string relPath = Utils::UriToRelPath(uri);
@@ -615,6 +615,24 @@ namespace SimulationInterfaces
                 return;
             }
             const AZ::Entity* root = *view.begin();
+
+            for (auto* entity : view)
+            {
+                ROS2::ROS2FrameComponent* frameComponent = entity->template FindComponent<ROS2::ROS2FrameComponent>();
+                if (frameComponent)
+                {
+                    const AZStd::string f = frameComponent->GetFrameID();
+                    if (f.empty())
+                    {
+                            frameComponent->SetFrameID(name);
+                    }
+                    else
+                    {
+                            frameComponent->SetFrameID(AZStd::string::format("%s/%s", name.c_str(), f.c_str()));
+                    }
+                }
+            }
+
 
             // change names for all entites
             for (auto* entity : view)

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -572,14 +572,6 @@ namespace SimulationInterfaces
             return;
         }
 
-//        if (!entityNamespace.empty())
-//        {
-//            // TODO: Mpelka - remove this error when ROS 2 namespace is implemented
-//            AZ_Error("SimulationInterfaces", false, "ROS 2 namespace is not implemented yet in spawning");
-//            completedCb(AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_NOT_FOUND, "This feature is not implemented yet in spawning entities")));
-//            return;
-//        }
-
         // get rel path from uri
         const AZStd::string relPath = Utils::UriToRelPath(uri);
 
@@ -628,7 +620,7 @@ namespace SimulationInterfaces
                     }
                     else
                     {
-                            frameComponent->SetFrameID(AZStd::string::format("%s/%s", name.c_str(), f.c_str()));
+                            frameComponent->SetFrameID(AZStd::string::format("%s/%s", entityNamespace.c_str(), f.c_str()));
                     }
                 }
             }

--- a/Gems/SimulationInterfaces/gem.json
+++ b/Gems/SimulationInterfaces/gem.json
@@ -20,7 +20,7 @@
     "icon_path": "preview.png",
     "requirements": "",
     "documentation_url": "",
-    "dependencies": [],
+    "dependencies": ["ROS2"],
     "repo_uri": "",
     "compatible_engines": [],
     "engine_api_dependencies": [],

--- a/Gems/SimulationInterfacesROS2/Code/Tests/Tools/InterfacesTest.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Tests/Tools/InterfacesTest.cpp
@@ -189,7 +189,7 @@ namespace UnitTest
                 {
                     EXPECT_EQ(name, "test_entity");
                     FailedResult failedResult;
-                    failedResult.error_code = SimulationInterfaces::ErrorCode::RESULT_NOT_FOUND;
+                    failedResult.error_code = simulation_interfaces::msg::Result::RESULT_NOT_FOUND,
                     failedResult.error_string = "FooBar not found.";
                     completedCb(AZ::Failure(failedResult));
                 }));


### PR DESCRIPTION
## What does this PR do?

Alternative approach to https://github.com/o3de/o3de-extras/pull/864
That introduced dependency in SimulationInterface to ROS 2 gem and Simulation Interfaces message package

## How was this PR tested?

Unit tests.
