### PR TITLE
[Simulation Interfaces] Validate Namespace and name 

### DIFF
--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/SpawnEntityServiceHandler.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/SpawnEntityServiceHandler.cpp
@@ -26,6 +26,27 @@ namespace SimulationInterfacesROS2
         const AZStd::string_view name{ request.name.c_str(), request.name.size() };
         const AZStd::string_view uri{ request.uri.c_str(), request.uri.size() };
         const AZStd::string_view entityNamespace{ request.entity_namespace.c_str(), request.entity_namespace.size() };
+
+        // Validate entity name
+        if (!ValidateEntityName(name))
+        {
+            Response response;
+            response.result.result = simulation_interfaces::srv::SpawnEntity::Response::NAME_INVALID;
+            response.result.error_message = "Invalid entity name. Entity names can only contain alphanumeric characters and underscores.";
+            SendResponse(response);
+            return AZStd::nullopt;
+        }
+
+        // Validate frame name
+        if (!entityNamespace.empty() && !ValidateFrameName(entityNamespace))
+        {
+            Response response;
+            response.result.result = simulation_interfaces::srv::SpawnEntity::Response::NAMESPACE_INVALID;
+            response.result.error_message = "Invalid entity namespace. Entity namespaces can only contain alphanumeric characters and forward slashes.";
+            SendResponse(response);
+            return AZStd::nullopt;
+        }
+
         const AZ::Transform initialPose = ROS2::ROS2Conversions::FromROS2Pose(request.initial_pose.pose);
         SimulationInterfaces::SimulationEntityManagerRequestBus::Broadcast(
             &SimulationInterfaces::SimulationEntityManagerRequests::SpawnEntity,
@@ -51,6 +72,18 @@ namespace SimulationInterfacesROS2
                 SendResponse(response);
             });
         return AZStd::nullopt;
+    }
+
+    bool SpawnEntityServiceHandler::ValidateEntityName(const AZStd::string& entityName)
+    {
+        const AZStd::regex entityRegex{ R"(^[a-zA-Z0-9_]+$)" }; // Entity names can only contain alphanumeric characters and underscores
+        return AZStd::regex_match(entityName, entityRegex);
+    }
+
+    bool SpawnEntityServiceHandler::ValidateFrameName(const AZStd::string& frameName)
+    {
+        const AZStd::regex frameRegex{ R"(^[a-zA-Z0-9_/]+$)" }; // Entity names can only contain alphanumeric characters and underscores and forward slashes
+        return AZStd::regex_match(frameName, frameRegex);
     }
 
 } // namespace SimulationInterfacesROS2

--- a/Gems/SimulationInterfacesROS2/Code/Source/Services/SpawnEntityServiceHandler.h
+++ b/Gems/SimulationInterfacesROS2/Code/Source/Services/SpawnEntityServiceHandler.h
@@ -11,7 +11,7 @@
 #include "ROS2ServiceBase.h"
 #include <AzCore/std/string/string_view.h>
 #include <simulation_interfaces/srv/spawn_entity.hpp>
-
+#include <AzCore/std/string/regex.h>
 namespace SimulationInterfacesROS2
 {
     class SpawnEntityServiceHandler : public ROS2ServiceBase<simulation_interfaces::srv::SpawnEntity>
@@ -31,6 +31,10 @@ namespace SimulationInterfacesROS2
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
 
     private:
+        bool ValidateEntityName(const AZStd::string& entityName);
+        bool ValidateFrameName(const AZStd::string& frameName);
+
+
     };
 
 } // namespace SimulationInterfacesROS2

--- a/Gems/SimulationInterfacesROS2/Code/Tests/Tools/InterfacesTest.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Tests/Tools/InterfacesTest.cpp
@@ -401,7 +401,7 @@ namespace UnitTest
         auto node = GetRos2Node();
         auto client = node->create_client<simulation_interfaces::srv::SpawnEntity>("/spawn_entity");
         auto request = std::make_shared<simulation_interfaces::srv::SpawnEntity::Request>();
-        request->name = "valid_name"; // invalid name
+        request->name = "valid_name";
         request->uri = "test_uri";
         request->entity_namespace = "test_namespace";
         request->allow_renaming = true;
@@ -447,7 +447,7 @@ namespace UnitTest
 
     }
 
-    //! Check if service fails when the name space is invalid
+    //! Check if service fails when the namespace is invalid
     TEST_F(SimulationInterfaceROS2TestFixture, TryToSpawnWithInvalidNamespace)
     {
         // strict mock, since we don't want to call the real implementation in this test

--- a/Gems/SimulationInterfacesROS2/Code/Tests/Tools/InterfacesTest.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Tests/Tools/InterfacesTest.cpp
@@ -392,6 +392,81 @@ namespace UnitTest
         EXPECT_EQ(response->features.features[0], simulation_interfaces::msg::SimulatorFeatures::SPAWNING) << "Feature is not SPAWNING.";
     }
 
+    //! Check if service succeeds when the name is valid
+    TEST_F(SimulationInterfaceROS2TestFixture, TryToSpawnWithValidName)
+    {
+        using ::testing::_;
+        SimulationEntityManagerMockedHandler mock;
+
+        auto node = GetRos2Node();
+        auto client = node->create_client<simulation_interfaces::srv::SpawnEntity>("/spawn_entity");
+        auto request = std::make_shared<simulation_interfaces::srv::SpawnEntity::Request>();
+        request->name = "valid_name"; // invalid name
+        request->uri = "test_uri";
+        request->entity_namespace = "test_namespace";
+        request->allow_renaming = true;
+
+        auto future = client->async_send_request(request);
+        EXPECT_CALL(mock, SpawnEntity(_, _, _, _, _, _)).WillOnce(
+                ::testing::Invoke(
+                [](const AZStd::string& name, const AZStd::string& uri, const AZStd::string& entityNamespace, const AZ::Transform& initialPose, const bool allowRename, SpawnCompletedCb completedCb)
+                {
+                    EXPECT_EQ(name, "valid_name");
+                    EXPECT_EQ(uri, "test_uri");
+                    EXPECT_EQ(entityNamespace, "test_namespace");
+                    EXPECT_TRUE(allowRename);
+                    completedCb(AZ::Success("valid_name"));
+                })
+            );
+        SpinAppSome();
+
+        ASSERT_TRUE(future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) << "Service call timed out.";
+        auto response = future.get();
+        EXPECT_EQ(response->result.result, simulation_interfaces::msg::Result::RESULT_OK);
+    }
+
+    //! Check if service fails when the name is invalid
+    TEST_F(SimulationInterfaceROS2TestFixture, TryToSpawnWithInvalidName)
+    {
+        // strict mock, since we don't want to call the real implementation in this test
+        [[maybe_unused]] testing::StrictMock<SimulationEntityManagerMockedHandler> mock;
+
+        auto node = GetRos2Node();
+        auto client = node->create_client<simulation_interfaces::srv::SpawnEntity>("/spawn_entity");
+        auto request = std::make_shared<simulation_interfaces::srv::SpawnEntity::Request>();
+        request->name = "invalid name"; // invalid name
+        request->uri = "test_uri";
+        request->entity_namespace = "test_namespace";
+
+        auto future = client->async_send_request(request);
+        SpinAppSome();
+
+        ASSERT_TRUE(future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) << "Service call timed out.";
+        auto response = future.get();
+        EXPECT_EQ(response->result.result, simulation_interfaces::srv::SpawnEntity::Response::NAME_INVALID) << "Service call should fail with invalid name.";
+
+    }
+
+    //! Check if service fails when the name space is invalid
+    TEST_F(SimulationInterfaceROS2TestFixture, TryToSpawnWithInvalidNamespace)
+    {
+        // strict mock, since we don't want to call the real implementation in this test
+        [[maybe_unused]] testing::StrictMock<SimulationEntityManagerMockedHandler> mock;
+
+        auto node = GetRos2Node();
+        auto client = node->create_client<simulation_interfaces::srv::SpawnEntity>("/spawn_entity");
+        auto request = std::make_shared<simulation_interfaces::srv::SpawnEntity::Request>();
+        request->name = "valid_name";
+        request->uri = "test_uri";
+        request->entity_namespace = "invalid namespace";
+
+        auto future = client->async_send_request(request);
+        SpinAppSome();
+
+        ASSERT_TRUE(future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) << "Service call timed out.";
+        auto response = future.get();
+        EXPECT_EQ(response->result.result, simulation_interfaces::srv::SpawnEntity::Response::NAMESPACE_INVALID) << "Service call should fail with invalid name.";
+    }
 } // namespace UnitTest
 
 // required to support running integration tests with Qt and PhysX


### PR DESCRIPTION
## What does this PR do?

Adds regex to validate namespace and name.

Rebase and merge on top of https://github.com/o3de/o3de-extras/pull/865

## How was this PR tested?
- Added and run unit tests 
- q_simulation_interface:
![image](https://github.com/user-attachments/assets/83cc7e8c-093a-4bc5-b449-b903df3ad5be)
![image](https://github.com/user-attachments/assets/8960a990-628e-4408-86a2-05cbddfb55cf)
