### PR TITLE
[Simulation Interfaces] Added simple test for the SimulateSteps action

### DIFF
--- a/Gems/SimulationInterfacesROS2/Code/Tests/Tools/InterfacesTest.cpp
+++ b/Gems/SimulationInterfacesROS2/Code/Tests/Tools/InterfacesTest.cpp
@@ -477,7 +477,7 @@ namespace UnitTest
     {
         using ::testing::_;
         auto node = GetRos2Node();
-        auto mock = std::make_shared<SimulationManagerMockedHandler>();
+        SimulationManagerMockedHandler mock;
         auto client = rclcpp_action::create_client<simulation_interfaces::action::SimulateSteps>(node, "/simulate_steps");
         auto goal = std::make_shared<simulation_interfaces::action::SimulateSteps::Goal>();
         constexpr AZ::u64 steps = 10;
@@ -485,16 +485,16 @@ namespace UnitTest
 
         ASSERT_TRUE(client->wait_for_action_server(std::chrono::seconds(0)) == true) << "Action server is unavailable";
 
-        EXPECT_CALL(*mock, IsSimulationPaused())
+        EXPECT_CALL(mock, IsSimulationPaused())
             .WillOnce(::testing::Invoke(
                 []()
                 {
                     return true;
                 }));
 
-        EXPECT_CALL(*mock, StepSimulation(steps));
+        EXPECT_CALL(mock, StepSimulation(steps));
 
-        EXPECT_CALL(*mock, IsSimulationStepsActive())
+        EXPECT_CALL(mock, IsSimulationStepsActive())
             .WillOnce(::testing::Invoke(
                 []()
                 {
@@ -516,14 +516,14 @@ namespace UnitTest
     {
         using ::testing::_;
         auto node = GetRos2Node();
-        auto mock = std::make_shared<SimulationManagerMockedHandler>();
+        SimulationManagerMockedHandler mock;
         auto client = rclcpp_action::create_client<simulation_interfaces::action::SimulateSteps>(node, "/simulate_steps");
         auto goal = std::make_shared<simulation_interfaces::action::SimulateSteps::Goal>();
         goal->steps = 10;
 
         ASSERT_TRUE(client->wait_for_action_server(std::chrono::seconds(0)) == true) << "Action server is unavailable";
 
-        EXPECT_CALL(*mock, IsSimulationPaused())
+        EXPECT_CALL(mock, IsSimulationPaused())
             .WillOnce(::testing::Invoke(
                 []()
                 {
@@ -545,7 +545,7 @@ namespace UnitTest
     {
         using ::testing::_;
         auto node = GetRos2Node();
-        auto mock = std::make_shared<SimulationManagerMockedHandler>();
+        SimulationManagerMockedHandler mock;
         auto client = rclcpp_action::create_client<simulation_interfaces::action::SimulateSteps>(node, "/simulate_steps");
         auto goal = std::make_shared<simulation_interfaces::action::SimulateSteps::Goal>();
         constexpr AZ::u64 steps = 10;
@@ -553,23 +553,23 @@ namespace UnitTest
 
         ASSERT_TRUE(client->wait_for_action_server(std::chrono::seconds(0)) == true) << "Action server is unavailable";
 
-        EXPECT_CALL(*mock, IsSimulationPaused())
+        EXPECT_CALL(mock, IsSimulationPaused())
             .WillOnce(::testing::Invoke(
                 []()
                 {
                     return true;
                 }));
 
-        EXPECT_CALL(*mock, StepSimulation(steps));
+        EXPECT_CALL(mock, StepSimulation(steps));
 
-        EXPECT_CALL(*mock, IsSimulationStepsActive())
+        EXPECT_CALL(mock, IsSimulationStepsActive())
             .WillRepeatedly(::testing::Invoke(
                 []()
                 {
                     return true;
                 }));
 
-        EXPECT_CALL(*mock, CancelStepSimulation());
+        EXPECT_CALL(mock, CancelStepSimulation());
 
         auto future = client->async_send_goal(*goal);
         SpinAppSome();

--- a/Gems/SimulationInterfacesROS2/Code/Tests/Tools/Mocks/SimulationManagerMock.h
+++ b/Gems/SimulationInterfacesROS2/Code/Tests/Tools/Mocks/SimulationManagerMock.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <SimulationInterfaces/SimulationMangerRequestBus.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+namespace UnitTest
+{
+    using namespace SimulationInterfaces;
+    class SimulationManagerMockedHandler : public SimulationInterfaces::SimulationManagerRequestBus::Handler
+    {
+    public:
+        SimulationManagerMockedHandler()
+        {
+            SimulationInterfaces::SimulationManagerRequestBus::Handler::BusConnect();
+        }
+        ~SimulationManagerMockedHandler()
+        {
+            SimulationInterfaces::SimulationManagerRequestBus::Handler::BusDisconnect();
+        }
+
+        MOCK_METHOD1(ReloadLevel, void(ReloadLevelCallback));
+        MOCK_METHOD1(SetSimulationPaused, void(bool));
+        MOCK_METHOD1(StepSimulation, void(AZ::u64));
+        MOCK_METHOD(bool, IsSimulationPaused, (), (const));
+        MOCK_METHOD0(CancelStepSimulation, void());
+        MOCK_METHOD(bool, IsSimulationStepsActive, (), (const));
+    };
+} // namespace UnitTest

--- a/Gems/SimulationInterfacesROS2/Code/Tests/Tools/Mocks/SimulationManagerMock.h
+++ b/Gems/SimulationInterfacesROS2/Code/Tests/Tools/Mocks/SimulationManagerMock.h
@@ -24,5 +24,7 @@ namespace UnitTest
         MOCK_METHOD(bool, IsSimulationPaused, (), (const));
         MOCK_METHOD0(CancelStepSimulation, void());
         MOCK_METHOD(bool, IsSimulationStepsActive, (), (const));
+        MOCK_METHOD(SimulationState, GetSimulationState, (), (const));
+        MOCK_METHOD1(SetSimulationState, AZ::Outcome<void, FailedResult>(SimulationState));
     };
 } // namespace UnitTest

--- a/Gems/SimulationInterfacesROS2/Code/simulationinterfacesros2_editor_tests_files.cmake
+++ b/Gems/SimulationInterfacesROS2/Code/simulationinterfacesros2_editor_tests_files.cmake
@@ -1,5 +1,6 @@
 
 set(FILES
+    Tests/Tools/Mocks/SimulationManagerMock.h
     Tests/Tools/Mocks/SimulationEntityManagerMock.h
     Tests/Tools/Mocks/SimulationFeaturesAggregatorRequestsHandlerMock.h
     Tests/Tools/InterfacesTest.cpp


### PR DESCRIPTION
## What does this PR do?

This PR adds tests to check communication correctness between ROS 2 interfaces and the mocked O3DE buses.

## How was this PR tested?

By running SimulationInterfacesROS2 tests.
