### PR TITLE
[simulation interfaces] Changed default behavior of the SimulationEntitiesManager to registry only main entity.

### DIFF
--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -28,11 +28,24 @@
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <simulation_interfaces/msg/result.hpp>
 #include <simulation_interfaces/msg/simulator_features.hpp>
 #include <simulation_interfaces/srv/spawn_entity.hpp>
+namespace {
+    constexpr AZStd::string_view RegisterEverySimulationEntity = "/SimulationInterfaces/RegisterEverySimulatedEntity";
+
+    bool GetRegisterAllEntities(bool defaultValue)
+    {
+        AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get();
+        AZ_Assert(settingsRegistry, "Settings Registry is not available");
+        settingsRegistry->Get(defaultValue, RegisterEverySimulationEntity);
+        return defaultValue;
+    }
+
+}
 namespace SimulationInterfaces
 {
     void SetRigidBodyVelocities(AzPhysics::RigidBody* rigidBody, const EntityState& state)
@@ -114,6 +127,9 @@ namespace SimulationInterfaces
 
     void SimulationEntitiesManager::Activate()
     {
+
+        m_registerEverySimulatedEntity = GetRegisterAllEntities(false);
+
         m_simulationBodyAddedHandler = AzPhysics::SceneEvents::OnSimulationBodyAdded::Handler(
             [this](AzPhysics::SceneHandle sceneHandle, AzPhysics::SimulatedBodyHandle bodyHandle)
             {
@@ -140,25 +156,33 @@ namespace SimulationInterfaces
                 AZ_Assert(entity, "Entity is not available.");
                 // check if entity is not spawned by this component
                 const auto ticketId = entity->GetEntitySpawnTicketId();
-                AZStd::string proposedName{};
-                // check if ticket is in the unregistered list
 
-                auto spawnData = m_spawnCompletedCallbacks.find(ticketId);
-                if (spawnData != m_spawnCompletedCallbacks.end())
+                auto spawnDataIt = m_spawnCompletedCallbacks.find(ticketId);
+                const bool wasSpawned = spawnDataIt != m_spawnCompletedCallbacks.end();
+
+                // return if entity was spawned and already registered
+                if (!m_registerEverySimulatedEntity && wasSpawned)
                 {
-                    proposedName = spawnData->second.m_userProposedName;
+                    if (spawnDataIt->second.m_registered)
+                    {
+                        return;
+                    }
                 }
 
+                const AZStd::string proposedName =
+                    wasSpawned ? spawnDataIt->second.m_userProposedName : entity->GetName();
+
+                // register entity
                 const AZStd::string registeredName = this->AddSimulatedEntity(entityId, proposedName);
-                // call the callback
-                if (spawnData != m_spawnCompletedCallbacks.end())
+
+                // cache registered name for later use in SpawnCompletionCallback
+                if (wasSpawned)
                 {
-                    // call and remove the callback
-                    spawnData->second.m_completedCb(AZ::Success(registeredName));
-                    m_spawnCompletedCallbacks.erase(spawnData);
+                    spawnDataIt->second.m_registered = true;
+                    spawnDataIt->second.m_resultedName = registeredName;
                 }
 
-                // cache the initial state
+                // cache the initial state - for simulator reset with SCOPE_STATE.
                 EntityState initialState{};
                 initialState.m_pose = entity->GetTransform()->GetWorldTM();
                 if (rigidBody)
@@ -256,6 +280,7 @@ namespace SimulationInterfaces
 
     AZStd::string SimulationEntitiesManager::AddSimulatedEntity(AZ::EntityId entityId, const AZStd::string& userProposedName)
     {
+
         if (!entityId.IsValid())
         {
             return "";
@@ -683,15 +708,7 @@ namespace SimulationInterfaces
                     }
                 }
             }
-
-            // change names for all entites
-            for (auto* entity : view)
-            {
-                AZStd::string entityName = AZStd::string::format("%s_%s", name.c_str(), entity->GetName().c_str());
-                entity->SetName(entityName);
-            }
             const AZ::Entity* root = *view.begin();
-
             auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
             if (transformInterface)
             {
@@ -708,17 +725,24 @@ namespace SimulationInterfaces
             auto spawnData = m_spawnCompletedCallbacks.find(ticketId);
             if (spawnData != m_spawnCompletedCallbacks.end())
             {
-                // call and remove the callback
-                const auto msg = AZStd::string::format(
-                    "Entity %s (uri : %s) was not registered in simulation interface - "
-                    "no physics component or physics component is not enabled in source prefab.\n"
-                    "Entity will be in simulation, but not available in simulation interface.\n"
-                    "Please add some physics component (at least one static rigid body component) to the prefab.\n"
-                    "Technically, it is a memory leak.\n",
-                    spawnData->second.m_userProposedName.c_str(),
-                    uri.c_str());
-                AZ_Error("SimulationInterfaces", false, msg.c_str());
-                spawnData->second.m_completedCb(msg);
+                // call the API user's callback, when the entity was registered
+                if (spawnData->second.m_registered)
+                {
+                    spawnData->second.m_completedCb(AZ::Success(spawnData->second.m_resultedName));
+                }
+                else
+                {
+                    // call the error callback, when the entity was not registered
+                    const auto msg = AZStd::string::format(
+                        "Entity %s (uri : %s) was not registered in simulation interface - "
+                        "no physics component or physics component is not enabled in source prefab.\n"
+                        "Entity will be in simulation, but not available in simulation interface.\n"
+                        "Please add some physics component (at least one static rigid body component) to the prefab.\n"
+                        "Technically, it is a memory leak.\n",
+                        spawnData->second.m_userProposedName.c_str(),
+                        uri.c_str());
+                    spawnData->second.m_completedCb(msg);
+                }
                 m_spawnCompletedCallbacks.erase(spawnData);
             }
         };
@@ -738,21 +762,22 @@ namespace SimulationInterfaces
     AZStd::string SimulationEntitiesManager::GetSimulatedEntityName(AZ::EntityId entityId, const AZStd::string& proposedName) const
     {
         // Get O3DE entity name
-        AZStd::string entityName = proposedName;
-        if (entityName.empty())
+        AZStd::string newName = proposedName;
+        // check if name is not unique. If not, add Entity Name to name
+        if (m_simulatedEntityToEntityIdMap.contains(newName))
         {
+            AZStd::string entityName;
             AZ::ComponentApplicationBus::BroadcastResult(entityName, &AZ::ComponentApplicationRequests::GetEntityName, entityId);
-        }
-        // Generate unique simulated entity name
-        AZStd::string simulatedEntityName = entityName;
-        // check if name is unique
-        auto otherEntityIt = m_simulatedEntityToEntityIdMap.find(simulatedEntityName);
-        if (otherEntityIt != m_simulatedEntityToEntityIdMap.end())
-        {
             // name is not unique, add entityId to name
-            simulatedEntityName = AZStd::string::format("%s_%s", entityName.c_str(), entityId.ToString().c_str());
+            newName = AZStd::string::format("%s_%s", newName.c_str(), entityName.c_str());
         }
-        return simulatedEntityName;
+
+        // check if name is still not unique, if not, add EntityId to name
+        if(m_simulatedEntityToEntityIdMap.contains(newName))
+        {
+            newName = AZStd::string::format("%s_%s", newName.c_str(), entityId.ToString().c_str());
+        }
+        return newName;
     }
 
     void SimulationEntitiesManager::ResetAllEntitiesToInitialState()

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -151,6 +151,11 @@ namespace SimulationInterfaces
                         rigidBody->GetEntityId().ToString().c_str());
                 }
                 const AZ::EntityId entityId = body->GetEntityId();
+                AZ_Assert(entityId.IsValid(), "EntityId is not valid");
+                if (!entityId.IsValid())
+                {
+                    return;
+                }
                 AZ::Entity* entity = nullptr;
                 AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, entityId);
                 AZ_Assert(entity, "Entity is not available.");

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
@@ -76,6 +76,8 @@ namespace SimulationInterfaces
         //! Set the state of the entity and their descendants.
         void SetEntitiesState(const AZStd::vector<AZ::EntityId>& entityAndDescendants, const EntityState& state);
 
+        bool m_registerEverySimulatedEntity = false; //! Flag to register every simulated entity
+
         AzPhysics::SceneEvents::OnSimulationBodyAdded::Handler m_simulationBodyAddedHandler;
         AzPhysics::SceneEvents::OnSimulationBodyRemoved::Handler m_simulationBodyRemovedHandler;
 
@@ -90,8 +92,10 @@ namespace SimulationInterfaces
         struct SpawnCompletedCbData
         {
             AZStd::string m_userProposedName; //! Name proposed by the User in spawn request
+            AZStd::string m_resultedName; //! Name of the entity in the simulation interface
             SpawnCompletedCb m_completedCb; //! User callback to be called when the entity is registered
             AZ::ScriptTimePoint m_spawnCompletedTime; //! Time at which the entity was spawned
+            bool m_registered = false; //! Flag to check if the entity was registered
         };
         AZStd::unordered_map<AzFramework::EntitySpawnTicket::Id, SpawnCompletedCbData>
             m_spawnCompletedCallbacks; //! Callbacks to be called when the entity is registered


### PR DESCRIPTION
## What does this PR do?

Changed default behavior of the SimulationEntitiesManager to registry only main entity.

We can register part of spawned robot, but it needs special design of the prefab. Advanced user can enable this behavior by setting the registry to:
```
"SimulationInterfaces":
{
    "RegisterEverySimulatedEntity" : true
}
```
Also naming strategy was adjusted to be more predictable.


**Default behavior**
Only main robot's entity is registered:
![image](https://github.com/user-attachments/assets/56e1b123-fd1a-4fe6-94dc-b5efa5092362)
**RegisterEverySimulatedEntity true behavior**
Robots parts are registered as well.
![image](https://github.com/user-attachments/assets/155bded3-66e2-4126-a4a5-4c2c00f1cfb3)

## How was this PR tested?

- manual tests
- run existing tests.
