### PR TITLE
[Simulation interfaces] Fix for wrong simulation state after reset

### DIFF
--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.cpp
@@ -84,6 +84,20 @@ namespace SimulationInterfaces
     void SimulationManager::Init()
     {
     }
+    void SimulationManager::InitializeSimulationState()
+    {
+        // if start in stopped state, pause simulation. Default state for simulation by the standard is STOPPED and
+        // SetSimulationState has logic to prevent transition to the same state.
+        if (StartInStoppedState())
+        {
+            m_simulationState = simulation_interfaces::msg::SimulationState::STATE_STOPPED;
+            SetSimulationPaused(true);
+        }
+        else
+        {
+            SetSimulationState(simulation_interfaces::msg::SimulationState::STATE_PLAYING);
+        }
+    }
 
     void SimulationManager::Activate()
     {
@@ -104,16 +118,7 @@ namespace SimulationInterfaces
         AZ::SystemTickBus::QueueFunction(
             [this]()
             {
-                // if start in stopped state, pause simulation. Default state for simulation by the standard is STOPPED and
-                // SetSimulationState has logic to prevent transition to the same state.
-                if (StartInStoppedState())
-                {
-                    SetSimulationPaused(true);
-                }
-                else
-                {
-                    SetSimulationState(simulation_interfaces::msg::SimulationState::STATE_PLAYING);
-                }
+                InitializeSimulationState();
             });
     }
 
@@ -224,6 +229,8 @@ namespace SimulationInterfaces
             m_reloadLevelCallback();
             m_reloadLevelCallback = nullptr;
         }
+        // reset of the simulation, assign the same state as at the beginning
+        InitializeSimulationState();
         AzFramework::LevelSystemLifecycleNotificationBus::Handler::BusDisconnect();
     }
 

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.h
@@ -68,6 +68,8 @@ namespace SimulationInterfaces
         SimulationState m_simulationState{
             simulation_interfaces::msg::SimulationState::STATE_STOPPED
         }; // default simulation state based on standard
+        void InitializeSimulationState();
+
     private:
         bool IsTransitionForbidden(SimulationState requestedState);
         // forbidden transition between state, first is current state, second is desire state


### PR DESCRIPTION
## What does this PR do?

PR fixes wrong simulation state after resetting it.

## How was this PR tested?
Manual calling to the `/set_simulation_state`, `/get_simulation_state` and `/reset_simulation`