### PR TITLE
[Simulation interfaces] - fix for test unity build

### DIFF
--- a/Gems/SimulationInterfaces/Code/Tests/Tools/TestFixture.h
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/TestFixture.h
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#pragma once
 
 #include <AzCore/Asset/AssetManagerComponent.h>
 #include <AzCore/Component/ComponentApplication.h>


### PR DESCRIPTION
## What does this PR do?
PR adds missing `#pragma once` which causes failed build in unity mode.

## How was this PR tested?

build gem and tests with unity build
ran built tests
