### PR TITLE
[Simulation Interfaces] Alias type from ROS 2 messages, instead of hardcoding

### DIFF
--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/ROS2SimulationInterfacesRequestBus.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/ROS2SimulationInterfacesRequestBus.h
@@ -13,10 +13,10 @@
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/std/containers/unordered_set.h>
-
+#include <simulation_interfaces/msg/simulator_features.hpp>
 namespace ROS2SimulationInterfaces
 {
-    using SimulationFeatureType = uint8_t;
+    using SimulationFeatureType = simulation_interfaces::msg::SimulatorFeatures::_features_type::value_type;
     class ROS2SimulationInterfacesRequests
     {
     public:

--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/Result.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/Result.h
@@ -9,11 +9,12 @@
 #pragma once
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/std/string/string.h>
+#include <simulation_interfaces/msg/result.hpp>
 namespace SimulationInterfaces
 {
     //! Result codes to be used in the Result message
     //!  @see <a href="https://github.com/ros-simulation/simulation_interfaces/blob/main/msg/Result.msg">Result.msg</a>
-    using ErrorCodeType = uint8_t;
+    using ErrorCodeType = simulation_interfaces::msg::Result::_result_type;
 
     //! A message type to represent the result of a failed operation
     struct FailedResult

--- a/Gems/SimulationInterfaces/Code/Source/Actions/ROS2ActionBase.h
+++ b/Gems/SimulationInterfaces/Code/Source/Actions/ROS2ActionBase.h
@@ -93,7 +93,7 @@ namespace ROS2SimulationInterfaces
 
         //! return features id defined by the handler, ids must follow the definition inside standard:
         //! @see https://github.com/ros-simulation/simulation_interfaces/blob/main/msg/SimulatorFeatures.msg
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override
         {
             return {};
         };

--- a/Gems/SimulationInterfaces/Code/Source/Actions/SimulateStepsActionServerHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Actions/SimulateStepsActionServerHandler.cpp
@@ -23,11 +23,11 @@ namespace ROS2SimulationInterfaces
         SimulationInterfaces::SimulationManagerNotificationsBus::Handler::BusDisconnect();
     }
 
-    AZStd::unordered_set<AZ::u8> SimulateStepsActionServerHandler::GetProvidedFeatures()
+    AZStd::unordered_set<SimulationFeatureType> SimulateStepsActionServerHandler::GetProvidedFeatures()
     {
-        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::STEP_SIMULATION_ACTION,
-                                             SimulationFeatures::STEP_SIMULATION_SINGLE,
-                                             SimulationFeatures::STEP_SIMULATION_MULTIPLE };
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::STEP_SIMULATION_ACTION,
+                                                            SimulationFeatures::STEP_SIMULATION_SINGLE,
+                                                            SimulationFeatures::STEP_SIMULATION_MULTIPLE };
     }
 
     AZStd::string_view SimulateStepsActionServerHandler::GetTypeName() const

--- a/Gems/SimulationInterfaces/Code/Source/Actions/SimulateStepsActionServerHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Actions/SimulateStepsActionServerHandler.h
@@ -25,7 +25,7 @@ namespace ROS2SimulationInterfaces
         ~SimulateStepsActionServerHandler();
 
         // IROS2HandlerBase overrides
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
         AZStd::string_view GetTypeName() const override;
         AZStd::string_view GetDefaultName() const override;
         void Initialize(rclcpp::Node::SharedPtr& node) override;

--- a/Gems/SimulationInterfaces/Code/Source/Clients/ROS2SimulationInterfacesSystemComponent.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/ROS2SimulationInterfacesSystemComponent.cpp
@@ -103,9 +103,9 @@ namespace ROS2SimulationInterfaces
         }
     }
 
-    AZStd::unordered_set<AZ::u8> ROS2SimulationInterfacesSystemComponent::GetSimulationFeatures()
+    AZStd::unordered_set<SimulationFeatureType> ROS2SimulationInterfacesSystemComponent::GetSimulationFeatures()
     {
-        AZStd::unordered_set<AZ::u8> result;
+        AZStd::unordered_set<SimulationFeatureType> result;
         for (auto& [handlerType, handler] : m_availableRos2Interface)
         {
             auto features = handler->GetProvidedFeatures();

--- a/Gems/SimulationInterfaces/Code/Source/Clients/ROS2SimulationInterfacesSystemComponent.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/ROS2SimulationInterfacesSystemComponent.h
@@ -56,7 +56,7 @@ namespace ROS2SimulationInterfaces
         void Deactivate() override;
 
         // ROS2SimulationInterfacesRequestBus override
-        AZStd::unordered_set<AZ::u8> GetSimulationFeatures() override;
+        AZStd::unordered_set<SimulationFeatureType> GetSimulationFeatures() override;
 
     private:
         AZStd::unordered_map<AZStd::string, AZStd::shared_ptr<IROS2HandlerBase>> m_availableRos2Interface;

--- a/Gems/SimulationInterfaces/Code/Source/Interfaces/IROS2HandlerBase.h
+++ b/Gems/SimulationInterfaces/Code/Source/Interfaces/IROS2HandlerBase.h
@@ -9,6 +9,7 @@
 #pragma once
 #include <AzCore/std/containers/unordered_set.h>
 #include <AzCore/std/string/string_view.h>
+#include <SimulationInterfaces/ROS2SimulationInterfacesRequestBus.h>
 #include <rclcpp/rclcpp.hpp>
 
 namespace ROS2SimulationInterfaces
@@ -17,8 +18,9 @@ namespace ROS2SimulationInterfaces
     class IROS2HandlerBase
     {
     public:
+        using SimulationFeatureType = ROS2SimulationInterfaces::SimulationFeatureType;
         virtual ~IROS2HandlerBase() = default;
-        virtual AZStd::unordered_set<AZ::u8> GetProvidedFeatures() = 0;
+        virtual AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() = 0;
         virtual AZStd::string_view GetTypeName() const = 0;
         virtual AZStd::string_view GetDefaultName() const = 0;
         virtual void Initialize(rclcpp::Node::SharedPtr& node) = 0;

--- a/Gems/SimulationInterfaces/Code/Source/Services/DeleteEntityServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/DeleteEntityServiceHandler.cpp
@@ -13,9 +13,9 @@
 namespace ROS2SimulationInterfaces
 {
 
-    AZStd::unordered_set<AZ::u8> DeleteEntityServiceHandler::GetProvidedFeatures()
+    AZStd::unordered_set<SimulationFeatureType> DeleteEntityServiceHandler::GetProvidedFeatures()
     {
-        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::DELETING };
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::DELETING };
     }
 
     AZStd::optional<DeleteEntityServiceHandler::Response> DeleteEntityServiceHandler::HandleServiceRequest(

--- a/Gems/SimulationInterfaces/Code/Source/Services/DeleteEntityServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/DeleteEntityServiceHandler.h
@@ -27,7 +27,7 @@ namespace ROS2SimulationInterfaces
         {
             return "delete_entity";
         }
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetEntitiesServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetEntitiesServiceHandler.cpp
@@ -13,12 +13,12 @@
 
 namespace ROS2SimulationInterfaces
 {
-    AZStd::unordered_set<AZ::u8> GetEntitiesServiceHandler::GetProvidedFeatures()
+    AZStd::unordered_set<SimulationFeatureType> GetEntitiesServiceHandler::GetProvidedFeatures()
     {
-        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::ENTITY_TAGS,
-                                             SimulationFeatures::ENTITY_BOUNDS_BOX,
-                                             SimulationFeatures::ENTITY_BOUNDS_CONVEX,
-                                             SimulationFeatures::ENTITY_CATEGORIES };
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::ENTITY_TAGS,
+                                                            SimulationFeatures::ENTITY_BOUNDS_BOX,
+                                                            SimulationFeatures::ENTITY_BOUNDS_CONVEX,
+                                                            SimulationFeatures::ENTITY_CATEGORIES };
     }
 
     AZStd::optional<GetEntitiesServiceHandler::Response> GetEntitiesServiceHandler::HandleServiceRequest(

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetEntitiesServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetEntitiesServiceHandler.h
@@ -26,7 +26,7 @@ namespace ROS2SimulationInterfaces
         {
             return "get_entities";
         }
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetEntitiesStatesServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetEntitiesStatesServiceHandler.cpp
@@ -14,13 +14,13 @@
 
 namespace ROS2SimulationInterfaces
 {
-    AZStd::unordered_set<AZ::u8> GetEntitiesStatesServiceHandler::GetProvidedFeatures()
+    AZStd::unordered_set<SimulationFeatureType> GetEntitiesStatesServiceHandler::GetProvidedFeatures()
     {
-        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::ENTITY_TAGS,
-                                             SimulationFeatures::ENTITY_BOUNDS_BOX,
-                                             SimulationFeatures::ENTITY_BOUNDS_CONVEX,
-                                             SimulationFeatures::ENTITY_CATEGORIES,
-                                             SimulationFeatures::ENTITY_STATE_GETTING };
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::ENTITY_TAGS,
+                                                            SimulationFeatures::ENTITY_BOUNDS_BOX,
+                                                            SimulationFeatures::ENTITY_BOUNDS_CONVEX,
+                                                            SimulationFeatures::ENTITY_CATEGORIES,
+                                                            SimulationFeatures::ENTITY_STATE_GETTING };
     }
 
     AZStd::optional<GetEntitiesStatesServiceHandler::Response> GetEntitiesStatesServiceHandler::HandleServiceRequest(

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetEntitiesStatesServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetEntitiesStatesServiceHandler.h
@@ -27,7 +27,7 @@ namespace ROS2SimulationInterfaces
         {
             return "get_entities_states";
         }
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetEntityStateServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetEntityStateServiceHandler.cpp
@@ -14,9 +14,9 @@
 namespace ROS2SimulationInterfaces
 {
 
-    AZStd::unordered_set<AZ::u8> GetEntityStateServiceHandler::GetProvidedFeatures()
+    AZStd::unordered_set<SimulationFeatureType> GetEntityStateServiceHandler::GetProvidedFeatures()
     {
-        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::ENTITY_STATE_GETTING };
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::ENTITY_STATE_GETTING };
     }
 
     AZStd::optional<GetEntityStateServiceHandler::Response> GetEntityStateServiceHandler::HandleServiceRequest(

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetEntityStateServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetEntityStateServiceHandler.h
@@ -27,7 +27,7 @@ namespace ROS2SimulationInterfaces
         {
             return "get_entity_state";
         }
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetSimulationStateServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetSimulationStateServiceHandler.cpp
@@ -13,9 +13,9 @@
 
 namespace ROS2SimulationInterfaces
 {
-    AZStd::unordered_set<AZ::u8> GetSimulationStateServiceHandler::GetProvidedFeatures()
+    AZStd::unordered_set<SimulationFeatureType> GetSimulationStateServiceHandler::GetProvidedFeatures()
     {
-        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::SIMULATION_STATE_GETTING };
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::SIMULATION_STATE_GETTING };
     }
 
     AZStd::optional<GetSimulationStateServiceHandler::Response> GetSimulationStateServiceHandler::HandleServiceRequest(

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetSimulationStateServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetSimulationStateServiceHandler.h
@@ -27,7 +27,7 @@ namespace ROS2SimulationInterfaces
         {
             return "get_simulation_state";
         }
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
     };

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetSpawnablesServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetSpawnablesServiceHandler.cpp
@@ -12,9 +12,9 @@
 namespace ROS2SimulationInterfaces
 {
 
-    AZStd::unordered_set<AZ::u8> GetSpawnablesServiceHandler::GetProvidedFeatures()
+    AZStd::unordered_set<SimulationFeatureType> GetSpawnablesServiceHandler::GetProvidedFeatures()
     {
-        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::SPAWNABLES };
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::SPAWNABLES };
     }
 
     AZStd::optional<GetSpawnablesServiceHandler::Response> GetSpawnablesServiceHandler::HandleServiceRequest(

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetSpawnablesServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetSpawnablesServiceHandler.h
@@ -27,7 +27,7 @@ namespace ROS2SimulationInterfaces
         {
             return "get_spawnables";
         }
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/ROS2ServiceBase.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/ROS2ServiceBase.h
@@ -48,7 +48,7 @@ namespace ROS2SimulationInterfaces
 
         //! return features id defined by the handler, ids must follow the definition inside standard:
         //! @see https://github.com/ros-simulation/simulation_interfaces/blob/main/msg/SimulatorFeatures.msg
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override
         {
             return {};
         };

--- a/Gems/SimulationInterfaces/Code/Source/Services/ResetSimulationServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/ResetSimulationServiceHandler.cpp
@@ -20,12 +20,12 @@
 namespace ROS2SimulationInterfaces
 {
 
-    AZStd::unordered_set<AZ::u8> ResetSimulationServiceHandler::GetProvidedFeatures()
+    AZStd::unordered_set<SimulationFeatureType> ResetSimulationServiceHandler::GetProvidedFeatures()
     {
-        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::SIMULATION_RESET,
-                                             SimulationFeatures::SIMULATION_RESET_TIME,
-                                             SimulationFeatures::SIMULATION_RESET_STATE,
-                                             SimulationFeatures::SIMULATION_RESET_SPAWNED };
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::SIMULATION_RESET,
+                                                            SimulationFeatures::SIMULATION_RESET_TIME,
+                                                            SimulationFeatures::SIMULATION_RESET_STATE,
+                                                            SimulationFeatures::SIMULATION_RESET_SPAWNED };
     }
 
     AZStd::optional<ResetSimulationServiceHandler::Response> ResetSimulationServiceHandler::HandleServiceRequest(

--- a/Gems/SimulationInterfaces/Code/Source/Services/ResetSimulationServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/ResetSimulationServiceHandler.h
@@ -26,7 +26,7 @@ namespace ROS2SimulationInterfaces
         {
             return "reset_simulation";
         }
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
     };

--- a/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
@@ -13,9 +13,9 @@
 namespace ROS2SimulationInterfaces
 {
 
-    AZStd::unordered_set<AZ::u8> SetEntityStateServiceHandler::GetProvidedFeatures()
+    AZStd::unordered_set<SimulationFeatureType> SetEntityStateServiceHandler::GetProvidedFeatures()
     {
-        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::ENTITY_STATE_SETTING };
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::ENTITY_STATE_SETTING };
     }
 
     AZStd::optional<SetEntityStateServiceHandler::Response> SetEntityStateServiceHandler::HandleServiceRequest(

--- a/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.h
@@ -27,7 +27,7 @@ namespace ROS2SimulationInterfaces
         {
             return "set_entity_state";
         }
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/SetSimulationStateServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SetSimulationStateServiceHandler.cpp
@@ -13,9 +13,10 @@
 
 namespace ROS2SimulationInterfaces
 {
-    AZStd::unordered_set<AZ::u8> SetSimulationStateServiceHandler::GetProvidedFeatures()
+    AZStd::unordered_set<SimulationFeatureType> SetSimulationStateServiceHandler::GetProvidedFeatures()
     {
-        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::SIMULATION_STATE_SETTING, SimulationFeatures::SIMULATION_STATE_PAUSE };
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::SIMULATION_STATE_SETTING,
+                                                            SimulationFeatures::SIMULATION_STATE_PAUSE };
     }
 
     AZStd::optional<SetSimulationStateServiceHandler::Response> SetSimulationStateServiceHandler::HandleServiceRequest(

--- a/Gems/SimulationInterfaces/Code/Source/Services/SetSimulationStateServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SetSimulationStateServiceHandler.h
@@ -27,7 +27,7 @@ namespace ROS2SimulationInterfaces
         {
             return "set_simulation_state";
         }
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
     };

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
@@ -15,9 +15,9 @@
 namespace ROS2SimulationInterfaces
 {
 
-    AZStd::unordered_set<AZ::u8> SpawnEntityServiceHandler::GetProvidedFeatures()
+    AZStd::unordered_set<SimulationFeatureType> SpawnEntityServiceHandler::GetProvidedFeatures()
     {
-        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::SPAWNING };
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::SPAWNING };
     }
 
     AZStd::optional<SpawnEntityServiceHandler::Response> SpawnEntityServiceHandler::HandleServiceRequest(

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.h
@@ -26,7 +26,7 @@ namespace ROS2SimulationInterfaces
         {
             return "spawn_entity";
         }
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/StepSimulationServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/StepSimulationServiceHandler.cpp
@@ -14,9 +14,10 @@
 namespace ROS2SimulationInterfaces
 {
 
-    AZStd::unordered_set<AZ::u8> StepSimulationServiceHandler::GetProvidedFeatures()
+    AZStd::unordered_set<SimulationFeatureType> StepSimulationServiceHandler::GetProvidedFeatures()
     {
-        return AZStd::unordered_set<AZ::u8>{ SimulationFeatures::STEP_SIMULATION_SINGLE, SimulationFeatures::STEP_SIMULATION_MULTIPLE };
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::STEP_SIMULATION_SINGLE,
+                                                            SimulationFeatures::STEP_SIMULATION_MULTIPLE };
     }
 
     AZStd::optional<StepSimulationServiceHandler::Response> StepSimulationServiceHandler::HandleServiceRequest(

--- a/Gems/SimulationInterfaces/Code/Source/Services/StepSimulationServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/StepSimulationServiceHandler.h
@@ -29,7 +29,7 @@ namespace ROS2SimulationInterfaces
         {
             return "step_simulation";
         }
-        AZStd::unordered_set<AZ::u8> GetProvidedFeatures() override;
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
 


### PR DESCRIPTION
## What does this PR do?

It remove hardocing (e.g. AZ::u8) of certain types in internal API of the gem.
It uses aliases from ROS 2 messages.

## How was this PR tested?

Unitests.