### PR TITLE
Added SpinUntilFuture to test fixture

### DIFF
--- a/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
@@ -143,7 +143,7 @@ namespace UnitTest
             pub->publish(msg);
         }
         SpinAppSome();
-ed         EXPECT_EQ(receivedMsgs, 10) << "Did not receive all messages.";
+        EXPECT_EQ(receivedMsgs, 10) << "Did not receive all messages.";
     }
 
     //! Check if expected services are available and has the default name


### PR DESCRIPTION
## What does this PR do?

It makes a little more intelligent (rather less dumb) test fixture, that waits for future to be ready.

## How was this PR tested?
Executed tests.