### PR TITLE
Prevent loading SimulationInterface.Editor in other tools than Editor.

### DIFF
--- a/Gems/SimulationInterfaces/Registry/SimulationInterface.Editor.setreg
+++ b/Gems/SimulationInterfaces/Registry/SimulationInterface.Editor.setreg
@@ -1,0 +1,13 @@
+{
+  "O3DE": {
+    "Gems": {
+      "SimulationInterfaces": {
+        "Targets": {
+          "SimulationInterfaces.Editor": {
+            "AutoLoad": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/Gems/SimulationInterfaces/Registry/SimulationInterface.setreg
+++ b/Gems/SimulationInterfaces/Registry/SimulationInterface.setreg
@@ -1,0 +1,13 @@
+{
+  "O3DE": {
+    "Gems": {
+      "SimulationInterfaces": {
+        "Targets": {
+          "SimulationInterfaces.Editor": {
+            "AutoLoad": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

The  SimulationInterfaces.Editor has system components that prevented loading tools like Material editor.

## How was this PR tested?

- Run Editor (**libSimulationInterfaces.Editor.so** loaded, functionality available)
- Run Material Editor (**libSimulationInterfaces.Editor.so** not loaded)
- Run GameLauncher (**libSimulationInterfaces.so** loaded, functionality available)
- Run tests.