### PR TITLE
[Simulation Interfaces] Reset tickets and cached information on deactivation of SimulationEntityManager

### DIFF
--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -283,6 +283,13 @@ namespace SimulationInterfaces
         m_physicsScenesHandle = AzPhysics::InvalidSceneHandle;
 
         m_sceneAddedHandler.Disconnect();
+        m_sceneRemovedHandler.Disconnect();
+
+        m_unconfiguredScenesHandles.clear();
+        m_entityIdToSimulatedEntityMap.clear();
+        m_simulatedEntityToEntityIdMap.clear();
+        m_entityIdToInitialState.clear();
+        m_spawnedTickets.clear();
     }
 
     AZStd::string SimulationEntitiesManager::AddSimulatedEntity(AZ::EntityId entityId, const AZStd::string& userProposedName)
@@ -636,8 +643,9 @@ namespace SimulationInterfaces
         if (!initialPose.IsOrthogonal())
         {
             AZ_Warning("SimulationInterfaces", false, "Initial pose is not orthogonal");
-            completedCb(AZ::Failure(FailedResult(
-                simulation_interfaces::srv::SpawnEntity::Response::INVALID_POSE, "Initial pose is not orthogonal"))); //  INVALID_POSE
+            completedCb(
+                AZ::Failure(FailedResult(
+                    simulation_interfaces::srv::SpawnEntity::Response::INVALID_POSE, "Initial pose is not orthogonal"))); //  INVALID_POSE
             return;
         }
 

--- a/Gems/SimulationInterfaces/Code/Source/Tools/SimulationEntitiesManagerEditor.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Tools/SimulationEntitiesManagerEditor.cpp
@@ -54,13 +54,23 @@ namespace SimulationInterfaces
 
     void SimulationEntitiesManagerEditor::Activate()
     {
-        SimulationEntitiesManager::Activate();
         AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
+        AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
     }
 
     void SimulationEntitiesManagerEditor::Deactivate()
     {
+        AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect();
+    }
+
+    void SimulationEntitiesManagerEditor::OnStartPlayInEditorBegin()
+    {
+        SimulationEntitiesManager::Activate();
+    }
+
+    void SimulationEntitiesManagerEditor::OnStopPlayInEditorBegin()
+    {
         SimulationEntitiesManager::Deactivate();
     }
 

--- a/Gems/SimulationInterfaces/Code/Source/Tools/SimulationEntitiesManagerEditor.h
+++ b/Gems/SimulationInterfaces/Code/Source/Tools/SimulationEntitiesManagerEditor.h
@@ -10,6 +10,7 @@
 
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 
+#include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <Clients/SimulationEntitiesManager.h>
 
 namespace SimulationInterfaces
@@ -18,6 +19,7 @@ namespace SimulationInterfaces
     class SimulationEntitiesManagerEditor
         : public SimulationEntitiesManager
         , protected AzToolsFramework::EditorEvents::Bus::Handler
+        , private AzToolsFramework::EditorEntityContextNotificationBus::Handler
     {
         using BaseSystemComponent = SimulationEntitiesManager;
 
@@ -38,5 +40,9 @@ namespace SimulationInterfaces
         // AZ::Component
         void Activate() override;
         void Deactivate() override;
+
+        // EditorEntityContextNotificationBus
+        void OnStartPlayInEditorBegin() override;
+        void OnStopPlayInEditorBegin() override;
     };
 } // namespace SimulationInterfaces


### PR DESCRIPTION


## What does this PR do?

The spawned entity were leaking in Editor workflow. I've made sure to clean tickets on leaving game mode.
## How was this PR tested?

- spawn with simulation interface in Editor, leave game mode.
- Test.