### PR TITLE
Add FrameSystemComponent to AssetBuilder

### DIFF
--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -39,12 +39,18 @@ namespace ROS2
     {
         ROS2FrameComponentBus::Handler::BusConnect(GetEntityId());
         AZ::EntityBus::Handler::BusConnect(GetEntityId());
-        ROS2FrameSystemInterface::Get()->RegisterFrame(GetEntityId());
+        if (auto* frameSystemInterface = ROS2FrameSystemInterface::Get())
+        {
+            frameSystemInterface->RegisterFrame(GetEntityId());
+        }
     }
 
     void ROS2FrameEditorComponent::Deactivate()
     {
-        ROS2FrameSystemInterface::Get()->UnregisterFrame(GetEntityId());
+        if (auto* frameSystemInterface = ROS2FrameSystemInterface::Get())
+        {
+            frameSystemInterface->UnregisterFrame(GetEntityId());
+        }
         AZ::EntityBus::Handler::BusDisconnect();
         ROS2FrameComponentBus::Handler::BusDisconnect();
     }

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameSystemBus.h
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameSystemBus.h
@@ -7,13 +7,13 @@
  */
 #pragma once
 
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/EBus/EBus.h>
 #include <AzCore/EBus/Policies.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 #include <AzCore/std/string/string.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
-#include <AzCore/Component/EntityId.h>
-#include <AzCore/EBus/EBus.h>
 
 namespace ROS2
 {
@@ -66,7 +66,7 @@ namespace ROS2
     {
     public:
         static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
-        static constexpr AZ::EBusHandlerPolicy AddressPolicy = AZ::EBusHandlerPolicy::Single;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
     };
 
     using ROS2FrameSystemInterface = AZ::Interface<ROS2FrameSystemRequests>;

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameSystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameSystemComponent.cpp
@@ -72,7 +72,8 @@ namespace ROS2
     {
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<ROS2FrameSystemComponent, AZ::Component>();
+            serialize->Class<ROS2FrameSystemComponent, AZ::Component>()->Version(1)->Attribute(
+                AZ::Edit::Attributes::SystemComponentTags, AZStd::vector<AZ::Crc32>({ AZ_CRC_CE("AssetBuilder") }));
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Edit: The text was updated following the update of the code, as explained below.

The implementation in ROS2Gem was not available in AssetBuilder. That said, it was not able to activate the component due to the missing implementation when importing URDF/SDF files (it might want to do so, e.g., when baking cylinder mesh while importing colliders). As a result, the asset builder was not able to import the model. This PR adds a missing system component to the asset builder. 

## How was this PR tested?
- executed tests
- changed namespace types (empty/custom/entity_name) within the Editor a few times
- created an entity within another entity to verify that the parent namespace was read correctly
- moved the entity with a frame component between two different parents to verify that the parent namespace was read correctly

