### PR TITLE
[RFC 96] Add temporal ROS2.Editor.Static target

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -71,6 +71,24 @@ ly_add_target(
             AZ::AzToolsFramework
             Gem::${gem_name}.Private.Object
 )
+ly_add_target(
+    NAME ${gem_name}.Editor.Static STATIC
+    NAMESPACE Gem
+    FILES_CMAKE
+        ros2_editor_api_files.cmake
+        ros2_editor_shared_api_files.cmake
+    INCLUDE_DIRECTORIES
+        PUBLIC
+            Include
+        PRIVATE
+            Source
+    BUILD_DEPENDENCIES
+        PUBLIC
+            AZ::AzCore
+            AZ::AzToolsFramework
+            Gem::${gem_name}.Editor.Private.Object
+)
+
 
 # The ${gem_name}.API target declares the common interface that users of this gem should depend on in their targets
 ly_add_target(
@@ -219,6 +237,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::${gem_name}.Editor.API
             PRIVATE
                 Gem::${gem_name}.Editor.Private.Object
+                Gem::${gem_name}.Editor.Static
     )
 
     # Include the gem name into the Editor Module source file
@@ -305,6 +324,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                         Legacy::Editor.Headers
                         AZ::AzManipulatorTestFramework.Static
                         Gem::${gem_name}.Editor.Private.Object
+                        Gem::${gem_name}.Editor.Static
                         Gem::${gem_name}.Static
                 RUNTIME_DEPENDENCIES
                     Legacy::Editor

--- a/Gems/ROS2/Code/ros2_editor_shared_api_files.cmake
+++ b/Gems/ROS2/Code/ros2_editor_shared_api_files.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+set(FILES
+    Source/Frame/ROS2FrameEditorComponent.cpp
+)

--- a/Gems/ROS2RobotImporter/Code/CMakeLists.txt
+++ b/Gems/ROS2RobotImporter/Code/CMakeLists.txt
@@ -146,7 +146,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 AZ::AzToolsFramework
                 Gem::CommonFeaturesAtom.Editor.Static
                 Gem::PhysX5.Editor.Static
-                Gem::ROS2.Editor
+                Gem::ROS2.Editor.Static
                 Gem::ROS2.Static
                 ${gem_name}.Private.Object
             PRIVATE


### PR DESCRIPTION
## What does this PR do?

**Note:** this PR targets the feature branch, not the `development` branch.

ROS2 Gem used to have _all public_ API. This was fixed in #897. Unfortunately, one file was missing, and linking in `ROS2RobotImporter` Gem fails. This PR adds temporarily a target with a component that is required by `ROS2RobotImporter` Gem. This target will be removed when redoing the API of `ROS2` Gem and moving to buses. 

## How was this PR tested?

The code builds, the `ROS2RobotImporter` can correctly set joint names in `ROS2FrameComponent`.