### PR TITLE
Port changes back stabilization/25050 -> development

### DIFF
--- a/Gems/LevelGeoreferencing/gem.json
+++ b/Gems/LevelGeoreferencing/gem.json
@@ -12,17 +12,20 @@
         "Gem"
     ],
     "user_tags": [
-        "Georeferencing", "LevelGeoreferencing"
+        "Georeferencing",
+        "LevelGeoreferencing"
     ],
-    "platforms": [
-        ""
-    ],
+    "platforms": [],
     "icon_path": "preview.png",
     "requirements": "",
     "documentation_url": "https://www.docs.o3de.org/docs/user-guide/interactivity/robotics/georeference/",
     "dependencies": [],
-    "repo_uri": "",
-    "compatible_engines": [],
+    "compatible_engines": [
+        "o3de-sdk>=2.4.0",
+        "o3de>=2.4.0"
+    ],
     "engine_api_dependencies": [],
-    "restricted": "LevelGeoreferencing"
+    "restricted": "LevelGeoreferencing",
+    "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/levelgeoreferencing-1.0.0-gem.zip"
 }

--- a/Gems/MachineLearning/gem.json
+++ b/Gems/MachineLearning/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "MachineLearning",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "display_name": "MachineLearning",
     "license": "License used i.e. Apache-2.0 or MIT",
     "license_url": "Link to the license web site i.e. https://opensource.org/licenses/Apache-2.0",
@@ -21,8 +21,9 @@
     "requirements": "Notice of any requirements for this Gem i.e. This requires X other gem",
     "documentation_url": "Link to any documentation of your Gem",
     "dependencies": [],
-    "repo_uri": "",
+    "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "compatible_engines": [],
     "engine_api_dependencies": [],
-    "restricted": "MachineLearning"
+    "restricted": "MachineLearning",
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/machinelearning-1.0.1-gem.zip"
 }

--- a/Gems/OpenXRVk/gem.json
+++ b/Gems/OpenXRVk/gem.json
@@ -15,6 +15,6 @@
     "documentation_url": "",
     "dependencies": [],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/openxrvk-1.0.1-gem.zip",
-    "version": "1.0.1"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/openxrvk-1.1.0-gem.zip",
+    "version": "1.1.0"
 }

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -1,9 +1,6 @@
 {
     "gem_name": "ROS2",
     "version": "3.3.0",
-    "platforms": [
-        "Linux"
-    ],
     "display_name": "ROS2",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -18,9 +15,8 @@
     "user_tags": [
         "ROS2"
     ],
-    "compatible_engines": [
-        "o3de-sdk>=4.2.0",
-        "o3de>=4.2.0"
+    "platforms": [
+        "Linux"
     ],
     "icon_path": "preview.png",
     "requirements": "Requires ROS 2 installation (supported distributions: Humble, Jazzy). Source your workspace before building the Gem",
@@ -35,8 +31,12 @@
         "StartingPointInput",
         "LevelGeoreferencing"
     ],
+    "compatible_engines": [
+        "o3de-sdk>=2.4.0",
+        "o3de>=2.4.0"
+    ],
+    "engine_api_dependencies": [],
     "restricted": "ROS2",
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.3.0-gem.zip"
 }
-

--- a/Gems/ROS2SampleRobots/gem.json
+++ b/Gems/ROS2SampleRobots/gem.json
@@ -23,11 +23,12 @@
     "dependencies": [
         "ROS2>=3.1.0"
     ],
-    "repo_uri": "",
+    "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "compatible_engines": [
         "o3de-sdk>=2.3.0",
         "o3de>=2.3.0"
     ],
     "engine_api_dependencies": [],
-    "restricted": "ROS2SampleRobots"
+    "restricted": "ROS2SampleRobots",
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2samplerobots-1.0.0-gem.zip"
 }

--- a/Gems/SimulationInterfaces/gem.json
+++ b/Gems/SimulationInterfaces/gem.json
@@ -20,14 +20,15 @@
         ""
     ],
     "icon_path": "preview.png",
-    "requirements": "Requires ROS 2 Gem",
-    "documentation_url": "",
+    "requirements": "Requires ROS 2 Gem and SimulationInterfaces package installed and sourced.",
+    "documentation_url": "https://www.docs.o3de.org/docs/user-guide/interactivity/robotics/simulation-interfaces/",
     "dependencies": [
         "ROS2>=3.3.0",
         "DebugDraw"
     ],
-    "repo_uri": "",
     "compatible_engines": [],
     "engine_api_dependencies": [],
-    "restricted": "SimulationInterfaces"
+    "restricted": "SimulationInterfaces",
+    "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/simulationinterfaces-1.0.0-gem.zip"
 }

--- a/Gems/WarehouseAssets/gem.json
+++ b/Gems/WarehouseAssets/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "WarehouseAssets",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "display_name": "WarehouseAssets",
     "license": "Apache-2.0 or MIT",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -22,10 +22,10 @@
     "documentation_url": "",
     "dependencies": [],
     "compatible_engines": [
-        "o3de-sdk>=1.2.0",
-        "o3de>=1.2.0"
+        "o3de-sdk>=2.3.0",
+        "o3de>=2.3.0"
     ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "restricted": "",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehouseassets-1.1.0-gem.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehouseassets-2.0.0-gem.zip"
 }

--- a/Gems/XR/gem.json
+++ b/Gems/XR/gem.json
@@ -14,7 +14,11 @@
     "requirements": "",
     "documentation_url": "",
     "dependencies": [],
+    "compatible_engines": [
+        "o3de-sdk>=2.4.0",
+        "o3de>=2.4.0"
+    ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/xr-1.0.1-gem.zip",
-    "version": "1.0.1"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/xr-1.1.0-gem.zip",
+    "version": "1.1.0"
 }

--- a/Templates/Multiplayer/template.json
+++ b/Templates/Multiplayer/template.json
@@ -1,6 +1,6 @@
 {
     "template_name": "Multiplayer",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "origin": "Open 3D Engine - o3de.org",
     "license": "https://opensource.org/licenses/MIT",
     "display_name": "Multiplayer",
@@ -1475,5 +1475,5 @@
         }
     ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/multiplayer-2.0.0-template.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/multiplayer-2.0.1-template.zip"
 }

--- a/Templates/Ros2ProjectTemplate/template.json
+++ b/Templates/Ros2ProjectTemplate/template.json
@@ -1,6 +1,6 @@
 {
     "template_name": "Ros2ProjectTemplate",
-    "version": "2.1.1",
+    "version": "3.0.0",
     "origin": "Open 3D Engine Extras",
     "origin_url": "https://github.com/o3de/o3de-extras",
     "license": "https://github.com/o3de/o3de-extras/tree/development/Templates/Ros2ProjectTemplate/Template/LICENSE.txt",
@@ -579,5 +579,5 @@
         }
     ],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2projecttemplate-2.1.1-template.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2projecttemplate-3.0.0-template.zip"
 }

--- a/repo.json
+++ b/repo.json
@@ -11580,50 +11580,5 @@
         }
     ],
     "projects_data": [
-        {
-            "project_name": "OpenXRTest",
-            "version": "1.0.0",
-            "project_id": "{947211d5-689a-437f-8ad7-7f558edcd40a}",
-            "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-            "origin": "https://github.com/o3de/o3de-extras",
-            "license": "For terms please see the LICENSE*.TXT files at the root of this distribution.",
-            "display_name": "OpenXRTest",
-            "summary": "A sample project that uses OpenXR.",
-            "canonical_tags": [
-                "Project"
-            ],
-            "user_tags": [
-                "OpenXRTest"
-            ],
-            "icon_path": "preview.png",
-            "engine": "o3de",
-            "external_subdirectories": [
-                "Gem"
-            ],
-            "restricted": "OpenXRTest",
-            "gem_names": [
-                "XR",
-                "OpenXRVk"
-            ],
-            "versions_data": [
-                {
-                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/openxrtest-1.0.0-project.zip",
-                    "gem_names": [
-                        "XR>=1.0.1",
-                        "OpenXRVk>=1.0.1"
-                    ],
-                    "version": "1.0.0"
-                },
-                {
-                    "version": "1.0.1",
-                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/openxrtest-1.0.1-project.zip",
-                    "gem_names": [
-                        "XR>=1.0.1",
-                        "OpenXRVk>=1.0.1"
-                    ],
-                    "sha256": "a08e465949826c204af2a9f32a15b616bf1b81c0cdfde62eb070558b7228312f"
-                }
-            ]
-        }
     ]
 }

--- a/repo.json
+++ b/repo.json
@@ -4,7 +4,7 @@
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "summary": "A repository to hold various gems, projects, and templates for the O3DE engine.",
     "additional_info": "Extras gems, projects, and templates for O3DE. See the README.md at the root of this repository for more information",
-    "last_updated": "2025-02-20",
+    "last_updated": "2025-05-26",
     "$schemaVersion": "1.0.0",
     "gems_data": [
         {
@@ -122,8 +122,8 @@
                         "ROS2>=3.1.0"
                     ],
                     "compatible_engines": [
-                        "o3de-sdk>=4.1.0",
-                        "o3de>=4.1.0"
+                        "o3de-sdk>=2.3.0",
+                        "o3de>=2.3.0"
                     ],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/proteusrobot-1.1.0-gem.zip",
                     "sha256": "dec32d93221e2514b59e1ac056b74c771dc4109b4599b5cf290f27a3f2486615"
@@ -7333,7 +7333,7 @@
                         }
                     ],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2projecttemplate-2.0.1-template.zip",
-                    "sha256": "dd56a62e5fa1cd7d412962382845885170edcc1373c1af4b388331f073404c9d"
+                    "sha256": "c7367b98bd6ee5305eb63e0a256899aa57ee299cb553f4ab2555b8e9fef2100b"
                 },
                 {
                     "version": "2.0.2",
@@ -11579,6 +11579,5 @@
             ]
         }
     ],
-    "projects_data": [
-    ]
+    "projects_data": []
 }

--- a/repo.json
+++ b/repo.json
@@ -69,6 +69,12 @@
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/openxrvk-1.0.1-gem.zip",
                     "version": "1.0.1",
                     "sha256": "2595eb8743b0dfc7523eaa1b891a4e8314d73cc3bbfd1a8865f6837ff273ffd1"
+                },
+                {
+                    "summary": "OpenXR Vulkan for Atom",
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/openxrvk-1.1.0-gem.zip",
+                    "version": "1.1.0",
+                    "sha256": "2a49fae6b3b3452cb52315d2131b67ec2a66afe9b031a2c025f678530e4ac673"
                 }
             ]
         },
@@ -271,6 +277,30 @@
                     ],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.2.3-gem.zip",
                     "sha256": "903ceef078984711d516ba9ab7466fb2165e9d3d447539cd10460c22d98563db"
+                },
+                {
+                    "version": "3.3.0",
+                    "origin_url": "https://robotec.ai",
+                    "source_control_uri": "https://github.com/o3de/o3de-extras/development/Gems/ROS2",
+                    "requirements": "Requires ROS 2 installation (supported distributions: Humble, Jazzy). Source your workspace before building the Gem",
+                    "documentation_url": "https://docs.o3de.org/docs/user-guide/gems/reference/robotics/ros2/",
+                    "dependencies": [
+                        "Atom_RPI",
+                        "Atom_Feature_Common",
+                        "Atom_Component_DebugCamera",
+                        "CommonFeaturesAtom",
+                        "PhysX5",
+                        "PrimitiveAssets",
+                        "StartingPointInput",
+                        "LevelGeoreferencing"
+                    ],
+                    "compatible_engines": [
+                        "o3de-sdk>=2.4.0",
+                        "o3de>=2.4.0"
+                    ],
+                    "engine_api_dependencies": [],
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.3.0-gem.zip",
+                    "sha256": "29735e8e634bfd6b5823a398984edd1d094cb02476d22df65a489927c5eb510b"
                 }
             ]
         },
@@ -392,6 +422,17 @@
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehouseassets-1.0.0-gem.zip",
                     "sha256": "5e69416d9c25bbcdd205bdaddcae689716044347942631d6b3e56d31b95cf094",
                     "version": "1.0.0"
+                },
+                {
+                    "version": "2.0.0",
+                    "origin": "RobotecAI",
+                    "origin_url": "https://robotec.ai",
+                    "compatible_engines": [
+                        "o3de-sdk>=2.3.0",
+                        "o3de>=2.3.0"
+                    ],
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehouseassets-2.0.0-gem.zip",
+                    "sha256": "2f983dbf19be64c9de9217cfa88c91b3dc1a59e08d57eb07b348cfbc2fb00f5e"
                 }
             ]
         },
@@ -457,6 +498,15 @@
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/xr-1.0.1-gem.zip",
                     "version": "1.0.1",
                     "sha256": "325a826e513611b37155c2eaa8b5b5578fdca8d96f3ef4faf34bf49c7d39a2f0"
+                },
+                {
+                    "compatible_engines": [
+                        "o3de-sdk>=2.4.0",
+                        "o3de>=2.4.0"
+                    ],
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/xr-1.1.0-gem.zip",
+                    "version": "1.1.0",
+                    "sha256": "fdef00fd5a9aeb4d98a3664d134358d9645f2c75034bf043284644fc158bc904"
                 }
             ]
         },
@@ -534,6 +584,138 @@
                     "version": "2.0.0"
                 }
             ]
+        },
+        {
+            "gem_name": "LevelGeoreferencing",
+            "version": "1.0.0",
+            "display_name": "LevelGeoreferencing",
+            "license": "Apache-2.0",
+            "license_url": "https://opensource.org/licenses/Apache-2.0",
+            "origin": "RobotecAI",
+            "origin_url": "https://robotec.ai",
+            "type": "Code",
+            "summary": "Toolset to georeference level",
+            "canonical_tags": [
+                "Gem"
+            ],
+            "user_tags": [
+                "Georeferencing",
+                "LevelGeoreferencing"
+            ],
+            "platforms": [],
+            "icon_path": "preview.png",
+            "requirements": "",
+            "documentation_url": "https://www.docs.o3de.org/docs/user-guide/interactivity/robotics/georeference/",
+            "dependencies": [],
+            "compatible_engines": [
+                "o3de-sdk>=2.4.0",
+                "o3de>=2.4.0"
+            ],
+            "engine_api_dependencies": [],
+            "restricted": "LevelGeoreferencing",
+            "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
+            "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/levelgeoreferencing-1.0.0-gem.zip",
+            "sha256": "3e77d7708dfbb6d383d7aadd77e98e4def4c2e3f14171c098840d4761dc6da50"
+        },
+        {
+            "gem_name": "MachineLearning",
+            "version": "1.0.1",
+            "display_name": "MachineLearning",
+            "license": "License used i.e. Apache-2.0 or MIT",
+            "license_url": "Link to the license web site i.e. https://opensource.org/licenses/Apache-2.0",
+            "origin": "The name of the originator or creator",
+            "origin_url": "The website for this Gem",
+            "type": "Code",
+            "summary": "A short description of this Gem",
+            "canonical_tags": [
+                "Gem"
+            ],
+            "user_tags": [
+                "MachineLearning"
+            ],
+            "platforms": [
+                ""
+            ],
+            "icon_path": "preview.png",
+            "requirements": "Notice of any requirements for this Gem i.e. This requires X other gem",
+            "documentation_url": "Link to any documentation of your Gem",
+            "dependencies": [],
+            "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
+            "compatible_engines": [],
+            "engine_api_dependencies": [],
+            "restricted": "MachineLearning",
+            "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/machinelearning-1.0.1-gem.zip",
+            "sha256": "af7c7eac3f95379677660eee826b4bce6f8232fa18cfec3572978ed374a92717"
+        },
+        {
+            "gem_name": "ROS2SampleRobots",
+            "version": "1.0.0",
+            "display_name": "ROS2 Sample Robots",
+            "license": "Apache-2.0 or MIT",
+            "license_url": "https://opensource.org/licenses/Apache-2.0",
+            "origin": "RobotecAI",
+            "origin_url": "https://robotec.ai",
+            "type": "Asset",
+            "summary": "Sample robots to be used in ROS2 projects",
+            "canonical_tags": [
+                "Gem"
+            ],
+            "user_tags": [
+                "ROS2SampleRobots"
+            ],
+            "platforms": [
+                ""
+            ],
+            "icon_path": "preview.png",
+            "requirements": "Requires ROS 2 Gem",
+            "documentation_url": "",
+            "dependencies": [
+                "ROS2>=3.1.0"
+            ],
+            "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
+            "compatible_engines": [
+                "o3de-sdk>=2.3.0",
+                "o3de>=2.3.0"
+            ],
+            "engine_api_dependencies": [],
+            "restricted": "ROS2SampleRobots",
+            "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2samplerobots-1.0.0-gem.zip",
+            "sha256": "f1dbabfd0f51969c4d105285e67113d4bd8d3d43d6294b5dc68bfde656c9b274"
+        },
+        {
+            "gem_name": "SimulationInterfaces",
+            "version": "1.0.0",
+            "display_name": "SimulationInterfaces",
+            "license": "Apache-2.0 ",
+            "license_url": "https://opensource.org/licenses/Apache-2.0",
+            "origin": "RobotecAI",
+            "origin_url": "https://robotec.ai",
+            "type": "Code",
+            "summary": "This gem provides ROS 2 and C++ API for simulation interfaces.",
+            "canonical_tags": [
+                "Gem"
+            ],
+            "user_tags": [
+                "SimulationInterfaces",
+                "ROS2",
+                "ROS 2"
+            ],
+            "platforms": [
+                ""
+            ],
+            "icon_path": "preview.png",
+            "requirements": "Requires ROS 2 Gem and SimulationInterfaces package installed and sourced.",
+            "documentation_url": "https://www.docs.o3de.org/docs/user-guide/interactivity/robotics/simulation-interfaces/",
+            "dependencies": [
+                "ROS2>=3.3.0",
+                "DebugDraw"
+            ],
+            "compatible_engines": [],
+            "engine_api_dependencies": [],
+            "restricted": "SimulationInterfaces",
+            "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
+            "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/simulationinterfaces-1.0.0-gem.zip",
+            "sha256": "d13ecb0e22aa50b74abb241a615d9026cad739c1522fe94e456ea5b94d9bbd06"
         }
     ],
     "templates": [
@@ -2021,7 +2203,14 @@
             ],
             "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
             "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/multiplayer-2.0.0-template.zip",
-            "sha256": "f6eaa01c0a66fef0a9fa55e00637ae087f11287f30540ccd479c2988f9e41ab4"
+            "sha256": "f6eaa01c0a66fef0a9fa55e00637ae087f11287f30540ccd479c2988f9e41ab4",
+            "versions_data": [
+                {
+                    "version": "2.0.1",
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/multiplayer-2.0.1-template.zip",
+                    "sha256": "2280b6682adeb9886d061c84de1d7aed0df0e84ed621bacda96de34d387a9ed8"
+                }
+            ]
         },
         {
             "template_name": "Ros2FleetRobotTemplate",
@@ -4836,6 +5025,470 @@
                     ],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2fleetrobottemplate-2.0.3-template.zip",
                     "sha256": "1fdb529bb39cbe1248b3af2ef6531cf1e95b8aadaf6db6aace0a2e221da67fd4"
+                },
+                {
+                    "version": "2.1.0",
+                    "copyFiles": [
+                        {
+                            "file": ".gitignore",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "AssetBundling/SeedLists/DefaultLevel.seed",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "CMakeLists.txt",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Config/shader_global_build_options.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/NOTICE",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/config/fleet_config.yaml",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/launch/o3de_fleet_nav_launch.py",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/launch/o3de_nav_launch.py",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/launch/o3de_rviz_launch.py",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/maps/map_warehouse.pgm",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/maps/map_warehouse.yaml",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/o3de_fleet_nav/__init__.py",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/o3de_fleet_nav/robot_spawner.py",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/package.xml",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/params/humble/nav2_multirobot_params.yaml",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/params/humble/nav2_params.yaml",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/params/jazzy/nav2_multirobot_params.yaml",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/params/jazzy/nav2_params.yaml",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/resource/o3de_fleet_nav",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/rviz/nav2_namespaced_view.rviz",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/setup.cfg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/setup.py",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/test/test_copyright.py",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/test/test_flake8.py",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/ros2_ws/src/o3de_fleet_nav/test/test_pep257.py",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/${Name}_files.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/${Name}_shared_files.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/CMakeLists.txt",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Include/${Name}/${Name}Bus.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Linux/${Name}_linux_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Linux/${Name}_shared_linux_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Linux/PAL_linux.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Mac/${Name}_mac_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Mac/${Name}_shared_mac_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Mac/PAL_mac.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Windows/${Name}_shared_windows_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Windows/${Name}_windows_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Windows/PAL_windows.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Registry/assetprocessor_settings.setreg",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}Module.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}SystemComponent.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}SystemComponent.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/gem.json",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Levels/Warehouse/Warehouse.prefab",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Linux/linux_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Linux/linux_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Mac/mac_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Mac/mac_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Windows/windows_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Windows/windows_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Prefabs/ProteusLaserScanner.prefab",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/assetprocessor_settings.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/awscoreconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/loadlevel.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/physxdebugconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/physxdefaultsceneconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/physxsystemconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/ros2.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/GameSDK.ico",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/LegacyLogoLauncher.bmp",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_128.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_128_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_16.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_16_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_256.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_256_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_32.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_32_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_512.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_512_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Info.plist",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "ShaderLib/README.md",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "ShaderLib/scenesrg.srgi",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "ShaderLib/viewsrg.srgi",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "cmake/EngineFinder.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "game.cfg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "preview.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "project.json",
+                            "isTemplated": true
+                        }
+                    ],
+                    "createDirectories": [
+                        {
+                            "dir": "AssetBundling"
+                        },
+                        {
+                            "dir": "AssetBundling/SeedLists"
+                        },
+                        {
+                            "dir": "Assets"
+                        },
+                        {
+                            "dir": "Config"
+                        },
+                        {
+                            "dir": "Examples"
+                        },
+                        {
+                            "dir": "Examples/ros2_ws"
+                        },
+                        {
+                            "dir": "Examples/ros2_ws/src"
+                        },
+                        {
+                            "dir": "Examples/ros2_ws/src/o3de_fleet_nav"
+                        },
+                        {
+                            "dir": "Examples/ros2_ws/src/o3de_fleet_nav/config"
+                        },
+                        {
+                            "dir": "Examples/ros2_ws/src/o3de_fleet_nav/launch"
+                        },
+                        {
+                            "dir": "Examples/ros2_ws/src/o3de_fleet_nav/maps"
+                        },
+                        {
+                            "dir": "Examples/ros2_ws/src/o3de_fleet_nav/o3de_fleet_nav"
+                        },
+                        {
+                            "dir": "Examples/ros2_ws/src/o3de_fleet_nav/params"
+                        },
+                        {
+                            "dir": "Examples/ros2_ws/src/o3de_fleet_nav/params/humble"
+                        },
+                        {
+                            "dir": "Examples/ros2_ws/src/o3de_fleet_nav/params/jazzy"
+                        },
+                        {
+                            "dir": "Examples/ros2_ws/src/o3de_fleet_nav/resource"
+                        },
+                        {
+                            "dir": "Examples/ros2_ws/src/o3de_fleet_nav/rviz"
+                        },
+                        {
+                            "dir": "Examples/ros2_ws/src/o3de_fleet_nav/test"
+                        },
+                        {
+                            "dir": "Gem"
+                        },
+                        {
+                            "dir": "Gem/Include"
+                        },
+                        {
+                            "dir": "Gem/Include/${Name}"
+                        },
+                        {
+                            "dir": "Gem/Platform"
+                        },
+                        {
+                            "dir": "Gem/Platform/Linux"
+                        },
+                        {
+                            "dir": "Gem/Platform/Mac"
+                        },
+                        {
+                            "dir": "Gem/Platform/Windows"
+                        },
+                        {
+                            "dir": "Gem/Registry"
+                        },
+                        {
+                            "dir": "Gem/Source"
+                        },
+                        {
+                            "dir": "Levels"
+                        },
+                        {
+                            "dir": "Levels/Warehouse"
+                        },
+                        {
+                            "dir": "Platform"
+                        },
+                        {
+                            "dir": "Platform/Android"
+                        },
+                        {
+                            "dir": "Platform/Linux"
+                        },
+                        {
+                            "dir": "Platform/Mac"
+                        },
+                        {
+                            "dir": "Platform/Windows"
+                        },
+                        {
+                            "dir": "Prefabs"
+                        },
+                        {
+                            "dir": "Registry"
+                        },
+                        {
+                            "dir": "Resources"
+                        },
+                        {
+                            "dir": "Resources/Platform"
+                        },
+                        {
+                            "dir": "Resources/Platform/Mac"
+                        },
+                        {
+                            "dir": "Resources/Platform/Mac/Images.xcassets"
+                        },
+                        {
+                            "dir": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset"
+                        },
+                        {
+                            "dir": "ShaderLib"
+                        },
+                        {
+                            "dir": "Shaders"
+                        },
+                        {
+                            "dir": "Shaders/ShaderResourceGroups"
+                        },
+                        {
+                            "dir": "cmake"
+                        }
+                    ],
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2fleetrobottemplate-2.1.0-template.zip",
+                    "sha256": "351fa25b6fafb7fa0f6f65ed8c2a6fb7cb4f3957021609292956cee813f27ad7"
                 }
             ]
         },
@@ -7555,6 +8208,576 @@
                     ],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2projecttemplate-2.0.3-template.zip",
                     "sha256": "8ac02c3c0341804653a5a41b300f0bf9edff33f75076b5853f91a45e10b3826a"
+                },
+                {
+                    "version": "3.0.0",
+                    "copyFiles": [
+                        {
+                            "file": ".clang-format",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": ".gitattributes",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": ".gitignore",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "AssetBundling/SeedLists/DefaultLevel.seed",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "CMakeLists.txt",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "cmake/EngineFinder.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Config/default_aws_resource_mappings.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Config/shader_global_build_options.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/${NameLower}_files.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/${NameLower}_editor_files.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/${NameLower}_editor_shared_files.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/${NameLower}_shared_files.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/CMakeLists.txt",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Include/${Name}/${Name}Bus.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Android/${NameLower}_android_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Android/${NameLower}_shared_android_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Android/PAL_android.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Linux/${NameLower}_linux_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Linux/${NameLower}_shared_linux_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Linux/PAL_linux.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Mac/${NameLower}_mac_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Mac/${NameLower}_shared_mac_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Mac/PAL_mac.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Windows/${NameLower}_shared_windows_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Windows/${NameLower}_windows_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Windows/PAL_windows.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/iOS/${NameLower}_ios_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/iOS/${NameLower}_shared_ios_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/iOS/PAL_ios.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Registry/assetprocessor_settings.setreg",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}EditorModule.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}EditorSystemComponent.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}EditorSystemComponent.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}Module.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}ModuleInterface.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}SampleComponent.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}SampleComponent.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}SystemComponent.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}SystemComponent.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/gem.json",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Levels/DemoLevel/DemoLevel.prefab",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Platform/Android/android_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Android/android_project.json",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Platform/Linux/linux_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Linux/linux_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Mac/mac_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Mac/mac_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Windows/windows_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Windows/windows_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/iOS/ios_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/iOS/ios_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/assetprocessor_settings.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/awscoreconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/editorpreferences.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/physxsystemconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/physxdebugconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/physxdefaultsceneconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/sceneassetimporter.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/ros2.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/loadlevel.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/GameSDK.ico",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/LegacyLogoLauncher.bmp",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_128.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_128_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_16.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_16_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_256.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_256_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_32.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_32_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_512.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_512_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Info.plist",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadAppIcon152x152.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadAppIcon76x76.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadProAppIcon167x167.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadSettingsIcon29x29.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadSettingsIcon58x58.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadSpotlightIcon40x40.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPadSpotlightIcon80x80.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPhoneAppIcon120x120.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPhoneAppIcon180x180.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPhoneSettingsIcon58x58.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPhoneSettingsIcon87x87.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPhoneSpotlightIcon120x120.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset/iPhoneSpotlightIcon80x80.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage1024x768.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage1536x2048.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage2048x1536.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPadLaunchImage768x1024.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPhoneLaunchImage640x1136.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage/iPhoneLaunchImage640x960.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/iOS/Info.plist",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "ShaderLib/README.md",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "ShaderLib/scenesrg.srgi",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "ShaderLib/viewsrg.srgi",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "game.cfg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "preview.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "project.json",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Examples/slam_navigation/README.md",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/slam_navigation/launch/config/config.rviz",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/slam_navigation/launch/config/navigation_params_humble.yaml",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/slam_navigation/launch/config/navigation_params_jazzy.yaml",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/slam_navigation/launch/config/slam_params.yaml",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/slam_navigation/launch/navigation.launch.py",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/slam_navigation/launch/slam.launch.py",
+                            "isTemplated": false
+                        }
+                    ],
+                    "createDirectories": [
+                        {
+                            "dir": "AssetBundling"
+                        },
+                        {
+                            "dir": "AssetBundling/SeedLists"
+                        },
+                        {
+                            "dir": "Assets"
+                        },
+                        {
+                            "dir": "Config"
+                        },
+                        {
+                            "dir": "Examples"
+                        },
+                        {
+                            "dir": "Examples/slam_navigation"
+                        },
+                        {
+                            "dir": "Examples/slam_navigation/launch"
+                        },
+                        {
+                            "dir": "Examples/slam_navigation/launch/config"
+                        },
+                        {
+                            "dir": "Gem"
+                        },
+                        {
+                            "dir": "Gem/Include"
+                        },
+                        {
+                            "dir": "Gem/Include/${Name}"
+                        },
+                        {
+                            "dir": "Gem/Platform"
+                        },
+                        {
+                            "dir": "Gem/Platform/Android"
+                        },
+                        {
+                            "dir": "Gem/Platform/Linux"
+                        },
+                        {
+                            "dir": "Gem/Platform/Mac"
+                        },
+                        {
+                            "dir": "Gem/Platform/Windows"
+                        },
+                        {
+                            "dir": "Gem/Platform/iOS"
+                        },
+                        {
+                            "dir": "Gem/Registry"
+                        },
+                        {
+                            "dir": "Gem/Source"
+                        },
+                        {
+                            "dir": "Levels"
+                        },
+                        {
+                            "dir": "Levels/DemoLevel"
+                        },
+                        {
+                            "dir": "Platform"
+                        },
+                        {
+                            "dir": "Platform/Android"
+                        },
+                        {
+                            "dir": "Platform/Linux"
+                        },
+                        {
+                            "dir": "Platform/Mac"
+                        },
+                        {
+                            "dir": "Platform/Windows"
+                        },
+                        {
+                            "dir": "Platform/iOS"
+                        },
+                        {
+                            "dir": "Registry"
+                        },
+                        {
+                            "dir": "Resources"
+                        },
+                        {
+                            "dir": "Resources/Platform"
+                        },
+                        {
+                            "dir": "Resources/Platform/Mac"
+                        },
+                        {
+                            "dir": "Resources/Platform/Mac/Images.xcassets"
+                        },
+                        {
+                            "dir": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset"
+                        },
+                        {
+                            "dir": "Resources/Platform/iOS"
+                        },
+                        {
+                            "dir": "Resources/Platform/iOS/Images.xcassets"
+                        },
+                        {
+                            "dir": "Resources/Platform/iOS/Images.xcassets/AppIcon.appiconset"
+                        },
+                        {
+                            "dir": "Resources/Platform/iOS/Images.xcassets/LaunchImage.launchimage"
+                        },
+                        {
+                            "dir": "ShaderLib"
+                        },
+                        {
+                            "dir": "cmake"
+                        }
+                    ],
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2projecttemplate-3.0.0-template.zip",
+                    "sha256": "3eef15b3e66138a6bfc62f6fe732bdbe0525f494766e3f2771a17a86d934e237"
                 }
             ]
         },
@@ -9827,6 +11050,531 @@
                     ],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2roboticmanipulationtemplate-2.0.2-template.zip",
                     "sha256": "718e6e95914fee3b84ba7bdabbba150672a624f3cc62c1671c1b40b9db5d9178"
+                },
+                {
+                    "version": "2.1.0",
+                    "copyFiles": [
+                        {
+                            "file": ".gitignore",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "AssetBundling/SeedLists/DefaultLevel.seed",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/BoxToyPuzzle/BoxCube.fbx",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/BoxToyPuzzle/BoxCylinder.fbx",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/BoxToyPuzzle/BoxTriangle.fbx",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/BoxToyPuzzle/BoxTriangle.fbx.assetinfo",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/BoxToyPuzzle/ToyBox.fbx",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/BoxToyPuzzle/ToyBox_MCube_pazzle.material",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/BoxToyPuzzle/texture/BoxToyPuzzle_MCube_pazzle_BaseMap.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/BoxToyPuzzle/texture/BoxToyPuzzle_MCube_pazzle_Metallic.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/BoxToyPuzzle/texture/BoxToyPuzzle_MCube_pazzle_Normal.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/BoxToyPuzzle/texture/BoxToyPuzzle_MCube_pazzle_Roughness.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/BoxToyPuzzle/texture/BoxToyPuzzle_MCube_pazzle_Specular.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Desk.fbx",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Desk_M_Desk.material",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Room.fbx",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Room.fbx.assetinfo",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Room_M_Floor.material",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Room_M_Walls.material",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Desk/Room_M_Desk_Ambient.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Desk/Room_M_Desk_Base_color.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Desk/Room_M_Desk_Metallic.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Desk/Room_M_Desk_Normal.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Desk/Room_M_Desk_Roughness.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Floor/plane_divided_DefaultMaterial_Ambient.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Floor/plane_divided_DefaultMaterial_Base_color.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Floor/plane_divided_DefaultMaterial_Metallic.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Floor/plane_divided_DefaultMaterial_Normal.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Floor/plane_divided_DefaultMaterial_Roughness.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Walls/Room_M_Walls_Ambient.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Walls/Room_M_Walls_Base_color.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Walls/Room_M_Walls_Metallic.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Walls/Room_M_Walls_Normal.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Assets/Room/Textures/Walls/Room_M_Walls_Roughness.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "CMakeLists.txt",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Config/shader_global_build_options.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "DiffuseProbeGrids/GI_10397901-C8DF-4757-A2F4-646BD2A929FF_ProbeData_lutrgba16f.dds",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "DiffuseProbeGrids/GI_6B97D93C-AF0E-4CD5-8CCE-C65F8563A707_Irradiance_lutrgba16f.dds",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "DiffuseProbeGrids/GI_89401C38-FA0A-4BA3-A166-D1F869F379D1_Distance_lutrg32f.dds",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/panda_moveit_config_demo.launch.py",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Examples/panda_moveit_config_demo.rviz",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/${Name}_files.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/${Name}_shared_files.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/CMakeLists.txt",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Include/${Name}/${Name}Bus.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Linux/${Name}_linux_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Linux/${Name}_shared_linux_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Linux/PAL_linux.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Mac/${Name}_mac_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Mac/${Name}_shared_mac_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Mac/PAL_mac.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Platform/Windows/${Name}_shared_windows_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Windows/${Name}_windows_files.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Gem/Platform/Windows/PAL_windows.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Registry/assetprocessor_settings.setreg",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}Module.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}SystemComponent.cpp",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/Source/${Name}SystemComponent.h",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Gem/gem.json",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "Levels/RoboticManipulation/RoboticManipulation.prefab",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Linux/linux_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Linux/linux_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Mac/mac_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Mac/mac_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Windows/windows_project.cmake",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Platform/Windows/windows_project.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/assetprocessor_settings.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/awscoreconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/loadlevel.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/physxdebugconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/physxdefaultsceneconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/physxsystemconfiguration.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/ros2.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Registry/sceneassetimporter.setreg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/GameSDK.ico",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/LegacyLogoLauncher.bmp",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_128.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_128_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_16.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_16_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_256.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_256_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_32.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_32_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_512.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset/icon_512_2x.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Images.xcassets/Contents.json",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "Resources/Platform/Mac/Info.plist",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "ShaderLib/README.md",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "ShaderLib/scenesrg.srgi",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "ShaderLib/viewsrg.srgi",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "cmake/EngineFinder.cmake",
+                            "isTemplated": true
+                        },
+                        {
+                            "file": "game.cfg",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "preview.png",
+                            "isTemplated": false
+                        },
+                        {
+                            "file": "project.json",
+                            "isTemplated": true
+                        }
+                    ],
+                    "createDirectories": [
+                        {
+                            "dir": "AssetBundling"
+                        },
+                        {
+                            "dir": "AssetBundling/AssetLists"
+                        },
+                        {
+                            "dir": "AssetBundling/BundleSettings"
+                        },
+                        {
+                            "dir": "AssetBundling/Bundles"
+                        },
+                        {
+                            "dir": "AssetBundling/Rules"
+                        },
+                        {
+                            "dir": "AssetBundling/SeedLists"
+                        },
+                        {
+                            "dir": "Assets"
+                        },
+                        {
+                            "dir": "Assets/BoxToyPuzzle"
+                        },
+                        {
+                            "dir": "Assets/BoxToyPuzzle/texture"
+                        },
+                        {
+                            "dir": "Assets/BoxToyPuzzle/texture/Roughness"
+                        },
+                        {
+                            "dir": "Assets/Room"
+                        },
+                        {
+                            "dir": "Assets/Room/Textures"
+                        },
+                        {
+                            "dir": "Assets/Room/Textures/Desk"
+                        },
+                        {
+                            "dir": "Assets/Room/Textures/Floor"
+                        },
+                        {
+                            "dir": "Assets/Room/Textures/Walls"
+                        },
+                        {
+                            "dir": "Config"
+                        },
+                        {
+                            "dir": "DiffuseProbeGrids"
+                        },
+                        {
+                            "dir": "Examples"
+                        },
+                        {
+                            "dir": "Gem"
+                        },
+                        {
+                            "dir": "Gem/Include"
+                        },
+                        {
+                            "dir": "Gem/Include/${Name}"
+                        },
+                        {
+                            "dir": "Gem/Platform"
+                        },
+                        {
+                            "dir": "Gem/Platform/Linux"
+                        },
+                        {
+                            "dir": "Gem/Platform/Mac"
+                        },
+                        {
+                            "dir": "Gem/Platform/Windows"
+                        },
+                        {
+                            "dir": "Gem/Registry"
+                        },
+                        {
+                            "dir": "Gem/Source"
+                        },
+                        {
+                            "dir": "Levels"
+                        },
+                        {
+                            "dir": "Levels/RoboticManipulation"
+                        },
+                        {
+                            "dir": "Platform"
+                        },
+                        {
+                            "dir": "Platform/Android"
+                        },
+                        {
+                            "dir": "Platform/Linux"
+                        },
+                        {
+                            "dir": "Platform/Mac"
+                        },
+                        {
+                            "dir": "Platform/Windows"
+                        },
+                        {
+                            "dir": "Registry"
+                        },
+                        {
+                            "dir": "Resources"
+                        },
+                        {
+                            "dir": "Resources/Platform"
+                        },
+                        {
+                            "dir": "Resources/Platform/Mac"
+                        },
+                        {
+                            "dir": "Resources/Platform/Mac/Images.xcassets"
+                        },
+                        {
+                            "dir": "Resources/Platform/Mac/Images.xcassets/AppIcon.appiconset"
+                        },
+                        {
+                            "dir": "ShaderLib"
+                        },
+                        {
+                            "dir": "Shaders"
+                        },
+                        {
+                            "dir": "Shaders/ShaderResourceGroups"
+                        },
+                        {
+                            "dir": "cmake"
+                        }
+                    ],
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2roboticmanipulationtemplate-2.1.0-template.zip",
+                    "sha256": "7f19a41dbfa17c40d59f38a7a355a1da27ef93797f1f039ea83f4adb70c108c5"
                 }
             ]
         }


### PR DESCRIPTION
## What does this PR do?

Versions of the Gems and `repo.json` file were updated on the stabilization branch, the changes were cherry-picked back to the `development` branch in this PR. In particular, changes from #915 and #919 were ported back.

## How was this PR tested?

The diff between the branches (the only difference is in `OpenXRVk` and `ExternalProfilers` Gems, which is expected).
