### PR TITLE
Fix WarehouseAssets gem.json and SHA in repo.json

### DIFF
--- a/Gems/WarehouseAssets/gem.json
+++ b/Gems/WarehouseAssets/gem.json
@@ -25,6 +25,7 @@
         "o3de-sdk>=2.3.0",
         "o3de>=2.3.0"
     ],
+    "engine_api_dependencies": [],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "restricted": "",
     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehouseassets-2.0.0-gem.zip"

--- a/repo.json
+++ b/repo.json
@@ -432,7 +432,7 @@
                         "o3de>=2.3.0"
                     ],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehouseassets-2.0.0-gem.zip",
-                    "sha256": "2f983dbf19be64c9de9217cfa88c91b3dc1a59e08d57eb07b348cfbc2fb00f5e"
+                    "sha256": "b91c685ea476523322b2864d17aafc5c6236092f950a4159fe59051d9c9449ce"
                 }
             ]
         },


### PR DESCRIPTION
## What does this PR do?

There was a problem in `gem.json` file in `WarehouseAssets` Gem in _o3de-extras_. The following empty data value is required to make it work correctly in _ProjectManager_:
```json
"engine_api_dependencies": []
```
It was removed in PR #840 in _o3de-extras_ in https://github.com/o3de/o3de-extras/pull/840/files#diff-70e2e613293787b72b69923e979f4f120054b876959bf7e299a2b9e3a1e71e41

Without this data, _ProjectManager_ downloads the file, but discovers the missing data value and terminates:
![Screenshot from 2025-06-17 19-23-03](https://github.com/user-attachments/assets/12220cfa-c599-4a35-8aab-94ade9b9338f)

The missing part was added to `gem.json,` and the package was regenerated and uploaded as a new release. Due to the changes, SHA was updated.

## How was this PR tested?

The code was pulled and the checksum was tested.
