### PR TITLE
[Simulation Interfaces] Add keyboard activated state transition

### DIFF
--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.cpp
@@ -48,14 +48,13 @@ namespace SimulationInterfaces
             }
 
             // Create a pretty name based on the key region and key name
-            AZStd::string prettyName;
             if (keyRegion == "alphanumeric" || keyRegion == "function")
             {
                 // For alphanumeric keys, we can return the key name directly
                 return AZStd::string::format("Key '%s'", keyName.c_str());
             }
 
-            return AZStd::string::format("Key '%s_%s' ", keyRegion.c_str(), keyName.c_str()); ;
+            return AZStd::string::format("Key '%s_%s'", keyRegion.c_str(), keyName.c_str());
         }
 
         const AZStd::unordered_map<SimulationState, AZStd::string> SimulationStateToString = {

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.h
@@ -29,7 +29,7 @@ namespace SimulationInterfaces
     {
         AzFramework::InputChannelId m_inputChannelId; //! Input channel ID for the keyboard key that triggers the transition
         SimulationState m_desiredState; //! Desired state to transition to when the key is pressed
-        AZStd::string m_prettyName; //! Pretty name for the keyboard transition, used in UI
+        AZStd::string m_uiDescription; //! Description of the transition, used in UI
     };
     class SimulationManager
         : public AZ::Component
@@ -56,6 +56,7 @@ namespace SimulationInterfaces
         void Deactivate() override;
 
     private:
+
         // SimulationManagerRequestBus interface implementation
         void SetSimulationPaused(bool paused) override;
         void StepSimulation(AZ::u64 steps) override;
@@ -74,6 +75,12 @@ namespace SimulationInterfaces
 
         // InputChannelEventListener
         bool OnInputChannelEventFiltered(const AzFramework::InputChannel& inputChannel) override;
+
+        //! Register a keyboard transition key in m_keyboardTransitions. Generate UI hints
+        //! \param key The input channel ID of the keyboard key
+        //! \param sourceState The current simulation state that the key is associated with
+        //! \param desiredState The desired simulation state to transition to when the key is pressed
+        void RegisterTransitionsKey(const AzFramework::InputChannelId& key, SimulationState sourceState, SimulationState desiredState);
 
         bool m_isSimulationPaused = false;
 

--- a/Gems/SimulationInterfaces/Registry/simulationinterface_settings.setreg
+++ b/Gems/SimulationInterfaces/Registry/simulationinterface_settings.setreg
@@ -1,6 +1,12 @@
 {
     "SimulationInterfaces": {
         "PrintStateNameInGui": true,
-        "StartInStoppedState": true
+        "StartInStoppedState": true,
+        "KeyboardTransitions":
+        {
+            "StoppedToPlaying": "keyboard_key_alphanumeric_R",
+            "PausedToPlaying": "keyboard_key_alphanumeric_R",
+            "PlayingToPaused": "keyboard_key_alphanumeric_P"
+        }
     }
 }


### PR DESCRIPTION
## What does this PR do?

This commit allows User to change simulation state with keyboard. There is possibility to set three transitions with registry:
```
{
    "SimulationInterfaces": {
        "PrintStateNameInGui": true,
        "StartInStoppedState": true,
        "KeyboardTransitions":
        {
            "StoppedToPlaying": "keyboard_key_alphanumeric_R",
            "PausedToPlaying": "keyboard_key_alphanumeric_R",
            "PlayingToPaused": "keyboard_key_alphanumeric_P"
        }
    }
}
```

It will:
show hint in UI, and will listen to keyboard inputs. Names if keyboard inputs are available `o3de/Code/Framework/AzFramework/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h`

https://github.com/user-attachments/assets/9015e058-4642-43cc-8256-14731bf38496


## How was this PR tested?
- run unit tests (little one failed due to being flaky)
- test with GUI
- test with q_simulation_interfaces