### PR TITLE
Remove not needed build requirements from ROS2.Editor.Tests

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -335,16 +335,8 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 BUILD_DEPENDENCIES
                     PRIVATE
                         AZ::AzTest
-                        AZ::AzTestShared
-                        Legacy::CryCommon
-                        Legacy::EditorCommon
-                        Legacy::Editor.Headers
                         AZ::AzManipulatorTestFramework.Static
                         Gem::${gem_name}.Editor.Private.Object
-                        Gem::${gem_name}.Editor.Static
-                        Gem::${gem_name}.Static
-                RUNTIME_DEPENDENCIES
-                    Legacy::Editor
             )
 
             # Add ${gem_name}.Editor.Tests to googletest

--- a/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
+++ b/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
@@ -53,8 +53,9 @@ namespace UnitTest
     {
         AddActiveGems(AZStd::to_array<AZStd::string_view>({ "ROS2" }));
         AddDynamicModulePaths({});
-        AddComponentDescriptors(AZStd::initializer_list<AZ::ComponentDescriptor*>{ ROS2::ROS2FrameComponent::CreateDescriptor(),
-                                                                                   ROS2::ROS2SystemComponent::CreateDescriptor() });
+        AddComponentDescriptors(
+            AZStd::initializer_list<AZ::ComponentDescriptor*>{ ROS2::ROS2FrameComponent::CreateDescriptor(),
+                                                               ROS2::ROS2SystemComponent::CreateDescriptor() });
         AddRequiredComponents(AZStd::to_array<AZ::TypeId const>({ ROS2::ROS2SystemComponent::TYPEINFO_Uuid() }));
     }
 
@@ -180,7 +181,7 @@ namespace UnitTest
 
 } // namespace UnitTest
 
-// required to support running integration tests with Qt and PhysX
+// required to support running integration tests with Qt
 AZTEST_EXPORT int AZ_UNIT_TEST_HOOK_NAME(int argc, char** argv)
 {
     ::testing::InitGoogleMock(&argc, argv);


### PR DESCRIPTION
## What does this PR do?

o3de: `2505.0`
o3de-extras: `6c1f346f81689fd83603652807e91ef8770877ad`
platform: linux

I built o3de sdk from `2505.0` 
```
export CMAKE_ARGS="\
  -DO3DE_INSTALL_ENGINE_NAME=o3de \
  -DLY_UNITY_BUILD=OFF \
  -DLY_DISABLE_TEST_MODULES=ON \
"
cmake --preset linux-default ${CMAKE_ARGS}
cmake --preset linux-mono-default ${CMAKE_ARGS}

cmake --build --preset linux-install --config profile --target install
cmake --build --preset linux-mono-install --config profile --target install
```
And after registering the engine, I tried to configure a project that uses ROS2 Gem.

I got an error
```
CMake Error at /__w/o3de-ros2-gem-testing/o3de-ros2-gem-testing/engine/o3de/install/cmake/Dependencies.cmake:40 (add_dependencies):
  The dependency target "Legacy::Editor" of target "ROS2.Editor.Tests" does
  not exist.
Call Stack (most recent call first):
  /__w/o3de-ros2-gem-testing/o3de-ros2-gem-testing/engine/o3de/install/cmake/LYWrappers.cmake:321 (ly_add_dependencies)
  /__w/o3de-ros2-gem-testing/o3de-ros2-gem-testing/engine/o3de-extras/Gems/ROS2/Code/CMakeLists.txt:325 (ly_add_target)
```

This is because `ROS2.Editor.Tests` required `Legacy::Editor` as runtime dependency since #897 

This PR addresses it by removing all not needed dependencies for `ROS2.Editor.Tests`

## How was this PR tested?

1. Configured the project using the same engine as above.
2. Build only affected test target 
   ```
   cmake --build Project/build/linux --config profile --target ROS2.Editor.Tests
   ```
3. run tests
   ```
   ctest -C profile --output-on-failure --test-dir Project/build/linux --verbose --tests-regex 'ROS2.Editor.Tests'
   ```

