### PR TITLE
[WarehouseAssets] Remove leftover material slot overrides

### DIFF
--- a/Gems/ROS2SampleRobots/Assets/RosbotXL/ROSbotXL.prefab
+++ b/Gems/ROS2SampleRobots/Assets/RosbotXL/ROSbotXL.prefab
@@ -602,16 +602,20 @@
                     "Id": 2016576711781101659,
                     "Controller": {
                         "Configuration": {
-                            "materials": {
-                                "{}": {
-                                    "MaterialAsset": {
-                                        "assetId": {
-                                            "guid": "{5B369E33-6E01-5794-9DB2-7CEFC2B205D5}"
-                                        },
-                                        "assetHint": "rosbotxl/models/materials/rosbotxl_antenna_plasticmatteblack.azmaterial"
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 3551515046
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{BC08A50C-9CCD-587F-B2B5-9DB0EF6907DF}"
+                                            }
+                                        }
                                     }
                                 }
-                            }
+                            ]
                         }
                     }
                 }
@@ -1452,16 +1456,21 @@
                     "Id": 17880601295840825835,
                     "Controller": {
                         "Configuration": {
-                            "materials": {
-                                "{}": {
-                                    "MaterialAsset": {
-                                        "assetId": {
-                                            "guid": "{5B369E33-6E01-5794-9DB2-7CEFC2B205D5}"
-                                        },
-                                        "assetHint": "rosbotxl/models/materials/rosbotxl_antenna_plasticmatteblack.azmaterial"
+                            "materials": [
+                                {
+                                    "Key": {
+                                        "materialSlotStableId": 2725144250
+                                    },
+                                    "Value": {
+                                        "MaterialAsset": {
+                                            "assetId": {
+                                                "guid": "{5B369E33-6E01-5794-9DB2-7CEFC2B205D5}"
+                                            },
+                                            "assetHint": "rosbotxl/models/materials/rosbotxl_antenna_plasticmatteblack.azmaterial"
+                                        }
                                     }
                                 }
-                            }
+                            ]
                         }
                     }
                 }

--- a/Gems/ROS2SampleRobots/gem.json
+++ b/Gems/ROS2SampleRobots/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ROS2SampleRobots",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "display_name": "ROS2 Sample Robots",
     "license": "Apache-2.0 or MIT",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -30,5 +30,5 @@
     ],
     "engine_api_dependencies": [],
     "restricted": "ROS2SampleRobots",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2samplerobots-1.0.0-gem.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2samplerobots-1.0.1-gem.zip"
 }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox1.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox1.prefab
@@ -100,19 +100,6 @@
                             "materials": [
                                 {
                                     "Key": {
-                                        "materialSlotStableId": 2919702015
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{5468360F-1789-50A3-96FF-118192B81B48}"
-                                            },
-                                            "assetHint": "assets/warehouse/materials/mwarehouseboxes.azmaterial"
-                                        }
-                                    }
-                                },
-                                {
-                                    "Key": {
                                         "materialSlotStableId": 4100903441
                                     },
                                     "Value": {

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox2.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox2.prefab
@@ -110,19 +110,6 @@
                                             "assetHint": "assets/warehouse/materials/mwarehouseboxes.azmaterial"
                                         }
                                     }
-                                },
-                                {
-                                    "Key": {
-                                        "materialSlotStableId": 2919702015
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{5468360F-1789-50A3-96FF-118192B81B48}"
-                                            },
-                                            "assetHint": "assets/warehouse/materials/mwarehouseboxes.azmaterial"
-                                        }
-                                    }
                                 }
                             ]
                         }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox3.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox3.prefab
@@ -110,19 +110,6 @@
                                             "assetHint": "assets/warehouse/materials/mwarehouseboxes.azmaterial"
                                         }
                                     }
-                                },
-                                {
-                                    "Key": {
-                                        "materialSlotStableId": 2919702015
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{5468360F-1789-50A3-96FF-118192B81B48}"
-                                            },
-                                            "assetHint": "assets/warehouse/materials/mwarehouseboxes.azmaterial"
-                                        }
-                                    }
                                 }
                             ]
                         }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox4.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Components/WarehouseBox4.prefab
@@ -122,19 +122,6 @@
                                             "assetHint": "assets/warehouse/materials/mwarehouseboxes.azmaterial"
                                         }
                                     }
-                                },
-                                {
-                                    "Key": {
-                                        "materialSlotStableId": 2919702015
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{5468360F-1789-50A3-96FF-118192B81B48}"
-                                            },
-                                            "assetHint": "assets/warehouse/materials/mwarehouseboxes.azmaterial"
-                                        }
-                                    }
                                 }
                             ]
                         }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Storage_on_wheels.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Storage_on_wheels.prefab
@@ -88,19 +88,6 @@
                                             "assetHint": "assets/warehouse/materials/mwarehousestorageonwheels.azmaterial"
                                         }
                                     }
-                                },
-                                {
-                                    "Key": {
-                                        "materialSlotStableId": 3528137216
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{B59DB34C-8CCC-5B6A-8F32-749689632151}"
-                                            },
-                                            "assetHint": "assets/warehouse/materials/mwarehousestorageonwheels.azmaterial"
-                                        }
-                                    }
                                 }
                             ]
                         }

--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Walls.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_structural/Warehouse_Walls.prefab
@@ -172,32 +172,6 @@
                             "materials": [
                                 {
                                     "Key": {
-                                        "materialSlotStableId": 103484566
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{9FF0270B-8936-528A-89EC-3E73A01AF755}"
-                                            },
-                                            "assetHint": "assets/warehouse/materials/mwarehousemodules.azmaterial"
-                                        }
-                                    }
-                                },
-                                {
-                                    "Key": {
-                                        "materialSlotStableId": 745211904
-                                    },
-                                    "Value": {
-                                        "MaterialAsset": {
-                                            "assetId": {
-                                                "guid": "{06298918-E750-5053-B55B-10D158B1ED8C}"
-                                            },
-                                            "assetHint": "assets/warehouse/materials/mwarehousegate.azmaterial"
-                                        }
-                                    }
-                                },
-                                {
-                                    "Key": {
                                         "materialSlotStableId": 3367833104
                                     },
                                     "Value": {

--- a/Gems/WarehouseAssets/gem.json
+++ b/Gems/WarehouseAssets/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "WarehouseAssets",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "display_name": "WarehouseAssets",
     "license": "Apache-2.0 or MIT",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -28,5 +28,5 @@
     "engine_api_dependencies": [],
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
     "restricted": "",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehouseassets-2.0.0-gem.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/warehouseassets-2.0.1-gem.zip"
 }


### PR DESCRIPTION
## What does this PR do?

This PR removes unnecessary, leftover material slot overrides from the Warehouse Assets gem's prefabs. This change is related to the new [RGL gem release](https://github.com/RobotecAI/o3de-rgl-gem/pull/81). Removed overrides referred to non-existent material slots.

## How was this PR tested?

Modified prefabs were tested in the editor to ensure proper material overrides. They were tested with the RGL gem active.
