### PR TITLE
Use Crc32 type for XR service ID

### DIFF
--- a/Gems/XR/Code/Include/XR/XRFactory.h
+++ b/Gems/XR/Code/Include/XR/XRFactory.h
@@ -34,7 +34,7 @@ namespace XR
         AZ_DISABLE_COPY_MOVE(Factory);
 
         //! Returns the component service name CRC used by the platform RHI system component.
-        static AZ::u32 GetPlatformService();
+        static AZ::Crc32 GetPlatformService();
 
         //! Registers the global factory instance.
         static void Register(XR::Factory* instance);

--- a/Gems/XR/Code/Source/XRFactory.cpp
+++ b/Gems/XR/Code/Source/XRFactory.cpp
@@ -11,7 +11,7 @@
 
 namespace XR
 {
-    AZ::u32 Factory::GetPlatformService()
+    AZ::Crc32 Factory::GetPlatformService()
     {
         return AZ_CRC_CE("XRPlatformService");
     }


### PR DESCRIPTION
## What does this PR do?

This PR changes the type of the `XR::Factory::GetPlatformService()` function from `AZ::u32` to `AZ::Crc32`, which is necessary for O3DE [PR19125](https://github.com/o3de/o3de/pull/19125) to compile successfully, which changed the single-argument Crc32 constructors to explicit.

## How was this PR tested?

Compile O3DE with the changes from PR19125 and the OpenXRTest project
