### PR TITLE
Adjust compatible services for RigidBodyTwistControlComponent

### DIFF
--- a/Gems/ROS2Controllers/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.cpp
+++ b/Gems/ROS2Controllers/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.cpp
@@ -194,7 +194,12 @@ namespace ROS2Controllers
     void RigidBodyTwistControlComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC_CE("ROS2RobotControl"));
-        required.push_back(AZ_CRC_CE("PhysicsRigidBodyService"));
+        required.push_back(AZ_CRC_CE("PhysicsDynamicRigidBodyService"));
+    }
+
+    void RigidBodyTwistControlComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+    {
+        incompatible.push_back(AZ_CRC_CE("ArticulationLinkService"));
     }
 
     void RigidBodyTwistControlComponent::TwistReceived(const AZ::Vector3& linear, const AZ::Vector3& angular)

--- a/Gems/ROS2Controllers/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.h
+++ b/Gems/ROS2Controllers/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.h
@@ -33,6 +33,8 @@ namespace ROS2Controllers
         //////////////////////////////////////////////////////////////////////////
 
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+
         static void Reflect(AZ::ReflectContext* context);
 
     private:


### PR DESCRIPTION
## What does this PR do?

Prevent the user from shooting their foot with one of RigidBodyTwistControlComponent.

## How was this PR tested?

By shooting own foot.