### PR TITLE
[Simulation Interfaces] Added possibility to disable ROS 2 service/action

### DIFF
--- a/Gems/SimulationInterfaces/Code/Source/Actions/ROS2ActionBase.h
+++ b/Gems/SimulationInterfaces/Code/Source/Actions/ROS2ActionBase.h
@@ -109,21 +109,17 @@ namespace ROS2SimulationInterfaces
         void CreateAction(rclcpp::Node::SharedPtr& node)
         {
             // Get the action name from the type name
-            // passing empty string to settings registry causes in not creating ROS 2 action
+            // passing an empty string to settings registry disables ROS 2 action
             AZStd::optional<AZStd::string> actionName = RegistryUtilities::GetName(GetTypeName());
-
-            // check if settings registry and apply early exit if value is equal to empty string
-            if (actionName.has_value())
+            
+            // do not create a ROS 2 action if the value is empty
+            if (actionName.has_value() && actionName.value().empty())
             {
-                if (actionName.value().empty())
-                {
-                    AZ_Warning(
-                        "SimulationInterfaces",
-                        false,
-                        "Action name for type %s is set to empty string, action server won't be created",
-                        GetTypeName().data());
-                    return;
-                }
+                AZ_Trace(
+                    "SimulationInterfaces",
+                    "Action name for type %s is set to empty string, action server won't be created",
+                    GetTypeName().data());
+                return;
             }
 
             if (!actionName.has_value())

--- a/Gems/SimulationInterfaces/Code/Source/Actions/ROS2ActionBase.h
+++ b/Gems/SimulationInterfaces/Code/Source/Actions/ROS2ActionBase.h
@@ -128,7 +128,7 @@ namespace ROS2SimulationInterfaces
 
             if (!actionName.has_value())
             {
-                // if the service name is empty, use the default name
+                // if the action name is empty, use the default name
                 actionName = GetDefaultName();
             }
 

--- a/Gems/SimulationInterfaces/Code/Source/Clients/ROS2SimulationInterfacesSystemComponent.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/ROS2SimulationInterfacesSystemComponent.cpp
@@ -22,7 +22,7 @@
 #include <Services/GetEntitiesServiceHandler.h>
 #include <Services/GetEntitiesStatesServiceHandler.h>
 #include <Services/GetEntityStateServiceHandler.h>
-#include <Services/GetSimulationFeaturesServiceHandler.h>
+#include <Services/GetSimulatorFeaturesServiceHandler.h>
 #include <Services/GetSimulationStateServiceHandler.h>
 #include <Services/GetSpawnablesServiceHandler.h>
 #include <Services/ROS2ServiceBase.h>
@@ -80,7 +80,7 @@ namespace ROS2SimulationInterfaces
         RegisterInterface<GetSpawnablesServiceHandler>(ros2Node);
         RegisterInterface<SetEntityStateServiceHandler>(ros2Node);
         RegisterInterface<SpawnEntityServiceHandler>(ros2Node);
-        RegisterInterface<GetSimulationFeaturesServiceHandler>(ros2Node);
+        RegisterInterface<GetSimulatorFeaturesServiceHandler>(ros2Node);
         RegisterInterface<ResetSimulationServiceHandler>(ros2Node);
         RegisterInterface<SimulateStepsActionServerHandler>(ros2Node);
         RegisterInterface<SetSimulationStateServiceHandler>(ros2Node);

--- a/Gems/SimulationInterfaces/Code/Source/Clients/ROS2SimulationInterfacesSystemComponent.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/ROS2SimulationInterfacesSystemComponent.h
@@ -54,7 +54,10 @@ namespace ROS2SimulationInterfaces
         {
             AZStd::shared_ptr handler = AZStd::make_shared<T>();
             handler->Initialize(ros2Node);
-            m_availableRos2Interface[handler->GetTypeName()] = AZStd::move(handler);
+            if (handler->IsValid())
+            {
+                m_availableRos2Interface[handler->GetTypeName()] = AZStd::move(handler);
+            }
             handler.reset();
         };
     };

--- a/Gems/SimulationInterfaces/Code/Source/Interfaces/IROS2HandlerBase.h
+++ b/Gems/SimulationInterfaces/Code/Source/Interfaces/IROS2HandlerBase.h
@@ -24,5 +24,6 @@ namespace ROS2SimulationInterfaces
         virtual AZStd::string_view GetTypeName() const = 0;
         virtual AZStd::string_view GetDefaultName() const = 0;
         virtual void Initialize(rclcpp::Node::SharedPtr& node) = 0;
+        virtual bool IsValid() = 0;
     };
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetSimulationFeaturesServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetSimulationFeaturesServiceHandler.h
@@ -21,7 +21,7 @@ namespace ROS2SimulationInterfaces
     public:
         AZStd::string_view GetTypeName() const override
         {
-            return "GetSimulationFeatures";
+            return "GetSimulatorFeatures";
         }
 
         AZStd::string_view GetDefaultName() const override

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetSimulatorFeaturesServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetSimulatorFeaturesServiceHandler.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include "GetSimulationFeaturesServiceHandler.h"
+#include "GetSimulatorFeaturesServiceHandler.h"
 #include <AzCore/base.h>
 #include <AzCore/std/containers/unordered_set.h>
 #include <AzCore/std/sort.h>
@@ -15,13 +15,13 @@
 namespace ROS2SimulationInterfaces
 {
 
-    AZStd::unordered_set<SimulationFeatureType> GetSimulationFeaturesServiceHandler::GetProvidedFeatures()
+    AZStd::unordered_set<SimulationFeatureType> GetSimulatorFeaturesServiceHandler::GetProvidedFeatures()
     {
         // standard doesn't define specific feature id for this service
         return AZStd::unordered_set<SimulationFeatureType>{};
     }
 
-    AZStd::optional<GetSimulationFeaturesServiceHandler::Response> GetSimulationFeaturesServiceHandler::HandleServiceRequest(
+    AZStd::optional<GetSimulatorFeaturesServiceHandler::Response> GetSimulatorFeaturesServiceHandler::HandleServiceRequest(
         const std::shared_ptr<rmw_request_id_t> header, const Request& request)
     {
         // call bus to get simulation features in ROS2SimulationInterfaces Gem side

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetSimulatorFeaturesServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetSimulatorFeaturesServiceHandler.h
@@ -16,7 +16,7 @@
 namespace ROS2SimulationInterfaces
 {
 
-    class GetSimulationFeaturesServiceHandler : public ROS2ServiceBase<simulation_interfaces::srv::GetSimulatorFeatures>
+    class GetSimulatorFeaturesServiceHandler : public ROS2ServiceBase<simulation_interfaces::srv::GetSimulatorFeatures>
     {
     public:
         AZStd::string_view GetTypeName() const override
@@ -26,7 +26,7 @@ namespace ROS2SimulationInterfaces
 
         AZStd::string_view GetDefaultName() const override
         {
-            return "get_simulation_features";
+            return "get_simulator_features";
         }
         AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/ROS2ServiceBase.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/ROS2ServiceBase.h
@@ -62,21 +62,17 @@ namespace ROS2SimulationInterfaces
         void CreateService(rclcpp::Node::SharedPtr& node)
         {
             // get the service name from the type name
-            // passing empty string to settings registry causes in not creating ROS 2 service
+            // passing an empty string to settings registry disables ROS 2 action
             AZStd::optional<AZStd::string> serviceName = RegistryUtilities::GetName(GetTypeName());
 
-            // check if settings registry and apply early exit if value is equal to empty string
-            if (serviceName.has_value())
+            // do not create a ROS 2 action if the value is empty
+            if (serviceName.has_value() && serviceName.value().empty())
             {
-                if (serviceName.value().empty())
-                {
-                    AZ_Warning(
-                        "SimulationInterfaces",
-                        false,
-                        "Service name for type %s is set to empty string, service won't be created",
-                        GetTypeName().data());
-                    return;
-                }
+                AZ_Trace(
+                    "SimulationInterfaces",
+                    "Service name for type %s is set to empty string, service won't be created",
+                    GetTypeName().data());
+                return;
             }
 
             if (!serviceName.has_value())

--- a/Gems/SimulationInterfaces/Code/Source/Utils/RegistryUtils.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Utils/RegistryUtils.cpp
@@ -12,13 +12,20 @@
 
 namespace ROS2SimulationInterfaces::RegistryUtilities
 {
-    AZStd::string GetName(const AZStd::string& serviceType)
+    AZStd::optional<AZStd::string> GetName(const AZStd::string& serviceType)
     {
         AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get();
         AZ_Assert(settingsRegistry, "Settings Registry is not available");
         AZStd::string output = "";
         AZ::IO::Path setRegPath = AZ::IO::Path(RegistryPrefix) / AZ::IO::Path(serviceType);
-        settingsRegistry->Get(output, setRegPath.String());
-        return output;
+        const auto setRegStatus = settingsRegistry->Get(output, setRegPath.String());
+        if (setRegStatus) // value gathering from settings registry succeeded
+        {
+            return output;
+        }
+        else
+        {
+            return AZStd::nullopt;
+        }
     }
 } // namespace ROS2SimulationInterfaces::RegistryUtilities

--- a/Gems/SimulationInterfaces/Code/Source/Utils/RegistryUtils.h
+++ b/Gems/SimulationInterfaces/Code/Source/Utils/RegistryUtils.h
@@ -16,6 +16,7 @@ namespace ROS2SimulationInterfaces::RegistryUtilities
     inline constexpr const char* RegistryPrefix = "/ROS2SimulationInterfaces";
 
     //! Gets name of the service with defined type form settings registry
-    //! @return string with service name, if setting registry doesn't exits returns empty string
+    //! @return optional string with service name. If setting registry entry exists, its value is returned.
+    //!         Otherwise AZStd::nullopt is returned
     [[nodiscard]] AZStd::optional<AZStd::string> GetName(const AZStd::string& serviceType);
 } // namespace ROS2SimulationInterfaces::RegistryUtilities

--- a/Gems/SimulationInterfaces/Code/Source/Utils/RegistryUtils.h
+++ b/Gems/SimulationInterfaces/Code/Source/Utils/RegistryUtils.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <AzCore/std/optional.h>
 #include <AzCore/std/string/string.h>
 
 namespace ROS2SimulationInterfaces::RegistryUtilities
@@ -16,5 +17,5 @@ namespace ROS2SimulationInterfaces::RegistryUtilities
 
     //! Gets name of the service with defined type form settings registry
     //! @return string with service name, if setting registry doesn't exits returns empty string
-    [[nodiscard]] AZStd::string GetName(const AZStd::string& serviceType);
+    [[nodiscard]] AZStd::optional<AZStd::string> GetName(const AZStd::string& serviceType);
 } // namespace ROS2SimulationInterfaces::RegistryUtilities

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
@@ -29,7 +29,7 @@
 #include <Services/GetEntitiesServiceHandler.h>
 #include <Services/GetEntitiesStatesServiceHandler.h>
 #include <Services/GetEntityStateServiceHandler.h>
-#include <Services/GetSimulationFeaturesServiceHandler.h>
+#include <Services/GetSimulatorFeaturesServiceHandler.h>
 #include <Services/GetSimulationStateServiceHandler.h>
 #include <Services/GetSpawnablesServiceHandler.h>
 #include <Services/ROS2ServiceBase.h>
@@ -178,7 +178,7 @@ namespace UnitTest
         EXPECT_NE(services.find("/get_spawnables"), services.end());
         EXPECT_NE(services.find("/set_entity_state"), services.end());
         EXPECT_NE(services.find("/spawn_entity"), services.end());
-        EXPECT_NE(services.find("/get_simulation_features"), services.end());
+        EXPECT_NE(services.find("/get_simulator_features"), services.end());
         EXPECT_NE(services.find("/step_simulation"), services.end());
     }
 
@@ -391,7 +391,7 @@ namespace UnitTest
         using ::testing::_;
         auto node = GetRos2Node();
 
-        auto client = node->create_client<simulation_interfaces::srv::GetSimulatorFeatures>("/get_simulation_features");
+        auto client = node->create_client<simulation_interfaces::srv::GetSimulatorFeatures>("/get_simulator_features");
         auto request = std::make_shared<simulation_interfaces::srv::GetSimulatorFeatures::Request>();
         auto future = client->async_send_request(request);
         SpinAppUntilFuture(future);
@@ -419,7 +419,7 @@ namespace UnitTest
                     return features;
                 }));
 
-        auto client = node->create_client<simulation_interfaces::srv::GetSimulatorFeatures>("/get_simulation_features");
+        auto client = node->create_client<simulation_interfaces::srv::GetSimulatorFeatures>("/get_simulator_features");
         auto request = std::make_shared<simulation_interfaces::srv::GetSimulatorFeatures::Request>();
         auto future = client->async_send_request(request);
         SpinAppUntilFuture(future);

--- a/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
+++ b/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
@@ -42,8 +42,8 @@ set(FILES
     Source/Services/SpawnEntityServiceHandler.h
     Source/Services/ResetSimulationServiceHandler.cpp
     Source/Services/ResetSimulationServiceHandler.h
-    Source/Services/GetSimulationFeaturesServiceHandler.cpp
-    Source/Services/GetSimulationFeaturesServiceHandler.h
+    Source/Services/GetSimulatorFeaturesServiceHandler.cpp
+    Source/Services/GetSimulatorFeaturesServiceHandler.h
     Source/Services/SetSimulationStateServiceHandler.cpp
     Source/Services/SetSimulationStateServiceHandler.h
     Source/Services/GetSimulationStateServiceHandler.cpp

--- a/Gems/SimulationInterfaces/gem.json
+++ b/Gems/SimulationInterfaces/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "SimulationInterfaces",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "display_name": "SimulationInterfaces",
     "license": "Apache-2.0 ",
     "license_url": "https://opensource.org/licenses/Apache-2.0",


### PR DESCRIPTION
## What does this PR do?

This PR adds possibility for selective disabling of ROS 2 services/actions related to Simulation Interfaces. If user assigns empty string as a name of a service via settings registry, this service will not be created. It also won't be present in `/get_simulation_features` service.

This PR also changes `GetSimulationFeaturesServiceHandler::TypeName` to make it consistent with the rest of the code and documentation. In the rest of the code `TypeName` is assigned based on ROS 2 service/action name written in UpperCammelCase. I case of mentioned `TypeName` there was typo and instead of `GetSimulatorFeatures`, there was `GetSimulationFeatures`. Consistency is important since `TypeName` is used as settings registry key.

## How was this PR tested?
It was built in non-unity and available services were gathered via `ros2 service list` and simulation features were gathered via `/get_simulation_features` service. Service/features gathering were performed in several test cases:
- without modified settings registry
- with changed name of the service in settings registry 
- with name set to `""` - only in this case simulator warns user about disabled service and service is not created 

Settings Registry Keys required to adjust service name have patterns:
`"/ROS2SimulationInterfaces/<TypeName>"`, e.g.
`"/ROS2SimulationInterfaces/DeleteEntity"`,

`TypeName` for ROS 2 Handlers are defined via method `AZStd::string_view GetTypeName()`. Each Handler defines this method.
