### PR TITLE
Removed unnecessary linkage from ROS2.Static

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -81,7 +81,6 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PUBLIC
             AZ::AzCore
-            AZ::AzToolsFramework
             Gem::${gem_name}.Private.Object
 )
 


### PR DESCRIPTION
## What does this PR do?
It prevented releasing project

## How was this PR tested?

Perform builds:
- Editor (non unity, shared)
- Project.GameLaucnher (non-unity, shared)
- Project.GameLaucnher (export script)