### PR TITLE
Added "Force dynamic" switch to the ros2 frame component

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
@@ -126,6 +126,7 @@ namespace ROS2
 
         bool m_publishTransform;
         bool m_isDynamic;
+        bool m_forceDynamic;
 
         AZStd::unique_ptr<ROS2Transform> m_ros2Transform;
     };

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameConfiguration.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameConfiguration.h
@@ -28,6 +28,7 @@ namespace ROS2
 
         bool m_publishTransform = true;
         bool m_isDynamic = false;
+        bool m_forceDynamic = false;
 
         //! Sets the effective namespace shown in the Editor.
         //! @param effectiveNamespace namespace to be set.

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameComponent.cpp
@@ -145,8 +145,8 @@ namespace ROS2
         {
             AZ_TracePrintf("ROS2FrameComponent", "Setting up %s", GetNamespacedFrameID().data());
 
-            // The frame will always be dynamic if it's a top entity.
-            if (IsTopLevel())
+            // The frame will always be dynamic if it is a top entity or if its configuration forces it to be dynamic..
+            if (IsTopLevel() || m_forceDynamic)
             {
                 m_isDynamic = true;
             }
@@ -298,6 +298,7 @@ namespace ROS2
                 ->Field("Frame Name", &ROS2FrameComponent::m_frameName)
                 ->Field("Joint Name", &ROS2FrameComponent::m_jointName)
                 ->Field("Publish Transform", &ROS2FrameComponent::m_publishTransform)
+                ->Field("Force Dynamic", &ROS2FrameComponent::m_forceDynamic)
                 ->Field("Namespace Configuration", &ROS2FrameComponent::m_namespaceConfiguration);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
@@ -321,6 +322,11 @@ namespace ROS2
                         &ROS2FrameComponent::m_publishTransform,
                         "Publish Transform",
                         "Publish the transform of this frame.")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2FrameComponent::m_forceDynamic,
+                        "Force Dynamic",
+                        "Force the frame to be dynamic.")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ROS2FrameComponent::m_namespaceConfiguration,
@@ -352,7 +358,8 @@ namespace ROS2
         , m_frameName(configuration.m_frameName)
         , m_jointName(configuration.m_jointName)
         , m_publishTransform(configuration.m_publishTransform)
-        , m_isDynamic(configuration.m_isDynamic){};
+        , m_isDynamic(configuration.m_isDynamic)
+        , m_forceDynamic(configuration.m_forceDynamic){};
 
     ROS2FrameConfiguration ROS2FrameComponent::GetConfiguration() const
     {

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameConfiguration.cpp
@@ -24,7 +24,8 @@ namespace ROS2
                 ->Field("Namespace Configuration", &ROS2FrameConfiguration::m_namespaceConfiguration)
                 ->Field("Frame Name", &ROS2FrameConfiguration::m_frameName)
                 ->Field("Joint Name", &ROS2FrameConfiguration::m_jointName)
-                ->Field("Publish Transform", &ROS2FrameConfiguration::m_publishTransform);
+                ->Field("Publish Transform", &ROS2FrameConfiguration::m_publishTransform)
+                ->Field("Force Dynamic", &ROS2FrameConfiguration::m_forceDynamic);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
@@ -42,6 +43,7 @@ namespace ROS2
                         &ROS2FrameConfiguration::m_publishTransform,
                         "Publish Transform",
                         "Publish Transform")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2FrameConfiguration::m_forceDynamic, "Force Dynamic", "Force Dynamic")
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Info")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->UIElement(AZ::Edit::UIHandlers::Label, "Effective namespace", "")

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ROS2",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "display_name": "ROS2",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ROS2",
-    "version": "4.0.1",
+    "version": "4.0.0",
     "display_name": "ROS2",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",


### PR DESCRIPTION
## What does this PR do?

This PR adds an additional switch to the `ROS 2 Frame` component that forces it to be a dynamic frame. This option is disabled by default.
## How was this PR tested?

I used different prefabs with ROS 2 frames, changed their configuration (mainly the dynamic force switch), and checked:
- rviz2
- `/tf` topic
- `/tf_static` topic
