### PR TITLE
[WarehouseAssets] fix decal materials for 2505.x

### DIFF
--- a/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_blue.material
+++ b/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_blue.material
@@ -3,6 +3,7 @@
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "markings_blue.png",
+        "normal.textureMap": "markings_blue.png",
         "normal.useTexture": false,
         "opacity.mode": "Cutout"
     }

--- a/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_corner.material
+++ b/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_corner.material
@@ -3,6 +3,7 @@
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "markings_corner.png",
+        "normal.textureMap": "markings_corner.png",
         "normal.useTexture": false,
         "opacity.mode": "Cutout"
     }

--- a/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_end1.material
+++ b/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_end1.material
@@ -3,6 +3,7 @@
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "markings_end1.png",
+        "normal.textureMap": "markings_end1.png",
         "normal.useTexture": false,
         "opacity.mode": "Cutout"
     }

--- a/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_end2.material
+++ b/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_end2.material
@@ -3,6 +3,7 @@
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "markings_end2.png",
+        "normal.textureMap": "markings_end2.png",
         "normal.useTexture": false,
         "opacity.mode": "Cutout"
     }

--- a/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_line.material
+++ b/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_line.material
@@ -3,6 +3,7 @@
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "markings_line.png",
+        "normal.textureMap": "markings_line.png",
         "normal.useTexture": false,
         "opacity.mode": "Cutout"
     }

--- a/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_mid1.material
+++ b/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_mid1.material
@@ -3,6 +3,7 @@
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "markings_mid1.png",
+        "normal.textureMap": "markings_mid1.png",
         "normal.useTexture": false,
         "opacity.mode": "Cutout"
     }

--- a/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_mid2.material
+++ b/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/markings_mid2.material
@@ -3,6 +3,7 @@
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "markings_mid2.png",
+        "normal.textureMap": "markings_mid2.png",
         "normal.useTexture": false,
         "opacity.mode": "Cutout"
     }

--- a/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/tire_traces1.material
+++ b/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/tire_traces1.material
@@ -3,6 +3,7 @@
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "tire_traces1.png",
+        "normal.textureMap": "tire_traces1.png",
         "normal.useTexture": false,
         "opacity.mode": "Cutout"
     }

--- a/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/tire_traces_circle.material
+++ b/Gems/WarehouseAssets/Assets/assets/Warehouse/Floor_markings/tire_traces_circle.material
@@ -3,6 +3,7 @@
     "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "tire_traces_circle.png",
+        "normal.textureMap": "tire_traces_circle.png",
         "normal.useTexture": false,
         "opacity.mode": "Cutout"
     }


### PR DESCRIPTION
## What does this PR do?

Workaround for decals: decal's implementation uses `normal.useTexture` when rendering, but ignores it while loading materials. Therefore, it throws warnings:
```
[Warning] (DecalTextureArray) - Material property: normal.textureMap does not have a valid asset Id
[Warning] (DecalTextureArray) - Missing decal texture maps for normal.textureMap. Please make sure all maps of this type are present.
```
Setting existing textures in materials in asset gem is a work around, significantly reducing the number of warnings and reducing the number of O3DE crashes. See https://github.com/o3de/o3de/issues/18818 for details

## How was this PR tested?

A sample project was built and tested.
