### PR TITLE
[Simulation Interfaces] Disconnect buses and event handlers in SimulationManager when stop game mode in Editor

### DIFF
--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.h
@@ -82,6 +82,9 @@ namespace SimulationInterfaces
         //! \param desiredState The desired simulation state to transition to when the key is pressed
         void RegisterTransitionsKey(const AzFramework::InputChannelId& key, SimulationState sourceState, SimulationState desiredState);
 
+        //! Remove all registered keyboard transition keys
+        void UnregisterAllTransitionKeys();
+
         bool m_isSimulationPaused = false;
 
         uint64_t m_numberOfPhysicsSteps = 0;

--- a/Gems/SimulationInterfaces/Code/Source/Tools/SimulationManagerEditor.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Tools/SimulationManagerEditor.cpp
@@ -65,12 +65,16 @@ namespace SimulationInterfaces
     {
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect();
-        BaseSystemComponent::Deactivate();
     }
 
     void SimulationManagerEditor::OnStartPlayInEditorBegin()
     {
         BaseSystemComponent::Activate();
+    }
+
+    void SimulationManagerEditor::OnStopPlayInEditor()
+    {
+        BaseSystemComponent::Deactivate();
     }
 
 } // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Tools/SimulationManagerEditor.h
+++ b/Gems/SimulationInterfaces/Code/Source/Tools/SimulationManagerEditor.h
@@ -44,5 +44,6 @@ namespace SimulationInterfaces
 
         // EditorEntityContextNotificationBus
         void OnStartPlayInEditorBegin() override;
+        void OnStopPlayInEditor() override;
     };
 } // namespace SimulationInterfaces


### PR DESCRIPTION
Editor stops game mode.

## What does this PR do?

Fixes bug #959


## How was this PR tested?

- By going to game mode in editor and back.
- Typing "unhappy"
