### PR TITLE
[Simulation Interfaces] Do not change applied state on set_entity_state request.

### DIFF
--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -491,7 +491,10 @@ namespace SimulationInterfaces
             {
                 AZ::Transform parentTransform;
                 AZ::TransformBus::EventResult(parentTransform, parentEntityId, &AZ::TransformBus::Events::GetWorldTM);
+                float scale = 1.0f;
+                AZ::TransformBus::EventResult(scale, entityId, &AZ::TransformBus::Events::GetLocalUniformScale);
                 auto transformToSet = parentTransform.GetInverse() * state.m_pose;
+                transformToSet.SetUniformScale(scale);
                 AZ::TransformBus::Event(entityId, &AZ::TransformBus::Events::SetLocalTM, transformToSet);
             }
             else


### PR DESCRIPTION
## What does this PR do?
The scale was cleared to one, when state of entity was applied.

## How was this PR tested?

I've fixed this issue in project I worked on.