### PR TITLE
Fix for broken project export

### DIFF
--- a/Gems/SimulationInterfaces/Code/Source/Clients/LevelManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/LevelManager.cpp
@@ -301,7 +301,7 @@ namespace SimulationInterfaces
     {
         if (m_isAppEditor)
         {
-            constexpr const char* errorMsg = "ReloadWorld is not supported in Editor";
+            [[maybe_unused]] constexpr const char* errorMsg = "ReloadWorld is not supported in Editor";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
             return;
         }


### PR DESCRIPTION
## What does this PR do?
PR fixes exporting of the project with added SimulationInterfaces Gem

## How was this PR tested?

I exported project in unity and non-unity build 
