### PR TITLE
[Simulation Interfaces] Added presinsertion callback to spawnEntity

### DIFF
--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
@@ -19,6 +19,7 @@
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzCore/std/string/string.h>
 #include <AzFramework/Physics/ShapeConfiguration.h>
+#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 #include <SimulationInterfaces/Bounds.h>
 #include <simulation_interfaces/msg/entity_category.hpp>
 
@@ -69,6 +70,8 @@ namespace SimulationInterfaces
     using SpawnableList = AZStd::vector<Spawnable>;
     using DeletionCompletedCb = AZStd::function<void(const AZ::Outcome<void, FailedResult>&)>;
     using SpawnCompletedCb = AZStd::function<void(const AZ::Outcome<AZStd::string, FailedResult>&)>;
+    using PreInsertionCb =
+        AZStd::function<void(const AZ::Outcome<AzFramework::SpawnableEntityContainerView, FailedResult>&)>;
 
     class SimulationEntityManagerRequests
     {
@@ -116,6 +119,7 @@ namespace SimulationInterfaces
             const AZStd::string& entityNamespace,
             const AZ::Transform& initialPose,
             const bool allowRename,
+            PreInsertionCb preinsertionCb,
             SpawnCompletedCb completedCb) = 0;
 
         //! Reset the simulation to begin.
@@ -125,7 +129,7 @@ namespace SimulationInterfaces
         //! Registers a new simulated body to the simulation interface.
         //! This method adds entity to simulation Interfaces cache with its name and initial state
         //! This method allows to register entity spawned by interface other than simulation_interfaces
-        //! If given name already exists in the registry, new unique name will be created. 
+        //! If given name already exists in the registry, new unique name will be created.
         //! @param proposedName Name to register entity under
         //! @param entityId id of entity related to given name
         //! @return final name which was used to register simulated body

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
@@ -56,6 +56,7 @@ namespace SimulationInterfaces
             const AZStd::string& entityNamespace,
             const AZ::Transform& initialPose,
             const bool allowRename,
+            PreInsertionCb preinsertionCb,
             SpawnCompletedCb completedCb) override;
         AZ::Outcome<void, FailedResult> ResetAllEntitiesToInitialState() override;
         AZ::Outcome<AZStd::string, FailedResult> RegisterNewSimulatedBody(
@@ -125,6 +126,7 @@ namespace SimulationInterfaces
         {
             AZStd::string m_userProposedName; //! Name proposed by the User in spawn request
             SpawnCompletedCb m_completedCb; //! User callback to be called when the entity is registered
+            PreInsertionCb m_preInsertionCb; //! User callback to be called when entity prefab is added but inactive
         };
         AZStd::unordered_map<AzFramework::EntitySpawnTicket::Id, SpawnCompletedCbData> m_spawnCompletedCallbacks;
     };

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
@@ -447,7 +447,7 @@ namespace UnitTest
         request->allow_renaming = true;
 
         auto future = client->async_send_request(request);
-        EXPECT_CALL(mock, SpawnEntity(_, _, _, _, _,_, _))
+        EXPECT_CALL(mock, SpawnEntity(_, _, _, _, _, _, _))
             .WillOnce(::testing::Invoke(
                 [](const AZStd::string& name,
                    const AZStd::string& uri,

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
@@ -447,13 +447,14 @@ namespace UnitTest
         request->allow_renaming = true;
 
         auto future = client->async_send_request(request);
-        EXPECT_CALL(mock, SpawnEntity(_, _, _, _, _, _))
+        EXPECT_CALL(mock, SpawnEntity(_, _, _, _, _,_, _))
             .WillOnce(::testing::Invoke(
                 [](const AZStd::string& name,
                    const AZStd::string& uri,
                    const AZStd::string& entityNamespace,
                    const AZ::Transform& initialPose,
                    const bool allowRename,
+                   PreInsertionCb preinsertionCb,
                    SpawnCompletedCb completedCb)
                 {
                     EXPECT_EQ(name, "valid_name");

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/Mocks/SimulationEntityManagerMock.h
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/Mocks/SimulationEntityManagerMock.h
@@ -26,7 +26,7 @@ namespace UnitTest
         MOCK_METHOD1(DeleteAllEntities, void(DeletionCompletedCb completedCb));
         MOCK_METHOD0(GetSpawnables, AZ::Outcome<SpawnableList, FailedResult>());
         MOCK_METHOD0(ResetAllEntitiesToInitialState, AZ::Outcome<void, FailedResult>());
-        MOCK_METHOD6(
+        MOCK_METHOD7(
             SpawnEntity,
             void(
                 const AZStd::string& name,
@@ -34,6 +34,7 @@ namespace UnitTest
                 const AZStd::string& entityNamespace,
                 const AZ::Transform& initialPose,
                 const bool allowRename,
+                PreInsertionCb preinsertionCb,
                 SpawnCompletedCb completedCb));
         MOCK_METHOD2(
             RegisterNewSimulatedBody,

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/SimulationIterfaceAppTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/SimulationIterfaceAppTest.cpp
@@ -75,6 +75,9 @@ namespace UnitTest
             EXPECT_TRUE(result.IsSuccess());
             completed = true;
         };
+        PreInsertionCb preinsertionCB = [](const AZ::Outcome<AzFramework::SpawnableEntityContainerView, FailedResult>& outcome)
+        {
+        };
 
         constexpr bool allowRename = false;
         SimulationEntityManagerRequestBus::Broadcast(
@@ -84,6 +87,7 @@ namespace UnitTest
             entityNamespace,
             initialPose,
             allowRename,
+            preinsertionCB,
             completedCb);
 
         // entities are spawned asynchronously, so we need to tick the app to let the entity be spawned
@@ -104,6 +108,7 @@ namespace UnitTest
             entityNamespace,
             initialPose,
             allowRename,
+            preinsertionCB,
             failedSpawnCompletedCb);
         EXPECT_TRUE(completed2);
 
@@ -173,11 +178,32 @@ namespace UnitTest
         {
         };
         SimulationEntityManagerRequestBus::Broadcast(
-            &SimulationEntityManagerRequestBus::Events::SpawnEntity, "entity1", uri, entityNamespace, initialPose, false, cb);
+            &SimulationEntityManagerRequestBus::Events::SpawnEntity,
+            "entity1",
+            uri,
+            entityNamespace,
+            initialPose,
+            false,
+            preinsertionCB,
+            cb);
         SimulationEntityManagerRequestBus::Broadcast(
-            &SimulationEntityManagerRequestBus::Events::SpawnEntity, "entity2", uri, entityNamespace, initialPose, false, cb);
+            &SimulationEntityManagerRequestBus::Events::SpawnEntity,
+            "entity2",
+            uri,
+            entityNamespace,
+            initialPose,
+            false,
+            preinsertionCB,
+            cb);
         SimulationEntityManagerRequestBus::Broadcast(
-            &SimulationEntityManagerRequestBus::Events::SpawnEntity, "entity3", uri, entityNamespace, initialPose, false, cb);
+            &SimulationEntityManagerRequestBus::Events::SpawnEntity,
+            "entity3",
+            uri,
+            entityNamespace,
+            initialPose,
+            false,
+            preinsertionCB,
+            cb);
         TickApp(100);
         EXPECT_EQ(getNumberOfEntities(), 3);
 


### PR DESCRIPTION
## What does this PR do?
This PR adds possibility to pass preinsertion callback to spawnEntity bus
## How was this PR tested?
non unity build,
run existing test
