### PR TITLE
[Simulation interfaces] Added required version for simulation_interfaces package

### DIFF
--- a/Gems/SimulationInterfaces/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfaces/Code/CMakeLists.txt
@@ -60,7 +60,8 @@ ly_add_target(
             Gem::ROS2.Static
             Gem::DebugDraw.API
 )
-target_depends_on_ros2_packages(${gem_name}.Private.Object rclcpp std_msgs geometry_msgs simulation_interfaces rclcpp_action tf2_ros)
+target_depends_on_ros2_packages(${gem_name}.Private.Object rclcpp std_msgs geometry_msgs rclcpp_action tf2_ros)
+target_depends_on_ros2_package(${gem_name}.Private.Object simulation_interfaces 1.1.0 REQUIRED)
 
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface
 ly_add_target(


### PR DESCRIPTION
## What does this PR do?
PR adds required version for simulation_interfaces package since new version of gem requires it.
## How was this PR tested?
built with simulation_interfaces 1.0.1 ->fail of cmake config
built with simulation_interfaces 1.1.0 -> success
