### PR TITLE
[Simulation Interfaces] Added linking of simulation_interfaces to API target

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -66,7 +66,6 @@ else()
 endif()
 
 # Add the static target with the API Interface and the code
-# TODO: This target should be removed after API is fully implemented with buses
 ly_add_target(
     NAME ${gem_name}.Static STATIC
     NAMESPACE Gem

--- a/Gems/SimulationInterfaces/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfaces/Code/CMakeLists.txt
@@ -37,6 +37,11 @@ ly_add_target(
            AZ::AzCore
 )
 
+# link simulation_interfaces to API, function target_depends_on_ros2_packages links only on as PUBLIC 
+find_package(simulation_interfaces 1.1.0 REQUIRED)
+include(${simulation_interfaces_DIR}/simulation_interfacesConfig.cmake OPTIONAL)
+target_link_libraries(${gem_name}.API INTERFACE ${simulation_interfaces_TARGETS})
+
 # The ${gem_name}.Private.Object target is an internal target
 # It should not be used outside of this Gems CMakeLists.txt
 ly_add_target(

--- a/Gems/SimulationInterfaces/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfaces/Code/CMakeLists.txt
@@ -37,10 +37,7 @@ ly_add_target(
            AZ::AzCore
 )
 
-# link simulation_interfaces to API, function target_depends_on_ros2_packages links only on as PUBLIC 
-find_package(simulation_interfaces 1.1.0 REQUIRED)
-include(${simulation_interfaces_DIR}/simulation_interfacesConfig.cmake OPTIONAL)
-target_link_libraries(${gem_name}.API INTERFACE ${simulation_interfaces_TARGETS})
+target_interface_depends_on_ros2_package(${gem_name}.API simulation_interfaces 1.1.0 REQUIRED)
 
 # The ${gem_name}.Private.Object target is an internal target
 # It should not be used outside of this Gems CMakeLists.txt


### PR DESCRIPTION
## What does this PR do?
PR adds linking of `simulation_interfaces` package to API target to allow user to use `Gem::SimulationInterfaces.API` without additional linking to `simulation_interfaces` in code.

## How was this PR tested?

_Please describe any testing performed._
non-unity build
run existing tests