### PR TITLE
[ROS2Controlers] Fix bug with figer gripper not seeing all joints

### DIFF
--- a/Gems/ROS2Controllers/Code/Source/Gripper/FingerGripperComponent.cpp
+++ b/Gems/ROS2Controllers/Code/Source/Gripper/FingerGripperComponent.cpp
@@ -116,7 +116,7 @@ namespace ROS2Controllers
             ROS2::ROS2FrameComponent* component = entity->FindComponent<ROS2::ROS2FrameComponent>();
             if (!component)
             {
-                break;
+                continue;
             }
 
             const auto jointName = component->GetNamespacedJointName();


### PR DESCRIPTION
## What does this PR do?

Fixes bug with finger gripper not seeing all joints.
Fixes https://github.com/o3de/o3de-extras/issues/978

## How was this PR tested?

By importing a custom UR10 robot with the finger gripper attached. Moving it using MoveIt.
