### PR TITLE
Check root articulation; remove verbose messages

### DIFF
--- a/Gems/ROS2Controllers/Code/Source/Manipulation/JointsManipulationComponent.cpp
+++ b/Gems/ROS2Controllers/Code/Source/Manipulation/JointsManipulationComponent.cpp
@@ -35,7 +35,6 @@ namespace ROS2Controllers
                 AZ_Assert(false, "Joint names in hierarchy need to be unique (%s is not)!", jointName.c_str());
                 return;
             }
-            AZ_Printf("JointsManipulationComponent", "Adding joint info for hinge joint %s\n", jointName.c_str());
             JointInfo jointInfo;
             jointInfo.m_isArticulation = false;
             jointInfo.m_axis = static_cast<PhysX::ArticulationJointAxis>(0);
@@ -45,21 +44,28 @@ namespace ROS2Controllers
 
         void AddArticulationJointInfo(const AZ::EntityComponentIdPair& idPair, const AZStd::string& jointName, ManipulationJoints& joints)
         {
+            bool isRoot = false;
+            PhysX::ArticulationJointRequestBus::EventResult(
+                isRoot, idPair.GetEntityId(), &PhysX::ArticulationJointRequests::IsRootArticulation);
+            if (isRoot)
+            { // Root articulation does not have a joint
+                return;
+            }
+
             PhysX::ArticulationJointAxis freeAxis;
-            bool hasFreeAxis = Utils::TryGetFreeArticulationAxis(idPair.GetEntityId(), freeAxis);
+            const bool hasFreeAxis = Utils::TryGetFreeArticulationAxis(idPair.GetEntityId(), freeAxis);
             if (!hasFreeAxis)
             { // Do not add a joint since it is a fixed one
-                AZ_Printf("JointsManipulationComponent", "Articulation joint %s is fixed, skipping\n", jointName.c_str());
                 return;
             }
 
             if (joints.find(jointName) != joints.end())
             {
-                AZ_Assert(false, "Joint names in hierarchy need to be unique (%s is not)!", jointName.c_str());
+                AZ_Error(
+                    "JointsManipulationComponent", false, "Joint names in hierarchy need to be unique (%s is not)!", jointName.c_str());
                 return;
             }
 
-            AZ_Printf("JointsManipulationComponent", "Adding joint info for articulation link %s\n", jointName.c_str());
             JointInfo jointInfo;
             jointInfo.m_isArticulation = true;
             jointInfo.m_axis = freeAxis;


### PR DESCRIPTION
## What does this PR do?

This PR adds a check for a root articulation (it was recently added to the engine, see https://github.com/o3de/o3de/pull/19227) in `JointManipulationComponent`. Previously. the code was looking for a free axis of a joint (root articulation has none), which resulted in the same early return. The only difference is that looking for a free axis in the root articulation causes an error. The error is not present after this change.

Some verbose messages that are not important were removed in the same context to keep the logs clean.

## How was this PR tested?

Manipulation template was tested against `stabilization` branch of the engine. No meaningless messages; no error.
