### PR TITLE
Ackermann fix (steering scale was not used)

### DIFF
--- a/Gems/ROS2Controllers/Code/Source/VehicleDynamics/DriveModels/AckermannDriveModel.cpp
+++ b/Gems/ROS2Controllers/Code/Source/VehicleDynamics/DriveModels/AckermannDriveModel.cpp
@@ -80,6 +80,7 @@ namespace ROS2Controllers::VehicleDynamics
         const auto& jointComponent = wheelData.m_steeringJoint;
 
         auto id = AZ::EntityComponentIdPair(steeringEntity, jointComponent);
+        auto scaledSteering = steering * wheelData.m_steeringScale;
 
         if (wheelData.m_isArticulation)
         {
@@ -88,7 +89,7 @@ namespace ROS2Controllers::VehicleDynamics
                 [&](PhysX::ArticulationJointRequests* joint)
                 {
                     double currentSteeringAngle = joint->GetJointPosition(wheelData.m_axis);
-                    const double pidCommand = m_steeringPid.ComputeCommand(steering - currentSteeringAngle, deltaTimeNs);
+                    const double pidCommand = m_steeringPid.ComputeCommand(scaledSteering - currentSteeringAngle, deltaTimeNs);
                     joint->SetDriveTargetVelocity(wheelData.m_axis, pidCommand);
                 });
         }
@@ -99,7 +100,7 @@ namespace ROS2Controllers::VehicleDynamics
                 [&](PhysX::JointRequests* joint)
                 {
                     double currentSteeringAngle = joint->GetPosition();
-                    const double pidCommand = m_steeringPid.ComputeCommand(steering - currentSteeringAngle, deltaTimeNs);
+                    const double pidCommand = m_steeringPid.ComputeCommand(scaledSteering - currentSteeringAngle, deltaTimeNs);
                     joint->SetVelocity(pidCommand);
                 });
         }


### PR DESCRIPTION
## What does this PR do?

Ackermann's `WheelController` has a setting called `SteeringScale` which is supposed to modify direction (and scaling) of steering force. It allows changing steering behavior - for example vehicles with rear-wheel steering (like forklifts) require opposite steering directions. However, the `SteeringScale` was not used when calculating steering rotation.

## How was this PR tested?
Tested with O3DE [2505.1](https://github.com/o3de/o3de/commit/faeeba431d2b22facb020608054ddfb4c66b7224)
It can be tested with any prefab containing Ackermann-steering vehicle. Go to the `WheelController` component of one of the steering wheels and change `SteeringScale` from 1.0 to -1.0. The direction of the steering rotation should change.