### PR TITLE
Add simple goal checking in JointsTrajectoryComponent

### DIFF
--- a/Gems/ROS2Controllers/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
+++ b/Gems/ROS2Controllers/Code/Source/Manipulation/JointsTrajectoryComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "JointsTrajectoryComponent.h"
+#include <AzCore/Outcome/Outcome.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <PhysX/ArticulationJointBus.h>
 #include <ROS2/Clock/ROS2ClockRequestBus.h>
@@ -61,8 +62,12 @@ namespace ROS2Controllers
     {
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<JointsTrajectoryComponent, AZ::Component>()->Version(0)->Field(
-                "Action name", &JointsTrajectoryComponent::m_followTrajectoryActionName);
+            serialize->Class<JointsTrajectoryComponent, AZ::Component>()->Version(1)
+                ->Field("Action name", &JointsTrajectoryComponent::m_followTrajectoryActionName)
+                ->Field("Check for position errors", &JointsTrajectoryComponent::m_checkForPositionErrors)
+                ->Field("Joint goal tolerance", &JointsTrajectoryComponent::m_jointPositionTolerance)
+                ->Field("Check for velocity", &JointsTrajectoryComponent::m_checkForVelocity)
+                ->Field("Joint velocity tolerance", &JointsTrajectoryComponent::m_jointVelocityTolerance);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
@@ -76,7 +81,32 @@ namespace ROS2Controllers
                         AZ::Edit::UIHandlers::Default,
                         &JointsTrajectoryComponent::m_followTrajectoryActionName,
                         "Action Name",
-                        "Name the follow trajectory action server to accept movement commands");
+                        "Name the follow trajectory action server to accept movement commands")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &JointsTrajectoryComponent::m_checkForPositionErrors,
+                        "Check for Position Errors",
+                        "If true, check if joints reached the goal position before reporting success")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &JointsTrajectoryComponent::m_jointPositionTolerance,
+                        "Joint Position Tolerance",
+                        "The threshold for joint position errors to report the goal as reached (one value for all joints, units depend on joint type)")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &JointsTrajectoryComponent::ShouldCheckForPositionErrors)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &JointsTrajectoryComponent::m_checkForVelocity,
+                        "Check for Velocity",
+                        "If true, check if joints velocity is below threshold before reporting success")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &JointsTrajectoryComponent::m_jointVelocityTolerance,
+                        "Joint Velocity Tolerance",
+                        "The threshold for joint velocities under which to report the goal as reached (one value for all joints, units depend on joint type)"
+                    )
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &JointsTrajectoryComponent::ShouldCheckForVelocity);
             }
         }
     }
@@ -95,6 +125,16 @@ namespace ROS2Controllers
     void JointsTrajectoryComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
     {
         incompatible.push_back(AZ_CRC_CE("ManipulatorJointTrajectoryService"));
+    }
+
+    bool JointsTrajectoryComponent::ShouldCheckForPositionErrors()
+    {
+        return m_checkForPositionErrors;
+    }
+
+    bool JointsTrajectoryComponent::ShouldCheckForVelocity()
+    {
+        return m_checkForVelocity;
     }
 
     AZ::Outcome<void, JointsTrajectoryComponent::TrajectoryResult> JointsTrajectoryComponent::StartTrajectoryGoal(
@@ -238,14 +278,71 @@ namespace ROS2Controllers
         rclcpp::Time timeNow = rclcpp::Time(timestamp); //!< Current simulation time.
         rclcpp::Duration threshold = rclcpp::Duration::from_nanoseconds(1e7);
 
-        if (m_trajectoryExecutionStartTime + targetGoalTime <= timeNow + threshold)
-        { // Jump to the next point if current simulation time is ahead of timeFromStart
+        // Jump to the next point if current simulation time is ahead of timeFromStart
+        bool canJumpToNextPoint = m_trajectoryExecutionStartTime + targetGoalTime <= timeNow + threshold;
+
+        // But if it's the last point, wait until the manipulator reaches it
+        bool lastTrajectoryPoint = m_trajectoryGoal.trajectory.points.size() == 1;
+        if (lastTrajectoryPoint)
+        {
+            if (m_checkForPositionErrors)
+            {
+                canJumpToNextPoint &= CheckIfPositionReachedTolerance(desiredGoal);
+            }
+
+            if (m_checkForVelocity)
+            {
+                canJumpToNextPoint &= CheckIfVelocityReachedTolerance();
+            }
+        }
+
+        if (canJumpToNextPoint)
+        { // Jump to the next point in the trajectory
             m_trajectoryGoal.trajectory.points.erase(m_trajectoryGoal.trajectory.points.begin());
             FollowTrajectory(deltaTimeNs);
             return;
         }
 
         MoveToNextPoint(desiredGoal);
+    }
+
+    bool JointsTrajectoryComponent::CheckIfPositionReachedTolerance(const trajectory_msgs::msg::JointTrajectoryPoint trajectoryPoint)
+    {
+        for (int jointIndex = 0; jointIndex < m_trajectoryGoal.trajectory.joint_names.size(); jointIndex++)
+        { // Check if each joint reached its target position
+            AZStd::string jointName(m_trajectoryGoal.trajectory.joint_names[jointIndex].c_str());
+            AZ_Assert(m_manipulationJoints.find(jointName) != m_manipulationJoints.end(), "Invalid trajectory executing");
+
+            AZ::Outcome<float, AZStd::string> currentJointPosition;
+            JointsManipulationRequestBus::EventResult(
+                currentJointPosition, GetEntityId(), &JointsManipulationRequests::GetJointPosition, jointName);
+
+            float targetPos = trajectoryPoint.positions[jointIndex];
+            if (AZ::IsClose(currentJointPosition.GetValue(), targetPos, m_jointPositionTolerance) == false)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool JointsTrajectoryComponent::CheckIfVelocityReachedTolerance()
+    {
+        for (int jointIndex = 0; jointIndex < m_trajectoryGoal.trajectory.joint_names.size(); jointIndex++)
+        { // Check if each joint velocity is below the threshold
+            AZStd::string jointName(m_trajectoryGoal.trajectory.joint_names[jointIndex].c_str());
+            AZ_Assert(m_manipulationJoints.find(jointName) != m_manipulationJoints.end(), "Invalid trajectory executing");
+
+            AZ::Outcome<float, AZStd::string> currentJointVelocity;
+            JointsManipulationRequestBus::EventResult(
+                currentJointVelocity, GetEntityId(), &JointsManipulationRequests::GetJointVelocity, jointName);
+
+            if (!AZ::IsClose(currentJointVelocity.GetValue(), 0.0f, m_jointVelocityTolerance))
+            {
+                return false;
+            }
+        }
+        return true;
     }
 
     void JointsTrajectoryComponent::MoveToNextPoint(const trajectory_msgs::msg::JointTrajectoryPoint currentTrajectoryPoint)

--- a/Gems/ROS2Controllers/Code/Source/Manipulation/JointsTrajectoryComponent.h
+++ b/Gems/ROS2Controllers/Code/Source/Manipulation/JointsTrajectoryComponent.h
@@ -56,6 +56,8 @@ namespace ROS2Controllers
         //! @param deltaTimeNs frame time step, to advance trajectory by.
         void FollowTrajectory(const uint64_t deltaTimeNs);
         AZ::Outcome<void, TrajectoryResult> ValidateGoal(TrajectoryGoalPtr trajectoryGoal);
+        bool CheckIfPositionReachedTolerance(const trajectory_msgs::msg::JointTrajectoryPoint currentTrajectoryPoint);
+        bool CheckIfVelocityReachedTolerance();
         void MoveToNextPoint(const trajectory_msgs::msg::JointTrajectoryPoint currentTrajectoryPoint);
         void UpdateFeedback();
 
@@ -69,5 +71,13 @@ namespace ROS2Controllers
         rclcpp::Time m_trajectoryExecutionStartTime;
         ManipulationJoints m_manipulationJoints;
         builtin_interfaces::msg::Time m_lastTickTimestamp; //!< ROS 2 Timestamp during last OnTick call
+
+        bool m_checkForPositionErrors = false; //!< If true, check if joints reached the goal position before reporting success
+        float m_jointPositionTolerance = 0.04f; //!< The threshold for joint position errors to report the goal as reached
+        bool ShouldCheckForPositionErrors();
+
+        bool m_checkForVelocity = false; //!< If true, check if joints velocity is below threshold before reporting success
+        float m_jointVelocityTolerance = 0.01f; //!< The threshold for joint velocities under which to report the goal as reached
+        bool ShouldCheckForVelocity();
     };
 } // namespace ROS2Controllers


### PR DESCRIPTION
## What does this PR do?

The `JointsTrajectoryComponent` would not check if the goal position was reached, and would report success based solely on the time elapsed from accepting the trajectory. This results in reporting success before the movement stops, thus making it impossible to chain multiple actions (involving other things than just joint trajectories, like gripper action or navigation) one after another without having big errors in position.

This PR adds two very simple ways of checking if the goal was reached: by calculating the joints' position errors and by checking if the joints' velocities reached 0 (both with parameterized tolerances). Both of those checks can be disabled independently and are **disabled by default**.

<img width="501" height="176" alt="image" src="https://github.com/user-attachments/assets/6ef4c24b-34d2-4242-8269-9846c860843a" />


## How was this PR tested?

In a project with a manipulator and vacuum gripper, a simple script was executed involving multiple steps of manipulation (moving the arm, closing the gripper, moving it again, opening the gripper) successfully.