### PR TITLE
Fix PID tests after #988

### DIFF
--- a/Gems/ROS2Controllers/Code/Tests/PIDTest.cpp
+++ b/Gems/ROS2Controllers/Code/Tests/PIDTest.cpp
@@ -31,7 +31,7 @@ namespace UnitTest
         double output = 0.0;
 
         output = pid.ComputeCommand(-10.0, 1 * secToNanosec);
-        EXPECT_EQ(0.0, output);
+        EXPECT_EQ(-1.0, output);
 
         output = pid.ComputeCommand(30.0, 1 * secToNanosec);
         EXPECT_EQ(1.0, output);


### PR DESCRIPTION
## What does this PR do?

PR #988 changed the PID implementation to allow the negative values. The tests were not updated and they started failing. This is fixed now.

## How was this PR tested?

Tests were run.
