### PR TITLE
Cherry-pick changes to `backports/25051`

### DIFF
--- a/Gems/ROS2/Code/Source/Utilities/Controllers/PidConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Utilities/Controllers/PidConfiguration.cpp
@@ -123,7 +123,7 @@ namespace ROS2::Controllers
 
         if (m_outputLimit > 0.0)
         {
-            output = AZStd::clamp<double>(output, 0.0, m_outputLimit);
+            output = AZStd::clamp<double>(output, -m_outputLimit, m_outputLimit);
         }
         return output;
     }

--- a/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/AckermannDriveModel.cpp
+++ b/Gems/ROS2/Code/Source/VehicleDynamics/DriveModels/AckermannDriveModel.cpp
@@ -80,6 +80,7 @@ namespace ROS2::VehicleDynamics
         const auto& jointComponent = wheelData.m_steeringJoint;
 
         auto id = AZ::EntityComponentIdPair(steeringEntity, jointComponent);
+        auto scaledSteering = steering * wheelData.m_steeringScale;
 
         if (wheelData.m_isArticulation)
         {
@@ -88,7 +89,7 @@ namespace ROS2::VehicleDynamics
                 [&](PhysX::ArticulationJointRequests* joint)
                 {
                     double currentSteeringAngle = joint->GetJointPosition(wheelData.m_axis);
-                    const double pidCommand = m_steeringPid.ComputeCommand(steering - currentSteeringAngle, deltaTimeNs);
+                    const double pidCommand = m_steeringPid.ComputeCommand(scaledSteering - currentSteeringAngle, deltaTimeNs);
                     joint->SetDriveTargetVelocity(wheelData.m_axis, pidCommand);
                 });
         }
@@ -99,7 +100,7 @@ namespace ROS2::VehicleDynamics
                 [&](PhysX::JointRequests* joint)
                 {
                     double currentSteeringAngle = joint->GetPosition();
-                    const double pidCommand = m_steeringPid.ComputeCommand(steering - currentSteeringAngle, deltaTimeNs);
+                    const double pidCommand = m_steeringPid.ComputeCommand(scaledSteering - currentSteeringAngle, deltaTimeNs);
                     joint->SetVelocity(pidCommand);
                 });
         }

--- a/Gems/ROS2/Code/Tests/PIDTest.cpp
+++ b/Gems/ROS2/Code/Tests/PIDTest.cpp
@@ -31,7 +31,7 @@ namespace UnitTest
         double output = 0.0;
 
         output = pid.ComputeCommand(-10.0, 1 * secToNanosec);
-        EXPECT_EQ(0.0, output);
+        EXPECT_EQ(-1.0, output);
 
         output = pid.ComputeCommand(30.0, 1 * secToNanosec);
         EXPECT_EQ(1.0, output);


### PR DESCRIPTION
## What does this PR do?

Cherry-pick changes from the `development` branch for 2510 release:
- #988 - this PR allows PID implementation to use negative values
- #985 - this PR fixes Ackermann
- #988 - this PR fixes tests

## How was this PR tested?

Built the code, ran tests, tested Ackermann with some manual tests.
