### PR TITLE
Remove assert in NamespaceComputation to ignore level entity

### DIFF
--- a/Gems/ROS2/Code/Source/Frame/NamespaceComputation.cpp
+++ b/Gems/ROS2/Code/Source/Frame/NamespaceComputation.cpp
@@ -92,7 +92,6 @@ namespace ROS2
                 return;
             }
             auto* transformInterface = entity->GetTransform();
-            AZ_Assert(transformInterface, "No transform for id : %s", id.ToString().c_str());
             if (!transformInterface)
             {
                 return;


### PR DESCRIPTION
## What does this PR do?

It removes assert from NamespaceComputation method, which traverses all entities from the leaf to the root. The root here can be a level entity, which has no transform. Hence, the assert always triggers. 

Reaching the level entity should be a termination. It happens when no parent is available.

## How was this PR tested?

Checked if assert still exists in the logs - it does not after the fix.
