### PR TITLE
Fix release build: add [[maybe_unused]]

### DIFF
--- a/Gems/ROS2Controllers/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.cpp
+++ b/Gems/ROS2Controllers/Code/Source/RobotControl/Controllers/RigidBodyController/RigidBodyTwistControlComponent.cpp
@@ -118,7 +118,7 @@ namespace ROS2Controllers
         AzPhysics::SceneInterface* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         AZ_Assert(sceneInterface, "No scene interface");
 
-        AzPhysics::SceneHandle defaultSceneHandle = sceneInterface->GetSceneHandle(AzPhysics::DefaultPhysicsSceneName);
+        [[maybe_unused]] AzPhysics::SceneHandle defaultSceneHandle = sceneInterface->GetSceneHandle(AzPhysics::DefaultPhysicsSceneName);
         AZ_Assert(defaultSceneHandle != AzPhysics::InvalidSceneHandle, "Invalid default physics scene handle");
 
         if (m_bodyHandle == AzPhysics::InvalidSimulatedBodyHandle)


### PR DESCRIPTION
## What does this PR do?

`defaultSceneHandle`  variable is only used in `AZ_Assert`, which means it is unused when build in release. It triggers errors in some compilers configurations.

## How was this PR tested?

Built in release.
