### PR TITLE
Added missing state restoring if request failed

### DIFF
--- a/Gems/SimulationInterfaces/Code/Source/Clients/LevelManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/LevelManager.cpp
@@ -123,6 +123,7 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "Additional Sources are not implemented yet";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, errorMsg));
         }
 
@@ -130,6 +131,7 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "Tags filter is not implemented yet";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, errorMsg));
         }
 
@@ -137,12 +139,14 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "Online search is not implemented yet, only pure offline search is supported";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, errorMsg));
         }
 
         const auto allLevels = GetAllAvailableLevels();
         if (!allLevels.IsSuccess())
         {
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(allLevels.GetError());
         }
         for (const auto& levelPath : allLevels.GetValue())
@@ -169,6 +173,7 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "Failed to get level interface";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::srv::GetAvailableWorlds::Response::DEFAULT_SOURCES_FAILED, errorMsg));
         }
 
@@ -176,6 +181,7 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "No level loaded";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::srv::GetCurrentWorld::Response::NO_WORLD_LOADED, errorMsg));
         }
 
@@ -184,6 +190,7 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "Failed to get current level path";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, errorMsg));
         }
         AZStd::string levelPathStr{ levelPath };
@@ -210,24 +217,28 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "uri and resource string in levelResource cannot be both empty";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::srv::LoadWorld::Response::NO_RESOURCE, errorMsg));
         }
         if (!request.levelResource.m_resourceString.empty() && !request.levelResource.m_uri.empty())
         {
             constexpr const char* errorMsg = "uri and resource string in levelResource cannot be both non-empty";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, errorMsg));
         }
         if (!request.levelResource.m_resourceString.empty())
         {
             constexpr const char* errorMsg = "Loading world from resource string is not implemented yet";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, errorMsg));
         }
 
         const auto levelNamesResult = GetAllAvailableLevels();
         if (!levelNamesResult.IsSuccess())
         {
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(levelNamesResult.GetError());
         }
         const auto& levelsPaths = levelNamesResult.GetValue();
@@ -236,6 +247,7 @@ namespace SimulationInterfaces
         {
             const AZStd::string errorMsg = AZStd::string::format("Requested world/level %s not found", request.levelResource.m_uri.c_str());
             AZ_Warning("SimulationInterfaces", false, errorMsg.c_str());
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::srv::LoadWorld::Response::MISSING_ASSETS, errorMsg));
         }
 
@@ -244,6 +256,7 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "Failed to start, level System not available";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, errorMsg));
         }
 
@@ -262,6 +275,7 @@ namespace SimulationInterfaces
             AZ_Warning("SimulationInterfaces", false, errorMsg);
             SimulationManagerRequestBus::Broadcast(
                 &SimulationManagerRequests::SetSimulationState, simulation_interfaces::msg::SimulationState::STATE_NO_WORLD);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::srv::LoadWorld::Response::RESOURCE_PARSE_ERROR, errorMsg));
         }
         // notify state machine
@@ -289,6 +303,7 @@ namespace SimulationInterfaces
             {
                 constexpr const char* errorMsg = "No level loaded";
                 AZ_Warning("SimulationInterfaces", false, errorMsg);
+                m_actionRequestedFromSimInterfaces = false;
                 return AZ::Failure(FailedResult(simulation_interfaces::srv::UnloadWorld::Response::NO_WORLD_LOADED, errorMsg));
             }
         }
@@ -297,6 +312,7 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "Level system is not available";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, errorMsg));
         }
 
@@ -320,6 +336,7 @@ namespace SimulationInterfaces
         if (!levelGathering.IsSuccess())
         {
             AZ_Error("LevelManager", false, "Error occurred during level gathering: %s", levelGathering.GetError().m_errorString.c_str());
+            m_actionRequestedFromSimInterfaces = false;
             return;
         }
         UnloadWorld();

--- a/Gems/SimulationInterfaces/Code/Source/Clients/LevelManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/LevelManager.cpp
@@ -116,14 +116,12 @@ namespace SimulationInterfaces
 
     AZ::Outcome<WorldResourcesList, FailedResult> LevelManager::GetAvailableWorlds(const GetWorldsRequest& request)
     {
-        m_actionRequestedFromSimInterfaces = true;
         WorldResourcesList availableWorlds;
         // request validation
         if (!request.additionalSources.empty())
         {
             constexpr const char* errorMsg = "Additional Sources are not implemented yet";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
-            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, errorMsg));
         }
 
@@ -131,7 +129,6 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "Tags filter is not implemented yet";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
-            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, errorMsg));
         }
 
@@ -139,14 +136,12 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "Online search is not implemented yet, only pure offline search is supported";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
-            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, errorMsg));
         }
 
         const auto allLevels = GetAllAvailableLevels();
         if (!allLevels.IsSuccess())
         {
-            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(allLevels.GetError());
         }
         for (const auto& levelPath : allLevels.GetValue())
@@ -154,7 +149,6 @@ namespace SimulationInterfaces
             availableWorlds.emplace_back(
                 GetLevelNameFromAssetPath(levelPath), Resource{ levelPath, "" }, "", AZStd::vector<AZStd::string>{});
         }
-        m_actionRequestedFromSimInterfaces = false;
         return AZ::Success(availableWorlds);
     }
 
@@ -166,14 +160,12 @@ namespace SimulationInterfaces
             AZ_Warning("SimulationInterfaces", false, errorMsg);
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, errorMsg));
         }
-        m_actionRequestedFromSimInterfaces = true;
         WorldResource currentWorld;
         auto* levelInterface = AzFramework::LevelSystemLifecycleInterface::Get();
         if (levelInterface == nullptr)
         {
             constexpr const char* errorMsg = "Failed to get level interface";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
-            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::srv::GetAvailableWorlds::Response::DEFAULT_SOURCES_FAILED, errorMsg));
         }
 
@@ -181,7 +173,6 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "No level loaded";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
-            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::srv::GetCurrentWorld::Response::NO_WORLD_LOADED, errorMsg));
         }
 
@@ -190,7 +181,6 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "Failed to get current level path";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
-            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, errorMsg));
         }
         AZStd::string levelPathStr{ levelPath };
@@ -198,7 +188,6 @@ namespace SimulationInterfaces
         auto levelName = GetLevelNameFromAssetPath(levelPathStr);
         currentWorld.m_worldResource.m_uri = levelPathStr;
         currentWorld.m_name = levelName;
-        m_actionRequestedFromSimInterfaces = false;
         return AZ::Success(currentWorld);
     }
 
@@ -210,35 +199,30 @@ namespace SimulationInterfaces
             AZ_Warning("SimulationInterfaces", false, errorMsg);
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, errorMsg));
         }
-        m_actionRequestedFromSimInterfaces = true;
         WorldResource loadedWorld;
 
         if (request.levelResource.m_resourceString.empty() && request.levelResource.m_uri.empty())
         {
             constexpr const char* errorMsg = "uri and resource string in levelResource cannot be both empty";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
-            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::srv::LoadWorld::Response::NO_RESOURCE, errorMsg));
         }
         if (!request.levelResource.m_resourceString.empty() && !request.levelResource.m_uri.empty())
         {
             constexpr const char* errorMsg = "uri and resource string in levelResource cannot be both non-empty";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
-            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, errorMsg));
         }
         if (!request.levelResource.m_resourceString.empty())
         {
             constexpr const char* errorMsg = "Loading world from resource string is not implemented yet";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
-            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, errorMsg));
         }
 
         const auto levelNamesResult = GetAllAvailableLevels();
         if (!levelNamesResult.IsSuccess())
         {
-            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(levelNamesResult.GetError());
         }
         const auto& levelsPaths = levelNamesResult.GetValue();
@@ -247,10 +231,10 @@ namespace SimulationInterfaces
         {
             const AZStd::string errorMsg = AZStd::string::format("Requested world/level %s not found", request.levelResource.m_uri.c_str());
             AZ_Warning("SimulationInterfaces", false, errorMsg.c_str());
-            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::srv::LoadWorld::Response::MISSING_ASSETS, errorMsg));
         }
 
+        m_actionRequestedFromSimInterfaces = true;
         ILevelSystem* levelSystem = GetLevelSystem();
         if (levelSystem == nullptr)
         {


### PR DESCRIPTION
## What does this PR do?

This PR fixes simulation interfaces LevelManager to correctly handle loading levels via ImGui. Original solution wasn't restoring internal state in case of request fail.

## How was this PR tested?

run GameLauncher with no level and loaded level via imgui. Simulation state changed as expected  