### PR TITLE
Update PhysX references to PhysX5

### DIFF
--- a/Gems/OpenXRVk/Code/CMakeLists.txt
+++ b/Gems/OpenXRVk/Code/CMakeLists.txt
@@ -65,7 +65,7 @@ ly_add_target(
             Gem::Atom_RHI_Vulkan.Reflect
             Gem::Atom_RHI_Vulkan.Glad.Static
             Gem::XR.Static
-            Gem::PhysX.Static			
+            Gem::PhysX5.Static
             Gem::Atom_Feature_Common.Public			
             Gem::CommonFeaturesAtom.Static
             Gem::EMotionFXStaticLib

--- a/Projects/OpenXRTest/Gem/enabled_gems.cmake
+++ b/Projects/OpenXRTest/Gem/enabled_gems.cmake
@@ -11,7 +11,7 @@ set(ENABLED_GEMS
     ImGui
     LandscapeCanvas
     LyShine
-    PhysX
+    PhysX5
     PrimitiveAssets
     PrefabBuilder
     SaveData

--- a/Projects/OpenXRTest/Registry/physxdebugconfiguration.setreg
+++ b/Projects/OpenXRTest/Registry/physxdebugconfiguration.setreg
@@ -1,7 +1,7 @@
 {
     "Amazon": {
         "Gems": {
-            "PhysX": {
+            "PhysX5": {
                 "Debug": {
                     "PhysXDebugConfiguration": {}
                 }

--- a/Projects/OpenXRTest/Registry/physxdefaultsceneconfiguration.setreg
+++ b/Projects/OpenXRTest/Registry/physxdefaultsceneconfiguration.setreg
@@ -1,7 +1,7 @@
 {
     "Amazon": {
         "Gems": {
-            "PhysX": {
+            "PhysX5": {
                 "DefaultSceneConfiguration": {}
             }
         }

--- a/Projects/OpenXRTest/Registry/physxsystemconfiguration.setreg
+++ b/Projects/OpenXRTest/Registry/physxsystemconfiguration.setreg
@@ -1,7 +1,7 @@
 {
     "Amazon": {
         "Gems": {
-            "PhysX": {
+            "PhysX5": {
                 "PhysXSystemConfiguration": {
                     "CollisionConfig": {
                         "Layers": {

--- a/Templates/Multiplayer/Template/Gem/CMakeLists.txt
+++ b/Templates/Multiplayer/Template/Gem/CMakeLists.txt
@@ -39,13 +39,13 @@ ly_add_target(
             Gem::LyShine
             Gem::StartingPointInput
             Gem::EMotionFXStaticLib
-            Gem::PhysX
+            Gem::PhysX5
             Gem::Multiplayer.Client
             Gem::AudioSystem.API
         PRIVATE
             Gem::LmbrCentral.Static
             Gem::Multiplayer.Client.Static
-            Gem::PhysX.Static
+            Gem::PhysX5.Static
             Gem::DebugDraw.Static
             Gem::ImGui.Static
             Gem::LyShine.Static
@@ -76,12 +76,12 @@ if (PAL_TRAIT_BUILD_SERVER_SUPPORTED)
             PUBLIC
                 Gem::StartingPointInput
                 Gem::EMotionFXStaticLib
-                Gem::PhysX
+                Gem::PhysX5
                 Gem::Multiplayer.Server
             PRIVATE
                 Gem::LmbrCentral.Static
                 Gem::Multiplayer.Server.Static
-                Gem::PhysX.Static
+                Gem::PhysX5.Static
                 Gem::GameState.Static
         AUTOGEN_RULES
             *.AutoComponent.xml,AutoComponent_Header.jinja,$path/$fileprefix.AutoComponent.h
@@ -112,13 +112,13 @@ ly_add_target(
             Gem::LyShine
             Gem::StartingPointInput
             Gem::EMotionFXStaticLib
-            Gem::PhysX
+            Gem::PhysX5
             Gem::Multiplayer
             Gem::AudioSystem.API
         PRIVATE
             Gem::LmbrCentral.Static
             Gem::Multiplayer.Unified.Static
-            Gem::PhysX.Static
+            Gem::PhysX5.Static
             Gem::DebugDraw.Static
             Gem::ImGui.Static
             Gem::LyShine.Static

--- a/Templates/Multiplayer/Template/Registry/physxdebugconfiguration.setreg
+++ b/Templates/Multiplayer/Template/Registry/physxdebugconfiguration.setreg
@@ -1,7 +1,7 @@
 {
     "Amazon": {
         "Gems": {
-            "PhysX": {
+            "PhysX5": {
                 "Debug": {
                     "PhysXDebugConfiguration": {}
                 }

--- a/Templates/Multiplayer/Template/Registry/physxdefaultsceneconfiguration.setreg
+++ b/Templates/Multiplayer/Template/Registry/physxdefaultsceneconfiguration.setreg
@@ -1,7 +1,7 @@
 {
     "Amazon": {
         "Gems": {
-            "PhysX": {
+            "PhysX5": {
                 "DefaultSceneConfiguration": {}
             }
         }

--- a/Templates/Multiplayer/Template/Registry/physxsystemconfiguration.setreg
+++ b/Templates/Multiplayer/Template/Registry/physxsystemconfiguration.setreg
@@ -1,7 +1,7 @@
 {
     "Amazon": {
         "Gems": {
-            "PhysX": {
+            "PhysX5": {
                 "PhysXSystemConfiguration": {
                     "CollisionConfig": {
                         "Layers": {

--- a/Templates/Multiplayer/Template/project.json
+++ b/Templates/Multiplayer/Template/project.json
@@ -33,7 +33,7 @@
         "LyShine",
         "MiniAudio",
         "Multiplayer",
-        "PhysX",
+        "PhysX5",
         "PrimitiveAssets",
         "PrefabBuilder",
         "SaveData",

--- a/repo.json
+++ b/repo.json
@@ -178,7 +178,7 @@
                 "Atom_Feature_Common",
                 "Atom_Component_DebugCamera",
                 "CommonFeaturesAtom",
-                "PhysX",
+                "PhysX5",
                 "StartingPointInput"
             ],
             "restricted": "ROS2",


### PR DESCRIPTION
## What does this PR do?

As part of the upcoming PhysX4 deprecation, this updates all the references to the PhysX4 gem to use PhysX5 instead.

## How was this PR tested?
This was tested against a incoming updated o3de-multiplayer-sample update