### PR TITLE
Add optional to setpoint articulation

### DIFF
--- a/Gems/ROS2Controllers/Code/Include/ROS2Controllers/Manipulation/JointInfo.h
+++ b/Gems/ROS2Controllers/Code/Include/ROS2Controllers/Manipulation/JointInfo.h
@@ -27,7 +27,7 @@ namespace ROS2Controllers
         bool m_isArticulation = false;
         PhysX::ArticulationJointAxis m_axis = PhysX::ArticulationJointAxis::Twist;
         AZ::EntityComponentIdPair m_entityComponentIdPair;
-        JointPosition m_restPosition = 0.0f; //!< Keeps this position if no commands are given (for example, opposing gravity).
+        AZStd::optional<JointPosition> m_restPosition ; //!< Keeps this position if no commands are given (for example, opposing gravity).
     };
     using ManipulationJoints = AZStd::unordered_map<AZStd::string, JointInfo>;
 } // namespace ROS2Controllers

--- a/Gems/ROS2Controllers/Code/Source/Manipulation/JointsManipulationComponent.cpp
+++ b/Gems/ROS2Controllers/Code/Source/Manipulation/JointsManipulationComponent.cpp
@@ -160,7 +160,7 @@ namespace ROS2Controllers
                 }
                 else
                 {
-                    AZ_Warning("JointsManipulationComponent", false, "No joint %s to set initial position", jointName.c_str());
+                    AZ_Warning("JointsManipulationComponent", false, "No set initial position for joint %s", jointName.c_str());
                 }
             }
         }
@@ -389,26 +389,35 @@ namespace ROS2Controllers
         for (const auto& [jointName, jointInfo] : m_manipulationJoints)
         {
             float currentPosition = GetJointPosition(jointName).GetValue();
-            float desiredPosition = jointInfo.m_restPosition;
+            auto desiredPosition = jointInfo.m_restPosition;
 
-            AZ::Outcome<void, AZStd::string> positionControlOutcome;
-            JointsPositionControllerRequestBus::EventResult(
-                positionControlOutcome,
-                GetEntityId(),
-                &JointsPositionControllerRequests::PositionControl,
-                jointName,
-                jointInfo,
-                currentPosition,
-                desiredPosition,
-                deltaTime);
+            if (desiredPosition.has_value())
+            {
+                AZ::Outcome<void, AZStd::string> positionControlOutcome;
+                JointsPositionControllerRequestBus::EventResult(
+                    positionControlOutcome,
+                    GetEntityId(),
+                    &JointsPositionControllerRequests::PositionControl,
+                    jointName,
+                    jointInfo,
+                    currentPosition,
+                    *desiredPosition,
+                    deltaTime);
+                if (positionControlOutcome.IsSuccess())
+                {
+                    // no need to update desired position, it will be updated on the next MoveJointToPosition call.
+                    // If the position is reached and there is no new desired position, the controller should keep the joint in place.
+                    desiredPosition = AZStd::nullopt; // If control failed, do not update desired position, try again in the next tick.
+                }
+                AZ_Warning(
+                    "JointsManipulationComponent",
+                    positionControlOutcome,
+                    "Position control failed for joint %s (%s): %s",
+                    jointName.c_str(),
+                    jointInfo.m_entityComponentIdPair.GetEntityId().ToString().c_str(),
+                    positionControlOutcome.GetError().c_str());
 
-            AZ_Warning(
-                "JointsManipulationComponent",
-                positionControlOutcome,
-                "Position control failed for joint %s (%s): %s",
-                jointName.c_str(),
-                jointInfo.m_entityComponentIdPair.GetEntityId().ToString().c_str(),
-                positionControlOutcome.GetError().c_str());
+            }
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Send setpoint to articulation only when it is needed.

Should resolve https://github.com/o3de/o3de-extras/issues/1017
It is paired with https://github.com/o3de/o3de/pull/19594
## How was this PR tested?

Not really., I've done some tests on 2505.
