### PR TITLE
Bump libsdformat 13.5.0->16.0.1

### DIFF
--- a/Gems/ROS2RobotImporter/Code/Include/ROS2RobotImporter/SDFormatModelPluginImporterHook.h
+++ b/Gems/ROS2RobotImporter/Code/Include/ROS2RobotImporter/SDFormatModelPluginImporterHook.h
@@ -18,12 +18,12 @@
 
 namespace sdf
 {
-    inline namespace v13
+    inline namespace v16
     {
         class Link;
         class Model;
         class Plugin;
-    } // namespace v13
+    } // namespace v16
 } // namespace sdf
 
 namespace ROS2RobotImporter::SDFormat

--- a/Gems/ROS2RobotImporter/Code/Include/ROS2RobotImporter/SDFormatSensorImporterHook.h
+++ b/Gems/ROS2RobotImporter/Code/Include/ROS2RobotImporter/SDFormatSensorImporterHook.h
@@ -16,11 +16,11 @@
 
 namespace sdf
 {
-    inline namespace v13
+    inline namespace v16
     {
         enum class SensorType;
         class Sensor;
-    } // namespace v13
+    } // namespace v16
 } // namespace sdf
 
 namespace ROS2RobotImporter::SDFormat

--- a/Gems/ROS2RobotImporter/Code/Platform/Linux/PAL_linux.cmake
+++ b/Gems/ROS2RobotImporter/Code/Platform/Linux/PAL_linux.cmake
@@ -11,11 +11,11 @@ set(PAL_TRAIT_ROS2ROBOTIMPORTER_TEST_SUPPORTED FALSE)
 set(PAL_TRAIT_ROS2ROBOTIMPORTER_EDITOR_TEST_SUPPORTED TRUE)
 
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
-    ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev2-linux
+    ly_associate_package(PACKAGE_NAME sdformat-16.0.1-rev1-linux
         TARGETS sdformat
-        PACKAGE_HASH b8e988954c07f41b99ba0950da3f4d3e8489ffabaaff157f79ab0c716e2142e0)
+        PACKAGE_HASH 41125211ce8f96c2985eca1181e2a5e820fa045511546af0f7a5f60669dd5ebf)
 elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
-    ly_associate_package(PACKAGE_NAME sdformat-13.5.0-rev2-linux-aarch64
+    ly_associate_package(PACKAGE_NAME sdformat-16.0.1-rev1-linux-aarch64
         TARGETS sdformat
-        PACKAGE_HASH 7e51cc60c61a058c1f8aba7277574946ab974af3ff4601884e72380e8585c0ea)
+        PACKAGE_HASH a4893bd1586fd7ceee93ae5e3febb8c95fe868cd053b44e4b0750d47968495c2)
 endif()

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Parsing/SdfParser.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Parsing/SdfParser.cpp
@@ -8,6 +8,7 @@
 
 #include "SdfParser.h"
 
+#include <sdformat.hh>
 #include <sstream>
 
 #include <AzCore/Debug/Trace.h>
@@ -53,10 +54,12 @@ namespace ROS2RobotImporter::SdfParser
     {
         return m_root;
     }
+
     const sdf::Root& ParseResult::GetRoot() const&
     {
         return m_root;
     }
+
     sdf::Root&& ParseResult::GetRoot() &&
     {
         return AZStd::move(m_root);
@@ -97,6 +100,7 @@ namespace ROS2RobotImporter::SdfParser
     {
         return Parse(std::string(xmlString.data(), xmlString.size()), parserConfig);
     }
+
     RootObjectOutcome Parse(const std::string& xmlString, const sdf::ParserConfig& parserConfig)
     {
         ParseResult parseResult;

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/ErrorUtils.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/ErrorUtils.h
@@ -20,10 +20,10 @@
 
 namespace sdf
 {
-    inline namespace v13
+    inline namespace v16
     {
         class Error;
-    } // namespace v13
+    } // namespace v16
 } // namespace sdf
 
 namespace AZStd
@@ -31,26 +31,26 @@ namespace AZStd
     // Allow std::vector<sdf::Error> to meet the requirements of contiguous iterator in C++17
     // This allows constructing an AZStd::span from a std::vector
     template<>
-    struct iterator_traits<typename std::vector<sdf::v13::Error>::iterator>
+    struct iterator_traits<typename std::vector<sdf::v16::Error>::iterator>
     {
         // Use the standard library iterator traits for all traits except for the iterator_concept
-        using difference_type = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::iterator>::difference_type;
-        using value_type = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::iterator>::value_type;
-        using pointer = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::iterator>::pointer;
-        using reference = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::iterator>::reference;
-        using iterator_category = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::iterator>::iterator_category;
+        using difference_type = typename std::iterator_traits<typename std::vector<sdf::v16::Error>::iterator>::difference_type;
+        using value_type = typename std::iterator_traits<typename std::vector<sdf::v16::Error>::iterator>::value_type;
+        using pointer = typename std::iterator_traits<typename std::vector<sdf::v16::Error>::iterator>::pointer;
+        using reference = typename std::iterator_traits<typename std::vector<sdf::v16::Error>::iterator>::reference;
+        using iterator_category = typename std::iterator_traits<typename std::vector<sdf::v16::Error>::iterator>::iterator_category;
         using iterator_concept = contiguous_iterator_tag;
     };
 
     template<>
-    struct iterator_traits<typename std::vector<sdf::v13::Error>::const_iterator>
+    struct iterator_traits<typename std::vector<sdf::v16::Error>::const_iterator>
     {
         // Use the standard library iterator traits for all traits except for the iterator_concept
-        using difference_type = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::const_iterator>::difference_type;
-        using value_type = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::const_iterator>::value_type;
-        using pointer = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::const_iterator>::pointer;
-        using reference = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::const_iterator>::reference;
-        using iterator_category = typename std::iterator_traits<typename std::vector<sdf::v13::Error>::const_iterator>::iterator_category;
+        using difference_type = typename std::iterator_traits<typename std::vector<sdf::v16::Error>::const_iterator>::difference_type;
+        using value_type = typename std::iterator_traits<typename std::vector<sdf::v16::Error>::const_iterator>::value_type;
+        using pointer = typename std::iterator_traits<typename std::vector<sdf::v16::Error>::const_iterator>::pointer;
+        using reference = typename std::iterator_traits<typename std::vector<sdf::v16::Error>::const_iterator>::reference;
+        using iterator_category = typename std::iterator_traits<typename std::vector<sdf::v16::Error>::const_iterator>::iterator_category;
         using iterator_concept = contiguous_iterator_tag;
     };
 } // namespace AZStd


### PR DESCRIPTION
## What does this PR do?

- bump 3rd party dependency libsdformat from 13.5.0 to 16.0.1 following https://github.com/o3de/3p-package-source/pull/365
- fix compile error in tests after https://github.com/o3de/o3de/pull/19585
```
build] /devroot/2604/o3de-extras/Gems/ROS2RobotImporter/Code/Tests/SdfParserTest.cpp:353:22: error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
[build]         links.insert(AZStd::move(otherLinks.begin()), AZStd::move(otherLinks.end()));
[build]                      ^
[build] /devroot/2604/o3de-extras/Gems/ROS2RobotImporter/Code/Tests/SdfParserTest.cpp:353:22: note: remove std::move call here
[build]         links.insert(AZStd::move(otherLinks.begin()), AZStd::move(otherLinks.end()));
[build]                      ^~~~~~~~~~~~                  ~
[build] /devroot/2604/o3de-extras/Gems/ROS2RobotImporter/Code/Tests/SdfParserTest.cpp:353:55: error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
[build]         links.insert(AZStd::move(otherLinks.begin()), AZStd::move(otherLinks.end()));
[build]                                                       ^
[build] /devroot/2604/o3de-extras/Gems/ROS2RobotImporter/Code/Tests/SdfParserTest.cpp:353:55: note: remove std::move call here
[build]         links.insert(AZStd::move(otherLinks.begin()), AZStd::move(otherLinks.end()));
```


Note: https://github.com/o3de/3p-package-source/pull/365 should be integrated first (marking as draft); it should target development branch only

## How was this PR tested?

Multiple different robots were imported; the version of the libsdformat library was printed:
```cpp
AZ_Error("JHDEBUG", false, "version: %s", SDF_VERSION_FULL);
```
```bash
<11:51:35> [Error] (JHDEBUG) - version: 16.0.1
```

