### PR TITLE
Fix JointsPositionComponent

### DIFF
--- a/Gems/ROS2Controllers/Code/Source/Manipulation/JointsManipulationComponent.cpp
+++ b/Gems/ROS2Controllers/Code/Source/Manipulation/JointsManipulationComponent.cpp
@@ -15,6 +15,7 @@
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/std/optional.h>
 #include <ROS2/Clock/ROS2ClockRequestBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <ROS2/Utilities/ROS2Conversions.h>
@@ -28,48 +29,36 @@ namespace ROS2Controllers
 {
     namespace Internal
     {
-        void Add1DOFJointInfo(const AZ::EntityComponentIdPair& idPair, const AZStd::string& jointName, ManipulationJoints& joints)
+        JointInfo Get1DOFJointInfo(const AZ::EntityComponentIdPair& idPair)
         {
-            if (joints.find(jointName) != joints.end())
-            {
-                AZ_Assert(false, "Joint names in hierarchy need to be unique (%s is not)!", jointName.c_str());
-                return;
-            }
             JointInfo jointInfo;
             jointInfo.m_isArticulation = false;
             jointInfo.m_axis = static_cast<PhysX::ArticulationJointAxis>(0);
             jointInfo.m_entityComponentIdPair = idPair;
-            joints[jointName] = jointInfo;
+            return jointInfo;
         }
 
-        void AddArticulationJointInfo(const AZ::EntityComponentIdPair& idPair, const AZStd::string& jointName, ManipulationJoints& joints)
+        AZStd::optional<JointInfo> GetArticulationJointInfo(const AZ::EntityComponentIdPair& idPair)
         {
             bool isRoot = false;
             PhysX::ArticulationJointRequestBus::EventResult(
                 isRoot, idPair.GetEntityId(), &PhysX::ArticulationJointRequests::IsRootArticulation);
             if (isRoot)
             { // Root articulation does not have a joint
-                return;
+                return AZStd::nullopt;
             }
 
             const auto freeAxis = Utils::TryGetFreeArticulationAxis(idPair.GetEntityId());
             if (!freeAxis.has_value())
             { // Do not add a joint since it is a fixed one
-                return;
-            }
-
-            if (joints.find(jointName) != joints.end())
-            {
-                AZ_Error(
-                    "JointsManipulationComponent", false, "Joint names in hierarchy need to be unique (%s is not)!", jointName.c_str());
-                return;
+                return AZStd::nullopt;
             }
 
             JointInfo jointInfo;
             jointInfo.m_isArticulation = true;
             jointInfo.m_axis = freeAxis.value();
             jointInfo.m_entityComponentIdPair = idPair;
-            joints[jointName] = jointInfo;
+            return jointInfo;
         }
 
         ManipulationJoints GetAllEntityHierarchyJoints(const AZ::EntityId& entityId)
@@ -109,7 +98,12 @@ namespace ROS2Controllers
                 { // Frame Component is required for joints.
                     continue;
                 }
-                const AZStd::string jointName(frameComponent->GetJointName().c_str());
+                const AZStd::string jointName(frameComponent->GetNamespacedJointName().c_str());
+                if (manipulationJoints.find(jointName) != manipulationJoints.end())
+                {
+                    AZ_Assert(false, "Joint names in hierarchy need to be unique (%s is not)!", jointName.c_str());
+                    return {};
+                }
 
                 auto* hingeComponent = entity->FindComponent<PhysX::HingeJointComponent>();
                 auto* prismaticComponent = entity->FindComponent<PhysX::PrismaticJointComponent>();
@@ -128,21 +122,25 @@ namespace ROS2Controllers
                 if (supportsClassicJoints && hingeComponent)
                 {
                     auto idPair = AZ::EntityComponentIdPair(hingeComponent->GetEntityId(), hingeComponent->GetId());
-                    Internal::Add1DOFJointInfo(idPair, jointName, manipulationJoints);
+                    manipulationJoints[jointName] = Get1DOFJointInfo(idPair);
                 }
 
                 // See if there is a Prismatic Joint in the entity, add it to map.
                 if (supportsClassicJoints && prismaticComponent)
                 {
                     auto idPair = AZ::EntityComponentIdPair(prismaticComponent->GetEntityId(), prismaticComponent->GetId());
-                    Internal::Add1DOFJointInfo(idPair, jointName, manipulationJoints);
+                    manipulationJoints[jointName] = Get1DOFJointInfo(idPair);
                 }
 
                 // See if there is an Articulation Link in the entity, add it to map.
                 if (supportsArticulation && articulationComponent)
                 {
                     auto idPair = AZ::EntityComponentIdPair(articulationComponent->GetEntityId(), articulationComponent->GetId());
-                    Internal::AddArticulationJointInfo(idPair, jointName, manipulationJoints);
+                    auto jointInfo = GetArticulationJointInfo(idPair);
+                    if (jointInfo)
+                    {
+                        manipulationJoints[jointName] = *jointInfo;
+                    }
                 }
             }
             return manipulationJoints;
@@ -160,7 +158,7 @@ namespace ROS2Controllers
                 }
                 else
                 {
-                    AZ_Warning("JointsManipulationComponent", false, "No set initial position for joint %s", jointName.c_str());
+                    AZ_Warning("JointsManipulationComponent", false, "Initial position not set for joint %s", jointName.c_str());
                 }
             }
         }
@@ -416,7 +414,6 @@ namespace ROS2Controllers
                     jointName.c_str(),
                     jointInfo.m_entityComponentIdPair.GetEntityId().ToString().c_str(),
                     positionControlOutcome.GetError().c_str());
-
             }
         }
     }

--- a/Gems/ROS2Controllers/Code/Source/Manipulation/JointsPositionsComponent.cpp
+++ b/Gems/ROS2Controllers/Code/Source/Manipulation/JointsPositionsComponent.cpp
@@ -29,6 +29,7 @@ namespace ROS2Controllers
     {
         required.push_back(AZ_CRC_CE("ROS2Frame"));
         required.push_back(AZ_CRC_CE("JointsControllerService"));
+        required.push_back(AZ_CRC_CE("JointsManipulationService"));
     }
 
     void JointsPositionsComponent::Activate()
@@ -103,7 +104,7 @@ namespace ROS2Controllers
                 AZ_Error(
                     "JointsPositionsComponent",
                     result,
-                    "PositionController: failed for joint %s and command %d: ",
+                    "PositionController: failed for joint %s and command %f: %s",
                     m_jointNames[i].c_str(),
                     message.data[i],
                     result.GetError().c_str());

--- a/Gems/ROS2Controllers/Code/Source/Manipulation/JointsPositionsEditorComponent.cpp
+++ b/Gems/ROS2Controllers/Code/Source/Manipulation/JointsPositionsEditorComponent.cpp
@@ -32,6 +32,7 @@ namespace ROS2Controllers
     {
         required.push_back(AZ_CRC_CE("ROS2Frame"));
         required.push_back(AZ_CRC_CE("JointsControllerService"));
+        required.push_back(AZ_CRC_CE("JointsManipulationService"));
     }
 
     void JointsPositionsEditorComponent::BuildGameEntity(AZ::Entity* gameEntity)


### PR DESCRIPTION
## What does this PR do?

Two main issues were fixed in this PR:
1. `JointsPositionComponent` relies on `JointsManipulationService`, which was not marked before
2. In all places we use joint names together with the namespace, see e.g. https://github.com/o3de/o3de-extras/blob/36d176cf6e1a3cda07eae479a2187470accf89ee/Gems/ROS2Controllers/Code/Source/Manipulation/JointsManipulationEditorComponent.cpp#L118 https://github.com/o3de/o3de-extras/blob/36d176cf6e1a3cda07eae479a2187470accf89ee/Gems/ROS2Controllers/Code/Source/Manipulation/JointsPositionsEditorComponent.cpp#L94 which was missing in one spot: https://github.com/o3de/o3de-extras/blob/36d176cf6e1a3cda07eae479a2187470accf89ee/Gems/ROS2Controllers/Code/Source/Manipulation/JointsManipulationComponent.cpp#L112

The second fix eliminated the errors when extra namespace is added to the gripper (in this example)
```
[Warning] (FingerGripperComponent) - Joint move cannot be realized: Joint asdf/panda_finger_joint2 does not exist for asdf/panda_finger_joint2
[Warning] (FingerGripperComponent) - Joint move cannot be realized: Joint fdsa/panda_finger_joint1 does not exist for fdsa/panda_finger_joint1
[Warning] (FingerGripperComponent) - Setting a max force for a joint cannot be realized: Joint asdf/panda_finger_joint2 does not exist for asdf/panda_finger_joint2
[Warning] (FingerGripperComponent) - Setting a max force for a joint cannot be realized: Joint fdsa/panda_finger_joint1 does not exist for fdsa/panda_finger_joint1
```

One minor issue was fixed: an error message log was printed with incorrect type (float was printed with %d).
An additional refactor was made in getting JointInfo, in which output structure was passed as a parameter for no reason and an early terminate was moved earlier in the code.

## How was this PR tested?

Tested with Panda Franka Robot with stabilization branch 2605.
