### PR TITLE
AZStd::string changed to c_str

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Handlers/ROS2TopicSubscriptionBase.h
+++ b/Gems/ROS2/Code/Include/ROS2/Handlers/ROS2TopicSubscriptionBase.h
@@ -74,7 +74,7 @@ namespace ROS2
             }
 
             m_subscriber = node->create_subscription<RosMessageType>(
-                m_topicConfig.m_topic,
+                m_topicConfig.m_topic.c_str(),
                 m_topicConfig.GetQoS(),
                 [this](const typename RosMessageType::SharedPtr message_ptr)
                 {


### PR DESCRIPTION
## What does this PR do?

PR replaces AZStd::string with c_str to make it compatible with ROS 2.

## How was this PR tested?

built project
