### PR TITLE
Added reverse lookup for simulated entities

### DIFF
--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
@@ -163,6 +163,11 @@ namespace SimulationInterfaces
         //! @param name Name of entity to get
         //! @return Returns entityId of the entity or fail if entity doesn't exist
         virtual AZ::Outcome<AZ::EntityId, FailedResult> GetEntityRoot(const AZStd::string& name) = 0;
+        //! Get simulation interfaces name of the entity with given id.
+        //! Mapping id to name is the same as in method @ref GetEntityId
+        //! @param entityId id of requested entity
+        //! @return name of the simulation entity if exists, Failure otherwise.
+        virtual AZ::Outcome<AZStd::string, FailedResult> GetSimulatedBodyNameById(const AZ::EntityId& entityId) = 0;
     };
 
     class SimulationInterfacesBusTraits : public AZ::EBusTraits

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -1053,4 +1053,20 @@ namespace SimulationInterfaces
         return AZ::Success(m_simulatedEntityToPrefabRoot.at(name));
     }
 
+    AZ::Outcome<AZStd::string, FailedResult> SimulationEntitiesManager::GetSimulatedBodyNameById(const AZ::EntityId& entityId)
+    {
+        const auto it = m_entityIdToSimulatedEntityMap.find(entityId);
+
+        if (it == m_entityIdToSimulatedEntityMap.end())
+        {
+            return AZ::Failure(SimulationInterfaces::FailedResult(
+                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                AZStd::string::format(
+                    "Entity with given ID \"%s\" doesn't exists in available cache of simulated entities names",
+                    entityId.ToString().c_str())));
+        }
+
+        return AZ::Success(it->second);
+    }
+
 } // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -1062,7 +1062,7 @@ namespace SimulationInterfaces
             return AZ::Failure(SimulationInterfaces::FailedResult(
                 simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
                 AZStd::string::format(
-                    "Entity with given ID \"%s\" doesn't exists in available cache of simulated entities names",
+                    "Entity with given ID \"%s\" doesn't exist in the available cache of simulated entities names",
                     entityId.ToString().c_str())));
         }
 

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
@@ -67,6 +67,7 @@ namespace SimulationInterfaces
         AZ::Outcome<Bounds, FailedResult> GetEntityBounds(const AZStd::string& name) override;
         AZ::Outcome<AZ::EntityId, FailedResult> GetEntityId(const AZStd::string& name) override;
         AZ::Outcome<AZ::EntityId, FailedResult> GetEntityRoot(const AZStd::string& name) override;
+        AZ::Outcome<AZStd::string, FailedResult> GetSimulatedBodyNameById(const AZ::EntityId& entityId) override;
 
         // helper methods to filter entities by different filters
         AZStd::vector<AZStd::string> FilterEntitiesByCategories(

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/Mocks/SimulationEntityManagerMock.h
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/Mocks/SimulationEntityManagerMock.h
@@ -45,5 +45,6 @@ namespace UnitTest
         MOCK_METHOD1(GetEntityBounds, AZ::Outcome<Bounds, FailedResult>(const AZStd::string& name));
         MOCK_METHOD1(GetEntityId, AZ::Outcome<AZ::EntityId, FailedResult>(const AZStd::string& name));
         MOCK_METHOD1(GetEntityRoot, AZ::Outcome<AZ::EntityId, FailedResult>(const AZStd::string& name));
+        MOCK_METHOD1(GetSimulatedBodyNameById, AZ::Outcome<AZStd::string, FailedResult>(const AZ::EntityId& entityId));
     };
 } // namespace UnitTest


### PR DESCRIPTION
## What does this PR do?

PR adds reverse lookup to simulation interfaces to retrieve simulated entity name based on root entity Id.

## How was this PR tested?

built project, tests and run test. Tests fails but they fail the same way on development
