### PR TITLE
Added missing check for static rigid bodies

### DIFF
--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -31,6 +31,7 @@
 #include <AzFramework/Physics/PhysicsSystem.h>
 #include <AzFramework/Physics/RigidBodyBus.h>
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
+#include <AzFramework/Physics/SimulatedBodies/StaticRigidBody.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 #include <AzFramework/Entity/EntityContextBus.h>
@@ -347,9 +348,14 @@ namespace SimulationInterfaces
             AZ::Outcome<AzPhysics::SimulatedBody*, AZStd::string> simulatedBody = Utils::GetSimulatedBody(entityId);
             if (simulatedBody.IsSuccess())
             {
+                // check for dynamic and static rigid bodies
                 auto rigidBody = azdynamic_cast<AzPhysics::RigidBody*>(simulatedBody.GetValue());
+                auto staticRigidBody = azdynamic_cast<AzPhysics::StaticRigidBody*>(simulatedBody.GetValue());
+
+                bool hasDynamicShapes = rigidBody ? rigidBody->GetShapeCount() > 0 : false;
+                bool hasStaticShapes = staticRigidBody ? staticRigidBody->GetShapeCount() > 0 : false;
                 // entity is simulated body and has collider, check overlap
-                if (rigidBody && rigidBody->GetShapeCount() > 0)
+                if (hasDynamicShapes || hasStaticShapes)
                 {
                     // perform relatively expensive search only for entities which really can be inside the shape
                     if (AZStd::ranges::contains(result.m_hits, entityId, &AzPhysics::SceneQueryHit::m_entityId))


### PR DESCRIPTION
## What does this PR do?

PR adds missing check for static rigid bodies colliders. It makes it possible to query static rigid bodies via GetEntities with bounds filter.

## How was this PR tested?

Spawned entity with static rigid body and check if it catch by bounds check.

Before change it was discarded, after change it is included in `get_entites` service

Built in non unity with tests as well.