### PR TITLE
Added notification for simulation state change

### DIFF
--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationMangerRequestBus.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationMangerRequestBus.h
@@ -86,9 +86,19 @@ namespace SimulationInterfaces
         AZ_RTTI(SimulationManagerNotifications, SimulationManagerNotificationsTypeId);
         virtual ~SimulationManagerNotifications() = default;
 
+        //! Both methods set as virtual with default implementation to not force users to define both callbacks if not needed
+
         //! Notify about simulation step finish
         //! @param remainingSteps - remaining steps to pause simulation
-        virtual void OnSimulationStepFinish(const AZ::u64 remainingSteps) = 0;
+        virtual void OnSimulationStepFinish(const AZ::u64 remainingSteps)
+        {
+        }
+
+        //! Notify about simulation state change
+        //! @param setState - id of the state that was set
+        virtual void OnSimulationStateChange(const SimulationState& setState)
+        {
+        }
     };
 
     class SimulationMangerNotificationsBusTraits : public AZ::EBusTraits

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.cpp
@@ -519,6 +519,7 @@ namespace SimulationInterfaces
             }
         }
         m_simulationState = stateToSet;
+        SimulationManagerNotificationsBus::Broadcast(&SimulationManagerNotifications::OnSimulationStateChange, m_simulationState);
         return AZ::Success();
     }
 


### PR DESCRIPTION
## What does this PR do?

PR adds notification triggered on simulation state change.
It also changes all `SimulationManagerNotifications` from pure virtual to virtual with empty implementation to not force users  to define both callbacks if they don't need it

## How was this PR tested?

Built in non-unity, checked if notification is triggered when state change. I user keyboard shortcuts for this
