### PR TITLE
Fixes to manipulation components and ROS 2 gems 

### DIFF
--- a/Gems/ROS2/Code/Source/Sensor/Events/TickBasedSource.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/Events/TickBasedSource.cpp
@@ -45,7 +45,7 @@ namespace ROS2
         // query time ROS2 system
         ROS2ClockRequestBus::BroadcastResult(
             expectedSimulationLoopTime, &ROS2ClockRequestBus::Events::GetExpectedLoopTime);
-        AZ_Assert(expectedSimulationLoopTime >= 0.f, "Did not receive expected simulation loop time from ROS2ClockRequestBus");
+        AZ_Warning("TickBasedSource", expectedSimulationLoopTime >= 0.f, "Did not receive expected simulation loop time from ROS2ClockRequestBus");
         m_sourceEvent.Signal(expectedSimulationLoopTime);
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.cpp
+++ b/Gems/ROS2/Code/Source/SimulationUtils/FollowingCameraComponent.cpp
@@ -217,7 +217,7 @@ namespace ROS2
     {
         const AzFramework::InputDeviceId& deviceId = inputChannel.GetInputDevice().GetInputDeviceId();
 
-        if (AzFramework::InputDeviceKeyboard::IsKeyboardDevice(deviceId) && inputChannel.IsStateBegan())
+        if (AzFramework::InputDeviceKeyboard::IsKeyboardDevice(deviceId))
         {
             OnKeyboardEvent(inputChannel);
         }

--- a/Gems/ROS2Controllers/Code/Source/Manipulation/JointStatePublisher.cpp
+++ b/Gems/ROS2Controllers/Code/Source/Manipulation/JointStatePublisher.cpp
@@ -10,7 +10,7 @@
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/ROS2NamesBus.h>
 #include <ROS2Controllers/Manipulation/JointsManipulationRequests.h>
-
+#include <ROS2/Frame/ROS2FrameComponentBus.h>
 #include "JointStatePublisher.h"
 #include "ManipulationUtils.h"
 
@@ -72,7 +72,14 @@ namespace ROS2Controllers
 
         for (const auto& [jointName, jointInfo] : manipulatorJoints)
         {
-            m_jointNames.push_back(jointName);
+            // query the entity for the joint name with namespace
+            const AZ::EntityId entityId = jointInfo.m_entityComponentIdPair.GetEntityId();
+            AZ_Assert(entityId.IsValid(), "Invalid EntityId for joint %s", jointName.c_str());
+
+            // get namespaced joint name
+            AZStd::string namespacedFrameId;
+            ROS2::ROS2FrameComponentBus::EventResult(namespacedFrameId, entityId, &ROS2::ROS2FrameComponentRequests::GetNamespacedJointName);
+            m_jointNames.push_back(namespacedFrameId);
             m_jointInfos.push_back(jointInfo);
         }
 

--- a/Gems/ROS2Controllers/Code/Source/Manipulation/JointsManipulationComponent.cpp
+++ b/Gems/ROS2Controllers/Code/Source/Manipulation/JointsManipulationComponent.cpp
@@ -431,6 +431,14 @@ namespace ROS2Controllers
     {
         if (m_manipulationJoints.empty())
         {
+            AZStd::string namespaceFromFrame;
+            ROS2::ROS2FrameComponentBus::EventResult(namespaceFromFrame, m_entity->GetId(), &ROS2::ROS2FrameComponentRequests::GetNamespace);
+
+            for (auto & [jointName, position] : m_initialPositions)
+            {
+                // apply namespace to the joint names in the configuration
+                ROS2::ROS2NamesRequestBus::BroadcastResult(jointName, &ROS2::ROS2NamesRequests::GetNamespacedName, namespaceFromFrame, jointName);
+            }
             m_manipulationJoints = Internal::GetAllEntityHierarchyJoints(GetEntityId());
             Internal::SetInitialPositions(m_manipulationJoints, m_initialPositions);
             if (m_manipulationJoints.empty())

--- a/Gems/ROS2Controllers/Code/Source/Manipulation/JointsTrajectoryComponent.h
+++ b/Gems/ROS2Controllers/Code/Source/Manipulation/JointsTrajectoryComponent.h
@@ -69,7 +69,8 @@ namespace ROS2Controllers
         TrajectoryGoal m_trajectoryGoal;
         TrajectoryActionStatus m_goalStatus = TrajectoryActionStatus::Idle;
         rclcpp::Time m_trajectoryExecutionStartTime;
-        ManipulationJoints m_manipulationJoints;
+        ManipulationJoints m_manipulationJoints; //!< Cached joints of the manipulator, initialized on the start of trajectory execution,
+                                                 //!< keyed by namespaced joint names
         builtin_interfaces::msg::Time m_lastTickTimestamp; //!< ROS 2 Timestamp during last OnTick call
 
         bool m_checkForPositionErrors = false; //!< If true, check if joints reached the goal position before reporting success

--- a/Gems/ROS2Controllers/Code/Source/ROS2ControllersModuleInterface.cpp
+++ b/Gems/ROS2Controllers/Code/Source/ROS2ControllersModuleInterface.cpp
@@ -57,6 +57,7 @@ namespace ROS2Controllers
                 JointMotorControllerComponent::CreateDescriptor(),
                 ManualMotorControllerComponent::CreateDescriptor(),
                 AckermannControlComponent::CreateDescriptor(),
+                PidMotorControllerComponent::CreateDescriptor(),
                 RigidBodyTwistControlComponent::CreateDescriptor(),
                 SkidSteeringControlComponent::CreateDescriptor(),
                 ROS2RobotControlComponent::CreateDescriptor(),

--- a/Gems/WarehouseAssets/Assets/assets/Warehouse/Models/Box5.fbx
+++ b/Gems/WarehouseAssets/Assets/assets/Warehouse/Models/Box5.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a50993c070e62cfd881cad106a4659ae7a15351b8b8ef23e95588d4230beffd3
+size 25308

--- a/Gems/WarehouseAssets/Assets/assets/Warehouse/Models/Box5.fbx
+++ b/Gems/WarehouseAssets/Assets/assets/Warehouse/Models/Box5.fbx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a50993c070e62cfd881cad106a4659ae7a15351b8b8ef23e95588d4230beffd3
-size 25308

--- a/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/ConveyorBelt_effector.fbx.assetinfo
+++ b/Gems/WarehouseAutomation/Assets/Factory/ConveyorLine/ConveyorBelt_effector.fbx.assetinfo
@@ -7,11 +7,11 @@
             "NodeSelectionList": {
                 "selectedNodes": [
                     "RootNode",
-                    "RootNode.ConveyorBelt_effector1",
-                    "RootNode.ConveyorBelt_effector1.transform",
-                    "RootNode.ConveyorBelt_effector1.custom_properties",
-                    "RootNode.ConveyorBelt_effector1.UVMap",
-                    "RootNode.ConveyorBelt_effector1.MFrame"
+                    "RootNode.ConveyorBelt_effector",
+                    "RootNode.ConveyorBelt_effector.MFrame",
+                    "RootNode.ConveyorBelt_effector.UVMap",
+                    "RootNode.ConveyorBelt_effector.custom_properties",
+                    "RootNode.ConveyorBelt_effector.transform"
                 ]
             },
             "export method": 1,
@@ -36,28 +36,41 @@
             "nodeSelectionList": {
                 "selectedNodes": [
                     "RootNode",
-                    "RootNode.ConveyorBelt_effector1",
-                    "RootNode.ConveyorBelt_effector1.transform",
-                    "RootNode.ConveyorBelt_effector1.custom_properties",
-                    "RootNode.ConveyorBelt_effector1.UVMap",
-                    "RootNode.ConveyorBelt_effector1.MFrame"
+                    "RootNode.ConveyorBelt_effector",
+                    "RootNode.ConveyorBelt_effector.MFrame",
+                    "RootNode.ConveyorBelt_effector.UVMap",
+                    "RootNode.ConveyorBelt_effector.custom_properties",
+                    "RootNode.ConveyorBelt_effector.transform"
                 ]
             },
             "rules": {
                 "rules": [
                     {
                         "$type": "MaterialRule"
+                    },
+                    {
+                        "$type": "CoordinateSystemRule",
+                        "useAdvancedData": true,
+                        "rotation": [
+                            0.0,
+                            0.0,
+                            0.7071067690849304,
+                            0.7071067094802856
+                        ]
                     }
                 ]
             },
             "id": "{EF775872-953F-5658-B5CD-84FFD540A594}"
         },
         {
+            "$type": "{41DCBEAB-203C-4A05-96FA-98E1D8A96FA1} ImportGroup"
+        },
+        {
             "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
-            "name": "default_ConveyorBelt_effector_CB384CBE_EF7A_5C86_A483_CE39D126478C_",
+            "name": "default_ConveyorBelt_effector_20C8B702_36C3_59F4_8FF7_E610CDDA9F11_",
             "nodeSelectionList": {
                 "selectedNodes": [
-                    "RootNode.ConveyorBelt_effector1"
+                    "RootNode.ConveyorBelt_effector"
                 ]
             },
             "rules": {
@@ -77,12 +90,12 @@
                     }
                 ]
             },
-            "id": "{CB384CBE-EF7A-5C86-A483-CE39D126478C}"
+            "id": "{20C8B702-36C3-59F4-8FF7-E610CDDA9F11}"
         },
         {
             "$type": "PrefabGroup",
-            "name": "Assets/Factory/ConveyorLine/ConveyorBelt_effector_fbx.procprefab",
-            "id": "{D615E2FC-D4AA-5CF2-935E-4C976F2B4E37}"
+            "name": "Factory/ConveyorLine/ConveyorBelt_effector_fbx.procprefab",
+            "id": "{B1E17BDD-A909-5A24-83B5-F8E9223F578C}"
         }
     ]
 }


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the ROS2 and ROS2Controllers modules, focusing on consistent use of namespaced joint names, enhanced configuration for joint manipulation, and minor usability and asset import updates. The most significant changes involve ensuring that joint names are always handled with their full namespace, which is important for correct operation in complex robotic systems.

**ROS2Controllers: Namespaced Joint Names and Manipulation Improvements**
* Updated all relevant code to use namespaced joint names for joints, ensuring consistency and correct behavior in multi-robot or namespaced environments. This includes retrieving namespaced names from `ROS2FrameComponent` and updating joint info storage and usage. [[1]](diffhunk://#diff-11e986186e87d97b2d8cc3dc19d1fbea6c3d2cf1a9788c349491888240f4af9fL75-R82) [[2]](diffhunk://#diff-130bd060542eba0683e0a939c9178f7ca6f5fad05485e748be8f9a506eb62b8aL112-R112) [[3]](diffhunk://#diff-bbc5ca31b57cd58c7f0ed233229ab67072b78d2e04b35d96116a53a21036b8c3L72-R73)
* During initialization, joint names in the configuration are now automatically prefixed with the appropriate namespace, using the `ROS2NamesRequests::GetNamespacedName` method.
* Added the `PidMotorControllerComponent` descriptor to the module interface, making it available for use.

**ROS2: Usability and Logging**
* Changed an assertion to a warning in `TickBasedSource.cpp` to prevent crashes if the expected simulation loop time is not received, improving robustness.
* Modified keyboard input handling in `FollowingCameraComponent.cpp` to process keyboard events regardless of state, potentially improving responsiveness.

**Asset Import and Configuration**
* Updated the asset info for `ConveyorBelt_effector.fbx` to use the correct node names, added a coordinate system rule, and changed group and prefab identifiers for improved import consistency and asset organization. [[1]](diffhunk://#diff-e724fff824013e309a63ab07fbad8ead2d1c20d2abaa261131fe01d29ef316cdL10-R14) [[2]](diffhunk://#diff-e724fff824013e309a63ab07fbad8ead2d1c20d2abaa261131fe01d29ef316cdL39-R73) [[3]](diffhunk://#diff-e724fff824013e309a63ab07fbad8ead2d1c20d2abaa261131fe01d29ef316cdL80-R98)
* Added a new warehouse asset model, `Box5.fbx`, to the repository.



## How was this PR tested?

Port Roscon2023 demo to 2605.
