### PR TITLE
Added missing reflection for PID controller.

### DIFF
--- a/Gems/ROS2Controllers/Code/Source/ROS2ControllersModuleInterface.cpp
+++ b/Gems/ROS2Controllers/Code/Source/ROS2ControllersModuleInterface.cpp
@@ -57,6 +57,7 @@ namespace ROS2Controllers
                 JointMotorControllerComponent::CreateDescriptor(),
                 ManualMotorControllerComponent::CreateDescriptor(),
                 AckermannControlComponent::CreateDescriptor(),
+                PidMotorControllerComponent::CreateDescriptor(),
                 RigidBodyTwistControlComponent::CreateDescriptor(),
                 SkidSteeringControlComponent::CreateDescriptor(),
                 ROS2RobotControlComponent::CreateDescriptor(),


### PR DESCRIPTION
## What does this PR do?

Solves missing reflection for PidMotorControllerComponent

## How was this PR tested?

During updating Roscon2023 for 2605.
