### PR TITLE
ROS2: Rosify namespace if needed

### DIFF
--- a/Gems/ROS2/Code/Source/Frame/NamespaceComputation.cpp
+++ b/Gems/ROS2/Code/Source/Frame/NamespaceComputation.cpp
@@ -191,7 +191,9 @@ namespace ROS2
             const auto ancestorStrategy = ancestorConfig.m_namespaceConfiguration.m_namespaceStrategy;
             if (ancestorStrategy == NamespaceConfiguration::NamespaceStrategy::FromEntityName)
             {
-                resolvedNames.emplace_back(ancestorName);
+                AZStd::string rosifiedName;
+                ROS2NamesRequestBus::BroadcastResult(rosifiedName, &ROS2NamesRequests::RosifyName, ancestorName);
+                resolvedNames.emplace_back(rosifiedName);
             }
             else if (ancestorStrategy == NamespaceConfiguration::NamespaceStrategy::Custom)
             {
@@ -205,7 +207,9 @@ namespace ROS2
             {
                 if (it == configurations.rbegin())
                 {
-                    resolvedNames.emplace_back(ancestorName);
+                    AZStd::string rosifiedName;
+                    ROS2NamesRequestBus::BroadcastResult(rosifiedName, &ROS2NamesRequests::RosifyName, ancestorName);
+                    resolvedNames.emplace_back(rosifiedName);
                 }
             }
         }


### PR DESCRIPTION
## What does this PR do?

This MR adds a call to modify a namespace name if needed. The call was implemented before the refactor of `ROS2FrameComponent` and was removed by accident:
https://github.com/o3de/o3de-extras/blob/af35d5c636a4d10aff9e09a2e4772c6c7f6e62a0/Gems/ROS2/Code/Source/Frame/NamespaceConfiguration.cpp#L31
https://github.com/o3de/o3de-extras/blob/af35d5c636a4d10aff9e09a2e4772c6c7f6e62a0/Gems/ROS2/Code/Source/Frame/NamespaceConfiguration.cpp#L34

**Note: this should be cherry-picked to stabilization!**

## How was this PR tested?

Added `ROS2FrameComponent` to _Shader Ball_ entity with default namespace strategy. Before this PR: crash. After: works as expected, with an info message notifying about the space removed from the namespace name.
