### PR TITLE
[Simulation Interfaces] Add support for INVALID_POSE

### DIFF
--- a/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "SetEntityStateServiceHandler.h"
+#include "SpawnServiceUtils.h"
 #include <ROS2/TF/TransformInterface.h>
 #include <ROS2/Utilities/ROS2Conversions.h>
 #include <SimulationInterfaces/RegistryUtils.h>
@@ -45,12 +46,24 @@ namespace ROS2SimulationInterfaces
                 return response;
             }
         }
+
+        const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(request.state.pose);
+        if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+        {
+            Response response;
+            response.result.result = simulation_interfaces::srv::SetEntityState::Response::INVALID_POSE;
+            response.result.error_message = poseValidation.GetError().c_str();
+            return response;
+        }
+
+        const AZ::Transform targetPose = transformOffset *
+            AZ::Transform::CreateFromQuaternionAndTranslation(requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+
         AZ::Outcome<void, SimulationInterfaces::FailedResult> outcome;
         AZStd::string entityName = request.entity.c_str();
 
         SimulationInterfaces::EntityState entityState;
-
-        entityState.m_pose = transformOffset * ROS2::ROS2Conversions::FromROS2Pose(request.state.pose);
+        entityState.m_pose = targetPose;
         entityState.m_twistAngular = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.angular));
         entityState.m_twistLinear = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.linear));
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "SpawnEntitiesServiceHandler.h"
+#include "SpawnServiceUtils.h"
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/TF/TransformInterface.h>
@@ -48,7 +49,7 @@ namespace ROS2SimulationInterfaces
             const AZStd::string_view messageFrameId{ spawnRequest.initial_pose.header.frame_id.c_str(),
                                                      spawnRequest.initial_pose.header.frame_id.size() };
 
-            if (!name.empty() && !ValidateEntityName(name))
+            if (!name.empty() && !SpawnServiceUtils::ValidateEntityName(name))
             {
                 spawnResult.result.result = simulation_interfaces::msg::SpawnResult::NAME_INVALID;
                 spawnResult.result.error_message =
@@ -57,7 +58,7 @@ namespace ROS2SimulationInterfaces
                 continue;
             }
 
-            if (!entityNamespace.empty() && !ValidateNamespaceName(entityNamespace))
+            if (!entityNamespace.empty() && !SpawnServiceUtils::ValidateNamespaceName(entityNamespace))
             {
                 spawnResult.result.result = simulation_interfaces::msg::SpawnResult::NAMESPACE_INVALID;
                 spawnResult.result.error_message =
@@ -86,11 +87,24 @@ namespace ROS2SimulationInterfaces
                 }
             }
 
+            const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(spawnRequest.initial_pose.pose);
+            if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+            {
+                spawnResult.result.result = simulation_interfaces::msg::SpawnResult::INVALID_POSE;
+                spawnResult.result.error_message = poseValidation.GetError().c_str();
+                hasFailures = true;
+                continue;
+            }
+
+            const AZ::Transform initialPose = transformOffset *
+                AZ::Transform::CreateFromQuaternionAndTranslation(
+                                                  requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+
             SimulationInterfaces::SpawningEntity spawningEntity;
             spawningEntity.name = AZStd::string(name);
             spawningEntity.uri = AZStd::string(uri);
             spawningEntity.entityNamespace = AZStd::string(entityNamespace);
-            spawningEntity.initialPose = transformOffset * ROS2::ROS2Conversions::FromROS2Pose(spawnRequest.initial_pose.pose);
+            spawningEntity.initialPose = initialPose;
             spawningEntity.allowRename = spawnRequest.allow_renaming;
             spawningEntity.preinsertionCb =
                 [](const AZ::Outcome<AzFramework::SpawnableEntityContainerView, SimulationInterfaces::FailedResult>&)
@@ -155,20 +169,6 @@ namespace ROS2SimulationInterfaces
             });
 
         return AZStd::nullopt;
-    }
-
-    bool SpawnEntitiesServiceHandler::ValidateEntityName(const AZStd::string& entityName)
-    {
-        const AZStd::regex entityRegex{ R"(^[a-zA-Z0-9_]+$)" }; // Entity names can only contain alphanumeric characters and underscores
-        return AZStd::regex_match(entityName, entityRegex);
-    }
-
-    bool SpawnEntitiesServiceHandler::ValidateNamespaceName(const AZStd::string& namespaceName)
-    {
-        const AZStd::regex namespaceRegex{
-            R"(^[a-zA-Z0-9_/]+$)"
-        }; // Namespace names can only contain alphanumeric characters and underscores and forward slashes
-        return AZStd::regex_match(namespaceName, namespaceRegex);
     }
 
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <AzCore/std/string/regex.h>
 #include <AzCore/std/string/string_view.h>
 #include <Interfaces/ISimulationFeaturesBase.h>
 #include <ROS2/Handlers/ROS2ServiceBase.h>
@@ -33,10 +32,6 @@ namespace ROS2SimulationInterfaces
         AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
-
-    private:
-        bool ValidateEntityName(const AZStd::string& entityName);
-        bool ValidateNamespaceName(const AZStd::string& namespaceName);
     };
 
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "SpawnEntityServiceHandler.h"
+#include "SpawnServiceUtils.h"
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/TF/TransformInterface.h>
@@ -33,7 +34,7 @@ namespace ROS2SimulationInterfaces
         const builtin_interfaces::msg::Time zeroTime = builtin_interfaces::msg::Time();
 
         // Validate entity name
-        if (!name.empty() && !ValidateEntityName(name))
+        if (!name.empty() && !SpawnServiceUtils::ValidateEntityName(name))
         {
             Response response;
             response.result.result = simulation_interfaces::srv::SpawnEntity::Response::NAME_INVALID;
@@ -43,7 +44,7 @@ namespace ROS2SimulationInterfaces
         }
 
         // Validate namespace name
-        if (!entityNamespace.empty() && !ValidateNamespaceName(entityNamespace))
+        if (!entityNamespace.empty() && !SpawnServiceUtils::ValidateNamespaceName(entityNamespace))
         {
             Response response;
             response.result.result = simulation_interfaces::srv::SpawnEntity::Response::NAMESPACE_INVALID;
@@ -71,11 +72,24 @@ namespace ROS2SimulationInterfaces
                 Response response;
                 response.result.result = simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED;
                 response.result.error_message = transformOutcome.GetError().c_str();
-                return response;
+                SendResponse(response);
+                return AZStd::nullopt;
             }
         }
 
-        const AZ::Transform initialPose = transformOffset * ROS2::ROS2Conversions::FromROS2Pose(request.initial_pose.pose);
+        const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(request.initial_pose.pose);
+        if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+        {
+            Response response;
+            response.result.result = simulation_interfaces::srv::SpawnEntity::Response::INVALID_POSE;
+            response.result.error_message = poseValidation.GetError().c_str();
+            SendResponse(response);
+            return AZStd::nullopt;
+        }
+
+        const AZ::Transform initialPose = transformOffset *
+            AZ::Transform::CreateFromQuaternionAndTranslation(requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+
         SimulationInterfaces::PreInsertionCb preinsertionCB =
             [this](const AZ::Outcome<AzFramework::SpawnableEntityContainerView, SimulationInterfaces::FailedResult>& outcome)
         {
@@ -114,20 +128,6 @@ namespace ROS2SimulationInterfaces
                 SendResponse(response);
             });
         return AZStd::nullopt;
-    }
-
-    bool SpawnEntityServiceHandler::ValidateEntityName(const AZStd::string& entityName)
-    {
-        const AZStd::regex entityRegex{ R"(^[a-zA-Z0-9_]+$)" }; // Entity names can only contain alphanumeric characters and underscores
-        return AZStd::regex_match(entityName, entityRegex);
-    }
-
-    bool SpawnEntityServiceHandler::ValidateNamespaceName(const AZStd::string& namespaceName)
-    {
-        const AZStd::regex namespaceRegex{
-            R"(^[a-zA-Z0-9_/]+$)"
-        }; // Namespace names can only contain alphanumeric characters and underscores and forward slashes
-        return AZStd::regex_match(namespaceName, namespaceRegex);
     }
 
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <AzCore/std/string/regex.h>
 #include <AzCore/std/string/string_view.h>
 #include <Interfaces/ISimulationFeaturesBase.h>
 #include <ROS2/Handlers/ROS2ServiceBase.h>
@@ -33,10 +32,6 @@ namespace ROS2SimulationInterfaces
         AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
-
-    private:
-        bool ValidateEntityName(const AZStd::string& entityName);
-        bool ValidateNamespaceName(const AZStd::string& namespaceName);
     };
 
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SpawnServiceUtils.h"
+#include <AzCore/std/string/regex.h>
+#include <AzCore/std/string/string.h>
+
+namespace ROS2SimulationInterfaces::SpawnServiceUtils
+{
+    bool ValidateEntityName(AZStd::string_view entityName)
+    {
+        static const AZStd::regex entityRegex{
+            R"(^[a-zA-Z0-9_]+$)"
+        }; // Entity names can only contain alphanumeric characters and underscores
+        return AZStd::regex_match(entityName.begin(), entityName.end(), entityRegex);
+    }
+
+    bool ValidateNamespaceName(AZStd::string_view namespaceName)
+    {
+        static const AZStd::regex namespaceRegex{
+            R"(^[a-zA-Z0-9_/]+$)"
+        }; // Namespace names can only contain alphanumeric characters and forward slashes
+        return AZStd::regex_match(namespaceName.begin(), namespaceName.end(), namespaceRegex);
+    }
+
+    AZ::Outcome<void, AZStd::string> ValidateTransformNormalized(
+        const AZ::Transform& transform, float quaternionTolerance, float maxTranslation)
+    {
+        // Check rotation quaternion is normalised.
+        const float quaternionLength = transform.GetRotation().GetLength();
+        if (!AZ::IsClose(quaternionLength, 1.0f, quaternionTolerance))
+        {
+            return AZ::Failure<AZStd::string>("Invalid pose orientation quaternion: length is not close to 1.0.");
+        }
+
+        // Check translation components are finite and within range.
+        const AZ::Vector3 translation = transform.GetTranslation();
+        if (!translation.IsFinite())
+        {
+            return AZ::Failure<AZStd::string>("Invalid pose translation: one or more components are NaN or infinite.");
+        }
+        const float absMax = translation.GetAbs().GetMaxElement();
+        if (absMax > maxTranslation)
+        {
+            return AZ::Failure<AZStd::string>("Invalid pose translation: exceeds the maximum allowed.");
+        }
+
+        return AZ::Success();
+    }
+} // namespace ROS2SimulationInterfaces::SpawnServiceUtils

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Math/Transform.h>
+#include <AzCore/Outcome/Outcome.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/string/string_view.h>
+
+namespace ROS2SimulationInterfaces::SpawnServiceUtils
+{
+    bool ValidateEntityName(AZStd::string_view entityName);
+    bool ValidateNamespaceName(AZStd::string_view namespaceName);
+
+    //! Validates that the transform has a normalised rotation quaternion and a finite, in-range translation.
+    //! @param transform     Transform to validate.
+    //! @param quaternionTolerance  Tolerance on |quaternion| - 1.0f. Defaults to 1e-3f.
+    //! @param maxTranslation Maximum allowed absolute value per axis in metres. Defaults to 1e7f (~10 000 km).
+    //! @return Success when valid, Failure with a descriptive error message when not.
+    AZ::Outcome<void, AZStd::string> ValidateTransformNormalized(
+        const AZ::Transform& transform, float quaternionTolerance = 1e-3f, float maxTranslation = 1e7f);
+} // namespace ROS2SimulationInterfaces::SpawnServiceUtils

--- a/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
+++ b/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
@@ -46,6 +46,8 @@ set(FILES
     Source/Services/GetEntityBoundsServiceHandler.h
     Source/Services/GetSpawnablesServiceHandler.cpp
     Source/Services/GetSpawnablesServiceHandler.h
+    Source/Services/SpawnServiceUtils.cpp
+    Source/Services/SpawnServiceUtils.h
     Source/Services/SpawnEntitiesServiceHandler.cpp
     Source/Services/SpawnEntitiesServiceHandler.h
     Source/Services/SpawnEntityServiceHandler.cpp


### PR DESCRIPTION
## What does this PR do?

As noticed in #1039 , invalid rotation value was resulting in undefined behavior (e.g. increasing object's scale). A proper handling of invalid rotation and invalid translation was added in this PR. 

~~Note: it was built on top of #1039 ; it should be merged only after (therefore draft)~~

## How was this PR tested?

Spawning with incorrect and with correct quaternion, the same repeated for translation in multi-spawn:
```
jhanca@robo-pc-051 ~/devtrunk/qsimulation
  % ros2 service call /spawn_entity simulation_interfaces/srv/SpawnEntity '{"name":"test_111","allow_renaming":true,"uri":"product_asset:///prefabs/test.spawnable","resource_string":"","entity_namespace":"","initial_pose":{"header":{"frame_id":"world"},"pose":{"position":{"x":-1.0,"y":-1.0,"z":1.0},"orientation":{"x":2.0,"y":0.0,"z":0.0,"w":0.0}}}}'
requester: making request: simulation_interfaces.srv.SpawnEntity_Request(name='test_111', allow_renaming=True, uri='product_asset:///prefabs/test.spawnable', resource_string='', entity_namespace='', initial_pose=geometry_msgs.msg.PoseStamped(header=std_msgs.msg.Header(stamp=builtin_interfaces.msg.Time(sec=0, nanosec=0), frame_id='world'), pose=geometry_msgs.msg.Pose(position=geometry_msgs.msg.Point(x=-1.0, y=-1.0, z=1.0), orientation=geometry_msgs.msg.Quaternion(x=2.0, y=0.0, z=0.0, w=0.0))))

response:
simulation_interfaces.srv.SpawnEntity_Response(result=simulation_interfaces.msg.Result(result=109, error_message='Invalid pose orientation quaternion: length is not close to 1.0.'), entity_name='')


jhanca@robo-pc-051 ~/devtrunk/qsimulation
  % ros2 service call /spawn_entity simulation_interfaces/srv/SpawnEntity '{"name":"test_111","allow_renaming":true,"uri":"product_asset:///prefabs/test.spawnable","resource_string":"","entity_namespace":"","initial_pose":{"header":{"frame_id":"world"},"pose":{"position":{"x":-1.0,"y":-1.0,"z":1.0},"orientation":{"x":0.707,"y":0.0,"z":0.0,"w":0.707}}}}'
requester: making request: simulation_interfaces.srv.SpawnEntity_Request(name='test_111', allow_renaming=True, uri='product_asset:///prefabs/test.spawnable', resource_string='', entity_namespace='', initial_pose=geometry_msgs.msg.PoseStamped(header=std_msgs.msg.Header(stamp=builtin_interfaces.msg.Time(sec=0, nanosec=0), frame_id='world'), pose=geometry_msgs.msg.Pose(position=geometry_msgs.msg.Point(x=-1.0, y=-1.0, z=1.0), orientation=geometry_msgs.msg.Quaternion(x=0.707, y=0.0, z=0.0, w=0.707))))

response:
simulation_interfaces.srv.SpawnEntity_Response(result=simulation_interfaces.msg.Result(result=1, error_message=''), entity_name='test_111')

```
