### PR TITLE
Robotic templates fixes

### DIFF
--- a/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_side_protector.prefab
+++ b/Gems/WarehouseAssets/Assets/Prefabs/Warehouse_storage/Rack_protectors/Rack_side_protector.prefab
@@ -164,11 +164,7 @@
                                 {
                                     "Name": "MWarehouseProps",
                                     "MaterialAsset": {
-                                        "assetId": {
-                                            "guid": "{2453EA64-38EF-546F-83F8-45EE0A0B6195}",
-                                            "subId": 1
-                                        },
-                                        "assetHint": "assets/materials/defaultstorage.physicsmaterial"
+                                        "assetId": {}
                                     }
                                 }
                             ]

--- a/Templates/Ros2FleetRobotTemplate/Template/.gitignore
+++ b/Templates/Ros2FleetRobotTemplate/Template/.gitignore
@@ -1,5 +1,7 @@
 [Bb]uild/
 [Cc]ache/
+[Ii]nstall/
+[Ll]og/
 [Uu]ser/
 [Uu]ser_test*/
 _savebackup/

--- a/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/launch/o3de_fleet_nav_launch.py
+++ b/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/launch/o3de_fleet_nav_launch.py
@@ -20,7 +20,7 @@ from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import (DeclareLaunchArgument, ExecuteProcess, GroupAction,
-                            IncludeLaunchDescription, LogInfo)
+                            IncludeLaunchDescription, LogInfo, SetEnvironmentVariable)
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, TextSubstitution
@@ -55,6 +55,13 @@ def generate_launch_description():
     log_settings = LaunchConfiguration('log_settings', default='true')
 
     distro = os.getenv('ROS_DISTRO')
+
+    cyclonedds_uri = (
+        '<CycloneDDS><Domain id="any"><Discovery>'
+        '<ParticipantIndex>auto</ParticipantIndex>'
+        '<MaxAutoParticipantIndex>256</MaxAutoParticipantIndex>'
+        '</Discovery></Domain></CycloneDDS>'
+    )
 
     # Declare the launch arguments
     declare_map_yaml_cmd = DeclareLaunchArgument(
@@ -147,6 +154,12 @@ def generate_launch_description():
     ld.add_action(declare_rviz_config_file_cmd)
 
     # Launch robots
+    # Multi-robot Nav2 can exhaust the default Cyclone DDS participant index
+    # range. Set a higher default only when the user has not provided a
+    # CYCLONEDDS_URI.
+    if 'CYCLONEDDS_URI' not in os.environ:
+        ld.add_action(SetEnvironmentVariable('CYCLONEDDS_URI', cyclonedds_uri))
+
     for simulation_instance_cmd in nav_instances_cmds:
         ld.add_action(simulation_instance_cmd)
 

--- a/Templates/Ros2RoboticManipulationTemplate/Template/Examples/panda_moveit_config_demo.launch.py
+++ b/Templates/Ros2RoboticManipulationTemplate/Template/Examples/panda_moveit_config_demo.launch.py
@@ -1,12 +1,9 @@
 from pathlib import Path
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch.conditions import IfCondition, UnlessCondition
+from launch.actions import OpaqueFunction
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
-from launch_ros.substitutions import FindPackageShare
-from launch.actions import ExecuteProcess
-from ament_index_python.packages import get_package_share_directory
+
 from moveit_configs_utils import MoveItConfigsBuilder
 
 from launch_ros.actions import ComposableNodeContainer
@@ -14,12 +11,7 @@ from launch_ros.descriptions import ComposableNode
 
 
 def generate_launch_description():
-
-    declared_arguments = []
-
-    return LaunchDescription(
-        declared_arguments + [OpaqueFunction(function=launch_setup)]
-    )
+    return LaunchDescription([OpaqueFunction(function=launch_setup)])
 
 
 def launch_setup(context, *args, **kwargs):
@@ -27,7 +19,7 @@ def launch_setup(context, *args, **kwargs):
     current_file_path = Path(__file__).resolve()
     current_directory = str(current_file_path.parent)
 
-    use_sim_time = { "use_sim_time": True}
+    use_sim_time = {"use_sim_time": True}
     moveit_config = (
         MoveItConfigsBuilder("moveit_resources_panda")
         .robot_description(file_path="config/panda.urdf.xacro")
@@ -48,11 +40,9 @@ def launch_setup(context, *args, **kwargs):
         parameters=[moveit_config.to_dict() | use_sim_time],
     )
 
-    rviz_base = LaunchConfiguration("rviz_config")
     rviz_config = PathJoinSubstitution(
         [current_directory, "panda_moveit_config_demo.rviz"]
     )
-
 
     # RViz
     rviz_node = Node(
@@ -80,25 +70,28 @@ def launch_setup(context, *args, **kwargs):
     )
 
     rgbd_pc = ComposableNodeContainer(
-            name='container0',
-            namespace='',
-            package='rclcpp_components',
-            executable='component_container',
-            composable_node_descriptions=[
-                ComposableNode(
-                    package='depth_image_proc',
-                    plugin='depth_image_proc::PointCloudXyzrgbNode',
-                    name='point_cloud_xyzrgb_node',
-                    remappings=[('rgb/camera_info', '/color_camera_info'),
-                                ('rgb/image_rect_color', '/camera_image_color'),
-                                ('depth_registered/image_rect','/camera_image_depth'),
-                                ('/points','/pointcloud')]
-                ),
-            ],
-            output='screen',
-            parameters=[{'use_sim_time': True}],
-        )
-    
+        name="container0",
+        namespace="",
+        package="rclcpp_components",
+        executable="component_container",
+        composable_node_descriptions=[
+            ComposableNode(
+                package="depth_image_proc",
+                plugin="depth_image_proc::PointCloudXyzrgbNode",
+                name="point_cloud_xyzrgb_node",
+                remappings=[
+                    ("rgb/camera_info", "/color_camera_info"),
+                    ("/camera_info", "/color_camera_info"),
+                    ("rgb/image_rect_color", "/camera_image_color"),
+                    ("depth_registered/image_rect", "/camera_image_depth"),
+                    ("/points", "/pointcloud"),
+                ],
+                parameters=[use_sim_time],
+            ),
+        ],
+        output="screen",
+    )
+
     # Publish TF
     robot_state_publisher = Node(
         package="robot_state_publisher",
@@ -107,7 +100,7 @@ def launch_setup(context, *args, **kwargs):
         output="both",
         parameters=[moveit_config.robot_description],
     )
-   
+
     nodes_to_start = [
         rviz_node,
         static_tf,


### PR DESCRIPTION
## What does this PR do?

I generated three project based on robotic templates with the newest O3DE on ROS 2 Humble (Ubuntu 22.04) and ROS 2 Jazzy (Ubuntu 24.04). I found few glitches that were fixed in this PR:
- `Rack_side_protector.prefab` material definition was not updated after mesh was updated
- some build folders (ROS 2 workspace) were visible in git due to missing definitions in `.gitignore`
- point cloud visualization in manipulation example was not displayed in Jazzy due to different default topics compared with Humble; additional remapping was added
- fleet example was not working in Jazzy with cyclone due to insufficient number of ROS 2 participants (different default value)

## How was this PR tested?

Regenerated templates in two setups and played examples.
