### PR TITLE
Fix ROS2FrameComponentTest

### DIFF
--- a/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
+++ b/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
@@ -147,6 +147,7 @@ namespace UnitTest
         ROS2::ROS2FrameConfiguration config;
 
         AZ::Entity entity;
+        entity.SetName("single_frame_entity");
         const std::string entityName = entity.GetName().c_str();
         entity.CreateComponent<AzFramework::TransformComponent>();
         auto frame = entity.CreateComponent<ROS2::ROS2FrameComponent>(config);
@@ -210,6 +211,7 @@ namespace UnitTest
         ROS2::ROS2FrameConfiguration config;
 
         AZ::Entity entity;
+        entity.SetName("update_namespace_entity");
         const std::string entityName = entity.GetName().c_str();
         entity.CreateComponent<AzFramework::TransformComponent>();
         auto frame = entity.CreateComponent<ROS2::ROS2FrameComponent>(config);


### PR DESCRIPTION
## What does this PR do?

Fix `ROS2FrameComponent` tests failing after #1037 due to numeric entity names:

```
[ctest] /home/jhanca/devroot/2605/o3de-extras/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp:161: Failure
[ctest] Expected equality of these values:
[ctest]   jointName.c_str()
[ctest]     Which is: "o3de_67820765617/"
[ctest]   (entityName + "/").c_str()
[ctest]     Which is: "67820765617/"
[ctest] Ignoring case
[ctest] 
[ctest] /home/jhanca/devroot/2605/o3de-extras/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp:162: Failure
[ctest] Expected equality of these values:
[ctest]   frameId.c_str()
[ctest]     Which is: "o3de_67820765617/sensor_frame"
[ctest]   (entityName + "/sensor_frame").c_str()
[ctest]     Which is: "67820765617/sensor_frame"
[ctest] Ignoring case
[ctest] 
[ctest] [  FAILED  ] ROS2FrameComponentFixture.SingleFrameDefault (0 ms)
[ctest] [ RUN      ] ROS2FrameComponentFixture.ThreeFramesDefault
[ctest] [       OK ] ROS2FrameComponentFixture.ThreeFramesDefault (0 ms)
[ctest] [ RUN      ] ROS2FrameComponentFixture.UpdateNamespace
[ctest] /home/jhanca/devroot/2605/o3de-extras/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp:221: Failure
[ctest] Expected equality of these values:
[ctest]   frame->GetNamespace().c_str()
[ctest]     Which is: "o3de_85000634801"
[ctest]   rosifiedName.c_str()
[ctest]     Which is: "85000634801"
```

PR #1037 added `RosifyName` calls to `ComputeNamespace` for the _FromEntityName_ and _Default_ strategies — correctly fixing a bug where the namespace wasn't being rosified. But the tests were not updated accordingly. The tests were comparing raw entity name against the rosified namespace output.

Fixed by setting explicit letter-prefixed entity names in both tests (rosification of the name is already tested elsewhere).

## How was this PR tested?

Tests do not fail anymore.
