### PR TITLE
Support simulation_interfaces 2.1.0 package alongside 1.4.0/1.5.0/1.6.0

### DIFF
--- a/Gems/ROS2/Code/Source/Clients/ROS2SystemComponent.h
+++ b/Gems/ROS2/Code/Source/Clients/ROS2SystemComponent.h
@@ -16,10 +16,10 @@
 #include <builtin_interfaces/msg/time.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/static_transform_broadcaster.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
+#include <tf2_ros/transform_listener.hpp>
 
 /**
  * \mainpage

--- a/Gems/ROS2/Code/Source/Frame/ROS2Transform.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2Transform.cpp
@@ -11,7 +11,7 @@
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/Utilities/ROS2Conversions.h>
 #include <tf2_ros/qos.hpp>
-#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_broadcaster.hpp>
 
 namespace ROS2
 {

--- a/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
+++ b/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
@@ -147,6 +147,7 @@ namespace UnitTest
         ROS2::ROS2FrameConfiguration config;
 
         AZ::Entity entity;
+        entity.SetName("single_frame_entity");
         const std::string entityName = entity.GetName().c_str();
         entity.CreateComponent<AzFramework::TransformComponent>();
         auto frame = entity.CreateComponent<ROS2::ROS2FrameComponent>(config);
@@ -210,6 +211,7 @@ namespace UnitTest
         ROS2::ROS2FrameConfiguration config;
 
         AZ::Entity entity;
+        entity.SetName("update_namespace_entity");
         const std::string entityName = entity.GetName().c_str();
         entity.CreateComponent<AzFramework::TransformComponent>();
         auto frame = entity.CreateComponent<ROS2::ROS2FrameComponent>(config);

--- a/Gems/SimulationInterfaces/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfaces/Code/CMakeLists.txt
@@ -22,6 +22,21 @@ if(NOT PAL_TRAIT_SIMULATIONINTERFACES_SUPPORTED)
     return()
 endif()
 
+# Detect simulation_interfaces API generation.
+# Version >= 2.0.0 introduced breaking API changes (e.g. entity_resource wrapper, set_pose/set_twist flags).
+# Version >= 1.4.0 is the minimum supported API.
+# Calling find_package directly here (not inside a helper function) so that
+# simulation_interfaces_VERSION is available in this scope for the version check below.
+find_package(simulation_interfaces REQUIRED)
+if(simulation_interfaces_VERSION VERSION_GREATER_EQUAL "2.0.0")
+    set(SIMULATION_INTERFACES_MAJOR_API_VERSION 2)
+elseif(simulation_interfaces_VERSION VERSION_GREATER_EQUAL "1.4.0")
+    set(SIMULATION_INTERFACES_MAJOR_API_VERSION 1)
+else()
+    message(FATAL_ERROR "simulation_interfaces version ${simulation_interfaces_VERSION} is not supported. Minimum required: 1.4.0")
+endif()
+message(STATUS "simulation_interfaces ${simulation_interfaces_VERSION} -> SIMULATION_INTERFACES_MAJOR_API_VERSION=${SIMULATION_INTERFACES_MAJOR_API_VERSION}")
+
 # The ${gem_name}.API target declares the common interface that users of this gem should depend on in their targets
 ly_add_target(
     NAME ${gem_name}.API INTERFACE
@@ -37,7 +52,7 @@ ly_add_target(
            AZ::AzCore
 )
 
-target_interface_depends_on_ros2_package(${gem_name}.API simulation_interfaces 2.1.0 REQUIRED)
+target_interface_depends_on_ros2_package(${gem_name}.API simulation_interfaces REQUIRED)
 
 # The ${gem_name}.Private.Object target is an internal target
 # It should not be used outside of this Gems CMakeLists.txt
@@ -63,7 +78,9 @@ ly_add_target(
             Gem::DebugDraw.API
 )
 target_depends_on_ros2_packages(${gem_name}.Private.Object rclcpp std_msgs geometry_msgs rclcpp_action tf2_ros)
-target_depends_on_ros2_package(${gem_name}.Private.Object simulation_interfaces 2.1.0 REQUIRED)
+target_depends_on_ros2_package(${gem_name}.Private.Object simulation_interfaces REQUIRED)
+target_compile_definitions(${gem_name}.Private.Object PUBLIC
+    SIMULATION_INTERFACES_MAJOR_API_VERSION=${SIMULATION_INTERFACES_MAJOR_API_VERSION})
 
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface
 ly_add_target(

--- a/Gems/SimulationInterfaces/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfaces/Code/CMakeLists.txt
@@ -37,7 +37,7 @@ ly_add_target(
            AZ::AzCore
 )
 
-target_interface_depends_on_ros2_package(${gem_name}.API simulation_interfaces 1.4.0 REQUIRED)
+target_interface_depends_on_ros2_package(${gem_name}.API simulation_interfaces 2.1.0 REQUIRED)
 
 # The ${gem_name}.Private.Object target is an internal target
 # It should not be used outside of this Gems CMakeLists.txt
@@ -63,7 +63,7 @@ ly_add_target(
             Gem::DebugDraw.API
 )
 target_depends_on_ros2_packages(${gem_name}.Private.Object rclcpp std_msgs geometry_msgs rclcpp_action tf2_ros)
-target_depends_on_ros2_package(${gem_name}.Private.Object simulation_interfaces 1.4.0 REQUIRED)
+target_depends_on_ros2_package(${gem_name}.Private.Object simulation_interfaces 2.1.0 REQUIRED)
 
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface
 ly_add_target(

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetSpawnablesServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetSpawnablesServiceHandler.cpp
@@ -36,7 +36,7 @@ namespace ROS2SimulationInterfaces
         auto convertToROS2 = [](const SimulationInterfaces::Spawnable& spawnable)
         {
             simulation_interfaces::msg::Spawnable simSpawnable;
-            simSpawnable.uri = spawnable.m_uri.c_str();
+            simSpawnable.entity_resource.uri = spawnable.m_uri.c_str();
             simSpawnable.description = spawnable.m_description.c_str();
             return simSpawnable;
         };

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetSpawnablesServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetSpawnablesServiceHandler.cpp
@@ -36,7 +36,11 @@ namespace ROS2SimulationInterfaces
         auto convertToROS2 = [](const SimulationInterfaces::Spawnable& spawnable)
         {
             simulation_interfaces::msg::Spawnable simSpawnable;
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
             simSpawnable.entity_resource.uri = spawnable.m_uri.c_str();
+#else
+            simSpawnable.uri = spawnable.m_uri.c_str();
+#endif
             simSpawnable.description = spawnable.m_description.c_str();
             return simSpawnable;
         };

--- a/Gems/SimulationInterfaces/Code/Source/Services/LoadWorldServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/LoadWorldServiceHandler.cpp
@@ -21,8 +21,8 @@ namespace ROS2SimulationInterfaces
             SimulationInterfaces::LoadWorldRequest request;
             request.failOnUnsupportedElement = ros2Request.fail_on_unsupported_element;
             request.ignoreMissingOrUnsupportedAssets = ros2Request.ignore_missing_or_unsupported_assets;
-            request.levelResource.m_uri = ros2Request.uri.c_str();
-            request.levelResource.m_resourceString = ros2Request.resource_string.c_str();
+            request.levelResource.m_uri = ros2Request.world_resource.uri.c_str();
+            request.levelResource.m_resourceString = ros2Request.world_resource.resource_string.c_str();
             return request;
         }
     } // namespace

--- a/Gems/SimulationInterfaces/Code/Source/Services/LoadWorldServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/LoadWorldServiceHandler.cpp
@@ -21,8 +21,13 @@ namespace ROS2SimulationInterfaces
             SimulationInterfaces::LoadWorldRequest request;
             request.failOnUnsupportedElement = ros2Request.fail_on_unsupported_element;
             request.ignoreMissingOrUnsupportedAssets = ros2Request.ignore_missing_or_unsupported_assets;
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
             request.levelResource.m_uri = ros2Request.world_resource.uri.c_str();
             request.levelResource.m_resourceString = ros2Request.world_resource.resource_string.c_str();
+#else
+            request.levelResource.m_uri = ros2Request.uri.c_str();
+            request.levelResource.m_resourceString = ros2Request.resource_string.c_str();
+#endif
             return request;
         }
     } // namespace

--- a/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
@@ -24,10 +24,13 @@ namespace ROS2SimulationInterfaces
     AZStd::optional<SetEntityStateServiceHandler::Response> SetEntityStateServiceHandler::HandleServiceRequest(
         const std::shared_ptr<rmw_request_id_t> header, const Request& request)
     {
+        const AZStd::string entityName = request.entity.c_str();
         const auto simulatorFrameId = RegistryUtilities::GetSimulatorROS2Frame();
         const AZStd::string_view messageFrameId{ request.state.header.frame_id.c_str(), request.state.header.frame_id.length() };
+
+        // Resolve frame transform offset once (needed for both pose and twist)
         AZ::Transform transformOffset = AZ::Transform::CreateIdentity();
-        if (!messageFrameId.empty() && simulatorFrameId != messageFrameId)
+        if ((request.set_pose || request.set_twist) && !messageFrameId.empty() && simulatorFrameId != messageFrameId)
         {
             const builtin_interfaces::msg::Time time = request.state.header.stamp;
             auto transformInterface = ROS2::TFInterface::Get();
@@ -47,26 +50,39 @@ namespace ROS2SimulationInterfaces
             }
         }
 
-        const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(request.state.pose);
-        if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+        // Fetch current state so unflagged fields are preserved
+        SimulationInterfaces::EntityState entityState;
         {
-            Response response;
-            response.result.result = simulation_interfaces::srv::SetEntityState::Response::INVALID_POSE;
-            response.result.error_message = poseValidation.GetError().c_str();
-            return response;
+            AZ::Outcome<SimulationInterfaces::EntityState, SimulationInterfaces::FailedResult> currentState;
+            SimulationInterfaces::SimulationEntityManagerRequestBus::BroadcastResult(
+                currentState, &SimulationInterfaces::SimulationEntityManagerRequests::GetEntityState, entityName);
+            if (currentState.IsSuccess())
+            {
+                entityState = currentState.GetValue();
+            }
         }
 
-        const AZ::Transform targetPose = transformOffset *
-            AZ::Transform::CreateFromQuaternionAndTranslation(requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+        if (request.set_pose)
+        {
+            const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(request.state.pose);
+            if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+            {
+                Response response;
+                response.result.result = simulation_interfaces::srv::SetEntityState::Response::INVALID_POSE;
+                response.result.error_message = poseValidation.GetError().c_str();
+                return response;
+            }
+            entityState.m_pose = transformOffset *
+                AZ::Transform::CreateFromQuaternionAndTranslation(requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+        }
+
+        if (request.set_twist)
+        {
+            entityState.m_twistAngular = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.angular));
+            entityState.m_twistLinear = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.linear));
+        }
 
         AZ::Outcome<void, SimulationInterfaces::FailedResult> outcome;
-        AZStd::string entityName = request.entity.c_str();
-
-        SimulationInterfaces::EntityState entityState;
-        entityState.m_pose = targetPose;
-        entityState.m_twistAngular = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.angular));
-        entityState.m_twistLinear = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.linear));
-
         SimulationInterfaces::SimulationEntityManagerRequestBus::BroadcastResult(
             outcome, &SimulationInterfaces::SimulationEntityManagerRequests::SetEntityState, entityName, entityState);
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
@@ -30,7 +30,11 @@ namespace ROS2SimulationInterfaces
 
         // Resolve frame transform offset once (needed for both pose and twist)
         AZ::Transform transformOffset = AZ::Transform::CreateIdentity();
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
         if ((request.set_pose || request.set_twist) && !messageFrameId.empty() && simulatorFrameId != messageFrameId)
+#else
+        if (!messageFrameId.empty() && simulatorFrameId != messageFrameId)
+#endif
         {
             const builtin_interfaces::msg::Time time = request.state.header.stamp;
             auto transformInterface = ROS2::TFInterface::Get();
@@ -50,8 +54,9 @@ namespace ROS2SimulationInterfaces
             }
         }
 
-        // Fetch current state so unflagged fields are preserved
         SimulationInterfaces::EntityState entityState;
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
+        // Fetch current state so unflagged fields are preserved
         {
             AZ::Outcome<SimulationInterfaces::EntityState, SimulationInterfaces::FailedResult> currentState;
             SimulationInterfaces::SimulationEntityManagerRequestBus::BroadcastResult(
@@ -81,6 +86,20 @@ namespace ROS2SimulationInterfaces
             entityState.m_twistAngular = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.angular));
             entityState.m_twistLinear = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.linear));
         }
+#else
+        const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(request.state.pose);
+        if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+        {
+            Response response;
+            response.result.result = simulation_interfaces::srv::SetEntityState::Response::INVALID_POSE;
+            response.result.error_message = poseValidation.GetError().c_str();
+            return response;
+        }
+        entityState.m_pose = transformOffset *
+            AZ::Transform::CreateFromQuaternionAndTranslation(requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+        entityState.m_twistAngular = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.angular));
+        entityState.m_twistLinear = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.linear));
+#endif
 
         AZ::Outcome<void, SimulationInterfaces::FailedResult> outcome;
         SimulationInterfaces::SimulationEntityManagerRequestBus::BroadcastResult(

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
@@ -27,7 +27,11 @@ namespace ROS2SimulationInterfaces
         const std::shared_ptr<rmw_request_id_t> header, const Request& request)
     {
         const AZStd::string_view name{ request.name.c_str(), request.name.size() };
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
         const AZStd::string_view uri{ request.entity_resource.uri.c_str(), request.entity_resource.uri.size() };
+#else
+        const AZStd::string_view uri{ request.uri.c_str(), request.uri.size() };
+#endif
         const AZStd::string_view entityNamespace{ request.entity_namespace.c_str(), request.entity_namespace.size() };
         const AZStd::string_view messageFrameId{ request.initial_pose.header.frame_id.c_str(),
                                                  request.initial_pose.header.frame_id.size() };

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
@@ -27,7 +27,7 @@ namespace ROS2SimulationInterfaces
         const std::shared_ptr<rmw_request_id_t> header, const Request& request)
     {
         const AZStd::string_view name{ request.name.c_str(), request.name.size() };
-        const AZStd::string_view uri{ request.uri.c_str(), request.uri.size() };
+        const AZStd::string_view uri{ request.entity_resource.uri.c_str(), request.entity_resource.uri.size() };
         const AZStd::string_view entityNamespace{ request.entity_namespace.c_str(), request.entity_namespace.size() };
         const AZStd::string_view messageFrameId{ request.initial_pose.header.frame_id.c_str(),
                                                  request.initial_pose.header.frame_id.size() };

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
@@ -441,7 +441,7 @@ namespace UnitTest
         auto client = node->create_client<simulation_interfaces::srv::SpawnEntity>("/spawn_entity");
         auto request = std::make_shared<simulation_interfaces::srv::SpawnEntity::Request>();
         request->name = "valid_name";
-        request->uri = "test_uri";
+        request->entity_resource.uri = "test_uri";
         request->entity_namespace = "test_namespace";
         request->allow_renaming = true;
 
@@ -479,7 +479,7 @@ namespace UnitTest
         auto client = node->create_client<simulation_interfaces::srv::SpawnEntity>("/spawn_entity");
         auto request = std::make_shared<simulation_interfaces::srv::SpawnEntity::Request>();
         request->name = "invalid name"; // invalid name
-        request->uri = "test_uri";
+        request->entity_resource.uri = "test_uri";
         request->entity_namespace = "test_namespace";
 
         auto future = client->async_send_request(request);
@@ -501,7 +501,7 @@ namespace UnitTest
         auto client = node->create_client<simulation_interfaces::srv::SpawnEntity>("/spawn_entity");
         auto request = std::make_shared<simulation_interfaces::srv::SpawnEntity::Request>();
         request->name = "valid_name";
-        request->uri = "test_uri";
+        request->entity_resource.uri = "test_uri";
         request->entity_namespace = "invalid namespace";
 
         auto future = client->async_send_request(request);

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
@@ -441,7 +441,11 @@ namespace UnitTest
         auto client = node->create_client<simulation_interfaces::srv::SpawnEntity>("/spawn_entity");
         auto request = std::make_shared<simulation_interfaces::srv::SpawnEntity::Request>();
         request->name = "valid_name";
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
         request->entity_resource.uri = "test_uri";
+#else
+        request->uri = "test_uri";
+#endif
         request->entity_namespace = "test_namespace";
         request->allow_renaming = true;
 
@@ -479,7 +483,11 @@ namespace UnitTest
         auto client = node->create_client<simulation_interfaces::srv::SpawnEntity>("/spawn_entity");
         auto request = std::make_shared<simulation_interfaces::srv::SpawnEntity::Request>();
         request->name = "invalid name"; // invalid name
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
         request->entity_resource.uri = "test_uri";
+#else
+        request->uri = "test_uri";
+#endif
         request->entity_namespace = "test_namespace";
 
         auto future = client->async_send_request(request);
@@ -501,7 +509,11 @@ namespace UnitTest
         auto client = node->create_client<simulation_interfaces::srv::SpawnEntity>("/spawn_entity");
         auto request = std::make_shared<simulation_interfaces::srv::SpawnEntity::Request>();
         request->name = "valid_name";
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
         request->entity_resource.uri = "test_uri";
+#else
+        request->uri = "test_uri";
+#endif
         request->entity_namespace = "invalid namespace";
 
         auto future = client->async_send_request(request);


### PR DESCRIPTION
## What does this PR do?

This PR adds a support for the latest [simulation_interfaces](https://github.com/ros-simulation/simulation_interfaces) 2.1.0 package alongside already supported 1.4.0/1.5.0/1.6.0. 2.1.0 will be a part of ROS 2 Lyrical Luth release in late May.

The implementation follows the pattern from `ROS2` Gem, i.e., the version of the API is checked at the configure level and respective implementation is selected using precompiler options.

Note: this PR includes changes that were pushed to the `stabilization/26050` branch:
- #1042
- #1043

## How was this PR tested?

I tested with ROS 2 Humble, Jazzy and Rolling using the following docker environment: https://github.com/jhanca-robotecai/TestROSRolling

The some basic CLI commands were used to check if services work as expected.
