### PR TITLE
Fix development (and tests)

### DIFF
--- a/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
+++ b/Gems/ROS2/Code/Tests/Frame/ROS2FrameComponentTest.cpp
@@ -147,6 +147,7 @@ namespace UnitTest
         ROS2::ROS2FrameConfiguration config;
 
         AZ::Entity entity;
+        entity.SetName("single_frame_entity");
         const std::string entityName = entity.GetName().c_str();
         entity.CreateComponent<AzFramework::TransformComponent>();
         auto frame = entity.CreateComponent<ROS2::ROS2FrameComponent>(config);
@@ -210,6 +211,7 @@ namespace UnitTest
         ROS2::ROS2FrameConfiguration config;
 
         AZ::Entity entity;
+        entity.SetName("update_namespace_entity");
         const std::string entityName = entity.GetName().c_str();
         entity.CreateComponent<AzFramework::TransformComponent>();
         auto frame = entity.CreateComponent<ROS2::ROS2FrameComponent>(config);

--- a/Gems/ROS2RobotImporter/Code/Tests/SdfParserTest.cpp
+++ b/Gems/ROS2RobotImporter/Code/Tests/SdfParserTest.cpp
@@ -350,7 +350,7 @@ namespace UnitTest
         // Make sure that all links are gathered
         AZStd::unordered_map<AZStd::string, const sdf::Link*> links = Utils::GetAllLinks(*myModel, true);
         auto otherLinks = Utils::GetAllLinks(*yourModel, true);
-        links.insert(AZStd::move(otherLinks.begin()), AZStd::move(otherLinks.end()));
+        links.insert(otherLinks.begin(), otherLinks.end());
 
         ASSERT_EQ(2, links.size());
         EXPECT_TRUE(links.contains("my_model::same_link_name"));

--- a/Gems/ROS2Sensors/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Gems/ROS2Sensors/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -202,7 +202,7 @@ namespace ROS2Sensors
         auto positionIt = positionField.begin();
 
         AZStd::optional<Pc2MsgIt<float>> messageIntensityIt;
-        AZStd::optional<RaycastResults::FieldSpan<RaycastResultFlags::Intensity>::const_iterator> intensityIt;
+        AZStd::optional<RaycastResults::ConstFieldSpan<RaycastResultFlags::Intensity>::iterator> intensityIt;
         if (results.IsFieldPresent<RaycastResultFlags::Intensity>())
         {
             messageIntensityIt = Pc2MsgIt<float>(message, "intensity");
@@ -217,7 +217,7 @@ namespace ROS2Sensors
         };
 
         AZStd::optional<MessageSegmentationIterators> messageSegDataIts;
-        AZStd::optional<RaycastResults::FieldSpan<RaycastResultFlags::SegmentationData>::const_iterator> segDataIt;
+        AZStd::optional<RaycastResults::ConstFieldSpan<RaycastResultFlags::SegmentationData>::iterator> segDataIt;
         if (results.IsFieldPresent<RaycastResultFlags::SegmentationData>())
         {
             messageSegDataIts = MessageSegmentationIterators{

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/EntityId.h>
+#include <AzCore/Memory/AllocatorManager.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Slice/SliceAssetHandler.h>
@@ -65,6 +66,7 @@ namespace UnitTest
         void AddGemsAndComponents() override;
         AZ::ComponentApplication* CreateApplicationInstance() override;
         void PostSystemEntityActivate() override;
+        void PostDestroyApplication() override;
 
     public:
         SimulationInterfaceROS2TestEnvironment() = default;
@@ -91,6 +93,17 @@ namespace UnitTest
     void SimulationInterfaceROS2TestEnvironment::PostSystemEntityActivate()
     {
         AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
+    }
+
+    void SimulationInterfaceROS2TestEnvironment::PostDestroyApplication()
+    {
+        // rclcpp maintains a global default context in a static std::shared_ptr<Context> that is only
+        // destroyed at process exit — after O3DE's allocator teardown. This causes false positive leak
+        // reports (confirmed as "still reachable" by valgrind, not truly lost). Clearing the allocation
+        // records here (after the application and all its components are fully torn down) prevents the
+        // spurious failure. All real O3DE allocations have been freed by this point.
+        AZ::AllocatorManager::Instance().SetDefaultTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_NO_RECORDS);
+        AZ::AllocatorManager::Instance().SetTrackingMode(AZ::Debug::AllocationRecords::Mode::RECORD_NO_RECORDS);
     }
 
     class SimulationInterfaceROS2TestFixture : public ::testing::Test


### PR DESCRIPTION
## What does this PR do?

This PR fixes the build with the `development` branch of the engine:
- adopt `AZStd::move` changes from the engine: https://github.com/o3de/o3de/pull/19585
- adopt `AZStd::span` changes from the engine: https://github.com/o3de/o3de/pull/19581

Additionally, it fixes the tests.

Failure without the change:
```
[build] /home/jhanca/devroot/2610/o3de-extras/Gems/ROS2RobotImporter/Code/Tests/SdfParserTest.cpp:353:22: error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
[build]         links.insert(AZStd::move(otherLinks.begin()), AZStd::move(otherLinks.end()));
[build]                      ^
[build] /home/jhanca/devroot/2610/o3de-extras/Gems/ROS2RobotImporter/Code/Tests/SdfParserTest.cpp:353:22: note: remove std::move call here
[build]         links.insert(AZStd::move(otherLinks.begin()), AZStd::move(otherLinks.end()));
[build]                      ^~~~~~~~~~~~                  ~
[build] /home/jhanca/devroot/2610/o3de-extras/Gems/ROS2RobotImporter/Code/Tests/SdfParserTest.cpp:353:55: error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
[build]         links.insert(AZStd::move(otherLinks.begin()), AZStd::move(otherLinks.end()));
[build]                                                       ^
[build] /home/jhanca/devroot/2610/o3de-extras/Gems/ROS2RobotImporter/Code/Tests/SdfParserTest.cpp:353:55: note: remove std::move call here
[build]         links.insert(AZStd::move(otherLinks.begin()), AZStd::move(otherLinks.end()));
[build]                                                       ^~~~~~~~~~~~                ~
[build] 2 errors generated.


[build] /home/jhanca/devroot/2610/o3de-extras/Gems/ROS2Sensors/Code/Source/Lidar/ROS2LidarSensorComponent.cpp:205:83: error: no member named 'const_iterator' in 'std::span<float, 18446744073709551615>'
[build]         AZStd::optional<RaycastResults::FieldSpan<RaycastResultFlags::Intensity>::const_iterator> intensityIt;
[build]                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
[build] /home/jhanca/devroot/2610/o3de-extras/Gems/ROS2Sensors/Code/Source/Lidar/ROS2LidarSensorComponent.cpp:220:90: error: no member named 'const_iterator' in 'std::span<ROS2Sensors::SegmentationIds, 18446744073709551615>'
[build]         AZStd::optional<RaycastResults::FieldSpan<RaycastResultFlags::SegmentationData>::const_iterator> segDataIt;
[build]                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
[build] 2 errors generated.
```


## How was this PR tested?

Code builds and tests pass on Ubuntu 22.04 with Humble.
