### PR TITLE
[2605.0 Release] Cherry-pick recent changes to backports/25051

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Handlers/ROS2TopicSubscriptionBase.h
+++ b/Gems/ROS2/Code/Include/ROS2/Handlers/ROS2TopicSubscriptionBase.h
@@ -74,7 +74,7 @@ namespace ROS2
             }
 
             m_subscriber = node->create_subscription<RosMessageType>(
-                m_topicConfig.m_topic,
+                m_topicConfig.m_topic.c_str(),
                 m_topicConfig.GetQoS(),
                 [this](const typename RosMessageType::SharedPtr message_ptr)
                 {

--- a/Gems/ROS2/gem.json
+++ b/Gems/ROS2/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ROS2",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "display_name": "ROS2",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -38,5 +38,5 @@
     "engine_api_dependencies": [],
     "restricted": "ROS2",
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.5.0-gem.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.5.1-gem.zip"
 }

--- a/Gems/SimulationInterfaces/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfaces/Code/CMakeLists.txt
@@ -37,7 +37,7 @@ ly_add_target(
            AZ::AzCore
 )
 
-target_interface_depends_on_ros2_package(${gem_name}.API simulation_interfaces 1.1.0 REQUIRED)
+target_interface_depends_on_ros2_package(${gem_name}.API simulation_interfaces 1.4.0 REQUIRED)
 
 # The ${gem_name}.Private.Object target is an internal target
 # It should not be used outside of this Gems CMakeLists.txt
@@ -64,7 +64,7 @@ ly_add_target(
             Gem::DebugDraw.API
 )
 target_depends_on_ros2_packages(${gem_name}.Private.Object rclcpp std_msgs geometry_msgs rclcpp_action tf2_ros)
-target_depends_on_ros2_package(${gem_name}.Private.Object simulation_interfaces 1.1.0 REQUIRED)
+target_depends_on_ros2_package(${gem_name}.Private.Object simulation_interfaces 1.4.0 REQUIRED)
 
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface
 ly_add_target(

--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/PathUtils.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/PathUtils.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/optional.h>
+#include <AzCore/std/string/string.h>
+
+namespace SimulationInterfaces::PathUtilities
+{
+    namespace
+    {
+        const char* const ProductAssetPrefix = "product_asset:///";
+    }
+
+    //! Converts a relative path to 
+    //! relative path: "path/to/file.txt"
+    //! URI: "product_asset:///path/to/file.txt"
+    inline AZStd::string RelPathToUri(AZStd::string_view relPath)
+    {
+        AZStd::string uri = relPath;
+        AZStd::replace(uri.begin(), uri.end(), '\\', '/');
+        uri.insert(0, ProductAssetPrefix);
+        return uri;
+    }
+
+    //! Converts an URI to a relative path 
+    //! URI: "product_asset:///path/to/file.txt"
+    //! relative path: "path/to/file.txt"
+    inline AZStd::string UriToRelPath(AZStd::string_view uri)
+    {
+        if (uri.starts_with(ProductAssetPrefix))
+        {
+            const AZStd::string_view productAssetPrefix{ ProductAssetPrefix };
+            return uri.substr(productAssetPrefix.length());
+        }
+        return {};
+    }
+
+} // namespace SimulationInterfaces::PathUtilities

--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
@@ -163,6 +163,11 @@ namespace SimulationInterfaces
         //! @param name Name of entity to get
         //! @return Returns entityId of the entity or fail if entity doesn't exist
         virtual AZ::Outcome<AZ::EntityId, FailedResult> GetEntityRoot(const AZStd::string& name) = 0;
+        //! Get simulation interfaces name of the entity with given id.
+        //! Mapping id to name is the same as in method @ref GetEntityId
+        //! @param entityId id of requested entity
+        //! @return name of the simulation entity if exists, Failure otherwise.
+        virtual AZ::Outcome<AZStd::string, FailedResult> GetSimulatedBodyNameById(const AZ::EntityId& entityId) = 0;
     };
 
     class SimulationInterfacesBusTraits : public AZ::EBusTraits

--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Result.h"
+#include <AzCore/std/algorithm.h>
 #include "SimulationInterfacesTypeIds.h"
 #include "TagFilter.h"
 #include <AzCore/Component/EntityId.h>
@@ -70,8 +71,36 @@ namespace SimulationInterfaces
     using SpawnableList = AZStd::vector<Spawnable>;
     using DeletionCompletedCb = AZStd::function<void(const AZ::Outcome<void, FailedResult>&)>;
     using SpawnCompletedCb = AZStd::function<void(const AZ::Outcome<AZStd::string, FailedResult>&)>;
-    using PreInsertionCb =
-        AZStd::function<void(const AZ::Outcome<AzFramework::SpawnableEntityContainerView, FailedResult>&)>;
+    using PreInsertionCb = AZStd::function<void(const AZ::Outcome<AzFramework::SpawnableEntityContainerView, FailedResult>&)>;
+
+    struct BatchSpawnResult
+    {
+        AZStd::vector<AZ::Outcome<AZStd::string, FailedResult>> m_spawnResults;
+
+        bool AllSucceeded() const
+        {
+            return AZStd::all_of(
+                m_spawnResults.begin(),
+                m_spawnResults.end(),
+                [](const AZ::Outcome<AZStd::string, FailedResult>& result)
+                {
+                    return result.IsSuccess();
+                });
+        }
+    };
+
+    using BatchSpawnCompletedCb = AZStd::function<void(const BatchSpawnResult&)>;
+
+    struct SpawningEntity
+    {
+        AZStd::string name;
+        AZStd::string uri;
+        AZStd::string entityNamespace;
+        AZ::Transform initialPose;
+        bool allowRename;
+        PreInsertionCb preinsertionCb;
+        SpawnCompletedCb completedCb;
+    };
 
     class SimulationEntityManagerRequests
     {
@@ -121,6 +150,10 @@ namespace SimulationInterfaces
             const bool allowRename,
             PreInsertionCb preinsertionCb,
             SpawnCompletedCb completedCb) = 0;
+
+        //! Callback for when all requested entities have either been spawned and registered or failed.
+        //! Results are returned in the same order as the input requests.
+        virtual void SpawnEntities(const AZStd::vector<SpawningEntity>& spawningEntities, BatchSpawnCompletedCb completedCb) = 0;
 
         //! Reset the simulation to begin.
         //! This will revert the entire simulation to the initial state.

--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationMangerRequestBus.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationMangerRequestBus.h
@@ -86,9 +86,19 @@ namespace SimulationInterfaces
         AZ_RTTI(SimulationManagerNotifications, SimulationManagerNotificationsTypeId);
         virtual ~SimulationManagerNotifications() = default;
 
+        //! Both methods set as virtual with default implementation to not force users to define both callbacks if not needed
+
         //! Notify about simulation step finish
         //! @param remainingSteps - remaining steps to pause simulation
-        virtual void OnSimulationStepFinish(const AZ::u64 remainingSteps) = 0;
+        virtual void OnSimulationStepFinish(const AZ::u64 remainingSteps)
+        {
+        }
+
+        //! Notify about simulation state change
+        //! @param setState - id of the state that was set
+        virtual void OnSimulationStateChange(const SimulationState& setState)
+        {
+        }
     };
 
     class SimulationMangerNotificationsBusTraits : public AZ::EBusTraits

--- a/Gems/SimulationInterfaces/Code/Source/Clients/CommonUtilities.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/CommonUtilities.cpp
@@ -20,25 +20,6 @@
 
 namespace SimulationInterfaces::Utils
 {
-    const char* const ProductAssetPrefix = "product_asset:///";
-    AZStd::string RelPathToUri(AZStd::string_view relPath)
-    {
-        AZStd::string uri = relPath;
-        AZStd::replace(uri.begin(), uri.end(), '\\', '/');
-        uri.insert(0, ProductAssetPrefix);
-        return uri;
-    }
-
-    AZStd::string UriToRelPath(AZStd::string_view uri)
-    {
-        if (uri.starts_with(ProductAssetPrefix))
-        {
-            const AZStd::string_view productAssetPrefix{ ProductAssetPrefix };
-            return uri.substr(productAssetPrefix.length());
-        }
-        return {};
-    }
-
     bool AreTagsMatching(const TagFilter& tagFilter, const AZStd::vector<AZStd::string>& entityTags)
     {
         if (tagFilter.m_tags.empty())

--- a/Gems/SimulationInterfaces/Code/Source/Clients/CommonUtilities.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/CommonUtilities.h
@@ -26,12 +26,6 @@
 
 namespace SimulationInterfaces::Utils
 {
-    //! Convert a relative path to a URI
-    //! relative path: "path/to/file.txt"
-    //! URI: "product_asset:///path/to/file.txt"
-    AZStd::string RelPathToUri(AZStd::string_view relPath);
-    AZStd::string UriToRelPath(AZStd::string_view relPath);
-
     //! Filter named poses given by map by given tag filter
     //! @param entitiesToFilter map [entityName,entityId] describing NamedPoses which should be processed
     //! @param tagFilter definition of tag filter to apply

--- a/Gems/SimulationInterfaces/Code/Source/Clients/LevelManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/LevelManager.cpp
@@ -116,7 +116,6 @@ namespace SimulationInterfaces
 
     AZ::Outcome<WorldResourcesList, FailedResult> LevelManager::GetAvailableWorlds(const GetWorldsRequest& request)
     {
-        m_actionRequestedFromSimInterfaces = true;
         WorldResourcesList availableWorlds;
         // request validation
         if (!request.additionalSources.empty())
@@ -150,7 +149,6 @@ namespace SimulationInterfaces
             availableWorlds.emplace_back(
                 GetLevelNameFromAssetPath(levelPath), Resource{ levelPath, "" }, "", AZStd::vector<AZStd::string>{});
         }
-        m_actionRequestedFromSimInterfaces = false;
         return AZ::Success(availableWorlds);
     }
 
@@ -162,7 +160,6 @@ namespace SimulationInterfaces
             AZ_Warning("SimulationInterfaces", false, errorMsg);
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, errorMsg));
         }
-        m_actionRequestedFromSimInterfaces = true;
         WorldResource currentWorld;
         auto* levelInterface = AzFramework::LevelSystemLifecycleInterface::Get();
         if (levelInterface == nullptr)
@@ -191,7 +188,6 @@ namespace SimulationInterfaces
         auto levelName = GetLevelNameFromAssetPath(levelPathStr);
         currentWorld.m_worldResource.m_uri = levelPathStr;
         currentWorld.m_name = levelName;
-        m_actionRequestedFromSimInterfaces = false;
         return AZ::Success(currentWorld);
     }
 
@@ -203,7 +199,6 @@ namespace SimulationInterfaces
             AZ_Warning("SimulationInterfaces", false, errorMsg);
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_FEATURE_UNSUPPORTED, errorMsg));
         }
-        m_actionRequestedFromSimInterfaces = true;
         WorldResource loadedWorld;
 
         if (request.levelResource.m_resourceString.empty() && request.levelResource.m_uri.empty())
@@ -239,11 +234,13 @@ namespace SimulationInterfaces
             return AZ::Failure(FailedResult(simulation_interfaces::srv::LoadWorld::Response::MISSING_ASSETS, errorMsg));
         }
 
+        m_actionRequestedFromSimInterfaces = true;
         ILevelSystem* levelSystem = GetLevelSystem();
         if (levelSystem == nullptr)
         {
             constexpr const char* errorMsg = "Failed to start, level System not available";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, errorMsg));
         }
 
@@ -262,6 +259,7 @@ namespace SimulationInterfaces
             AZ_Warning("SimulationInterfaces", false, errorMsg);
             SimulationManagerRequestBus::Broadcast(
                 &SimulationManagerRequests::SetSimulationState, simulation_interfaces::msg::SimulationState::STATE_NO_WORLD);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::srv::LoadWorld::Response::RESOURCE_PARSE_ERROR, errorMsg));
         }
         // notify state machine
@@ -289,6 +287,7 @@ namespace SimulationInterfaces
             {
                 constexpr const char* errorMsg = "No level loaded";
                 AZ_Warning("SimulationInterfaces", false, errorMsg);
+                m_actionRequestedFromSimInterfaces = false;
                 return AZ::Failure(FailedResult(simulation_interfaces::srv::UnloadWorld::Response::NO_WORLD_LOADED, errorMsg));
             }
         }
@@ -297,6 +296,7 @@ namespace SimulationInterfaces
         {
             constexpr const char* errorMsg = "Level system is not available";
             AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, errorMsg));
         }
 
@@ -320,6 +320,7 @@ namespace SimulationInterfaces
         if (!levelGathering.IsSuccess())
         {
             AZ_Error("LevelManager", false, "Error occurred during level gathering: %s", levelGathering.GetError().m_errorString.c_str());
+            m_actionRequestedFromSimInterfaces = false;
             return;
         }
         UnloadWorld();

--- a/Gems/SimulationInterfaces/Code/Source/Clients/ROS2SimulationInterfacesSystemComponent.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/ROS2SimulationInterfacesSystemComponent.cpp
@@ -37,6 +37,7 @@
 #include <Services/SetEntityInfoServiceHandler.h>
 #include <Services/SetEntityStateServiceHandler.h>
 #include <Services/SetSimulationStateServiceHandler.h>
+#include <Services/SpawnEntitiesServiceHandler.h>
 #include <Services/SpawnEntityServiceHandler.h>
 #include <Services/StepSimulationServiceHandler.h>
 #include <Services/UnloadWorldServiceHandler.h>
@@ -93,6 +94,7 @@ namespace ROS2SimulationInterfaces
         RegisterInterface<GetSpawnablesServiceHandler>(ros2Node);
         RegisterInterface<SetEntityStateServiceHandler>(ros2Node);
         RegisterInterface<SpawnEntityServiceHandler>(ros2Node);
+        RegisterInterface<SpawnEntitiesServiceHandler>(ros2Node);
         RegisterInterface<GetSimulatorFeaturesServiceHandler>(ros2Node);
         RegisterInterface<ResetSimulationServiceHandler>(ros2Node);
         RegisterInterface<SimulateStepsActionServerHandler>(ros2Node);

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -31,6 +31,7 @@
 #include <AzFramework/Physics/PhysicsSystem.h>
 #include <AzFramework/Physics/RigidBodyBus.h>
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
+#include <AzFramework/Physics/SimulatedBodies/StaticRigidBody.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 #include <AzFramework/Entity/EntityContextBus.h>
@@ -347,9 +348,14 @@ namespace SimulationInterfaces
             AZ::Outcome<AzPhysics::SimulatedBody*, AZStd::string> simulatedBody = Utils::GetSimulatedBody(entityId);
             if (simulatedBody.IsSuccess())
             {
+                // check for dynamic and static rigid bodies
                 auto rigidBody = azdynamic_cast<AzPhysics::RigidBody*>(simulatedBody.GetValue());
+                auto staticRigidBody = azdynamic_cast<AzPhysics::StaticRigidBody*>(simulatedBody.GetValue());
+
+                bool hasDynamicShapes = rigidBody ? rigidBody->GetShapeCount() > 0 : false;
+                bool hasStaticShapes = staticRigidBody ? staticRigidBody->GetShapeCount() > 0 : false;
                 // entity is simulated body and has collider, check overlap
-                if (rigidBody && rigidBody->GetShapeCount() > 0)
+                if (hasDynamicShapes || hasStaticShapes)
                 {
                     // perform relatively expensive search only for entities which really can be inside the shape
                     if (AZStd::ranges::contains(result.m_hits, entityId, &AzPhysics::SceneQueryHit::m_entityId))

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -207,7 +207,8 @@ namespace SimulationInterfaces
                 simulation_interfaces::msg::SimulatorFeatures::ENTITY_BOUNDS,
                 simulation_interfaces::msg::SimulatorFeatures::DELETING,
                 simulation_interfaces::msg::SimulatorFeatures::SPAWNABLES,
-                simulation_interfaces::msg::SimulatorFeatures::SPAWNING });
+                simulation_interfaces::msg::SimulatorFeatures::SPAWNING,
+                simulation_interfaces::msg::SimulatorFeatures::SPAWNING_ENTITIES });
     }
 
     void SimulationEntitiesManager::Deactivate()
@@ -889,9 +890,8 @@ namespace SimulationInterfaces
                 }
                 else
                 {
-                    spawnData->second.m_completedCb(
-                        AZ::Failure(FailedResult(
-                            simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, "Failed to spawn/or register simulation entity")));
+                    spawnData->second.m_completedCb(AZ::Failure(FailedResult(
+                        simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, "Failed to spawn/or register simulation entity")));
                 }
                 m_spawnCompletedCallbacks.erase(spawnData);
             }
@@ -1027,10 +1027,9 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToEntityIdMap.contains(name))
         {
-            return AZ::Failure(
-                SimulationInterfaces::FailedResult(
-                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                    AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
+            return AZ::Failure(SimulationInterfaces::FailedResult(
+                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
         }
         // check if entity with given name has entity info assigned, clear it if needed
         RemoveEntityInfoIfNeeded(name);
@@ -1051,10 +1050,9 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToEntityIdMap.contains(name))
         {
-            return AZ::Failure(
-                SimulationInterfaces::FailedResult(
-                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                    AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
+            return AZ::Failure(SimulationInterfaces::FailedResult(
+                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
         }
 
         auto findIt = m_nameToEntityInfo.find(name);
@@ -1084,10 +1082,9 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToEntityIdMap.contains(name))
         {
-            return AZ::Failure(
-                SimulationInterfaces::FailedResult(
-                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                    AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
+            return AZ::Failure(SimulationInterfaces::FailedResult(
+                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
         }
         auto simulatedBodyOutcome = Utils::GetSimulatedBody(m_simulatedEntityToEntityIdMap.at(name));
         if (!simulatedBodyOutcome.IsSuccess())
@@ -1122,10 +1119,9 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToEntityIdMap.contains(name))
         {
-            return AZ::Failure(
-                SimulationInterfaces::FailedResult(
-                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                    AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
+            return AZ::Failure(SimulationInterfaces::FailedResult(
+                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
         }
         return AZ::Success(m_simulatedEntityToEntityIdMap.at(name));
     }
@@ -1134,11 +1130,9 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToPrefabRoot.contains(name))
         {
-            return AZ::Failure(
-                SimulationInterfaces::FailedResult(
-                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                    AZStd::string::format(
-                        "Entity with given name \"%s\" doesn't exists in available cache of prefab roots", name.c_str())));
+            return AZ::Failure(SimulationInterfaces::FailedResult(
+                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                AZStd::string::format("Entity with given name \"%s\" doesn't exists in available cache of prefab roots", name.c_str())));
         }
         return AZ::Success(m_simulatedEntityToPrefabRoot.at(name));
     }

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -888,8 +888,9 @@ namespace SimulationInterfaces
                 }
                 else
                 {
-                    spawnData->second.m_completedCb(AZ::Failure(FailedResult(
-                        simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, "Failed to spawn/or register simulation entity")));
+                    spawnData->second.m_completedCb(
+                        AZ::Failure(FailedResult(
+                            simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, "Failed to spawn/or register simulation entity")));
                 }
                 m_spawnCompletedCallbacks.erase(spawnData);
             }
@@ -905,6 +906,68 @@ namespace SimulationInterfaces
         m_spawnCompletedCallbacks[ticketId] = data;
         m_spawnedTickets[ticketId] = ticket;
         AZ_Info("SimulationInterfaces", "Spawning uri %s with ticket id %d\n", uri.c_str(), ticketId);
+    }
+
+    void SimulationEntitiesManager::SpawnEntities(const AZStd::vector<SpawningEntity>& spawningEntities, BatchSpawnCompletedCb completedCb)
+    {
+        if (auto outcome = IsWorldLoaded(); !outcome.IsSuccess())
+        {
+            AZ_Warning(
+                "SimulationInterfaces",
+                false,
+                "SpawnEntities called but world is not loaded: %s",
+                outcome.GetError().m_errorString.c_str());
+            if (completedCb)
+            {
+                BatchSpawnResult result;
+                result.m_spawnResults.reserve(spawningEntities.size());
+                for (size_t i = 0; i < spawningEntities.size(); ++i)
+                {
+                    result.m_spawnResults.push_back(AZ::Failure(outcome.GetError()));
+                }
+                completedCb(result);
+            }
+            return;
+        }
+
+        if (spawningEntities.empty())
+        {
+            AZ_Warning("SimulationInterfaces", false, "SpawnEntities called with an empty list of entities");
+            if (completedCb)
+            {
+                completedCb(BatchSpawnResult{});
+            }
+            return;
+        }
+
+        auto batchContext = AZStd::make_shared<BatchSpawnContext>();
+        batchContext->m_completedCb = AZStd::move(completedCb);
+        batchContext->m_result.m_spawnResults.resize(spawningEntities.size());
+
+        for (size_t i = 0; i < spawningEntities.size(); ++i)
+        {
+            const auto& spawningEntity = spawningEntities[i];
+
+            SpawnCompletedCb wrappedCompletedCb =
+                [batchContext, i, entityCompletedCb = spawningEntity.completedCb](const AZ::Outcome<AZStd::string, FailedResult>& outcome)
+            {
+                if (entityCompletedCb)
+                {
+                    entityCompletedCb(outcome);
+                }
+
+                batchContext->m_result.m_spawnResults[i] = outcome;
+            };
+
+            SpawnEntity(
+                spawningEntity.name,
+                spawningEntity.uri,
+                spawningEntity.entityNamespace,
+                spawningEntity.initialPose,
+                spawningEntity.allowRename,
+                spawningEntity.preinsertionCb,
+                AZStd::move(wrappedCompletedCb));
+        }
     }
 
     AZStd::string SimulationEntitiesManager::GetSimulatedEntityName(AZ::EntityId entityId, const AZStd::string& proposedName) const
@@ -963,9 +1026,10 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToEntityIdMap.contains(name))
         {
-            return AZ::Failure(SimulationInterfaces::FailedResult(
-                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
+            return AZ::Failure(
+                SimulationInterfaces::FailedResult(
+                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                    AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
         }
         // check if entity with given name has entity info assigned, clear it if needed
         RemoveEntityInfoIfNeeded(name);
@@ -986,9 +1050,10 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToEntityIdMap.contains(name))
         {
-            return AZ::Failure(SimulationInterfaces::FailedResult(
-                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
+            return AZ::Failure(
+                SimulationInterfaces::FailedResult(
+                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                    AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
         }
 
         auto findIt = m_nameToEntityInfo.find(name);
@@ -1018,9 +1083,10 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToEntityIdMap.contains(name))
         {
-            return AZ::Failure(SimulationInterfaces::FailedResult(
-                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
+            return AZ::Failure(
+                SimulationInterfaces::FailedResult(
+                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                    AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
         }
         auto simulatedBodyOutcome = Utils::GetSimulatedBody(m_simulatedEntityToEntityIdMap.at(name));
         if (!simulatedBodyOutcome.IsSuccess())
@@ -1055,9 +1121,10 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToEntityIdMap.contains(name))
         {
-            return AZ::Failure(SimulationInterfaces::FailedResult(
-                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
+            return AZ::Failure(
+                SimulationInterfaces::FailedResult(
+                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                    AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
         }
         return AZ::Success(m_simulatedEntityToEntityIdMap.at(name));
     }
@@ -1066,9 +1133,11 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToPrefabRoot.contains(name))
         {
-            return AZ::Failure(SimulationInterfaces::FailedResult(
-                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                AZStd::string::format("Entity with given name \"%s\" doesn't exists in available cache of prefab roots", name.c_str())));
+            return AZ::Failure(
+                SimulationInterfaces::FailedResult(
+                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                    AZStd::string::format(
+                        "Entity with given name \"%s\" doesn't exists in available cache of prefab roots", name.c_str())));
         }
         return AZ::Success(m_simulatedEntityToPrefabRoot.at(name));
     }

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -39,6 +39,7 @@
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <SimulationInterfaces/Bounds.h>
+#include <SimulationInterfaces/PathUtils.h>
 #include <SimulationInterfaces/Result.h>
 #include <SimulationInterfaces/SimulationFeaturesAggregatorRequestBus.h>
 #include <SimulationInterfaces/SimulationInterfacesTypeIds.h>
@@ -730,7 +731,7 @@ namespace SimulationInterfaces
             if (isSpawnable)
             {
                 Spawnable spawnable;
-                spawnable.m_uri = Utils::RelPathToUri(assetInfo.m_relativePath);
+                spawnable.m_uri = PathUtilities::RelPathToUri(assetInfo.m_relativePath);
                 spawnables.push_back(spawnable);
             }
         };
@@ -778,7 +779,7 @@ namespace SimulationInterfaces
         }
 
         // get rel path from uri
-        const AZStd::string relPath = Utils::UriToRelPath(uri);
+        const AZStd::string relPath = PathUtilities::UriToRelPath(uri);
 
         // create spawnable
         AZ::Data::AssetId assetId;

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Console/IConsole.h>
+#include <AzCore/Math/Capsule.h>
 #include <AzCore/Math/Obb.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/RTTI/RTTIMacros.h>
@@ -26,6 +27,8 @@
 #include <AzCore/std/string/regex.h>
 #include <AzCore/std/string/string.h>
 #include <AzFramework/Components/TransformComponent.h>
+#include <AzFramework/Entity/EntityContextBus.h>
+#include <AzFramework/Entity/GameEntityContextBus.h>
 #include <AzFramework/Physics/Common/PhysicsSceneQueries.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
@@ -34,8 +37,6 @@
 #include <AzFramework/Physics/SimulatedBodies/StaticRigidBody.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
-#include <AzFramework/Entity/EntityContextBus.h>
-#include <AzFramework/Entity/GameEntityContextBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
 #include <SimulationInterfaces/Bounds.h>
 #include <SimulationInterfaces/Result.h>
@@ -367,6 +368,8 @@ namespace SimulationInterfaces
                 }
             }
 
+            // Allow check for all supported shapes. Simulation interfaces standard constraints are checked in ROS 2 layer of the node.
+
             // for non physical or no-colliding entities check if World TM is inside the control shape
             AZ::Vector3 worldTranslation;
             AZ::TransformBus::EventResult(worldTranslation, entityId, &AZ::TransformBus::Events::GetWorldTranslation);
@@ -387,9 +390,17 @@ namespace SimulationInterfaces
                     entities.push_back(name);
                 }
             }
+            else if (auto capsuleShape = dynamic_cast<Physics::CapsuleShapeConfiguration*>(shape.get()))
+            {
+                const auto capsule = capsuleShape->ToCapsule(shapePose);
+                if (capsule.Contains(worldTranslation))
+                {
+                    entities.push_back(name);
+                }
+            }
             else
             {
-                AZ_Warning("SimulationInterfaces", false, "Unsupported bounds type, skipped");
+                AZ_WarningOnce("SimulationInterfaces", false, "Non-physical entities support only primitive shapes for bounds check");
             }
         }
         return entities;
@@ -761,9 +772,8 @@ namespace SimulationInterfaces
         if (!initialPose.IsOrthogonal())
         {
             AZ_Warning("SimulationInterfaces", false, "Initial pose is not orthogonal");
-            completedCb(
-                AZ::Failure(FailedResult(
-                    simulation_interfaces::srv::SpawnEntity::Response::INVALID_POSE, "Initial pose is not orthogonal"))); //  INVALID_POSE
+            completedCb(AZ::Failure(FailedResult(
+                simulation_interfaces::srv::SpawnEntity::Response::INVALID_POSE, "Initial pose is not orthogonal"))); //  INVALID_POSE
             return;
         }
 
@@ -809,12 +819,21 @@ namespace SimulationInterfaces
             }
             AZ::Entity* root = *view.begin();
 
-            for (AZ::Entity* entity : view)
+            for (auto* entity : view)
             {
-                auto* ros2Frame = entity->FindComponent<ROS2::ROS2FrameComponent>();
-                if (ros2Frame)
+                ROS2::ROS2FrameComponent* frameComponent = entity->template FindComponent<ROS2::ROS2FrameComponent>();
+                if (frameComponent)
                 {
-                    ros2Frame->UpdateNamespaceConfiguration(entityNamespace, ROS2::NamespaceConfiguration::NamespaceStrategy::Custom);
+                    const AZStd::string f = frameComponent->GetNamespacedFrameID();
+                    auto config = frameComponent->GetConfiguration();
+                    config.m_namespaceConfiguration.m_customNamespace = entityNamespace;
+                    config.m_namespaceConfiguration.m_namespaceStrategy = ROS2::NamespaceConfiguration::NamespaceStrategy::Custom;
+                    AZ_Printf(
+                        "SimulationInterfaces::SpawnEntity",
+                        "Setting namespace to %s for entity %s\n",
+                        entityNamespace.c_str(),
+                        entity->GetName().c_str());
+                    frameComponent->SetConfiguration(config);
                     break;
                 }
             }
@@ -1022,7 +1041,8 @@ namespace SimulationInterfaces
             "Simulation Interfaces",
             rigidBody->GetShapeCount() == 1,
             "Entity Bounds in simulation interfaces doesn't support multiple shapes, only first one will be taken ");
-        auto boundsOutput = Utils::ConvertPhysicalShapeToBounds(m_simulatedEntityToEntityIdMap.at(name));
+        auto shape = rigidBody->GetShape(0);
+        auto boundsOutput = Utils::ConvertPhysicalShapeToBounds(shape, m_simulatedEntityToEntityIdMap.at(name));
         if (boundsOutput.IsSuccess())
         {
             return AZ::Success(boundsOutput.GetValue());

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -821,21 +821,12 @@ namespace SimulationInterfaces
             }
             AZ::Entity* root = *view.begin();
 
-            for (auto* entity : view)
+            for (AZ::Entity* entity : view)
             {
-                ROS2::ROS2FrameComponent* frameComponent = entity->template FindComponent<ROS2::ROS2FrameComponent>();
-                if (frameComponent)
+                auto* ros2Frame = entity->FindComponent<ROS2::ROS2FrameComponent>();
+                if (ros2Frame)
                 {
-                    const AZStd::string f = frameComponent->GetNamespacedFrameID();
-                    auto config = frameComponent->GetConfiguration();
-                    config.m_namespaceConfiguration.m_customNamespace = entityNamespace;
-                    config.m_namespaceConfiguration.m_namespaceStrategy = ROS2::NamespaceConfiguration::NamespaceStrategy::Custom;
-                    AZ_Printf(
-                        "SimulationInterfaces::SpawnEntity",
-                        "Setting namespace to %s for entity %s\n",
-                        entityNamespace.c_str(),
-                        entity->GetName().c_str());
-                    frameComponent->SetConfiguration(config);
+                    ros2Frame->UpdateNamespaceConfiguration(entityNamespace, ROS2::NamespaceConfiguration::NamespaceStrategy::Custom);
                     break;
                 }
             }
@@ -1105,8 +1096,7 @@ namespace SimulationInterfaces
             "Simulation Interfaces",
             rigidBody->GetShapeCount() == 1,
             "Entity Bounds in simulation interfaces doesn't support multiple shapes, only first one will be taken ");
-        auto shape = rigidBody->GetShape(0);
-        auto boundsOutput = Utils::ConvertPhysicalShapeToBounds(shape, m_simulatedEntityToEntityIdMap.at(name));
+        auto boundsOutput = Utils::ConvertPhysicalShapeToBounds(m_simulatedEntityToEntityIdMap.at(name));
         if (boundsOutput.IsSuccess())
         {
             return AZ::Success(boundsOutput.GetValue());

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -1047,4 +1047,20 @@ namespace SimulationInterfaces
         return AZ::Success(m_simulatedEntityToPrefabRoot.at(name));
     }
 
+    AZ::Outcome<AZStd::string, FailedResult> SimulationEntitiesManager::GetSimulatedBodyNameById(const AZ::EntityId& entityId)
+    {
+        const auto it = m_entityIdToSimulatedEntityMap.find(entityId);
+
+        if (it == m_entityIdToSimulatedEntityMap.end())
+        {
+            return AZ::Failure(SimulationInterfaces::FailedResult(
+                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                AZStd::string::format(
+                    "Entity with given ID \"%s\" doesn't exist in the available cache of simulated entities names",
+                    entityId.ToString().c_str())));
+        }
+
+        return AZ::Success(it->second);
+    }
+
 } // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
@@ -58,6 +58,9 @@ namespace SimulationInterfaces
             const bool allowRename,
             PreInsertionCb preinsertionCb,
             SpawnCompletedCb completedCb) override;
+
+        void SpawnEntities(const AZStd::vector<SpawningEntity>& spawningEntities, BatchSpawnCompletedCb completedCb) override;
+
         AZ::Outcome<void, FailedResult> ResetAllEntitiesToInitialState() override;
         AZ::Outcome<AZStd::string, FailedResult> RegisterNewSimulatedBody(
             const AZStd::string& proposedName, const AZ::EntityId& entityId) override;
@@ -129,6 +132,21 @@ namespace SimulationInterfaces
             SpawnCompletedCb m_completedCb; //! User callback to be called when the entity is registered
             PreInsertionCb m_preInsertionCb; //! User callback to be called when entity prefab is added but inactive
         };
+
+        struct BatchSpawnContext
+        {
+            BatchSpawnResult m_result;
+            BatchSpawnCompletedCb m_completedCb;
+
+            ~BatchSpawnContext()
+            {
+                if (m_completedCb)
+                {
+                    m_completedCb(m_result);
+                }
+            }
+        };
+
         AZStd::unordered_map<AzFramework::EntitySpawnTicket::Id, SpawnCompletedCbData> m_spawnCompletedCallbacks;
     };
 

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.h
@@ -67,6 +67,7 @@ namespace SimulationInterfaces
         AZ::Outcome<Bounds, FailedResult> GetEntityBounds(const AZStd::string& name) override;
         AZ::Outcome<AZ::EntityId, FailedResult> GetEntityId(const AZStd::string& name) override;
         AZ::Outcome<AZ::EntityId, FailedResult> GetEntityRoot(const AZStd::string& name) override;
+        AZ::Outcome<AZStd::string, FailedResult> GetSimulatedBodyNameById(const AZ::EntityId& entityId) override;
 
         // helper methods to filter entities by different filters
         AZStd::vector<AZStd::string> FilterEntitiesByCategories(

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationManager.cpp
@@ -519,6 +519,7 @@ namespace SimulationInterfaces
             }
         }
         m_simulationState = stateToSet;
+        SimulationManagerNotificationsBus::Broadcast(&SimulationManagerNotifications::OnSimulationStateChange, m_simulationState);
         return AZ::Success();
     }
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "SetEntityStateServiceHandler.h"
+#include "SpawnServiceUtils.h"
 #include <ROS2/TF/TransformInterface.h>
 #include <ROS2/Utilities/ROS2Conversions.h>
 #include <SimulationInterfaces/RegistryUtils.h>
@@ -45,12 +46,24 @@ namespace ROS2SimulationInterfaces
                 return response;
             }
         }
+
+        const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(request.state.pose);
+        if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+        {
+            Response response;
+            response.result.result = simulation_interfaces::srv::SetEntityState::Response::INVALID_POSE;
+            response.result.error_message = poseValidation.GetError().c_str();
+            return response;
+        }
+
+        const AZ::Transform targetPose = transformOffset *
+            AZ::Transform::CreateFromQuaternionAndTranslation(requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+
         AZ::Outcome<void, SimulationInterfaces::FailedResult> outcome;
         AZStd::string entityName = request.entity.c_str();
 
         SimulationInterfaces::EntityState entityState;
-
-        entityState.m_pose = transformOffset * ROS2::ROS2Conversions::FromROS2Pose(request.state.pose);
+        entityState.m_pose = targetPose;
         entityState.m_twistAngular = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.angular));
         entityState.m_twistLinear = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.linear));
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "SpawnEntitiesServiceHandler.h"
+#include "SpawnServiceUtils.h"
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/TF/TransformInterface.h>
@@ -48,7 +49,7 @@ namespace ROS2SimulationInterfaces
             const AZStd::string_view messageFrameId{ spawnRequest.initial_pose.header.frame_id.c_str(),
                                                      spawnRequest.initial_pose.header.frame_id.size() };
 
-            if (!name.empty() && !ValidateEntityName(name))
+            if (!name.empty() && !SpawnServiceUtils::ValidateEntityName(name))
             {
                 spawnResult.result.result = simulation_interfaces::msg::SpawnResult::NAME_INVALID;
                 spawnResult.result.error_message =
@@ -57,7 +58,7 @@ namespace ROS2SimulationInterfaces
                 continue;
             }
 
-            if (!entityNamespace.empty() && !ValidateNamespaceName(entityNamespace))
+            if (!entityNamespace.empty() && !SpawnServiceUtils::ValidateNamespaceName(entityNamespace))
             {
                 spawnResult.result.result = simulation_interfaces::msg::SpawnResult::NAMESPACE_INVALID;
                 spawnResult.result.error_message =
@@ -86,11 +87,24 @@ namespace ROS2SimulationInterfaces
                 }
             }
 
+            const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(spawnRequest.initial_pose.pose);
+            if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+            {
+                spawnResult.result.result = simulation_interfaces::msg::SpawnResult::INVALID_POSE;
+                spawnResult.result.error_message = poseValidation.GetError().c_str();
+                hasFailures = true;
+                continue;
+            }
+
+            const AZ::Transform initialPose = transformOffset *
+                AZ::Transform::CreateFromQuaternionAndTranslation(
+                                                  requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+
             SimulationInterfaces::SpawningEntity spawningEntity;
             spawningEntity.name = AZStd::string(name);
             spawningEntity.uri = AZStd::string(uri);
             spawningEntity.entityNamespace = AZStd::string(entityNamespace);
-            spawningEntity.initialPose = transformOffset * ROS2::ROS2Conversions::FromROS2Pose(spawnRequest.initial_pose.pose);
+            spawningEntity.initialPose = initialPose;
             spawningEntity.allowRename = spawnRequest.allow_renaming;
             spawningEntity.preinsertionCb =
                 [](const AZ::Outcome<AzFramework::SpawnableEntityContainerView, SimulationInterfaces::FailedResult>&)
@@ -155,20 +169,6 @@ namespace ROS2SimulationInterfaces
             });
 
         return AZStd::nullopt;
-    }
-
-    bool SpawnEntitiesServiceHandler::ValidateEntityName(const AZStd::string& entityName)
-    {
-        const AZStd::regex entityRegex{ R"(^[a-zA-Z0-9_]+$)" }; // Entity names can only contain alphanumeric characters and underscores
-        return AZStd::regex_match(entityName, entityRegex);
-    }
-
-    bool SpawnEntitiesServiceHandler::ValidateNamespaceName(const AZStd::string& namespaceName)
-    {
-        const AZStd::regex namespaceRegex{
-            R"(^[a-zA-Z0-9_/]+$)"
-        }; // Namespace names can only contain alphanumeric characters and underscores and forward slashes
-        return AZStd::regex_match(namespaceName, namespaceRegex);
     }
 
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SpawnEntitiesServiceHandler.h"
+#include <AzFramework/Physics/ShapeConfiguration.h>
+#include <ROS2/ROS2Bus.h>
+#include <ROS2/TF/TransformInterface.h>
+#include <ROS2/Utilities/ROS2Conversions.h>
+#include <SimulationInterfaces/RegistryUtils.h>
+#include <SimulationInterfaces/SimulationEntityManagerRequestBus.h>
+
+namespace ROS2SimulationInterfaces
+{
+
+    AZStd::unordered_set<SimulationFeatureType> SpawnEntitiesServiceHandler::GetProvidedFeatures()
+    {
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::SPAWNING_ENTITIES };
+    }
+
+    AZStd::optional<SpawnEntitiesServiceHandler::Response> SpawnEntitiesServiceHandler::HandleServiceRequest(
+        const std::shared_ptr<rmw_request_id_t> header, const Request& request)
+    {
+        const builtin_interfaces::msg::Time zeroTime = builtin_interfaces::msg::Time();
+        const auto simulatorFrameId = RegistryUtilities::GetSimulatorROS2Frame();
+
+        Response response;
+        response.results.resize(request.spawn_requests.size());
+
+        AZStd::vector<SimulationInterfaces::SpawningEntity> spawningEntities;
+        spawningEntities.reserve(request.spawn_requests.size());
+        AZStd::vector<size_t> spawnedRequestsIndices;
+        spawnedRequestsIndices.reserve(request.spawn_requests.size());
+
+        bool hasFailures = false;
+        for (size_t requestIdx = 0; requestIdx < request.spawn_requests.size(); ++requestIdx)
+        {
+            const auto& spawnRequest = request.spawn_requests[requestIdx];
+            auto& spawnResult = response.results[requestIdx];
+
+            const AZStd::string_view name{ spawnRequest.name.c_str(), spawnRequest.name.size() };
+            const AZStd::string_view uri{ spawnRequest.entity_resource.uri.c_str(), spawnRequest.entity_resource.uri.size() };
+            const AZStd::string_view entityNamespace{ spawnRequest.entity_namespace.c_str(), spawnRequest.entity_namespace.size() };
+            const AZStd::string_view messageFrameId{ spawnRequest.initial_pose.header.frame_id.c_str(),
+                                                     spawnRequest.initial_pose.header.frame_id.size() };
+
+            if (!name.empty() && !ValidateEntityName(name))
+            {
+                spawnResult.result.result = simulation_interfaces::msg::SpawnResult::NAME_INVALID;
+                spawnResult.result.error_message =
+                    "Invalid entity name. Entity names can only contain alphanumeric characters and underscores.";
+                hasFailures = true;
+                continue;
+            }
+
+            if (!entityNamespace.empty() && !ValidateNamespaceName(entityNamespace))
+            {
+                spawnResult.result.result = simulation_interfaces::msg::SpawnResult::NAMESPACE_INVALID;
+                spawnResult.result.error_message =
+                    "Invalid entity namespace. Entity namespaces can only contain alphanumeric characters and forward slashes.";
+                hasFailures = true;
+                continue;
+            }
+
+            AZ::Transform transformOffset = AZ::Transform::CreateIdentity();
+            if (!messageFrameId.empty() && simulatorFrameId != messageFrameId)
+            {
+                auto transformInterface = ROS2::TFInterface::Get();
+                AZ_Assert(transformInterface, "TFInterface is not available, cannot set entity state without transform offset.");
+                const auto transformOutcome = transformInterface->GetTransform(simulatorFrameId, messageFrameId, zeroTime);
+
+                if (transformOutcome.IsSuccess())
+                {
+                    transformOffset = transformOutcome.GetValue();
+                }
+                else
+                {
+                    spawnResult.result.result = simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED;
+                    spawnResult.result.error_message = transformOutcome.GetError().c_str();
+                    hasFailures = true;
+                    continue;
+                }
+            }
+
+            SimulationInterfaces::SpawningEntity spawningEntity;
+            spawningEntity.name = AZStd::string(name);
+            spawningEntity.uri = AZStd::string(uri);
+            spawningEntity.entityNamespace = AZStd::string(entityNamespace);
+            spawningEntity.initialPose = transformOffset * ROS2::ROS2Conversions::FromROS2Pose(spawnRequest.initial_pose.pose);
+            spawningEntity.allowRename = spawnRequest.allow_renaming;
+            spawningEntity.preinsertionCb =
+                [](const AZ::Outcome<AzFramework::SpawnableEntityContainerView, SimulationInterfaces::FailedResult>&)
+            {
+            };
+            spawningEntity.completedCb = [](const AZ::Outcome<AZStd::string, SimulationInterfaces::FailedResult>&)
+            {
+            };
+
+            spawningEntities.push_back(AZStd::move(spawningEntity));
+            spawnedRequestsIndices.push_back(requestIdx);
+        }
+
+        if (spawningEntities.empty())
+        {
+            response.result.result = hasFailures ? simulation_interfaces::srv::SpawnEntities::Response::ENTITIES_SPAWN_FAILED
+                                                 : simulation_interfaces::msg::Result::RESULT_OK;
+            if (hasFailures)
+            {
+                response.result.error_message = "One or more entity spawn requests failed.";
+            }
+            SendResponse(response);
+            return AZStd::nullopt;
+        }
+
+        SimulationInterfaces::SimulationEntityManagerRequestBus::Broadcast(
+            &SimulationInterfaces::SimulationEntityManagerRequests::SpawnEntities,
+            spawningEntities,
+            [this, response, spawnedRequestsIndices, hasFailures](const SimulationInterfaces::BatchSpawnResult& batchResult) mutable
+            {
+                bool hasBatchFailures = hasFailures;
+
+                for (size_t spawnedIdx = 0; spawnedIdx < batchResult.m_spawnResults.size() && spawnedIdx < spawnedRequestsIndices.size();
+                     ++spawnedIdx)
+                {
+                    const size_t requestIdx = spawnedRequestsIndices[spawnedIdx];
+                    auto& spawnResult = response.results[requestIdx];
+                    const auto& outcome = batchResult.m_spawnResults[spawnedIdx];
+
+                    if (outcome.IsSuccess())
+                    {
+                        spawnResult.result.result = simulation_interfaces::msg::Result::RESULT_OK;
+                        spawnResult.entity_name = outcome.GetValue().c_str();
+                    }
+                    else
+                    {
+                        const auto& failedResult = outcome.GetError();
+                        spawnResult.result.result = failedResult.m_errorCode;
+                        spawnResult.result.error_message = failedResult.m_errorString.c_str();
+                        hasBatchFailures = true;
+                    }
+                }
+
+                response.result.result = hasBatchFailures ? simulation_interfaces::srv::SpawnEntities::Response::ENTITIES_SPAWN_FAILED
+                                                          : simulation_interfaces::msg::Result::RESULT_OK;
+                if (hasBatchFailures)
+                {
+                    response.result.error_message = "One or more entity spawn requests failed.";
+                }
+
+                SendResponse(response);
+            });
+
+        return AZStd::nullopt;
+    }
+
+    bool SpawnEntitiesServiceHandler::ValidateEntityName(const AZStd::string& entityName)
+    {
+        const AZStd::regex entityRegex{ R"(^[a-zA-Z0-9_]+$)" }; // Entity names can only contain alphanumeric characters and underscores
+        return AZStd::regex_match(entityName, entityRegex);
+    }
+
+    bool SpawnEntitiesServiceHandler::ValidateNamespaceName(const AZStd::string& namespaceName)
+    {
+        const AZStd::regex namespaceRegex{
+            R"(^[a-zA-Z0-9_/]+$)"
+        }; // Namespace names can only contain alphanumeric characters and underscores and forward slashes
+        return AZStd::regex_match(namespaceName, namespaceRegex);
+    }
+
+} // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/string/regex.h>
+#include <AzCore/std/string/string_view.h>
+#include <Interfaces/ISimulationFeaturesBase.h>
+#include <ROS2/Handlers/ROS2ServiceBase.h>
+#include <simulation_interfaces/srv/spawn_entities.hpp>
+
+namespace ROS2SimulationInterfaces
+{
+    class SpawnEntitiesServiceHandler
+        : public ROS2::ROS2ServiceBase<simulation_interfaces::srv::SpawnEntities>
+        , public ISimulationFeaturesBase
+    {
+    public:
+        AZStd::string_view GetTypeName() const override
+        {
+            return "SpawnEntities";
+        }
+
+        AZStd::string_view GetDefaultName() const override
+        {
+            return "spawn_entities";
+        }
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
+
+        AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
+
+    private:
+        bool ValidateEntityName(const AZStd::string& entityName);
+        bool ValidateNamespaceName(const AZStd::string& namespaceName);
+    };
+
+} // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <AzCore/std/string/regex.h>
 #include <AzCore/std/string/string_view.h>
 #include <Interfaces/ISimulationFeaturesBase.h>
 #include <ROS2/Handlers/ROS2ServiceBase.h>
@@ -33,10 +32,6 @@ namespace ROS2SimulationInterfaces
         AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
-
-    private:
-        bool ValidateEntityName(const AZStd::string& entityName);
-        bool ValidateNamespaceName(const AZStd::string& namespaceName);
     };
 
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "SpawnEntityServiceHandler.h"
+#include "SpawnServiceUtils.h"
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/TF/TransformInterface.h>
@@ -33,7 +34,7 @@ namespace ROS2SimulationInterfaces
         const builtin_interfaces::msg::Time zeroTime = builtin_interfaces::msg::Time();
 
         // Validate entity name
-        if (!name.empty() && !ValidateEntityName(name))
+        if (!name.empty() && !SpawnServiceUtils::ValidateEntityName(name))
         {
             Response response;
             response.result.result = simulation_interfaces::srv::SpawnEntity::Response::NAME_INVALID;
@@ -43,7 +44,7 @@ namespace ROS2SimulationInterfaces
         }
 
         // Validate namespace name
-        if (!entityNamespace.empty() && !ValidateNamespaceName(entityNamespace))
+        if (!entityNamespace.empty() && !SpawnServiceUtils::ValidateNamespaceName(entityNamespace))
         {
             Response response;
             response.result.result = simulation_interfaces::srv::SpawnEntity::Response::NAMESPACE_INVALID;
@@ -71,11 +72,24 @@ namespace ROS2SimulationInterfaces
                 Response response;
                 response.result.result = simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED;
                 response.result.error_message = transformOutcome.GetError().c_str();
-                return response;
+                SendResponse(response);
+                return AZStd::nullopt;
             }
         }
 
-        const AZ::Transform initialPose = transformOffset * ROS2::ROS2Conversions::FromROS2Pose(request.initial_pose.pose);
+        const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(request.initial_pose.pose);
+        if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+        {
+            Response response;
+            response.result.result = simulation_interfaces::srv::SpawnEntity::Response::INVALID_POSE;
+            response.result.error_message = poseValidation.GetError().c_str();
+            SendResponse(response);
+            return AZStd::nullopt;
+        }
+
+        const AZ::Transform initialPose = transformOffset *
+            AZ::Transform::CreateFromQuaternionAndTranslation(requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+
         SimulationInterfaces::PreInsertionCb preinsertionCB =
             [this](const AZ::Outcome<AzFramework::SpawnableEntityContainerView, SimulationInterfaces::FailedResult>& outcome)
         {
@@ -114,20 +128,6 @@ namespace ROS2SimulationInterfaces
                 SendResponse(response);
             });
         return AZStd::nullopt;
-    }
-
-    bool SpawnEntityServiceHandler::ValidateEntityName(const AZStd::string& entityName)
-    {
-        const AZStd::regex entityRegex{ R"(^[a-zA-Z0-9_]+$)" }; // Entity names can only contain alphanumeric characters and underscores
-        return AZStd::regex_match(entityName, entityRegex);
-    }
-
-    bool SpawnEntityServiceHandler::ValidateNamespaceName(const AZStd::string& namespaceName)
-    {
-        const AZStd::regex namespaceRegex{
-            R"(^[a-zA-Z0-9_/]+$)"
-        }; // Namespace names can only contain alphanumeric characters and underscores and forward slashes
-        return AZStd::regex_match(namespaceName, namespaceRegex);
     }
 
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <AzCore/std/string/regex.h>
 #include <AzCore/std/string/string_view.h>
 #include <Interfaces/ISimulationFeaturesBase.h>
 #include <ROS2/Handlers/ROS2ServiceBase.h>
@@ -33,10 +32,6 @@ namespace ROS2SimulationInterfaces
         AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
-
-    private:
-        bool ValidateEntityName(const AZStd::string& entityName);
-        bool ValidateNamespaceName(const AZStd::string& namespaceName);
     };
 
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SpawnServiceUtils.h"
+#include <AzCore/std/string/regex.h>
+#include <AzCore/std/string/string.h>
+
+namespace ROS2SimulationInterfaces::SpawnServiceUtils
+{
+    bool ValidateEntityName(AZStd::string_view entityName)
+    {
+        static const AZStd::regex entityRegex{
+            R"(^[a-zA-Z0-9_]+$)"
+        }; // Entity names can only contain alphanumeric characters and underscores
+        return AZStd::regex_match(entityName.begin(), entityName.end(), entityRegex);
+    }
+
+    bool ValidateNamespaceName(AZStd::string_view namespaceName)
+    {
+        static const AZStd::regex namespaceRegex{
+            R"(^[a-zA-Z0-9_/]+$)"
+        }; // Namespace names can only contain alphanumeric characters and forward slashes
+        return AZStd::regex_match(namespaceName.begin(), namespaceName.end(), namespaceRegex);
+    }
+
+    AZ::Outcome<void, AZStd::string> ValidateTransformNormalized(
+        const AZ::Transform& transform, float quaternionTolerance, float maxTranslation)
+    {
+        // Check rotation quaternion is normalised.
+        const float quaternionLength = transform.GetRotation().GetLength();
+        if (!AZ::IsClose(quaternionLength, 1.0f, quaternionTolerance))
+        {
+            return AZ::Failure<AZStd::string>("Invalid pose orientation quaternion: length is not close to 1.0.");
+        }
+
+        // Check translation components are finite and within range.
+        const AZ::Vector3 translation = transform.GetTranslation();
+        if (!translation.IsFinite())
+        {
+            return AZ::Failure<AZStd::string>("Invalid pose translation: one or more components are NaN or infinite.");
+        }
+        const float absMax = translation.GetAbs().GetMaxElement();
+        if (absMax > maxTranslation)
+        {
+            return AZ::Failure<AZStd::string>("Invalid pose translation: exceeds the maximum allowed.");
+        }
+
+        return AZ::Success();
+    }
+} // namespace ROS2SimulationInterfaces::SpawnServiceUtils

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Math/Transform.h>
+#include <AzCore/Outcome/Outcome.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/string/string_view.h>
+
+namespace ROS2SimulationInterfaces::SpawnServiceUtils
+{
+    bool ValidateEntityName(AZStd::string_view entityName);
+    bool ValidateNamespaceName(AZStd::string_view namespaceName);
+
+    //! Validates that the transform has a normalised rotation quaternion and a finite, in-range translation.
+    //! @param transform     Transform to validate.
+    //! @param quaternionTolerance  Tolerance on |quaternion| - 1.0f. Defaults to 1e-3f.
+    //! @param maxTranslation Maximum allowed absolute value per axis in metres. Defaults to 1e7f (~10 000 km).
+    //! @return Success when valid, Failure with a descriptive error message when not.
+    AZ::Outcome<void, AZStd::string> ValidateTransformNormalized(
+        const AZ::Transform& transform, float quaternionTolerance = 1e-3f, float maxTranslation = 1e7f);
+} // namespace ROS2SimulationInterfaces::SpawnServiceUtils

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/Mocks/SimulationEntityManagerMock.h
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/Mocks/SimulationEntityManagerMock.h
@@ -26,6 +26,7 @@ namespace UnitTest
         MOCK_METHOD1(DeleteAllEntities, void(DeletionCompletedCb completedCb));
         MOCK_METHOD0(GetSpawnables, AZ::Outcome<SpawnableList, FailedResult>());
         MOCK_METHOD0(ResetAllEntitiesToInitialState, AZ::Outcome<void, FailedResult>());
+        MOCK_METHOD2(SpawnEntities, void(const AZStd::vector<SpawningEntity>& spawningEntities, BatchSpawnCompletedCb completedCb));
         MOCK_METHOD7(
             SpawnEntity,
             void(

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/Mocks/SimulationEntityManagerMock.h
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/Mocks/SimulationEntityManagerMock.h
@@ -45,5 +45,6 @@ namespace UnitTest
         MOCK_METHOD1(GetEntityBounds, AZ::Outcome<Bounds, FailedResult>(const AZStd::string& name));
         MOCK_METHOD1(GetEntityId, AZ::Outcome<AZ::EntityId, FailedResult>(const AZStd::string& name));
         MOCK_METHOD1(GetEntityRoot, AZ::Outcome<AZ::EntityId, FailedResult>(const AZStd::string& name));
+        MOCK_METHOD1(GetSimulatedBodyNameById, AZ::Outcome<AZStd::string, FailedResult>(const AZ::EntityId& entityId));
     };
 } // namespace UnitTest

--- a/Gems/SimulationInterfaces/Code/simulationinterfaces_api_files.cmake
+++ b/Gems/SimulationInterfaces/Code/simulationinterfaces_api_files.cmake
@@ -19,4 +19,5 @@ set(FILES
     Include/SimulationInterfaces/LevelManagerRequestBus.h
     Include/SimulationInterfaces/ROS2SimulationInterfacesTypeIds.h
     Include/SimulationInterfaces/ROS2SimulationInterfacesRequestBus.h
+    Include/SimulationInterfaces/PathUtils.h
 )

--- a/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
+++ b/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
@@ -46,6 +46,8 @@ set(FILES
     Source/Services/GetEntityBoundsServiceHandler.h
     Source/Services/GetSpawnablesServiceHandler.cpp
     Source/Services/GetSpawnablesServiceHandler.h
+    Source/Services/SpawnServiceUtils.cpp
+    Source/Services/SpawnServiceUtils.h
     Source/Services/SpawnEntitiesServiceHandler.cpp
     Source/Services/SpawnEntitiesServiceHandler.h
     Source/Services/SpawnEntityServiceHandler.cpp

--- a/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
+++ b/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
@@ -46,6 +46,8 @@ set(FILES
     Source/Services/GetEntityBoundsServiceHandler.h
     Source/Services/GetSpawnablesServiceHandler.cpp
     Source/Services/GetSpawnablesServiceHandler.h
+    Source/Services/SpawnEntitiesServiceHandler.cpp
+    Source/Services/SpawnEntitiesServiceHandler.h
     Source/Services/SpawnEntityServiceHandler.cpp
     Source/Services/SpawnEntityServiceHandler.h
     Source/Services/ResetSimulationServiceHandler.cpp

--- a/Gems/SimulationInterfaces/Registry/simulationinterface_settings.setreg
+++ b/Gems/SimulationInterfaces/Registry/simulationinterface_settings.setreg
@@ -3,8 +3,7 @@
         "SimulatorFrame": "world",
         "PrintStateNameInGui": true,
         "StartInStoppedState": true,
-        "KeyboardTransitions":
-        {
+        "KeyboardTransitions": {
             "StoppedToPlaying": "keyboard_key_alphanumeric_R",
             "PausedToPlaying": "keyboard_key_alphanumeric_R",
             "PlayingToPaused": "keyboard_key_alphanumeric_P"

--- a/Gems/SimulationInterfaces/gem.json
+++ b/Gems/SimulationInterfaces/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "SimulationInterfaces",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "display_name": "SimulationInterfaces",
     "license": "Apache-2.0 ",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -30,5 +30,5 @@
     "engine_api_dependencies": [],
     "restricted": "SimulationInterfaces",
     "repo_uri": "https://raw.githubusercontent.com/o3de/o3de-extras/development",
-    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/simulationinterfaces-2.0.1-gem.zip"
+    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/simulationinterfaces-2.0.2-gem.zip"
 }

--- a/repo.json
+++ b/repo.json
@@ -373,6 +373,30 @@
                     "engine_api_dependencies": [],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.5.0-gem.zip",
                     "sha256": "1142a78256af12bbc1b49de0ff1aab7b9251b99ee913ea47fa2c23ae6a476512"
+                },
+                {
+                    "version": "3.5.1",
+                    "origin_url": "https://robotec.ai",
+                    "source_control_uri": "https://github.com/o3de/o3de-extras/development/Gems/ROS2",
+                    "requirements": "Requires ROS 2 installation (supported distributions: Humble, Jazzy). Source your workspace before building the Gem",
+                    "documentation_url": "https://docs.o3de.org/docs/user-guide/gems/reference/robotics/ros2/",
+                    "dependencies": [
+                        "Atom_RPI",
+                        "Atom_Feature_Common",
+                        "Atom_Component_DebugCamera",
+                        "CommonFeaturesAtom",
+                        "PhysX5",
+                        "PrimitiveAssets",
+                        "StartingPointInput",
+                        "LevelGeoreferencing"
+                    ],
+                    "compatible_engines": [
+                        "o3de-sdk>=2.4.0",
+                        "o3de>=2.4.0"
+                    ],
+                    "engine_api_dependencies": [],
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/ros2-3.5.1-gem.zip",
+                    "sha256": "de9b58f9f50ca7fcaa60c8e8734131bd21ff390cc8cb40f660f0d358860fd6a9"
                 }
             ]
         },
@@ -820,6 +844,15 @@
                     ],
                     "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/simulationinterfaces-2.0.1-gem.zip",
                     "sha256": "e1c6a8b0d34b50886b2cb0a11523941d879ec0ed7582785bd7ec229ceba4a17d"
+                },
+                {
+                    "version": "2.0.2",
+                    "dependencies": [
+                        "ROS2>=3.5.0",
+                        "DebugDraw"
+                    ],
+                    "download_source_uri": "https://github.com/o3de/o3de-extras/releases/download/2.0/simulationinterfaces-2.0.2-gem.zip",
+                    "sha256": "09456bcc95787d3ab54c662c2819555e876ad62877f04d9e6f9d0f045c0bb019"
                 }
             ]
         }


### PR DESCRIPTION
## What does this PR do?

This PR cherry-picks recent changes from the `development` branch to `backports/25051` to prepare another release of O3DE Gems for engine 2505.1. It might be considered as o3de-extras 2505.4 (there were two other releases of the backports).

In particular, all recent changes from `SimulationInterfaces` Gem are ported back, hence all features that will be present in `SimulationInterfaces` Gem in 2605.0 but #1044 will be available for engine 2505.1. Additionally, a small fix to ROS 2 subscriber handler was ported to `ROS2` Gem (namely #1027).

The full list of cherry-picked commits:
- #1040
- #1039
- #1033
- #1031
- #1032
- #1029
- #1030
- #1028
- #1020
- #1027

On top of the changes, the versions of both Gems were updated:
- `ROS2`: 3.5.0 -> 3.5.1 (bugfix)
- `SimulationInterfaces`: 2.0.1 -> 2.0.2 (should be minor due to the new features, but 2.1.0 is already taken by 2510.0 release)

Both Gems were released and uploaded, the `repo.json` file was updated.

Marking this PR as a draft to ensure it is not merged before the release.

## How was this PR tested?

- self-code review of all changes
- running o3de and testing modified functionalities
- pulling the released Gems to verify the hashes
