### PR TITLE
Cherry-picks development -> stabilization/2605, part 2

### DIFF
--- a/Gems/ROS2SampleRobots/Assets/PandaRobot/PandaRobot.prefab
+++ b/Gems/ROS2SampleRobots/Assets/PandaRobot/PandaRobot.prefab
@@ -179,7 +179,8 @@
                             "ForceLimit": 1000.0,
                             "Stiffness": 5000.0,
                             "Damping": 200.0
-                        }
+                        },
+                        "Offset": 90.0
                     }
                 },
                 "EditorDisabledCompositionComponent": {
@@ -595,7 +596,8 @@
                             "ForceLimit": 1000.0,
                             "Stiffness": 5000.0,
                             "Damping": 200.0
-                        }
+                        },
+                        "Offset": -135.0
                     }
                 },
                 "EditorDisabledCompositionComponent": {
@@ -839,7 +841,8 @@
                             "ForceLimit": 1000.0,
                             "Stiffness": 5000.0,
                             "Damping": 200.0
-                        }
+                        },
+                        "Offset": 45.0
                     }
                 },
                 "EditorDisabledCompositionComponent": {
@@ -1306,7 +1309,8 @@
                             "ForceLimit": 1000.0,
                             "Stiffness": 5000.0,
                             "Damping": 100.0
-                        }
+                        },
+                        "Offset": -44.0
                     }
                 },
                 "EditorDisabledCompositionComponent": {
@@ -1906,45 +1910,7 @@
                                 "Reliability": 1
                             }
                         }
-                    },
-                    "Initial positions": [
-                        [
-                            "panda_joint1",
-                            {}
-                        ],
-                        [
-                            "panda_joint2",
-                            -0.7850000262260437
-                        ],
-                        [
-                            "panda_joint3",
-                            {}
-                        ],
-                        [
-                            "panda_joint4",
-                            -2.3559999465942383
-                        ],
-                        [
-                            "panda_joint5",
-                            {}
-                        ],
-                        [
-                            "panda_joint6",
-                            1.5709999799728394
-                        ],
-                        [
-                            "panda_joint7",
-                            0.7850000262260437
-                        ],
-                        [
-                            "panda_finger_joint1",
-                            0.03999999910593033
-                        ],
-                        [
-                            "panda_finger_joint2",
-                            0.03999999910593033
-                        ]
-                    ]
+                    }
                 },
                 "JointsTrajectoryComponent": {
                     "$type": "GenericComponentWrapper",
@@ -2342,7 +2308,8 @@
                             "ForceLimit": 1000.0,
                             "Stiffness": 1000.0,
                             "Damping": 10.0
-                        }
+                        },
+                        "Offset": 0.03999999910593033
                     }
                 },
                 "EditorDisabledCompositionComponent": {
@@ -2466,7 +2433,8 @@
                             "ForceLimit": 1000.0,
                             "Stiffness": 1000.0,
                             "Damping": 10.0
-                        }
+                        },
+                        "Offset": 0.03999999910593033
                     }
                 },
                 "EditorDisabledCompositionComponent": {

--- a/Gems/SimulationInterfaces/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfaces/Code/CMakeLists.txt
@@ -22,6 +22,21 @@ if(NOT PAL_TRAIT_SIMULATIONINTERFACES_SUPPORTED)
     return()
 endif()
 
+# Detect simulation_interfaces API generation.
+# Version >= 2.0.0 introduced breaking API changes (e.g. entity_resource wrapper, set_pose/set_twist flags).
+# Version >= 1.4.0 is the minimum supported API.
+# Calling find_package directly here (not inside a helper function) so that
+# simulation_interfaces_VERSION is available in this scope for the version check below.
+find_package(simulation_interfaces REQUIRED)
+if(simulation_interfaces_VERSION VERSION_GREATER_EQUAL "2.0.0")
+    set(SIMULATION_INTERFACES_MAJOR_API_VERSION 2)
+elseif(simulation_interfaces_VERSION VERSION_GREATER_EQUAL "1.4.0")
+    set(SIMULATION_INTERFACES_MAJOR_API_VERSION 1)
+else()
+    message(FATAL_ERROR "simulation_interfaces version ${simulation_interfaces_VERSION} is not supported. Minimum required: 1.4.0")
+endif()
+message(STATUS "simulation_interfaces ${simulation_interfaces_VERSION} -> SIMULATION_INTERFACES_MAJOR_API_VERSION=${SIMULATION_INTERFACES_MAJOR_API_VERSION}")
+
 # The ${gem_name}.API target declares the common interface that users of this gem should depend on in their targets
 ly_add_target(
     NAME ${gem_name}.API INTERFACE
@@ -37,7 +52,7 @@ ly_add_target(
            AZ::AzCore
 )
 
-target_interface_depends_on_ros2_package(${gem_name}.API simulation_interfaces 1.4.0 REQUIRED)
+target_interface_depends_on_ros2_package(${gem_name}.API simulation_interfaces REQUIRED)
 
 # The ${gem_name}.Private.Object target is an internal target
 # It should not be used outside of this Gems CMakeLists.txt
@@ -63,7 +78,9 @@ ly_add_target(
             Gem::DebugDraw.API
 )
 target_depends_on_ros2_packages(${gem_name}.Private.Object rclcpp std_msgs geometry_msgs rclcpp_action tf2_ros)
-target_depends_on_ros2_package(${gem_name}.Private.Object simulation_interfaces 1.4.0 REQUIRED)
+target_depends_on_ros2_package(${gem_name}.Private.Object simulation_interfaces REQUIRED)
+target_compile_definitions(${gem_name}.Private.Object PUBLIC
+    SIMULATION_INTERFACES_MAJOR_API_VERSION=${SIMULATION_INTERFACES_MAJOR_API_VERSION})
 
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface
 ly_add_target(

--- a/Gems/SimulationInterfaces/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfaces/Code/CMakeLists.txt
@@ -37,7 +37,7 @@ ly_add_target(
            AZ::AzCore
 )
 
-target_interface_depends_on_ros2_package(${gem_name}.API simulation_interfaces 1.1.0 REQUIRED)
+target_interface_depends_on_ros2_package(${gem_name}.API simulation_interfaces 1.4.0 REQUIRED)
 
 # The ${gem_name}.Private.Object target is an internal target
 # It should not be used outside of this Gems CMakeLists.txt
@@ -63,7 +63,7 @@ ly_add_target(
             Gem::DebugDraw.API
 )
 target_depends_on_ros2_packages(${gem_name}.Private.Object rclcpp std_msgs geometry_msgs rclcpp_action tf2_ros)
-target_depends_on_ros2_package(${gem_name}.Private.Object simulation_interfaces 1.1.0 REQUIRED)
+target_depends_on_ros2_package(${gem_name}.Private.Object simulation_interfaces 1.4.0 REQUIRED)
 
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface
 ly_add_target(

--- a/Gems/SimulationInterfaces/Code/Source/Clients/ROS2SimulationInterfacesSystemComponent.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/ROS2SimulationInterfacesSystemComponent.cpp
@@ -37,6 +37,7 @@
 #include <Services/SetEntityInfoServiceHandler.h>
 #include <Services/SetEntityStateServiceHandler.h>
 #include <Services/SetSimulationStateServiceHandler.h>
+#include <Services/SpawnEntitiesServiceHandler.h>
 #include <Services/SpawnEntityServiceHandler.h>
 #include <Services/StepSimulationServiceHandler.h>
 #include <Services/UnloadWorldServiceHandler.h>
@@ -93,6 +94,7 @@ namespace ROS2SimulationInterfaces
         RegisterInterface<GetSpawnablesServiceHandler>(ros2Node);
         RegisterInterface<SetEntityStateServiceHandler>(ros2Node);
         RegisterInterface<SpawnEntityServiceHandler>(ros2Node);
+        RegisterInterface<SpawnEntitiesServiceHandler>(ros2Node);
         RegisterInterface<GetSimulatorFeaturesServiceHandler>(ros2Node);
         RegisterInterface<ResetSimulationServiceHandler>(ros2Node);
         RegisterInterface<SimulateStepsActionServerHandler>(ros2Node);

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -207,7 +207,8 @@ namespace SimulationInterfaces
                 simulation_interfaces::msg::SimulatorFeatures::ENTITY_BOUNDS,
                 simulation_interfaces::msg::SimulatorFeatures::DELETING,
                 simulation_interfaces::msg::SimulatorFeatures::SPAWNABLES,
-                simulation_interfaces::msg::SimulatorFeatures::SPAWNING });
+                simulation_interfaces::msg::SimulatorFeatures::SPAWNING,
+                simulation_interfaces::msg::SimulatorFeatures::SPAWNING_ENTITIES });
     }
 
     void SimulationEntitiesManager::Deactivate()
@@ -889,9 +890,8 @@ namespace SimulationInterfaces
                 }
                 else
                 {
-                    spawnData->second.m_completedCb(
-                        AZ::Failure(FailedResult(
-                            simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, "Failed to spawn/or register simulation entity")));
+                    spawnData->second.m_completedCb(AZ::Failure(FailedResult(
+                        simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, "Failed to spawn/or register simulation entity")));
                 }
                 m_spawnCompletedCallbacks.erase(spawnData);
             }
@@ -1027,10 +1027,9 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToEntityIdMap.contains(name))
         {
-            return AZ::Failure(
-                SimulationInterfaces::FailedResult(
-                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                    AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
+            return AZ::Failure(SimulationInterfaces::FailedResult(
+                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
         }
         // check if entity with given name has entity info assigned, clear it if needed
         RemoveEntityInfoIfNeeded(name);
@@ -1051,10 +1050,9 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToEntityIdMap.contains(name))
         {
-            return AZ::Failure(
-                SimulationInterfaces::FailedResult(
-                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                    AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
+            return AZ::Failure(SimulationInterfaces::FailedResult(
+                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
         }
 
         auto findIt = m_nameToEntityInfo.find(name);
@@ -1084,10 +1082,9 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToEntityIdMap.contains(name))
         {
-            return AZ::Failure(
-                SimulationInterfaces::FailedResult(
-                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                    AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
+            return AZ::Failure(SimulationInterfaces::FailedResult(
+                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
         }
         auto simulatedBodyOutcome = Utils::GetSimulatedBody(m_simulatedEntityToEntityIdMap.at(name));
         if (!simulatedBodyOutcome.IsSuccess())
@@ -1122,10 +1119,9 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToEntityIdMap.contains(name))
         {
-            return AZ::Failure(
-                SimulationInterfaces::FailedResult(
-                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                    AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
+            return AZ::Failure(SimulationInterfaces::FailedResult(
+                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                AZStd::string::format("Entity with given name \"%s\" doesn't exists", name.c_str())));
         }
         return AZ::Success(m_simulatedEntityToEntityIdMap.at(name));
     }
@@ -1134,11 +1130,9 @@ namespace SimulationInterfaces
     {
         if (!m_simulatedEntityToPrefabRoot.contains(name))
         {
-            return AZ::Failure(
-                SimulationInterfaces::FailedResult(
-                    simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
-                    AZStd::string::format(
-                        "Entity with given name \"%s\" doesn't exists in available cache of prefab roots", name.c_str())));
+            return AZ::Failure(SimulationInterfaces::FailedResult(
+                simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED,
+                AZStd::string::format("Entity with given name \"%s\" doesn't exists in available cache of prefab roots", name.c_str())));
         }
         return AZ::Success(m_simulatedEntityToPrefabRoot.at(name));
     }

--- a/Gems/SimulationInterfaces/Code/Source/Services/GetSpawnablesServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/GetSpawnablesServiceHandler.cpp
@@ -36,7 +36,11 @@ namespace ROS2SimulationInterfaces
         auto convertToROS2 = [](const SimulationInterfaces::Spawnable& spawnable)
         {
             simulation_interfaces::msg::Spawnable simSpawnable;
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
+            simSpawnable.entity_resource.uri = spawnable.m_uri.c_str();
+#else
             simSpawnable.uri = spawnable.m_uri.c_str();
+#endif
             simSpawnable.description = spawnable.m_description.c_str();
             return simSpawnable;
         };

--- a/Gems/SimulationInterfaces/Code/Source/Services/LoadWorldServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/LoadWorldServiceHandler.cpp
@@ -21,8 +21,13 @@ namespace ROS2SimulationInterfaces
             SimulationInterfaces::LoadWorldRequest request;
             request.failOnUnsupportedElement = ros2Request.fail_on_unsupported_element;
             request.ignoreMissingOrUnsupportedAssets = ros2Request.ignore_missing_or_unsupported_assets;
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
+            request.levelResource.m_uri = ros2Request.world_resource.uri.c_str();
+            request.levelResource.m_resourceString = ros2Request.world_resource.resource_string.c_str();
+#else
             request.levelResource.m_uri = ros2Request.uri.c_str();
             request.levelResource.m_resourceString = ros2Request.resource_string.c_str();
+#endif
             return request;
         }
     } // namespace

--- a/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "SetEntityStateServiceHandler.h"
+#include "SpawnServiceUtils.h"
 #include <ROS2/TF/TransformInterface.h>
 #include <ROS2/Utilities/ROS2Conversions.h>
 #include <SimulationInterfaces/RegistryUtils.h>
@@ -45,12 +46,24 @@ namespace ROS2SimulationInterfaces
                 return response;
             }
         }
+
+        const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(request.state.pose);
+        if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+        {
+            Response response;
+            response.result.result = simulation_interfaces::srv::SetEntityState::Response::INVALID_POSE;
+            response.result.error_message = poseValidation.GetError().c_str();
+            return response;
+        }
+
+        const AZ::Transform targetPose = transformOffset *
+            AZ::Transform::CreateFromQuaternionAndTranslation(requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+
         AZ::Outcome<void, SimulationInterfaces::FailedResult> outcome;
         AZStd::string entityName = request.entity.c_str();
 
         SimulationInterfaces::EntityState entityState;
-
-        entityState.m_pose = transformOffset * ROS2::ROS2Conversions::FromROS2Pose(request.state.pose);
+        entityState.m_pose = targetPose;
         entityState.m_twistAngular = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.angular));
         entityState.m_twistLinear = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.linear));
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
@@ -24,10 +24,17 @@ namespace ROS2SimulationInterfaces
     AZStd::optional<SetEntityStateServiceHandler::Response> SetEntityStateServiceHandler::HandleServiceRequest(
         const std::shared_ptr<rmw_request_id_t> header, const Request& request)
     {
+        const AZStd::string entityName = request.entity.c_str();
         const auto simulatorFrameId = RegistryUtilities::GetSimulatorROS2Frame();
         const AZStd::string_view messageFrameId{ request.state.header.frame_id.c_str(), request.state.header.frame_id.length() };
+
+        // Resolve frame transform offset once (needed for both pose and twist)
         AZ::Transform transformOffset = AZ::Transform::CreateIdentity();
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
+        if ((request.set_pose || request.set_twist) && !messageFrameId.empty() && simulatorFrameId != messageFrameId)
+#else
         if (!messageFrameId.empty() && simulatorFrameId != messageFrameId)
+#endif
         {
             const builtin_interfaces::msg::Time time = request.state.header.stamp;
             auto transformInterface = ROS2::TFInterface::Get();
@@ -47,6 +54,39 @@ namespace ROS2SimulationInterfaces
             }
         }
 
+        SimulationInterfaces::EntityState entityState;
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
+        // Fetch current state so unflagged fields are preserved
+        {
+            AZ::Outcome<SimulationInterfaces::EntityState, SimulationInterfaces::FailedResult> currentState;
+            SimulationInterfaces::SimulationEntityManagerRequestBus::BroadcastResult(
+                currentState, &SimulationInterfaces::SimulationEntityManagerRequests::GetEntityState, entityName);
+            if (currentState.IsSuccess())
+            {
+                entityState = currentState.GetValue();
+            }
+        }
+
+        if (request.set_pose)
+        {
+            const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(request.state.pose);
+            if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+            {
+                Response response;
+                response.result.result = simulation_interfaces::srv::SetEntityState::Response::INVALID_POSE;
+                response.result.error_message = poseValidation.GetError().c_str();
+                return response;
+            }
+            entityState.m_pose = transformOffset *
+                AZ::Transform::CreateFromQuaternionAndTranslation(requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+        }
+
+        if (request.set_twist)
+        {
+            entityState.m_twistAngular = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.angular));
+            entityState.m_twistLinear = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.linear));
+        }
+#else
         const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(request.state.pose);
         if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
         {
@@ -55,18 +95,13 @@ namespace ROS2SimulationInterfaces
             response.result.error_message = poseValidation.GetError().c_str();
             return response;
         }
-
-        const AZ::Transform targetPose = transformOffset *
+        entityState.m_pose = transformOffset *
             AZ::Transform::CreateFromQuaternionAndTranslation(requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
-
-        AZ::Outcome<void, SimulationInterfaces::FailedResult> outcome;
-        AZStd::string entityName = request.entity.c_str();
-
-        SimulationInterfaces::EntityState entityState;
-        entityState.m_pose = targetPose;
         entityState.m_twistAngular = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.angular));
         entityState.m_twistLinear = transformOffset.TransformVector(ROS2::ROS2Conversions::FromROS2Vector3(request.state.twist.linear));
+#endif
 
+        AZ::Outcome<void, SimulationInterfaces::FailedResult> outcome;
         SimulationInterfaces::SimulationEntityManagerRequestBus::BroadcastResult(
             outcome, &SimulationInterfaces::SimulationEntityManagerRequests::SetEntityState, entityName, entityState);
 

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "SpawnEntitiesServiceHandler.h"
+#include "SpawnServiceUtils.h"
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/TF/TransformInterface.h>
@@ -48,7 +49,7 @@ namespace ROS2SimulationInterfaces
             const AZStd::string_view messageFrameId{ spawnRequest.initial_pose.header.frame_id.c_str(),
                                                      spawnRequest.initial_pose.header.frame_id.size() };
 
-            if (!name.empty() && !ValidateEntityName(name))
+            if (!name.empty() && !SpawnServiceUtils::ValidateEntityName(name))
             {
                 spawnResult.result.result = simulation_interfaces::msg::SpawnResult::NAME_INVALID;
                 spawnResult.result.error_message =
@@ -57,7 +58,7 @@ namespace ROS2SimulationInterfaces
                 continue;
             }
 
-            if (!entityNamespace.empty() && !ValidateNamespaceName(entityNamespace))
+            if (!entityNamespace.empty() && !SpawnServiceUtils::ValidateNamespaceName(entityNamespace))
             {
                 spawnResult.result.result = simulation_interfaces::msg::SpawnResult::NAMESPACE_INVALID;
                 spawnResult.result.error_message =
@@ -86,11 +87,24 @@ namespace ROS2SimulationInterfaces
                 }
             }
 
+            const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(spawnRequest.initial_pose.pose);
+            if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+            {
+                spawnResult.result.result = simulation_interfaces::msg::SpawnResult::INVALID_POSE;
+                spawnResult.result.error_message = poseValidation.GetError().c_str();
+                hasFailures = true;
+                continue;
+            }
+
+            const AZ::Transform initialPose = transformOffset *
+                AZ::Transform::CreateFromQuaternionAndTranslation(
+                                                  requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+
             SimulationInterfaces::SpawningEntity spawningEntity;
             spawningEntity.name = AZStd::string(name);
             spawningEntity.uri = AZStd::string(uri);
             spawningEntity.entityNamespace = AZStd::string(entityNamespace);
-            spawningEntity.initialPose = transformOffset * ROS2::ROS2Conversions::FromROS2Pose(spawnRequest.initial_pose.pose);
+            spawningEntity.initialPose = initialPose;
             spawningEntity.allowRename = spawnRequest.allow_renaming;
             spawningEntity.preinsertionCb =
                 [](const AZ::Outcome<AzFramework::SpawnableEntityContainerView, SimulationInterfaces::FailedResult>&)
@@ -155,20 +169,6 @@ namespace ROS2SimulationInterfaces
             });
 
         return AZStd::nullopt;
-    }
-
-    bool SpawnEntitiesServiceHandler::ValidateEntityName(const AZStd::string& entityName)
-    {
-        const AZStd::regex entityRegex{ R"(^[a-zA-Z0-9_]+$)" }; // Entity names can only contain alphanumeric characters and underscores
-        return AZStd::regex_match(entityName, entityRegex);
-    }
-
-    bool SpawnEntitiesServiceHandler::ValidateNamespaceName(const AZStd::string& namespaceName)
-    {
-        const AZStd::regex namespaceRegex{
-            R"(^[a-zA-Z0-9_/]+$)"
-        }; // Namespace names can only contain alphanumeric characters and underscores and forward slashes
-        return AZStd::regex_match(namespaceName, namespaceRegex);
     }
 
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SpawnEntitiesServiceHandler.h"
+#include <AzFramework/Physics/ShapeConfiguration.h>
+#include <ROS2/ROS2Bus.h>
+#include <ROS2/TF/TransformInterface.h>
+#include <ROS2/Utilities/ROS2Conversions.h>
+#include <SimulationInterfaces/RegistryUtils.h>
+#include <SimulationInterfaces/SimulationEntityManagerRequestBus.h>
+
+namespace ROS2SimulationInterfaces
+{
+
+    AZStd::unordered_set<SimulationFeatureType> SpawnEntitiesServiceHandler::GetProvidedFeatures()
+    {
+        return AZStd::unordered_set<SimulationFeatureType>{ SimulationFeatures::SPAWNING_ENTITIES };
+    }
+
+    AZStd::optional<SpawnEntitiesServiceHandler::Response> SpawnEntitiesServiceHandler::HandleServiceRequest(
+        const std::shared_ptr<rmw_request_id_t> header, const Request& request)
+    {
+        const builtin_interfaces::msg::Time zeroTime = builtin_interfaces::msg::Time();
+        const auto simulatorFrameId = RegistryUtilities::GetSimulatorROS2Frame();
+
+        Response response;
+        response.results.resize(request.spawn_requests.size());
+
+        AZStd::vector<SimulationInterfaces::SpawningEntity> spawningEntities;
+        spawningEntities.reserve(request.spawn_requests.size());
+        AZStd::vector<size_t> spawnedRequestsIndices;
+        spawnedRequestsIndices.reserve(request.spawn_requests.size());
+
+        bool hasFailures = false;
+        for (size_t requestIdx = 0; requestIdx < request.spawn_requests.size(); ++requestIdx)
+        {
+            const auto& spawnRequest = request.spawn_requests[requestIdx];
+            auto& spawnResult = response.results[requestIdx];
+
+            const AZStd::string_view name{ spawnRequest.name.c_str(), spawnRequest.name.size() };
+            const AZStd::string_view uri{ spawnRequest.entity_resource.uri.c_str(), spawnRequest.entity_resource.uri.size() };
+            const AZStd::string_view entityNamespace{ spawnRequest.entity_namespace.c_str(), spawnRequest.entity_namespace.size() };
+            const AZStd::string_view messageFrameId{ spawnRequest.initial_pose.header.frame_id.c_str(),
+                                                     spawnRequest.initial_pose.header.frame_id.size() };
+
+            if (!name.empty() && !ValidateEntityName(name))
+            {
+                spawnResult.result.result = simulation_interfaces::msg::SpawnResult::NAME_INVALID;
+                spawnResult.result.error_message =
+                    "Invalid entity name. Entity names can only contain alphanumeric characters and underscores.";
+                hasFailures = true;
+                continue;
+            }
+
+            if (!entityNamespace.empty() && !ValidateNamespaceName(entityNamespace))
+            {
+                spawnResult.result.result = simulation_interfaces::msg::SpawnResult::NAMESPACE_INVALID;
+                spawnResult.result.error_message =
+                    "Invalid entity namespace. Entity namespaces can only contain alphanumeric characters and forward slashes.";
+                hasFailures = true;
+                continue;
+            }
+
+            AZ::Transform transformOffset = AZ::Transform::CreateIdentity();
+            if (!messageFrameId.empty() && simulatorFrameId != messageFrameId)
+            {
+                auto transformInterface = ROS2::TFInterface::Get();
+                AZ_Assert(transformInterface, "TFInterface is not available, cannot set entity state without transform offset.");
+                const auto transformOutcome = transformInterface->GetTransform(simulatorFrameId, messageFrameId, zeroTime);
+
+                if (transformOutcome.IsSuccess())
+                {
+                    transformOffset = transformOutcome.GetValue();
+                }
+                else
+                {
+                    spawnResult.result.result = simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED;
+                    spawnResult.result.error_message = transformOutcome.GetError().c_str();
+                    hasFailures = true;
+                    continue;
+                }
+            }
+
+            SimulationInterfaces::SpawningEntity spawningEntity;
+            spawningEntity.name = AZStd::string(name);
+            spawningEntity.uri = AZStd::string(uri);
+            spawningEntity.entityNamespace = AZStd::string(entityNamespace);
+            spawningEntity.initialPose = transformOffset * ROS2::ROS2Conversions::FromROS2Pose(spawnRequest.initial_pose.pose);
+            spawningEntity.allowRename = spawnRequest.allow_renaming;
+            spawningEntity.preinsertionCb =
+                [](const AZ::Outcome<AzFramework::SpawnableEntityContainerView, SimulationInterfaces::FailedResult>&)
+            {
+            };
+            spawningEntity.completedCb = [](const AZ::Outcome<AZStd::string, SimulationInterfaces::FailedResult>&)
+            {
+            };
+
+            spawningEntities.push_back(AZStd::move(spawningEntity));
+            spawnedRequestsIndices.push_back(requestIdx);
+        }
+
+        if (spawningEntities.empty())
+        {
+            response.result.result = hasFailures ? simulation_interfaces::srv::SpawnEntities::Response::ENTITIES_SPAWN_FAILED
+                                                 : simulation_interfaces::msg::Result::RESULT_OK;
+            if (hasFailures)
+            {
+                response.result.error_message = "One or more entity spawn requests failed.";
+            }
+            SendResponse(response);
+            return AZStd::nullopt;
+        }
+
+        SimulationInterfaces::SimulationEntityManagerRequestBus::Broadcast(
+            &SimulationInterfaces::SimulationEntityManagerRequests::SpawnEntities,
+            spawningEntities,
+            [this, response, spawnedRequestsIndices, hasFailures](const SimulationInterfaces::BatchSpawnResult& batchResult) mutable
+            {
+                bool hasBatchFailures = hasFailures;
+
+                for (size_t spawnedIdx = 0; spawnedIdx < batchResult.m_spawnResults.size() && spawnedIdx < spawnedRequestsIndices.size();
+                     ++spawnedIdx)
+                {
+                    const size_t requestIdx = spawnedRequestsIndices[spawnedIdx];
+                    auto& spawnResult = response.results[requestIdx];
+                    const auto& outcome = batchResult.m_spawnResults[spawnedIdx];
+
+                    if (outcome.IsSuccess())
+                    {
+                        spawnResult.result.result = simulation_interfaces::msg::Result::RESULT_OK;
+                        spawnResult.entity_name = outcome.GetValue().c_str();
+                    }
+                    else
+                    {
+                        const auto& failedResult = outcome.GetError();
+                        spawnResult.result.result = failedResult.m_errorCode;
+                        spawnResult.result.error_message = failedResult.m_errorString.c_str();
+                        hasBatchFailures = true;
+                    }
+                }
+
+                response.result.result = hasBatchFailures ? simulation_interfaces::srv::SpawnEntities::Response::ENTITIES_SPAWN_FAILED
+                                                          : simulation_interfaces::msg::Result::RESULT_OK;
+                if (hasBatchFailures)
+                {
+                    response.result.error_message = "One or more entity spawn requests failed.";
+                }
+
+                SendResponse(response);
+            });
+
+        return AZStd::nullopt;
+    }
+
+    bool SpawnEntitiesServiceHandler::ValidateEntityName(const AZStd::string& entityName)
+    {
+        const AZStd::regex entityRegex{ R"(^[a-zA-Z0-9_]+$)" }; // Entity names can only contain alphanumeric characters and underscores
+        return AZStd::regex_match(entityName, entityRegex);
+    }
+
+    bool SpawnEntitiesServiceHandler::ValidateNamespaceName(const AZStd::string& namespaceName)
+    {
+        const AZStd::regex namespaceRegex{
+            R"(^[a-zA-Z0-9_/]+$)"
+        }; // Namespace names can only contain alphanumeric characters and underscores and forward slashes
+        return AZStd::regex_match(namespaceName, namespaceRegex);
+    }
+
+} // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/string/regex.h>
+#include <AzCore/std/string/string_view.h>
+#include <Interfaces/ISimulationFeaturesBase.h>
+#include <ROS2/Handlers/ROS2ServiceBase.h>
+#include <simulation_interfaces/srv/spawn_entities.hpp>
+
+namespace ROS2SimulationInterfaces
+{
+    class SpawnEntitiesServiceHandler
+        : public ROS2::ROS2ServiceBase<simulation_interfaces::srv::SpawnEntities>
+        , public ISimulationFeaturesBase
+    {
+    public:
+        AZStd::string_view GetTypeName() const override
+        {
+            return "SpawnEntities";
+        }
+
+        AZStd::string_view GetDefaultName() const override
+        {
+            return "spawn_entities";
+        }
+        AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
+
+        AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
+
+    private:
+        bool ValidateEntityName(const AZStd::string& entityName);
+        bool ValidateNamespaceName(const AZStd::string& namespaceName);
+    };
+
+} // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntitiesServiceHandler.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <AzCore/std/string/regex.h>
 #include <AzCore/std/string/string_view.h>
 #include <Interfaces/ISimulationFeaturesBase.h>
 #include <ROS2/Handlers/ROS2ServiceBase.h>
@@ -33,10 +32,6 @@ namespace ROS2SimulationInterfaces
         AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
-
-    private:
-        bool ValidateEntityName(const AZStd::string& entityName);
-        bool ValidateNamespaceName(const AZStd::string& namespaceName);
     };
 
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
@@ -27,7 +27,11 @@ namespace ROS2SimulationInterfaces
         const std::shared_ptr<rmw_request_id_t> header, const Request& request)
     {
         const AZStd::string_view name{ request.name.c_str(), request.name.size() };
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
+        const AZStd::string_view uri{ request.entity_resource.uri.c_str(), request.entity_resource.uri.size() };
+#else
         const AZStd::string_view uri{ request.uri.c_str(), request.uri.size() };
+#endif
         const AZStd::string_view entityNamespace{ request.entity_namespace.c_str(), request.entity_namespace.size() };
         const AZStd::string_view messageFrameId{ request.initial_pose.header.frame_id.c_str(),
                                                  request.initial_pose.header.frame_id.size() };

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "SpawnEntityServiceHandler.h"
+#include "SpawnServiceUtils.h"
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <ROS2/ROS2Bus.h>
 #include <ROS2/TF/TransformInterface.h>
@@ -33,7 +34,7 @@ namespace ROS2SimulationInterfaces
         const builtin_interfaces::msg::Time zeroTime = builtin_interfaces::msg::Time();
 
         // Validate entity name
-        if (!name.empty() && !ValidateEntityName(name))
+        if (!name.empty() && !SpawnServiceUtils::ValidateEntityName(name))
         {
             Response response;
             response.result.result = simulation_interfaces::srv::SpawnEntity::Response::NAME_INVALID;
@@ -43,7 +44,7 @@ namespace ROS2SimulationInterfaces
         }
 
         // Validate namespace name
-        if (!entityNamespace.empty() && !ValidateNamespaceName(entityNamespace))
+        if (!entityNamespace.empty() && !SpawnServiceUtils::ValidateNamespaceName(entityNamespace))
         {
             Response response;
             response.result.result = simulation_interfaces::srv::SpawnEntity::Response::NAMESPACE_INVALID;
@@ -71,11 +72,24 @@ namespace ROS2SimulationInterfaces
                 Response response;
                 response.result.result = simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED;
                 response.result.error_message = transformOutcome.GetError().c_str();
-                return response;
+                SendResponse(response);
+                return AZStd::nullopt;
             }
         }
 
-        const AZ::Transform initialPose = transformOffset * ROS2::ROS2Conversions::FromROS2Pose(request.initial_pose.pose);
+        const AZ::Transform requestedPose = ROS2::ROS2Conversions::FromROS2Pose(request.initial_pose.pose);
+        if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
+        {
+            Response response;
+            response.result.result = simulation_interfaces::srv::SpawnEntity::Response::INVALID_POSE;
+            response.result.error_message = poseValidation.GetError().c_str();
+            SendResponse(response);
+            return AZStd::nullopt;
+        }
+
+        const AZ::Transform initialPose = transformOffset *
+            AZ::Transform::CreateFromQuaternionAndTranslation(requestedPose.GetRotation().GetNormalized(), requestedPose.GetTranslation());
+
         SimulationInterfaces::PreInsertionCb preinsertionCB =
             [this](const AZ::Outcome<AzFramework::SpawnableEntityContainerView, SimulationInterfaces::FailedResult>& outcome)
         {
@@ -114,20 +128,6 @@ namespace ROS2SimulationInterfaces
                 SendResponse(response);
             });
         return AZStd::nullopt;
-    }
-
-    bool SpawnEntityServiceHandler::ValidateEntityName(const AZStd::string& entityName)
-    {
-        const AZStd::regex entityRegex{ R"(^[a-zA-Z0-9_]+$)" }; // Entity names can only contain alphanumeric characters and underscores
-        return AZStd::regex_match(entityName, entityRegex);
-    }
-
-    bool SpawnEntityServiceHandler::ValidateNamespaceName(const AZStd::string& namespaceName)
-    {
-        const AZStd::regex namespaceRegex{
-            R"(^[a-zA-Z0-9_/]+$)"
-        }; // Namespace names can only contain alphanumeric characters and underscores and forward slashes
-        return AZStd::regex_match(namespaceName, namespaceRegex);
     }
 
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnEntityServiceHandler.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <AzCore/std/string/regex.h>
 #include <AzCore/std/string/string_view.h>
 #include <Interfaces/ISimulationFeaturesBase.h>
 #include <ROS2/Handlers/ROS2ServiceBase.h>
@@ -33,10 +32,6 @@ namespace ROS2SimulationInterfaces
         AZStd::unordered_set<SimulationFeatureType> GetProvidedFeatures() override;
 
         AZStd::optional<Response> HandleServiceRequest(const std::shared_ptr<rmw_request_id_t> header, const Request& request) override;
-
-    private:
-        bool ValidateEntityName(const AZStd::string& entityName);
-        bool ValidateNamespaceName(const AZStd::string& namespaceName);
     };
 
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SpawnServiceUtils.h"
+#include <AzCore/std/string/regex.h>
+#include <AzCore/std/string/string.h>
+
+namespace ROS2SimulationInterfaces::SpawnServiceUtils
+{
+    bool ValidateEntityName(AZStd::string_view entityName)
+    {
+        static const AZStd::regex entityRegex{
+            R"(^[a-zA-Z0-9_]+$)"
+        }; // Entity names can only contain alphanumeric characters and underscores
+        return AZStd::regex_match(entityName.begin(), entityName.end(), entityRegex);
+    }
+
+    bool ValidateNamespaceName(AZStd::string_view namespaceName)
+    {
+        static const AZStd::regex namespaceRegex{
+            R"(^[a-zA-Z0-9_/]+$)"
+        }; // Namespace names can only contain alphanumeric characters and forward slashes
+        return AZStd::regex_match(namespaceName.begin(), namespaceName.end(), namespaceRegex);
+    }
+
+    AZ::Outcome<void, AZStd::string> ValidateTransformNormalized(
+        const AZ::Transform& transform, float quaternionTolerance, float maxTranslation)
+    {
+        // Check rotation quaternion is normalised.
+        const float quaternionLength = transform.GetRotation().GetLength();
+        if (!AZ::IsClose(quaternionLength, 1.0f, quaternionTolerance))
+        {
+            return AZ::Failure<AZStd::string>("Invalid pose orientation quaternion: length is not close to 1.0.");
+        }
+
+        // Check translation components are finite and within range.
+        const AZ::Vector3 translation = transform.GetTranslation();
+        if (!translation.IsFinite())
+        {
+            return AZ::Failure<AZStd::string>("Invalid pose translation: one or more components are NaN or infinite.");
+        }
+        const float absMax = translation.GetAbs().GetMaxElement();
+        if (absMax > maxTranslation)
+        {
+            return AZ::Failure<AZStd::string>("Invalid pose translation: exceeds the maximum allowed.");
+        }
+
+        return AZ::Success();
+    }
+} // namespace ROS2SimulationInterfaces::SpawnServiceUtils

--- a/Gems/SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.h
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SpawnServiceUtils.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Math/Transform.h>
+#include <AzCore/Outcome/Outcome.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/string/string_view.h>
+
+namespace ROS2SimulationInterfaces::SpawnServiceUtils
+{
+    bool ValidateEntityName(AZStd::string_view entityName);
+    bool ValidateNamespaceName(AZStd::string_view namespaceName);
+
+    //! Validates that the transform has a normalised rotation quaternion and a finite, in-range translation.
+    //! @param transform     Transform to validate.
+    //! @param quaternionTolerance  Tolerance on |quaternion| - 1.0f. Defaults to 1e-3f.
+    //! @param maxTranslation Maximum allowed absolute value per axis in metres. Defaults to 1e7f (~10 000 km).
+    //! @return Success when valid, Failure with a descriptive error message when not.
+    AZ::Outcome<void, AZStd::string> ValidateTransformNormalized(
+        const AZ::Transform& transform, float quaternionTolerance = 1e-3f, float maxTranslation = 1e7f);
+} // namespace ROS2SimulationInterfaces::SpawnServiceUtils

--- a/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Tools/InterfacesTest.cpp
@@ -441,7 +441,11 @@ namespace UnitTest
         auto client = node->create_client<simulation_interfaces::srv::SpawnEntity>("/spawn_entity");
         auto request = std::make_shared<simulation_interfaces::srv::SpawnEntity::Request>();
         request->name = "valid_name";
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
+        request->entity_resource.uri = "test_uri";
+#else
         request->uri = "test_uri";
+#endif
         request->entity_namespace = "test_namespace";
         request->allow_renaming = true;
 
@@ -479,7 +483,11 @@ namespace UnitTest
         auto client = node->create_client<simulation_interfaces::srv::SpawnEntity>("/spawn_entity");
         auto request = std::make_shared<simulation_interfaces::srv::SpawnEntity::Request>();
         request->name = "invalid name"; // invalid name
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
+        request->entity_resource.uri = "test_uri";
+#else
         request->uri = "test_uri";
+#endif
         request->entity_namespace = "test_namespace";
 
         auto future = client->async_send_request(request);
@@ -501,7 +509,11 @@ namespace UnitTest
         auto client = node->create_client<simulation_interfaces::srv::SpawnEntity>("/spawn_entity");
         auto request = std::make_shared<simulation_interfaces::srv::SpawnEntity::Request>();
         request->name = "valid_name";
+#if SIMULATION_INTERFACES_MAJOR_API_VERSION >= 2
+        request->entity_resource.uri = "test_uri";
+#else
         request->uri = "test_uri";
+#endif
         request->entity_namespace = "invalid namespace";
 
         auto future = client->async_send_request(request);

--- a/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
+++ b/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
@@ -46,6 +46,8 @@ set(FILES
     Source/Services/GetEntityBoundsServiceHandler.h
     Source/Services/GetSpawnablesServiceHandler.cpp
     Source/Services/GetSpawnablesServiceHandler.h
+    Source/Services/SpawnServiceUtils.cpp
+    Source/Services/SpawnServiceUtils.h
     Source/Services/SpawnEntitiesServiceHandler.cpp
     Source/Services/SpawnEntitiesServiceHandler.h
     Source/Services/SpawnEntityServiceHandler.cpp

--- a/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
+++ b/Gems/SimulationInterfaces/Code/simulationinterfaces_private_files.cmake
@@ -46,6 +46,8 @@ set(FILES
     Source/Services/GetEntityBoundsServiceHandler.h
     Source/Services/GetSpawnablesServiceHandler.cpp
     Source/Services/GetSpawnablesServiceHandler.h
+    Source/Services/SpawnEntitiesServiceHandler.cpp
+    Source/Services/SpawnEntitiesServiceHandler.h
     Source/Services/SpawnEntityServiceHandler.cpp
     Source/Services/SpawnEntityServiceHandler.h
     Source/Services/ResetSimulationServiceHandler.cpp


### PR DESCRIPTION
## What does this PR do?

This is a the second and the final part of the cherry-picks from the `development` to the `stabilization` branch. In particular, it cherry-picks the following changes:
- #1039 
- #1040 
- #1044 

The changes are updates to `SimulationInterfaces` Gem alone. The changes were not integrated in the `stabilization` branch earlier as we were waiting for the sync of ROS 2 packages. This did not happen until now, which means that the `stablizatoin` branch will **NOT** work with the current ROS 2 releases:
- _ROS 2 Humble LTS_: the sync to 1.4.0 is expected soon
- _ROS 2 Jazzy LTS_: there was a sync for 1.5.0 mid April, but it missed `INVALID_POSE` error code implementation, the sync to 1.5.1 will happen in second half of May
- _ROS 2 Kilted_: the last sync missed `INVALID_POSE` error code implementation; no idea about the next sync (non-LTS distro, no fix dates for updates)

There is no time to wait further, as the official testing phase for _ROS 2 Lyrical_ [will start on the 30th of April](https://discourse.openrobotics.org/t/ros-2-lyrical-luth-testing-kicks-off-on-april-30th/54184). This revision will implement version 2.1.0 of `simulation_interfaces` ROS 2 package that was cherry-picked in this bundle of PRs. The official release of _ROS 2 Lyrical_ will happen on the 22nd of May.

As of now, it is necessary to build _simulation_interfaces_ package from source to use `SimulationInterfaces` Gem.

There is one more change added to the `stabilization` branch in this bundle:
- #1025

This change follows the late integration of https://github.com/o3de/o3de/pull/19708 in the engine.

## How was this PR tested?

The code was tested against the most recent 2605.0 engine using _ROS 2 Humble_ with `simulation_interfaces` 1.4.0 and 2.1.0.
