### PR TITLE
Updated Ros2FleetRobotTemplate to use simulation-interfaces

### DIFF
--- a/Templates/Ros2FleetRobotTemplate/README.md
+++ b/Templates/Ros2FleetRobotTemplate/README.md
@@ -24,7 +24,7 @@ You can spawn a robot manually with a service call, for example:
 
 ```shell
 ros2 service call /spawn_entity simulation_interfaces/srv/SpawnEntity \
-  '{uri: "product_asset:///prefabs/proteuslaserscanner.spawnable", name: "proteus", entity_namespace: "robot1", allow_renaming: true, initial_pose: {pose: {pose: {position: {x: -6.0, y: 0.5, z: 0.2}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}}}'
+  '{uri: "product_asset:///prefabs/proteuslaserscanner.spawnable", name: "proteus", entity_namespace: "robot1", allow_renaming: true, initial_pose: {pose: {position: {x: -6.0, y: 0.5, z: 0.2}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}}'
 ```
 
 In the fleet navigation example, spawning is handled automatically by the `robot_spawner` node launched for each robot.

--- a/Templates/Ros2FleetRobotTemplate/README.md
+++ b/Templates/Ros2FleetRobotTemplate/README.md
@@ -19,17 +19,15 @@ to install all required dependencies and create your project with a template (ma
 
 ## Spawning robots
 
-The level contains spawn points configured to easily add more Proteus robots through ROS 2 calls.
-
-This is done with the [Spawner Component](https://development--o3deorg.netlify.app/docs/user-guide/interactivity/robotics/concepts-and-components-overview/#spawner).
-There are 4 spawn points already added in the level. You can use them all with the following service calls:
+Robots are spawned via the `simulation_interfaces/srv/SpawnEntity` service provided by O3DE.
+You can spawn a robot manually with a service call, for example:
 
 ```shell
-ros2 service call /spawn_entity gazebo_msgs/srv/SpawnEntity '{name: 'proteus', xml: 'spawnPoint1'}'& \
-ros2 service call /spawn_entity gazebo_msgs/srv/SpawnEntity '{name: 'proteus', xml: 'spawnPoint2'}'& \
-ros2 service call /spawn_entity gazebo_msgs/srv/SpawnEntity '{name: 'proteus', xml: 'spawnPoint3'}'& \
-ros2 service call /spawn_entity gazebo_msgs/srv/SpawnEntity '{name: 'proteus', xml: 'spawnPoint4'}'
+ros2 service call /spawn_entity simulation_interfaces/srv/SpawnEntity \
+  '{uri: "product_asset:///prefabs/proteuslaserscanner.spawnable", name: "proteus", entity_namespace: "robot1", allow_renaming: true, initial_pose: {pose: {pose: {position: {x: -6.0, y: 0.5, z: 0.2}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}}}'
 ```
+
+In the fleet navigation example, spawning is handled automatically by the `robot_spawner` node launched for each robot.
 
 ## Fleet navigation
 
@@ -45,34 +43,52 @@ In this example, a fleet of robots is automatically spawned and each individual 
 
 You can configure the fleet by modifying `Example/ros2_ws/src/o3de_fleet_nav/config/fleet_config.yaml` file:
 
-```
+```yaml
 fleet:
   - robot_name: proteus
+    robot_uri: product_asset:///prefabs/proteuslaserscanner.spawnable
     robot_namespace: robot1
-    position: 
+    position:
       x: -6.0
       y: 0.5
       z: 0.2
+    orientation:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
   - robot_name: proteus
+    robot_uri: product_asset:///prefabs/proteuslaserscanner.spawnable
     robot_namespace: robot2
-    position: 
+    position:
       x: -6.0
       y: 7.5
       z: 0.2
+    orientation:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
   - robot_name: proteus
+    robot_uri: product_asset:///prefabs/proteuslaserscanner.spawnable
     robot_namespace: robot3
-    position: 
+    position:
       x: -6.0
       y: -6.0
       z: 0.2
+    orientation:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
 ```
 
 This configuration file contains the data about each robot in a fleet:
-- name (a type of the robot to spawn), 
-- namespace (must be unique per spawned robot),
-- spawning position (spawn position is also used as an AMCL initial estimation). 
-
-In this example, only the `proteus` robot is supported.
+- `robot_name`: identifier for the spawned entity,
+- `robot_uri`: asset URI of the robot prefab to spawn (in `product_asset:///` format),
+- `robot_namespace`: must be unique per spawned robot,
+- `position`: spawn position, also used as the AMCL initial pose estimate,
+- `orientation`: spawn orientation as a quaternion.
 
 You can modify contents of this file to add/remove robots or change their initial positions.
 
@@ -111,11 +127,11 @@ You can also use your robots in the simulation. To do so, you need to:
 - is controlled via the `cmd_vel` topic (see [Robot Control](https://docs.o3de.org/docs/user-guide/interactivity/robotics/concepts-and-components-overview/#robot-control)).
 
 When you have your robot set up:
-- create a prefab out of it (skip if URDF importer did that for you),
-- load the `Warehouse` level,
-- assign the prefab to the `RobotSpawner` entity inside `ROS2 Spawner Component` with a preferred name.
+- create a prefab out of it (skip if the URDF importer did that for you),
+- build the O3DE project so the prefab is processed into a `.spawnable` asset,
+- load the `Warehouse` level.
 
-Then you can alter `fleet_config.yaml` file to change the robot name to the assigned one, and start the fleet simulation with your robot!
+Then update `fleet_config.yaml` to set `robot_uri` to the `.spawnable` asset path of your prefab (e.g. `product_asset:///prefabs/myrobot.spawnable`) and start the fleet simulation with your robot!
 
 ### Building
 

--- a/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/config/fleet_config.yaml
+++ b/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/config/fleet_config.yaml
@@ -1,19 +1,37 @@
 fleet:
   - robot_name: proteus
+    robot_uri: product_asset:///prefabs/proteuslaserscanner.spawnable
     robot_namespace: robot1
-    position: 
+    position:
       x: -6.0
       y: 0.5
       z: 0.2
+    orientation:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
   - robot_name: proteus
+    robot_uri: product_asset:///prefabs/proteuslaserscanner.spawnable
     robot_namespace: robot2
-    position: 
+    position:
       x: -6.0
       y: 7.5
       z: 0.2
+    orientation:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
   - robot_name: proteus
+    robot_uri: product_asset:///prefabs/proteuslaserscanner.spawnable
     robot_namespace: robot3
-    position: 
+    position:
       x: -6.0
       y: -6.0
       z: 0.2
+    orientation:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0

--- a/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/launch/o3de_fleet_nav_launch.py
+++ b/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/launch/o3de_fleet_nav_launch.py
@@ -41,10 +41,15 @@ def generate_launch_description():
             robots.append(
                 {
                     "name": robot["robot_name"],
+                    "uri": robot["robot_uri"],
                     "namespace": robot["robot_namespace"],
                     "x_pose": robot["position"]["x"],
                     "y_pose": robot["position"]["y"],
-                    "z_pose": robot["position"]["z"]
+                    "z_pose": robot["position"]["z"],
+                    "x_orientation": robot["orientation"]["x"],
+                    "y_orientation": robot["orientation"]["y"],
+                    "z_orientation": robot["orientation"]["z"],
+                    "w_orientation": robot["orientation"]["w"]
                 }
             )
 
@@ -97,10 +102,15 @@ def generate_launch_description():
             source_file=params_file,
             replacements={
                 '<robot_name>': robot['name'],
+                '<robot_uri>': robot['uri'],
                 '<robot_namespace>': robot['namespace'],
                 '<robot_initial_pose_x>': str(robot['x_pose']),
                 '<robot_initial_pose_y>': str(robot['y_pose']),
-                '<robot_initial_pose_z>': str(robot['z_pose'])
+                '<robot_initial_pose_z>': str(robot['z_pose']),
+                '<robot_initial_orientation_x>': str(robot['x_orientation']),
+                '<robot_initial_orientation_y>': str(robot['y_orientation']),
+                '<robot_initial_orientation_z>': str(robot['z_orientation']),
+                '<robot_initial_orientation_w>': str(robot['w_orientation'])
             })
         
 

--- a/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/o3de_fleet_nav/robot_spawner.py
+++ b/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/o3de_fleet_nav/robot_spawner.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gazebo_msgs.srv import SpawnEntity
+from simulation_interfaces.srv import SpawnEntity
+from simulation_interfaces.msg import Result
 
 import rclpy
 from rclpy.exceptions import ParameterUninitializedException
@@ -24,49 +25,73 @@ class RobotSpawner(Node):
     def __init__(self):
         super().__init__('robot_spawner_client')
 
+        self.declare_parameter('robot_uri', rclpy.Parameter.Type.STRING)
         self.declare_parameter('robot_name', rclpy.Parameter.Type.STRING)
         self.declare_parameter('robot_namespace', '')
         self.declare_parameter('robot_initial_position', [0.0, 0.0, 0.0])
+        self.declare_parameter('robot_initial_orientation', [0.0, 0.0, 0.0, 1.0])
 
         try:
+            self.robot_uri = self.get_parameter('robot_uri').get_parameter_value().string_value
             self.robot_name = self.get_parameter('robot_name').get_parameter_value().string_value
-        except ParameterUninitializedException as e:
-            self.get_logger().warn("Nothing to spawn. 'robot_name' parameter not set.")
+        except ParameterUninitializedException:
+            self.get_logger().warn("Nothing to spawn. 'robot_uri' or 'robot_name' parameter not set.")
             return
-        
+
         self.robot_namespace = self.get_parameter('robot_namespace').get_parameter_value().string_value
         self.robot_initial_position = self.get_parameter('robot_initial_position').get_parameter_value().double_array_value
+        self.robot_initial_orientation = self.get_parameter('robot_initial_orientation').get_parameter_value().double_array_value
 
+        if len(self.robot_initial_position) != 3:
+            self.get_logger().error("robot_initial_position must have 3 values")
+            return
 
-        self.cli = self.create_client(SpawnEntity, 'spawn_entity')
-        
-        while not self.cli.wait_for_service(timeout_sec=1.0):
+        if len(self.robot_initial_orientation) != 4:
+            self.get_logger().error("robot_initial_orientation must have 4 values (quaternion)")
+            return
+
+        self._spawn_client = self.create_client(SpawnEntity, 'spawn_entity')
+
+        while not self._spawn_client.wait_for_service(timeout_sec=1.0):
             self.get_logger().info('Spawning service not available, waiting...')
 
-        self.req = SpawnEntity.Request()
-        result = self.send_request()
+        spawn_result = self._call_spawn_service()
+        if spawn_result is None:
+            self.get_logger().error("Service call failed.")
+            return
 
-        if result.success:
-            self.get_logger().info(f'{self.robot_namespace} spawned.')
+        if spawn_result.result.result == Result.RESULT_OK:
+            self.get_logger().info(f'{self.robot_namespace} spawned as {spawn_result.entity_name}.')
         else:
-            self.get_logger().error(f'Failed to spawn {self.robot_namespace}: {result.status_message}')
+            self.get_logger().error(f'Failed to spawn {self.robot_namespace}: {spawn_result.result.error_message}')
 
-    def send_request(self):
+    def _call_spawn_service(self):
         self.get_logger().info(f"Spawning robot: {self.robot_namespace}/{self.robot_name} on ("
-                            f"{self.robot_initial_position[0]}, "
-                            f"{self.robot_initial_position[1]}, "
-                            f"{self.robot_initial_position[2]})")
-        
-        self.req.name = self.robot_name
-        self.req.robot_namespace = self.robot_namespace
-        self.req.initial_pose.position.x = self.robot_initial_position[0]
-        self.req.initial_pose.position.y = self.robot_initial_position[1]
-        self.req.initial_pose.position.z = self.robot_initial_position[2]
+                               f"{self.robot_initial_position[0]}, "
+                               f"{self.robot_initial_position[1]}, "
+                               f"{self.robot_initial_position[2]}) with orientation ("
+                               f"{self.robot_initial_orientation[0]}, "
+                               f"{self.robot_initial_orientation[1]}, "
+                               f"{self.robot_initial_orientation[2]}, "
+                               f"{self.robot_initial_orientation[3]})")
 
-        self.future = self.cli.call_async(self.req)
-        rclpy.spin_until_future_complete(self, self.future)
+        request = SpawnEntity.Request()
+        request.uri = self.robot_uri
+        request.name = self.robot_name
+        request.entity_namespace = self.robot_namespace
+        request.allow_renaming = True
+        request.initial_pose.pose.position.x = self.robot_initial_position[0]
+        request.initial_pose.pose.position.y = self.robot_initial_position[1]
+        request.initial_pose.pose.position.z = self.robot_initial_position[2]
+        request.initial_pose.pose.orientation.x = self.robot_initial_orientation[0]
+        request.initial_pose.pose.orientation.y = self.robot_initial_orientation[1]
+        request.initial_pose.pose.orientation.z = self.robot_initial_orientation[2]
+        request.initial_pose.pose.orientation.w = self.robot_initial_orientation[3]
 
-        return self.future.result()
+        response_future = self._spawn_client.call_async(request)
+        rclpy.spin_until_future_complete(self, response_future)
+
+        return response_future.result()
 
 
 def main(args=None):

--- a/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/package.xml
+++ b/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/package.xml
@@ -11,7 +11,7 @@
   <exec_depend>nav2_bringup</exec_depend>
   <exec_depend>nav2_common</exec_depend>
   <exec_depend>slam_toolbox</exec_depend>
-  <exec_depend>gazebo_msgs</exec_depend>
+  <exec_depend>simulation_interfaces</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/params/humble/nav2_multirobot_params.yaml
+++ b/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/params/humble/nav2_multirobot_params.yaml
@@ -1,17 +1,19 @@
 robot_spawner_client:
   ros__parameters:
+    robot_uri: <robot_uri>
     robot_name: <robot_name>
     robot_namespace: <robot_namespace>
     robot_initial_position: [<robot_initial_pose_x>, <robot_initial_pose_y>, <robot_initial_pose_z>]
+    robot_initial_orientation: [<robot_initial_orientation_x>, <robot_initial_orientation_y>, <robot_initial_orientation_z>, <robot_initial_orientation_w>]
 
 amcl:
   ros__parameters:
     use_sim_time: True
-    alpha1: 0.2
-    alpha2: 0.2
-    alpha3: 0.2
-    alpha4: 0.2
-    alpha5: 0.2
+    alpha1: 0.1
+    alpha2: 0.1
+    alpha3: 0.1
+    alpha4: 0.1
+    alpha5: 0.1
     base_frame_id: "<robot_namespace>/base_link"
     beam_skip_distance: 0.5
     beam_skip_error_threshold: 0.9
@@ -20,26 +22,26 @@ amcl:
     global_frame_id: "map"
     map_topic: "map"
     lambda_short: 0.1
-    laser_likelihood_max_dist: 2.0
+    laser_likelihood_max_dist: 10.0
     laser_max_range: 100.0
-    laser_min_range: -1.0
-    laser_model_type: "<robot_namespace>/likelihood_field"
-    max_beams: 60
-    max_particles: 2000
-    min_particles: 500
+    laser_min_range: 0.0
+    laser_model_type: "likelihood_field"
+    max_beams: 924
+    max_particles: 15000
+    min_particles: 5000
     odom_frame_id: "<robot_namespace>/odom"
     pf_err: 0.05
     pf_z: 0.99
-    recovery_alpha_fast: 0.0
-    recovery_alpha_slow: 0.0
+    recovery_alpha_fast: 0.1
+    recovery_alpha_slow: 0.001
     resample_interval: 1
     robot_model_type: "nav2_amcl::DifferentialMotionModel"
     save_pose_rate: 0.5
     sigma_hit: 0.2
     tf_broadcast: true
     transform_tolerance: 1.0
-    update_min_a: 0.2
-    update_min_d: 0.25
+    update_min_a: 0.05
+    update_min_d: 0.05
     z_hit: 0.5
     z_max: 0.05
     z_rand: 0.5
@@ -53,10 +55,10 @@ amcl:
 
 bt_navigator:
   ros__parameters:
-    use_sim_time: True
+    use_sim_time: true
     global_frame: map
     robot_base_frame: <robot_namespace>/base_link
-    odom_topic: odom
+    odom_topic: /<robot_namespace>/odom
     bt_loop_duration: 10
     default_server_timeout: 20
     # 'default_nav_through_poses_bt_xml' and 'default_nav_to_pose_bt_xml' are use defaults:
@@ -147,21 +149,21 @@ controller_server:
       debug_trajectory_details: True
       min_vel_x: 0.0
       min_vel_y: 0.0
-      max_vel_x: 0.26
+      max_vel_x: 0.5
       max_vel_y: 0.0
-      max_vel_theta: 1.0
+      max_vel_theta: 0.3
       min_speed_xy: 0.0
-      max_speed_xy: 0.26
+      max_speed_xy: 0.5
       min_speed_theta: 0.0
       acc_lim_x: 2.5
       acc_lim_y: 0.0
-      acc_lim_theta: 3.2
+      acc_lim_theta: 0.8
       decel_lim_x: -2.5
       decel_lim_y: 0.0
-      decel_lim_theta: -3.2
+      decel_lim_theta: -0.8
       vx_samples: 20
       vy_samples: 5
-      vtheta_samples: 20
+      vtheta_samples: 30
       sim_time: 1.7
       linear_granularity: 0.05
       angular_granularity: 0.025
@@ -186,8 +188,8 @@ local_costmap:
       use_sim_time: True
       global_frame: <robot_namespace>/odom
       rolling_window: true
-      width: 3
-      height: 3
+      width: 8
+      height: 8
       resolution: 0.05
       robot_radius: 0.22
       plugins: ["voxel_layer", "inflation_layer"]
@@ -211,9 +213,9 @@ local_costmap:
           clearing: True
           marking: True
           data_type: "LaserScan"
-          raytrace_max_range: 3.0
+          raytrace_max_range: 6.0
           raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
+          obstacle_max_range: 5.5
           obstacle_min_range: 0.0
       static_layer:
         map_subscribe_transient_local: True
@@ -262,8 +264,8 @@ planner_server:
     use_sim_time: True
     planner_plugins: ["GridBased"]
     GridBased:
-      plugin: "nav2_navfn_planner/NavfnPlanner"
-      tolerance: 0.5
+      plugin: "nav2_navfn_planner::NavfnPlanner"
+      tolerance: 1.0
       use_astar: false
       allow_unknown: true
 
@@ -279,13 +281,13 @@ behavior_server:
     cycle_frequency: 10.0
     behavior_plugins: ["spin", "backup", "drive_on_heading", "wait"]
     spin:
-      plugin: "nav2_behaviors/Spin"
+      plugin: "nav2_behaviors::Spin"
     backup:
-      plugin: "nav2_behaviors/BackUp"
+      plugin: "nav2_behaviors::BackUp"
     drive_on_heading:
-      plugin: "nav2_behaviors/DriveOnHeading"
+      plugin: "nav2_behaviors::DriveOnHeading"
     wait:
-      plugin: "nav2_behaviors/Wait"
+      plugin: "nav2_behaviors::Wait"
     global_frame: <robot_namespace>/odom
     robot_base_frame: <robot_namespace>/base_link
     transform_tolerance: 0.1

--- a/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/params/humble/nav2_params.yaml
+++ b/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/params/humble/nav2_params.yaml
@@ -1,11 +1,11 @@
 amcl:
   ros__parameters:
     use_sim_time: True
-    alpha1: 0.2
-    alpha2: 0.2
-    alpha3: 0.2
-    alpha4: 0.2
-    alpha5: 0.2
+    alpha1: 0.1
+    alpha2: 0.1
+    alpha3: 0.1
+    alpha4: 0.1
+    alpha5: 0.1
     base_frame_id: "base_link"
     beam_skip_distance: 0.5
     beam_skip_error_threshold: 0.9
@@ -14,26 +14,26 @@ amcl:
     global_frame_id: "map"
     map_topic: "map"
     lambda_short: 0.1
-    laser_likelihood_max_dist: 2.0
+    laser_likelihood_max_dist: 10.0
     laser_max_range: 100.0
-    laser_min_range: -1.0
+    laser_min_range: 0.0
     laser_model_type: "likelihood_field"
-    max_beams: 60
-    max_particles: 2000
-    min_particles: 500
+    max_beams: 924
+    max_particles: 15000
+    min_particles: 5000
     odom_frame_id: "odom"
     pf_err: 0.05
     pf_z: 0.99
-    recovery_alpha_fast: 0.0
-    recovery_alpha_slow: 0.0
+    recovery_alpha_fast: 0.1
+    recovery_alpha_slow: 0.001
     resample_interval: 1
     robot_model_type: "nav2_amcl::DifferentialMotionModel"
     save_pose_rate: 0.5
     sigma_hit: 0.2
     tf_broadcast: true
     transform_tolerance: 1.0
-    update_min_a: 0.2
-    update_min_d: 0.25
+    update_min_a: 0.05
+    update_min_d: 0.05
     z_hit: 0.5
     z_max: 0.05
     z_rand: 0.5
@@ -43,7 +43,7 @@ amcl:
 
 bt_navigator:
   ros__parameters:
-    use_sim_time: True
+    use_sim_time: true
     global_frame: map
     robot_base_frame: base_link
     odom_topic: odom
@@ -137,21 +137,21 @@ controller_server:
       debug_trajectory_details: True
       min_vel_x: 0.0
       min_vel_y: 0.0
-      max_vel_x: 0.26
+      max_vel_x: 0.5
       max_vel_y: 0.0
-      max_vel_theta: 1.0
+      max_vel_theta: 0.3
       min_speed_xy: 0.0
-      max_speed_xy: 0.26
+      max_speed_xy: 0.5
       min_speed_theta: 0.0
       acc_lim_x: 2.5
       acc_lim_y: 0.0
-      acc_lim_theta: 3.2
+      acc_lim_theta: 0.8
       decel_lim_x: -2.5
       decel_lim_y: 0.0
-      decel_lim_theta: -3.2
+      decel_lim_theta: -0.8
       vx_samples: 20
       vy_samples: 5
-      vtheta_samples: 20
+      vtheta_samples: 30
       sim_time: 1.7
       linear_granularity: 0.05
       angular_granularity: 0.025
@@ -176,8 +176,8 @@ local_costmap:
       use_sim_time: True
       global_frame: odom
       rolling_window: true
-      width: 3
-      height: 3
+      width: 8
+      height: 8
       resolution: 0.05
       robot_radius: 0.22
       plugins: ["voxel_layer", "inflation_layer"]
@@ -201,9 +201,9 @@ local_costmap:
           clearing: True
           marking: True
           data_type: "LaserScan"
-          raytrace_max_range: 3.0
+          raytrace_max_range: 6.0
           raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
+          obstacle_max_range: 5.5
           obstacle_min_range: 0.0
       static_layer:
         map_subscribe_transient_local: True
@@ -252,8 +252,8 @@ planner_server:
     use_sim_time: True
     planner_plugins: ["GridBased"]
     GridBased:
-      plugin: "nav2_navfn_planner/NavfnPlanner"
-      tolerance: 0.5
+      plugin: "nav2_navfn_planner::NavfnPlanner"
+      tolerance: 1.0
       use_astar: false
       allow_unknown: true
 
@@ -269,13 +269,13 @@ behavior_server:
     cycle_frequency: 10.0
     behavior_plugins: ["spin", "backup", "drive_on_heading", "wait"]
     spin:
-      plugin: "nav2_behaviors/Spin"
+      plugin: "nav2_behaviors::Spin"
     backup:
-      plugin: "nav2_behaviors/BackUp"
+      plugin: "nav2_behaviors::BackUp"
     drive_on_heading:
-      plugin: "nav2_behaviors/DriveOnHeading"
+      plugin: "nav2_behaviors::DriveOnHeading"
     wait:
-      plugin: "nav2_behaviors/Wait"
+      plugin: "nav2_behaviors::Wait"
     global_frame: odom
     robot_base_frame: base_link
     transform_tolerance: 0.1

--- a/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/params/jazzy/nav2_multirobot_params.yaml
+++ b/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/params/jazzy/nav2_multirobot_params.yaml
@@ -1,17 +1,19 @@
 robot_spawner_client:
   ros__parameters:
+    robot_uri: <robot_uri>
     robot_name: <robot_name>
     robot_namespace: <robot_namespace>
     robot_initial_position: [<robot_initial_pose_x>, <robot_initial_pose_y>, <robot_initial_pose_z>]
+    robot_initial_orientation: [<robot_initial_orientation_x>, <robot_initial_orientation_y>, <robot_initial_orientation_z>, <robot_initial_orientation_w>]
 
 amcl:
   ros__parameters:
     use_sim_time: True
-    alpha1: 0.2
-    alpha2: 0.2
-    alpha3: 0.2
-    alpha4: 0.2
-    alpha5: 0.2
+    alpha1: 0.1
+    alpha2: 0.1
+    alpha3: 0.1
+    alpha4: 0.1
+    alpha5: 0.1
     base_frame_id: "<robot_namespace>/base_link"
     beam_skip_distance: 0.5
     beam_skip_error_threshold: 0.9
@@ -20,26 +22,26 @@ amcl:
     global_frame_id: "map"
     map_topic: "map"
     lambda_short: 0.1
-    laser_likelihood_max_dist: 2.0
+    laser_likelihood_max_dist: 10.0
     laser_max_range: 100.0
-    laser_min_range: -1.0
-    laser_model_type: "<robot_namespace>/likelihood_field"
-    max_beams: 60
-    max_particles: 2000
-    min_particles: 500
+    laser_min_range: 0.0
+    laser_model_type: "likelihood_field"
+    max_beams: 924
+    max_particles: 15000
+    min_particles: 5000
     odom_frame_id: "<robot_namespace>/odom"
     pf_err: 0.05
     pf_z: 0.99
-    recovery_alpha_fast: 0.0
-    recovery_alpha_slow: 0.0
+    recovery_alpha_fast: 0.1
+    recovery_alpha_slow: 0.001
     resample_interval: 1
     robot_model_type: "nav2_amcl::DifferentialMotionModel"
     save_pose_rate: 0.5
     sigma_hit: 0.2
     tf_broadcast: true
     transform_tolerance: 1.0
-    update_min_a: 0.2
-    update_min_d: 0.25
+    update_min_a: 0.05
+    update_min_d: 0.05
     z_hit: 0.5
     z_max: 0.05
     z_rand: 0.5
@@ -56,7 +58,7 @@ bt_navigator:
     use_sim_time: true
     global_frame: map
     robot_base_frame: <robot_namespace>/base_link
-    odom_topic: /odom
+    odom_topic: /<robot_namespace>/odom
     bt_loop_duration: 10
     default_server_timeout: 20
     wait_for_service_timeout: 1000
@@ -103,21 +105,21 @@ controller_server:
       debug_trajectory_details: True
       min_vel_x: 0.0
       min_vel_y: 0.0
-      max_vel_x: 0.26
+      max_vel_x: 0.5
       max_vel_y: 0.0
-      max_vel_theta: 1.0
+      max_vel_theta: 0.3
       min_speed_xy: 0.0
-      max_speed_xy: 0.26
+      max_speed_xy: 0.5
       min_speed_theta: 0.0
       acc_lim_x: 2.5
       acc_lim_y: 0.0
-      acc_lim_theta: 3.2
+      acc_lim_theta: 0.8
       decel_lim_x: -2.5
       decel_lim_y: 0.0
-      decel_lim_theta: -3.2
+      decel_lim_theta: -0.8
       vx_samples: 20
       vy_samples: 5
-      vtheta_samples: 20
+      vtheta_samples: 30
       sim_time: 1.7
       linear_granularity: 0.05
       angular_granularity: 0.025
@@ -142,8 +144,8 @@ local_costmap:
       use_sim_time: True
       global_frame: <robot_namespace>/odom
       rolling_window: true
-      width: 3
-      height: 3
+      width: 8
+      height: 8
       resolution: 0.05
       robot_radius: 0.22
       plugins: ["voxel_layer", "inflation_layer"]
@@ -167,9 +169,9 @@ local_costmap:
           clearing: True
           marking: True
           data_type: "LaserScan"
-          raytrace_max_range: 3.0
+          raytrace_max_range: 6.0
           raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
+          obstacle_max_range: 5.5
           obstacle_min_range: 0.0
       static_layer:
         map_subscribe_transient_local: True
@@ -219,7 +221,7 @@ planner_server:
     planner_plugins: ["GridBased"]
     GridBased:
       plugin: "nav2_navfn_planner::NavfnPlanner"
-      tolerance: 0.5
+      tolerance: 1.0
       use_astar: false
       allow_unknown: true
 

--- a/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/params/jazzy/nav2_params.yaml
+++ b/Templates/Ros2FleetRobotTemplate/Template/Examples/ros2_ws/src/o3de_fleet_nav/params/jazzy/nav2_params.yaml
@@ -1,11 +1,11 @@
 amcl:
   ros__parameters:
     use_sim_time: True
-    alpha1: 0.2
-    alpha2: 0.2
-    alpha3: 0.2
-    alpha4: 0.2
-    alpha5: 0.2
+    alpha1: 0.1
+    alpha2: 0.1
+    alpha3: 0.1
+    alpha4: 0.1
+    alpha5: 0.1
     base_frame_id: "base_link"
     beam_skip_distance: 0.5
     beam_skip_error_threshold: 0.9
@@ -14,26 +14,26 @@ amcl:
     global_frame_id: "map"
     map_topic: "map"
     lambda_short: 0.1
-    laser_likelihood_max_dist: 2.0
+    laser_likelihood_max_dist: 10.0
     laser_max_range: 100.0
-    laser_min_range: -1.0
+    laser_min_range: 0.0
     laser_model_type: "likelihood_field"
-    max_beams: 60
-    max_particles: 2000
-    min_particles: 500
+    max_beams: 924
+    max_particles: 15000
+    min_particles: 5000
     odom_frame_id: "odom"
     pf_err: 0.05
     pf_z: 0.99
-    recovery_alpha_fast: 0.0
-    recovery_alpha_slow: 0.0
+    recovery_alpha_fast: 0.1
+    recovery_alpha_slow: 0.001
     resample_interval: 1
     robot_model_type: "nav2_amcl::DifferentialMotionModel"
     save_pose_rate: 0.5
     sigma_hit: 0.2
     tf_broadcast: true
     transform_tolerance: 1.0
-    update_min_a: 0.2
-    update_min_d: 0.25
+    update_min_a: 0.05
+    update_min_d: 0.05
     z_hit: 0.5
     z_max: 0.05
     z_rand: 0.5
@@ -93,21 +93,21 @@ controller_server:
       debug_trajectory_details: True
       min_vel_x: 0.0
       min_vel_y: 0.0
-      max_vel_x: 0.26
+      max_vel_x: 0.5
       max_vel_y: 0.0
-      max_vel_theta: 1.0
+      max_vel_theta: 0.3
       min_speed_xy: 0.0
-      max_speed_xy: 0.26
+      max_speed_xy: 0.5
       min_speed_theta: 0.0
       acc_lim_x: 2.5
       acc_lim_y: 0.0
-      acc_lim_theta: 3.2
+      acc_lim_theta: 0.8
       decel_lim_x: -2.5
       decel_lim_y: 0.0
-      decel_lim_theta: -3.2
+      decel_lim_theta: -0.8
       vx_samples: 20
       vy_samples: 5
-      vtheta_samples: 20
+      vtheta_samples: 30
       sim_time: 1.7
       linear_granularity: 0.05
       angular_granularity: 0.025
@@ -132,8 +132,8 @@ local_costmap:
       use_sim_time: True
       global_frame: odom
       rolling_window: true
-      width: 3
-      height: 3
+      width: 8
+      height: 8
       resolution: 0.05
       robot_radius: 0.22
       plugins: ["voxel_layer", "inflation_layer"]
@@ -157,9 +157,9 @@ local_costmap:
           clearing: True
           marking: True
           data_type: "LaserScan"
-          raytrace_max_range: 3.0
+          raytrace_max_range: 6.0
           raytrace_min_range: 0.0
-          obstacle_max_range: 2.5
+          obstacle_max_range: 5.5
           obstacle_min_range: 0.0
       static_layer:
         map_subscribe_transient_local: True
@@ -209,7 +209,7 @@ planner_server:
     planner_plugins: ["GridBased"]
     GridBased:
       plugin: "nav2_navfn_planner::NavfnPlanner"
-      tolerance: 0.5
+      tolerance: 1.0
       use_astar: false
       allow_unknown: true
 

--- a/Templates/Ros2FleetRobotTemplate/Template/Prefabs/ProteusLaserScanner.prefab
+++ b/Templates/Ros2FleetRobotTemplate/Template/Prefabs/ProteusLaserScanner.prefab
@@ -207,7 +207,7 @@
                     "op": "remove",
                     "path": "/Entities/Entity_[4434522030989]/Components/Component_[15707946702459327170]"
                 },
-                                {
+                {
                     "op": "replace",
                     "path": "/Entities/Entity_[4473176736653]/Components/Component_[12319911397194903150]/m_template/DriveModel/Limits/AngularLimit",
                     "value": 0.5

--- a/Templates/Ros2FleetRobotTemplate/Template/Prefabs/ProteusLaserScanner.prefab
+++ b/Templates/Ros2FleetRobotTemplate/Template/Prefabs/ProteusLaserScanner.prefab
@@ -206,6 +206,16 @@
                 {
                     "op": "remove",
                     "path": "/Entities/Entity_[4434522030989]/Components/Component_[15707946702459327170]"
+                },
+                                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[4473176736653]/Components/Component_[12319911397194903150]/m_template/DriveModel/Limits/AngularLimit",
+                    "value": 0.5
+                },
+                {
+                    "op": "replace",
+                    "path": "/Entities/Entity_[4473176736653]/Components/Component_[12319911397194903150]/m_template/DriveModel/Limits/AngularAcceleration",
+                    "value": 0.5
                 }
             ]
         }

--- a/Templates/Ros2FleetRobotTemplate/Template/Registry/simulationinterface_settings.setreg
+++ b/Templates/Ros2FleetRobotTemplate/Template/Registry/simulationinterface_settings.setreg
@@ -1,0 +1,6 @@
+{
+    "SimulationInterfaces": {
+        "PrintStateNameInGui": false,
+        "StartInStoppedState": false
+    }
+}

--- a/Templates/Ros2FleetRobotTemplate/Template/project.json
+++ b/Templates/Ros2FleetRobotTemplate/Template/project.json
@@ -38,6 +38,7 @@
         "ROS2Sensors",
         "ScriptCanvasPhysics",
         "ScriptEvents",
+        "SimulationInterfaces",
         "StartingPointInput",
         "TextureAtlas",
         "WhiteBox",

--- a/Templates/Ros2FleetRobotTemplate/template.json
+++ b/Templates/Ros2FleetRobotTemplate/template.json
@@ -248,6 +248,10 @@
             "isTemplated": false
         },
         {
+            "file": "Registry/simulationinterface_settings.setreg",
+            "isTemplated": false
+        },
+        {
             "file": "Resources/GameSDK.ico",
             "isTemplated": false
         },


### PR DESCRIPTION
## What does this PR do?

This PR replaces the use of gazebo_msgs for spawning robots with simulation_interfaces. 
The Nav2 configuration has also been adjusted slightly to address the issue of the AMCL losing the robot's place on the map during movement.

## How was this PR tested?

By creating a project using this template and testing the ROS 2 stack.
