### PR TITLE
[SimulationIntefaces] Fix compilation issue with older ROS 2 simulation-interfaces packages

### DIFF
--- a/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/SetEntityStateServiceHandler.cpp
@@ -13,6 +13,22 @@
 #include <SimulationInterfaces/RegistryUtils.h>
 #include <SimulationInterfaces/SimulationEntityManagerRequestBus.h>
 
+namespace detail
+{
+    template<typename ResponseT>
+    auto InvalidPoseResultCode()
+    {
+        if constexpr (requires { ResponseT::INVALID_POSE; })
+        {
+            return ResponseT::INVALID_POSE;
+        }
+        else
+        {
+            return simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED;
+        }
+    }
+} // namespace detail
+
 namespace ROS2SimulationInterfaces
 {
 
@@ -73,7 +89,7 @@ namespace ROS2SimulationInterfaces
             if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
             {
                 Response response;
-                response.result.result = simulation_interfaces::srv::SetEntityState::Response::INVALID_POSE;
+                response.result.result = detail::InvalidPoseResultCode<Response>();
                 response.result.error_message = poseValidation.GetError().c_str();
                 return response;
             }
@@ -91,7 +107,9 @@ namespace ROS2SimulationInterfaces
         if (const auto poseValidation = SpawnServiceUtils::ValidateTransformNormalized(requestedPose); !poseValidation.IsSuccess())
         {
             Response response;
-            response.result.result = simulation_interfaces::srv::SetEntityState::Response::INVALID_POSE;
+
+            response.result.result = detail::InvalidPoseResultCode<Response>();
+
             response.result.error_message = poseValidation.GetError().c_str();
             return response;
         }


### PR DESCRIPTION
## What does this PR do?

Problem solved here is to choose compile-time which version of response message to use. In version 1.5.0 there is no simulation_interfaces::msg::Result::INVALID_POSE, so we need to use both constexpr and SFINAE to give compiler a way out to compile.


## How was this PR tested?

- Build with version Simulation Interfaces 1.5.0 on Jazzy.
- Build with version Simulation Interfaces 1.5.1 on Jazzy.