### PR TITLE
[SimulationInterfaces] Fix build dependencies

### DIFF
--- a/Gems/SimulationInterfaces/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfaces/Code/CMakeLists.txt
@@ -50,6 +50,7 @@ ly_add_target(
     BUILD_DEPENDENCIES
         INTERFACE
            AZ::AzCore
+           AZ::AzFramework
 )
 
 target_interface_depends_on_ros2_package(${gem_name}.API simulation_interfaces REQUIRED)


### PR DESCRIPTION
## What does this PR do?

Linking the code with `Gem::SimulationInterfaces.API` triggers a build failure due to missing build dependencies:
```
/home/jhanca/O3DE/Gems/SimulationInterfaces/2.2.0/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h:22:10: fatal error: 'AzFramework/Physics/ShapeConfiguration.h' file not found
   22 | #include <AzFramework/Physics/ShapeConfiguration.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

This is fixed in this PR.

## How was this PR tested?

Build a project linked to `Gem::SimulationInterfaces.API`.