### PR TITLE
Fix AUTOMOC warnings

### DIFF
--- a/Gems/LevelGeoreferencing/Code/CMakeLists.txt
+++ b/Gems/LevelGeoreferencing/Code/CMakeLists.txt
@@ -144,7 +144,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             georeferencing_editor_shared_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -223,7 +223,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             ros2_editor_shared_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/ROS2Controllers/Code/CMakeLists.txt
+++ b/Gems/ROS2Controllers/Code/CMakeLists.txt
@@ -153,7 +153,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             ros2controllers_editor_shared_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/ROS2RobotImporter/Code/CMakeLists.txt
+++ b/Gems/ROS2RobotImporter/Code/CMakeLists.txt
@@ -161,7 +161,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             ros2robotimporter_editor_shared_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/ROS2Sensors/Code/CMakeLists.txt
+++ b/Gems/ROS2Sensors/Code/CMakeLists.txt
@@ -194,7 +194,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             ros2sensors_editor_shared_files.cmake
         INCLUDE_DIRECTORIES

--- a/Gems/SimulationInterfaces/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfaces/Code/CMakeLists.txt
@@ -174,7 +174,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor GEM_MODULE
         NAMESPACE Gem
-        AUTOMOC
         FILES_CMAKE
             simulationinterfaces_editor_shared_files.cmake
         INCLUDE_DIRECTORIES


### PR DESCRIPTION
## What does this PR do?

This PR fixes warnings such as:
```
  Target ROS2Controllers.Editor contains AUTOMOC but doesn't have any Q_OBJECT macro in a .h or .hxx file
  Target ROS2.Editor contains AUTOMOC but doesn't have any Q_OBJECT macro in a .h or .hxx file
  Target ROS2RobotImporter.Editor contains AUTOMOC but doesn't have any Q_OBJECT macro in a .h or .hxx file
  Target ROS2Sensors.Editor contains AUTOMOC but doesn't have any Q_OBJECT macro in a .h or .hxx file
  Target SimulationInterfaces.Editor contains AUTOMOC but doesn't have any Q_OBJECT macro in a .h or .hxx file
```

The warnings appeared after Qt5 -> Qt6 change.

## How was this PR tested?

Built on Ubuntu 2404 with cmake 3.28.3 and clang 18.