### PR TITLE
Remove unused automoc and autorcc in project template

### DIFF
--- a/Templates/Ros2ProjectTemplate/Template/Gem/CMakeLists.txt
+++ b/Templates/Ros2ProjectTemplate/Template/Gem/CMakeLists.txt
@@ -91,8 +91,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_target(
         NAME ${gem_name}.Editor.Static STATIC
         NAMESPACE Gem
-        AUTOMOC
-        AUTORCC
         FILES_CMAKE
             ${NameLower}_editor_files.cmake
         INCLUDE_DIRECTORIES


### PR DESCRIPTION
## What does this PR do?

Very similar to https://github.com/o3de/o3de-extras/pull/1062 - but for cmake in project template.

## How was this PR tested?

Project configured.