### PR TITLE
Added GetFrameTransform to the ROS2Frame EBus

### DIFF
--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponent.h
@@ -63,10 +63,12 @@ namespace ROS2
         AZStd::string GetJointName() const override;
         AZStd::string GetFrameName() const override;
         AZStd::string GetGlobalFrameID() const override;
+        AZ::Transform GetFrameTransform() const override;
 
         // ROSFrameInterface overrides
         ROS2FrameConfiguration GetConfiguration() const override;
         void SetConfiguration(const ROS2FrameConfiguration& config) override;
+
     private:
         AZStd::string m_computedNamespace; //!< Cached namespace
         AZStd::string m_computedFrameName; //!< Cached full frame name, including namespace
@@ -77,7 +79,6 @@ namespace ROS2
         AZStd::optional<AZStd::string> m_sourceFrame; //!< If not set, the source frame is assumed to be the parent frame in the TF tree
         AZStd::unique_ptr<ROS2Transform> m_ros2Transform;
 
-        AZ::Transform GetFrameTransform() const;
         const ROS2FrameComponent* GetParentROS2FrameComponent() const;
 
         // AZ::TickBus::Handler overrides

--- a/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponentBus.h
+++ b/Gems/ROS2/Code/Include/ROS2/Frame/ROS2FrameComponentBus.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Math/Transform.h>
 #include <ROS2/ROS2TypeIds.h>
 
 namespace ROS2
@@ -53,6 +54,10 @@ namespace ROS2
         //! If empty, root frame is not published by the simulator.
         //! It is typically "odom", "map", "world", "myRobot/odom"
         virtual AZStd::string GetGlobalFrameID() const = 0;
+
+        //! Get the transform relative to the nearest ancestor entity with a ROS2Frame component.
+        //! @return If a parent ROS2Frame exists, the transform from that parent frame to this entity. Otherwise, the world transform.
+        virtual AZ::Transform GetFrameTransform() const = 0;
     };
 
     using ROS2FrameComponentBus = AZ::EBus<ROS2FrameComponentRequests>;

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.cpp
@@ -203,4 +203,13 @@ namespace ROS2
         return m_configuration.m_frameName;
     }
 
+    AZ::Transform ROS2FrameEditorComponent::GetFrameTransform() const
+    {
+        AZ_Warning(
+            "ROS2FrameEditorComponent",
+            false,
+            "GetFrameComponent should only be used on the game component. Returning identity transform.");
+        return AZ::Transform::CreateIdentity();
+    }
+
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.h
+++ b/Gems/ROS2/Code/Source/Frame/ROS2FrameEditorComponent.h
@@ -66,6 +66,7 @@ namespace ROS2
         AZ::EntityId GetFrameParent() const override;
         AZStd::set<AZ::EntityId> GetFrameDescendants() const override;
         void SetJointName(const AZStd::string& frameId) override;
+        AZ::Transform GetFrameTransform() const override;
 
         // AZ::EntityBus::Handler override.
         void OnEntityNameChanged(const AZStd::string& name) override;


### PR DESCRIPTION
## What does this PR do?

This PR adds the `GetFrameTransform` method to the public API of the ROS2FrameComponent (accessible via its EBus) - this method has been moved to the `private` section in the [PR968](https://github.com/o3de/o3de-extras/pull/968) without adding it to the public Bus. Additionally I moved the method back to the `public` section to be consistent with all of the other Bus::Handler overrides.

## How was this PR tested?

By using it in the project and checking entity's transform correctness. 
