### PR TITLE
Change of old URDF terminology in ROS2RobotImporter gem.

### DIFF
--- a/Gems/ROS2RobotImporter/Code/Include/ROS2RobotImporter/ROS2RobotImporterBus.h
+++ b/Gems/ROS2RobotImporter/Code/Include/ROS2RobotImporter/ROS2RobotImporterBus.h
@@ -21,11 +21,11 @@ namespace ROS2RobotImporter
         static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
         static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
 
-        //! Generate prefab from the urdf file.
-        //! @param filePath The path of the urdf file
-        //! @param importAssetWithUrdf If true, the assets referenced in the urdf file will be imported
+        //! Generate prefab from the URDF/SDF file.
+        //! @param filePath The path of the URDF/SDF file
+        //! @param importAssetWithFile If true, the assets referenced in the URDF/SDF file will be imported
         //! @param useArticulation If true, the prefab will be generated with articulation
-        virtual bool GeneratePrefabFromFile(const AZStd::string_view filePath, bool importAssetWithUrdf, bool useArticulation) = 0;
+        virtual bool GeneratePrefabFromFile(const AZStd::string_view filePath, bool importAssetWithFile, bool useArticulation) = 0;
 
         //! Return the reference to the list of sensor importer hooks
         virtual const SDFormat::SensorImporterHooksStorage& GetSensorHooks() const = 0;

--- a/Gems/ROS2RobotImporter/Code/Source/Clients/ROS2RobotImporterSystemComponent.h
+++ b/Gems/ROS2RobotImporter/Code/Source/Clients/ROS2RobotImporterSystemComponent.h
@@ -12,7 +12,7 @@
 
 namespace ROS2RobotImporter
 {
-    //! A Component for importing robot definition from standard formats such as URDF.
+    //! A Component for importing robot definition from standard formats such as URDF, SDF or XACRO.
     //! Sometimes, user decisions will be involved in the process.
     class ROS2RobotImporterSystemComponent : public AZ::Component
     {

--- a/Gems/ROS2RobotImporter/Code/Source/Clients/ROS2RobotImporterSystemComponent.h
+++ b/Gems/ROS2RobotImporter/Code/Source/Clients/ROS2RobotImporterSystemComponent.h
@@ -29,9 +29,9 @@ namespace ROS2RobotImporter
     protected:
         //////////////////////////////////////////////////////////////////////////
         // Component overrides
-        void Init() override{};
-        void Activate() override{};
-        void Deactivate() override{};
+        void Init() override {};
+        void Activate() override {};
+        void Deactivate() override {};
         //////////////////////////////////////////////////////////////////////////
     };
 } // namespace ROS2RobotImporter

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
@@ -105,7 +105,8 @@ namespace ROS2RobotImporter
         m_copyReferencedAssetsThread = copyThread;
     }
 
-    void CheckAssetPage::ReportAsset(const AZStd::string unresolvedFileName, const Utils::ReferencedAsset& referencedAsset, const QString& type)
+    void CheckAssetPage::ReportAsset(
+        const AZStd::string unresolvedFileName, const Utils::ReferencedAsset& referencedAsset, const QString& type)
     {
         int rowId = m_table->rowCount();
         m_table->setRowCount(rowId + 1);
@@ -127,7 +128,8 @@ namespace ROS2RobotImporter
                 rowId,
                 Columns::ResolvedMeshPath,
                 createCell(
-                    true, QString::fromUtf8(referencedAsset.m_resolvedPath.String().data(), referencedAsset.m_resolvedPath.String().size())));
+                    true,
+                    QString::fromUtf8(referencedAsset.m_resolvedPath.String().data(), referencedAsset.m_resolvedPath.String().size())));
             m_table->item(rowId, Columns::ResolvedMeshPath)->setIcon(m_okIcon);
         }
         else

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Pages/CheckAssetPage.cpp
@@ -105,29 +105,29 @@ namespace ROS2RobotImporter
         m_copyReferencedAssetsThread = copyThread;
     }
 
-    void CheckAssetPage::ReportAsset(const AZStd::string unresolvedFileName, const Utils::UrdfAsset& urdfAsset, const QString& type)
+    void CheckAssetPage::ReportAsset(const AZStd::string unresolvedFileName, const Utils::ReferencedAsset& referencedAsset, const QString& type)
     {
         int rowId = m_table->rowCount();
         m_table->setRowCount(rowId + 1);
 
         SetTitle();
-        const AZStd::string crcStr = AZStd::to_string(urdfAsset.m_urdfFileCRC);
+        const AZStd::string crcStr = AZStd::to_string(referencedAsset.m_resolvedFileCRC);
 
         QTableWidgetItem* p =
-            createCell(true, QString::fromUtf8(urdfAsset.m_assetUri.String().data(), urdfAsset.m_assetUri.String().size()));
-        if (urdfAsset.m_urdfFileCRC != AZ::Crc32())
+            createCell(true, QString::fromUtf8(referencedAsset.m_assetUri.String().data(), referencedAsset.m_assetUri.String().size()));
+        if (referencedAsset.m_resolvedFileCRC != AZ::Crc32())
         {
             p->setToolTip(tr("CRC for file : ") + QString::fromUtf8(crcStr.data(), crcStr.size()));
         }
         m_table->setItem(rowId, Columns::SdfMeshPath, p);
 
-        if (!urdfAsset.m_resolvedUrdfPath.empty())
+        if (!referencedAsset.m_resolvedPath.empty())
         {
             m_table->setItem(
                 rowId,
                 Columns::ResolvedMeshPath,
                 createCell(
-                    true, QString::fromUtf8(urdfAsset.m_resolvedUrdfPath.String().data(), urdfAsset.m_resolvedUrdfPath.String().size())));
+                    true, QString::fromUtf8(referencedAsset.m_resolvedPath.String().data(), referencedAsset.m_resolvedPath.String().size())));
             m_table->item(rowId, Columns::ResolvedMeshPath)->setIcon(m_okIcon);
         }
         else
@@ -217,7 +217,7 @@ namespace ROS2RobotImporter
     }
 
     void CheckAssetPage::OnAssetProcessStatusChanged(
-        const AZStd::string& unresolvedFileName, const Utils::UrdfAsset& urdfAsset, bool isError)
+        const AZStd::string& unresolvedFileName, const Utils::ReferencedAsset& referencedAsset, bool isError)
     {
         int rowId = GetRowIndex(unresolvedFileName);
         if (rowId == -1)
@@ -227,7 +227,7 @@ namespace ROS2RobotImporter
 
         if (!isError)
         {
-            const AZStd::vector<AZStd::string> productPaths = Utils::GetProductAssets(urdfAsset.m_availableAssetInfo.m_sourceGuid);
+            const AZStd::vector<AZStd::string> productPaths = Utils::GetProductAssets(referencedAsset.m_availableAssetInfo.m_sourceGuid);
             QString text;
             for (const auto& productPath : productPaths)
             {
@@ -245,15 +245,15 @@ namespace ROS2RobotImporter
 
     void CheckAssetPage::DoubleClickRow(int row, [[maybe_unused]] int col)
     {
-        if (!m_urdfAssetMap)
+        if (!m_referencedAssetMap)
         {
             return;
         }
         for (const auto& [assetPath, columnId] : m_assetsToColumnIndex)
         {
-            if (columnId == row && (*m_urdfAssetMap).contains(assetPath))
+            if (columnId == row && (*m_referencedAssetMap).contains(assetPath))
             {
-                auto productAssetRelativePath = (*m_urdfAssetMap)[assetPath].m_availableAssetInfo.m_productAssetRelativePath;
+                auto productAssetRelativePath = (*m_referencedAssetMap)[assetPath].m_availableAssetInfo.m_productAssetRelativePath;
                 if (productAssetRelativePath.empty())
                 {
                     return;

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Pages/CheckAssetPage.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Pages/CheckAssetPage.h
@@ -44,7 +44,8 @@ namespace ROS2RobotImporter
         void OnAssetCopyStatusChanged(
             const Utils::CopyStatus& status, const AZStd::string& unresolvedFileName, const AZStd::string assetPath);
 
-        void OnAssetProcessStatusChanged(const AZStd::string& unresolvedFileName, const Utils::ReferencedAsset& referencedAsset, bool isError);
+        void OnAssetProcessStatusChanged(
+            const AZStd::string& unresolvedFileName, const Utils::ReferencedAsset& referencedAsset, bool isError);
 
         void SetCopyThread(AZStd::shared_ptr<AZStd::thread> copyThread);
 

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Pages/CheckAssetPage.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Pages/CheckAssetPage.h
@@ -35,7 +35,7 @@ namespace ROS2RobotImporter
         explicit CheckAssetPage(QWizard* parent);
 
         //! Function reports assets that will be copied/processed by asset processor.
-        void ReportAsset(const AZStd::string unresolvedFileName, const Utils::UrdfAsset& urdfAsset, const QString& type);
+        void ReportAsset(const AZStd::string unresolvedFileName, const Utils::ReferencedAsset& referencedAsset, const QString& type);
         void ClearAssetsList();
         bool IsEmpty() const;
         bool isComplete() const override;
@@ -44,7 +44,7 @@ namespace ROS2RobotImporter
         void OnAssetCopyStatusChanged(
             const Utils::CopyStatus& status, const AZStd::string& unresolvedFileName, const AZStd::string assetPath);
 
-        void OnAssetProcessStatusChanged(const AZStd::string& unresolvedFileName, const Utils::UrdfAsset& urdfAsset, bool isError);
+        void OnAssetProcessStatusChanged(const AZStd::string& unresolvedFileName, const Utils::ReferencedAsset& referencedAsset, bool isError);
 
         void SetCopyThread(AZStd::shared_ptr<AZStd::thread> copyThread);
 
@@ -56,7 +56,7 @@ namespace ROS2RobotImporter
         unsigned int m_failedCount{ 0 };
         void SetTitle();
         AZStd::unordered_map<AZStd::string, int> m_assetsToColumnIndex; //!< Map of unresolved asset to column index in the table.
-        AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetMap;
+        AZStd::shared_ptr<Utils::ReferencedAssetMap> m_referencedAssetMap;
 
         void DoubleClickRow(int row, int col);
         QIcon m_failureIcon;

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Pages/FileSelectionPage.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Pages/FileSelectionPage.cpp
@@ -107,16 +107,16 @@ namespace ROS2RobotImporter
 
     void FileSelectionPage::onFileSelected(const QString& file)
     {
-        QFileInfo urdfFile(file);
+        QFileInfo selectedFile(file);
         m_textEdit->setText(file);
-        m_fileExists = urdfFile.exists() && urdfFile.isFile();
+        m_fileExists = selectedFile.exists() && selectedFile.isFile();
         emit completeChanged();
     }
 
     void FileSelectionPage::onEditingFinished()
     {
-        QFileInfo urdfFile(m_textEdit->text());
-        m_fileExists = urdfFile.exists() && urdfFile.isFile();
+        QFileInfo selectedFile(m_textEdit->text());
+        m_fileExists = selectedFile.exists() && selectedFile.isFile();
         emit completeChanged();
     }
 

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -16,8 +16,8 @@
 #include <QApplication>
 #include <QScreen>
 #include <QTranslator>
-#include <RobotImporter/URDF/URDFPrefabMaker.h>
-#include <RobotImporter/URDF/UrdfParser.h>
+#include <RobotImporter/URDF/SdfPrefabMaker.h>
+#include <RobotImporter/URDF/SdfParser.h>
 #include <RobotImporter/Utils/ErrorUtils.h>
 #include <RobotImporter/Utils/FilePath.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
@@ -45,7 +45,7 @@ namespace ROS2RobotImporter
         addPage(m_prefabMakerPage);
 
         connect(this, &QWizard::currentIdChanged, this, &RobotImporterWidget::onCurrentIdChanged);
-        connect(m_prefabMakerPage, &QWizardPage::completeChanged, this, &RobotImporterWidget::OnUrdfCreated);
+        connect(m_prefabMakerPage, &QWizardPage::completeChanged, this, &RobotImporterWidget::OnPrefabCreated);
         connect(m_prefabMakerPage, &PrefabMakerPage::onCreateButtonPressed, this, &RobotImporterWidget::onCreateButtonPressed);
         connect(
             m_robotDescriptionPage,
@@ -87,7 +87,7 @@ namespace ROS2RobotImporter
         connect(m_refreshTimerCheckAssets, &QTimer::timeout, this, &RobotImporterWidget::RefreshTimerElapsed);
     }
 
-    void RobotImporterWidget::OnUrdfCreated()
+    void RobotImporterWidget::OnPrefabCreated()
     {
         // hide cancel and back buttons when last page succeed
         if (currentPage() == m_prefabMakerPage && m_prefabMakerPage->isComplete())
@@ -98,7 +98,7 @@ namespace ROS2RobotImporter
         }
     }
 
-    void RobotImporterWidget::AddModificationWarningsToReportString(QString& report, const UrdfParser::RootObjectOutcome& parsedSdfOutcome)
+    void RobotImporterWidget::AddModificationWarningsToReportString(QString& report, const SdfParser::RootObjectOutcome& parsedSdfOutcome)
     {
         // This is a URDF only path, and therefore the report text does not mention SDF
         report += "# " + tr("The URDF was parsed, though results were modified to be compatible with SDFormat") + "\n";
@@ -145,24 +145,24 @@ namespace ROS2RobotImporter
         m_modifiedUrdfWindow->SetUrdfData(AZStd::move(parsedSdfOutcome.m_modifiedURDFContent));
     }
 
-    void RobotImporterWidget::OpenUrdf()
+    void RobotImporterWidget::OpenRobotDescription()
     {
-        UrdfParser::RootObjectOutcome parsedSdfOutcome;
+        SdfParser::RootObjectOutcome parsedSdfOutcome;
         QString report;
-        if (!m_urdfPath.empty())
+        if (!m_sourceFilePath.empty())
         {
             // Read the SDF Settings from PrefabMakerPage
             const SdfAssetBuilderSettings& sdfBuilderSettings = m_fileSelectPage->GetSdfAssetBuilderSettings();
 
             // Set the parser config settings for URDF content
-            sdf::ParserConfig parserConfig = Utils::SDFormat::CreateSdfParserConfigFromSettings(sdfBuilderSettings, m_urdfPath);
+            sdf::ParserConfig parserConfig = Utils::SDFormat::CreateSdfParserConfigFromSettings(sdfBuilderSettings, m_sourceFilePath);
 
-            if (Utils::IsFileXacro(m_urdfPath))
+            if (Utils::IsFileXacro(m_sourceFilePath))
             {
                 Utils::xacro::ExecutionOutcome outcome =
-                    Utils::xacro::ParseXacro(m_urdfPath.String(), m_params, parserConfig, sdfBuilderSettings);
+                    Utils::xacro::ParseXacro(m_sourceFilePath.String(), m_params, parserConfig, sdfBuilderSettings);
                 // Store off the URDF parsing outcome which will be output later in this function
-                parsedSdfOutcome = AZStd::move(outcome.m_urdfHandle);
+                parsedSdfOutcome = AZStd::move(outcome.m_parseResult);
                 if (outcome)
                 {
                     report += "# " + tr("XACRO execution succeeded") + "\n";
@@ -208,22 +208,22 @@ namespace ROS2RobotImporter
                     }
                 }
             }
-            else if (Utils::IsFileUrdfOrSdf(m_urdfPath))
+            else if (Utils::IsFileUrdfOrSdf(m_sourceFilePath))
             {
-                // standard URDF
-                parsedSdfOutcome = UrdfParser::ParseFromFile(m_urdfPath, parserConfig, sdfBuilderSettings);
+                // Sdf root object from SDF/URDF file.
+                parsedSdfOutcome = SdfParser::ParseFromFile(m_sourceFilePath, parserConfig, sdfBuilderSettings);
             }
             else
             {
-                AZ_Assert(false, "Unknown file extension : %s \n", m_urdfPath.c_str());
+                AZ_Assert(false, "Unknown file extension : %s \n", m_sourceFilePath.c_str());
             }
 
             AZStd::string log;
-            const bool urdfParsedSuccess{ parsedSdfOutcome };
-            bool urdfParsedWithWarnings{ parsedSdfOutcome.UrdfParsedWithModifiedContent() };
-            if (urdfParsedSuccess)
+            const bool parsingSucceeded{ parsedSdfOutcome };
+            bool parsedWithWarnings{ parsedSdfOutcome.UrdfParsedWithModifiedContent() };
+            if (parsingSucceeded)
             {
-                if (urdfParsedWithWarnings)
+                if (parsedWithWarnings)
                 {
                     AddModificationWarningsToReportString(report, parsedSdfOutcome);
                 }
@@ -233,7 +233,7 @@ namespace ROS2RobotImporter
                 }
                 m_parsedSdf = AZStd::move(parsedSdfOutcome.GetRoot());
                 m_prefabMaker.reset();
-                m_urdfAssetsMapping = Utils::GetReferencedAssetFilenames(m_parsedSdf);
+                m_referencedAssetMap = Utils::GetReferencedAssetFilenames(m_parsedSdf);
                 m_assetPage->ClearAssetsList();
             }
             else
@@ -248,7 +248,7 @@ namespace ROS2RobotImporter
                 report += QString::fromUtf8(log.data(), int(log.size()));
                 report += "\n```\n";
                 AZ_Printf("RobotImporterWidget", "SDF Stream: %s\n", log.c_str());
-                urdfParsedWithWarnings = true;
+                parsedWithWarnings = true;
             }
             const auto& messages = parsedSdfOutcome.GetParseMessages();
             if (!messages.empty())
@@ -259,9 +259,9 @@ namespace ROS2RobotImporter
                 report += QString::fromUtf8(messages.c_str(), int(messages.size()));
                 report += "\n```\n";
                 AZ_Printf("RobotImporterWidget", "SDF Stream: %s\n", messages.c_str());
-                urdfParsedWithWarnings = true;
+                parsedWithWarnings = true;
             }
-            m_robotDescriptionPage->ReportParsingResult(report, urdfParsedSuccess, urdfParsedWithWarnings);
+            m_robotDescriptionPage->ReportParsingResult(report, parsingSucceeded, parsedWithWarnings);
         }
     }
 
@@ -281,7 +281,7 @@ namespace ROS2RobotImporter
         }
         else if (currentPage() == m_robotDescriptionPage)
         {
-            AZStd::string urdfName = m_urdfPath.ReplaceExtension("").String();
+            AZStd::string urdfName = m_sourceFilePath.ReplaceExtension("").String();
             urdfName.append("_modified.urdf");
             m_robotDescriptionPage->SetModifiedUrdfName(urdfName);
         }
@@ -339,11 +339,11 @@ namespace ROS2RobotImporter
             // Read the SDF Settings from PrefabMakerPage
             const SdfAssetBuilderSettings& sdfBuilderSettings = m_fileSelectPage->GetSdfAssetBuilderSettings();
 
-            Utils::ResolveAssetMap(m_urdfAssetsMapping, m_urdfPath, sdfBuilderSettings);
+            Utils::ResolveAssetMap(m_referencedAssetMap, m_sourceFilePath, sdfBuilderSettings);
             if (!m_copyReferencedAssets)
             {
-                Utils::FindReferencedAssets(m_urdfAssetsMapping, m_urdfPath, sdfBuilderSettings);
-                for (const auto& [_, asset] : m_urdfAssetsMapping)
+                Utils::FindReferencedAssets(m_referencedAssetMap, m_sourceFilePath, sdfBuilderSettings);
+                for (const auto& [_, asset] : m_referencedAssetMap)
                 {
                     const bool visual =
                         (asset.m_assetType & Utils::ReferencedAssetType::VisualMesh) == Utils::ReferencedAssetType::VisualMesh;
@@ -356,7 +356,7 @@ namespace ROS2RobotImporter
                 }
             };
 
-            for (auto& [unresolvedFileName, asset] : m_urdfAssetsMapping)
+            for (auto& [unresolvedFileName, asset] : m_referencedAssetMap)
             {
                 QString type = tr("Unknown");
 
@@ -389,7 +389,7 @@ namespace ROS2RobotImporter
                 m_copyReferencedAssetsThread = AZStd::make_shared<AZStd::thread>(
                     [this, dirSuffix]()
                     {
-                        auto destStatus = Utils::PrepareImportedAssetsDest(m_urdfPath.String(), dirSuffix);
+                        auto destStatus = Utils::PrepareImportedAssetsDest(m_sourceFilePath.String(), dirSuffix);
                         if (!destStatus.IsSuccess())
                         {
                             AZ_Error("RobotImporterWidget", false, "Failed to create destination folder for imported assets");
@@ -397,37 +397,37 @@ namespace ROS2RobotImporter
                             return;
                         }
                         AZStd::unordered_map<AZ::IO::Path, unsigned int> duplicatedFilenames;
-                        for (auto& [unresolvedFileName, urdfAsset] : m_urdfAssetsMapping)
+                        for (auto& [unresolvedFileName, referencedAsset] : m_referencedAssetMap)
                         {
-                            if (duplicatedFilenames.contains(urdfAsset.m_assetUri))
+                            if (duplicatedFilenames.contains(referencedAsset.m_assetUri))
                             {
-                                duplicatedFilenames[urdfAsset.m_assetUri]++;
+                                duplicatedFilenames[referencedAsset.m_assetUri]++;
                             }
                             else
                             {
-                                duplicatedFilenames[urdfAsset.m_assetUri] = 0;
+                                duplicatedFilenames[referencedAsset.m_assetUri] = 0;
                             }
-                            if (urdfAsset.m_copyStatus == Utils::CopyStatus::Waiting)
+                            if (referencedAsset.m_copyStatus == Utils::CopyStatus::Waiting)
                             {
                                 m_assetPage->OnAssetCopyStatusChanged(
                                     Utils::CopyStatus::Copying, AZStd::string(unresolvedFileName.c_str()), "");
                             }
 
                             auto copyStatus = Utils::CopyStatus::Unresolvable;
-                            if (urdfAsset.m_resolvedUrdfPath.empty())
+                            if (referencedAsset.m_resolvedPath.empty())
                             {
-                                AZ_Warning("CopyAssetForURDF", false, "There is no resolved path for %s", unresolvedFileName.c_str());
+                                AZ_Warning("CopyReferencedAsset", false, "There is no resolved path for %s", unresolvedFileName.c_str());
                             }
                             else
                             {
                                 copyStatus =
-                                    Utils::CopyReferencedAsset(destStatus.GetValue(), urdfAsset, duplicatedFilenames[urdfAsset.m_assetUri]);
+                                    Utils::CopyReferencedAsset(destStatus.GetValue(), referencedAsset, duplicatedFilenames[referencedAsset.m_assetUri]);
                             }
 
                             m_assetPage->OnAssetCopyStatusChanged(
                                 copyStatus,
                                 AZStd::string(unresolvedFileName.c_str()),
-                                AZStd::string(urdfAsset.m_availableAssetInfo.m_sourceAssetRelativePath.c_str()));
+                                AZStd::string(referencedAsset.m_availableAssetInfo.m_sourceAssetRelativePath.c_str()));
 
                             if (copyStatus == Utils::CopyStatus::Copied || copyStatus == Utils::CopyStatus::Exists)
                             {
@@ -472,19 +472,19 @@ namespace ROS2RobotImporter
         AZStd::set<AZ::IO::Path> processedAssets;
         for (auto& assetToProcessPath : m_toProcessAssets)
         {
-            auto urdfAsset = m_urdfAssetsMapping.find(assetToProcessPath)->second;
-            auto assetFinishedOutcome = CheckIfAssetFinished(urdfAsset.m_availableAssetInfo.m_sourceAssetGlobalPath.c_str());
+            auto referencedAsset = m_referencedAssetMap.find(assetToProcessPath)->second;
+            auto assetFinishedOutcome = CheckIfAssetFinished(referencedAsset.m_availableAssetInfo.m_sourceAssetGlobalPath.c_str());
 
             if (assetFinishedOutcome.IsSuccess())
             {
                 processedAssets.insert(assetToProcessPath);
                 if (assetFinishedOutcome.GetValue() == false)
                 {
-                    m_assetPage->OnAssetProcessStatusChanged(assetToProcessPath.c_str(), urdfAsset, true);
+                    m_assetPage->OnAssetProcessStatusChanged(assetToProcessPath.c_str(), referencedAsset, true);
                 }
                 else
                 {
-                    m_assetPage->OnAssetProcessStatusChanged(assetToProcessPath.c_str(), urdfAsset, false);
+                    m_assetPage->OnAssetProcessStatusChanged(assetToProcessPath.c_str(), referencedAsset, false);
                 }
             }
         }
@@ -498,7 +498,7 @@ namespace ROS2RobotImporter
     void RobotImporterWidget::FillPrefabMakerPage()
     {
         // Use the URDF/SDF file name stem the prefab name
-        AZStd::string robotName = AZStd::string::format("%.*s.prefab", AZ_PATH_ARG(m_urdfPath.Stem()));
+        AZStd::string robotName = AZStd::string::format("%.*s.prefab", AZ_PATH_ARG(m_sourceFilePath.Stem()));
         m_prefabMakerPage->SetProposedPrefabName(robotName);
         QWizard::button(PrefabCreationButtonId)->setText(tr("Create Prefab"));
         QWizard::setOption(HavePrefabCreationButton, true);
@@ -511,26 +511,26 @@ namespace ROS2RobotImporter
         if (currentPage() == m_fileSelectPage)
         {
             m_params.clear();
-            m_urdfPath = AZStd::string(m_fileSelectPage->getFileName().toUtf8().constData());
-            if (Utils::IsFileXacro(m_urdfPath))
+            m_sourceFilePath = AZStd::string(m_fileSelectPage->getFileName().toUtf8().constData());
+            if (Utils::IsFileXacro(m_sourceFilePath))
             {
-                m_params = Utils::xacro::GetParameterFromXacroFile(m_urdfPath.String());
+                m_params = Utils::xacro::GetParameterFromXacroFile(m_sourceFilePath.String());
                 AZ_Printf("RobotImporterWidget", "Xacro has %d arguments\n", m_params.size());
                 m_xacroParamsPage->SetXacroParameters(m_params);
             }
             // no need to wait for param page - parse urdf now, nextId will skip unnecessary pages
-            if (m_params.empty() && Utils::IsFileXacroOrUrdfOrSdf(m_urdfPath))
+            if (m_params.empty() && Utils::IsFileXacroOrUrdfOrSdf(m_sourceFilePath))
             {
-                OpenUrdf();
+                OpenRobotDescription();
             }
             m_copyReferencedAssets = m_fileSelectPage->GetSdfAssetBuilderSettings().m_importReferencedMeshFiles;
         }
         if (currentPage() == m_xacroParamsPage)
         {
             m_params = m_xacroParamsPage->GetXacroParameters();
-            if (Utils::IsFileXacroOrUrdfOrSdf(m_urdfPath))
+            if (Utils::IsFileXacroOrUrdfOrSdf(m_sourceFilePath))
             {
-                OpenUrdf();
+                OpenRobotDescription();
             }
         }
         if (currentPage() == m_introPage)
@@ -565,7 +565,7 @@ namespace ROS2RobotImporter
                     // do not skip robot description page
                     return m_xacroParamsPage->nextId();
                 }
-                if (m_urdfAssetsMapping.empty())
+                if (m_referencedAssetMap.empty())
                 {
                     // skip two pages when urdf/sdf is parsed without problems, and it has no assets
                     return m_assetPage->nextId();
@@ -614,10 +614,10 @@ namespace ROS2RobotImporter
 
         const auto& sdfAssetBuilderSettings = m_fileSelectPage->GetSdfAssetBuilderSettings();
         const bool useArticulation = sdfAssetBuilderSettings.m_useArticulations;
-        m_prefabMaker = AZStd::make_unique<URDFPrefabMaker>(
+        m_prefabMaker = AZStd::make_unique<SdfPrefabMaker>(
             &m_parsedSdf,
             prefabPath.String(),
-            AZStd::make_shared<Utils::UrdfAssetMap>(m_urdfAssetsMapping),
+            AZStd::make_shared<Utils::ReferencedAssetMap>(m_referencedAssetMap),
             useArticulation,
             m_prefabMakerPage->getSelectedSpawnPoint());
 

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -16,8 +16,8 @@
 #include <QApplication>
 #include <QScreen>
 #include <QTranslator>
-#include <RobotImporter/URDF/SdfPrefabMaker.h>
 #include <RobotImporter/URDF/SdfParser.h>
+#include <RobotImporter/URDF/SdfPrefabMaker.h>
 #include <RobotImporter/Utils/ErrorUtils.h>
 #include <RobotImporter/Utils/FilePath.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
@@ -420,8 +420,8 @@ namespace ROS2RobotImporter
                             }
                             else
                             {
-                                copyStatus =
-                                    Utils::CopyReferencedAsset(destStatus.GetValue(), referencedAsset, duplicatedFilenames[referencedAsset.m_assetUri]);
+                                copyStatus = Utils::CopyReferencedAsset(
+                                    destStatus.GetValue(), referencedAsset, duplicatedFilenames[referencedAsset.m_assetUri]);
                             }
 
                             m_assetPage->OnAssetCopyStatusChanged(

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -17,8 +17,8 @@
 #include "Pages/RobotDescriptionPage.h"
 #include "Pages/XacroParamsPage.h"
 
-#include "URDF/URDFPrefabMaker.h"
-#include "URDF/UrdfParser.h"
+#include "URDF/SdfPrefabMaker.h"
+#include "URDF/SdfParser.h"
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/parallel/thread.h>
@@ -49,9 +49,9 @@
 namespace ROS2RobotImporter
 {
     class RobotImporterWidget;
-    class URDFPrefabMaker;
+    class SdfPrefabMaker;
 
-    //! Handles UI for the process of URDF importing
+    //! Handles UI for the process of robot description importing
     class RobotImporterWidget : public QWizard
     {
         Q_OBJECT
@@ -62,8 +62,8 @@ namespace ROS2RobotImporter
     private:
         int nextId() const override;
         bool validateCurrentPage() override;
-        void OpenUrdf();
-        void OnUrdfCreated();
+        void OpenRobotDescription();
+        void OnPrefabCreated();
         void onCreateButtonPressed();
         void onSaveModifiedUrdfPressed();
         void onShowModifiedUrdfPressed();
@@ -75,17 +75,17 @@ namespace ROS2RobotImporter
         PrefabMakerPage* m_prefabMakerPage;
         XacroParamsPage* m_xacroParamsPage;
         ModifiedURDFWindow* m_modifiedUrdfWindow;
-        AZ::IO::Path m_urdfPath;
+        AZ::IO::Path m_sourceFilePath;
         sdf::Root m_parsedSdf{};
 
-        //! User's choice to copy meshes during urdf import
+        //! User's choice to copy meshes during import
         bool m_copyReferencedAssets{ false };
 
-        /// mapping from urdf path to asset source
-        Utils::UrdfAssetMap m_urdfAssetsMapping;
+        /// mapping from unresolved URI to asset source
+        Utils::ReferencedAssetMap m_referencedAssetMap;
 
         AZStd::shared_ptr<AZStd::thread> m_copyReferencedAssetsThread;
-        AZStd::unique_ptr<URDFPrefabMaker> m_prefabMaker;
+        AZStd::unique_ptr<SdfPrefabMaker> m_prefabMaker;
 
         /// Xacro params
         Utils::xacro::Params m_params;
@@ -122,7 +122,7 @@ namespace ROS2RobotImporter
         //! @param errorMessage error message to display to the user
         void ReportError(const QString& errorMessage);
 
-        void AddModificationWarningsToReportString(QString& report, const UrdfParser::RootObjectOutcome& parsedSdfOutcome);
+        void AddModificationWarningsToReportString(QString& report, const SdfParser::RootObjectOutcome& parsedSdfOutcome);
 
         static constexpr QWizard::WizardButton PrefabCreationButtonId{ QWizard::CustomButton1 };
         static constexpr QWizard::WizardOption HavePrefabCreationButton{ QWizard::HaveCustomButton1 };

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.h
@@ -17,8 +17,8 @@
 #include "Pages/RobotDescriptionPage.h"
 #include "Pages/XacroParamsPage.h"
 
-#include "URDF/SdfPrefabMaker.h"
 #include "URDF/SdfParser.h"
+#include "URDF/SdfPrefabMaker.h"
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/parallel/thread.h>

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/SDFormat/ROS2SDFormatHooksUtils.cpp
@@ -79,7 +79,7 @@ namespace ROS2RobotImporter::SDFormat
     void HooksUtils::SetSensorEntityTransform(AZ::Entity& entity, const sdf::Sensor& sdfSensor)
     {
         const auto sensorSemanticPose = sdfSensor.SemanticPose();
-        AZ::Transform tf = Utils::GetLocalTransformURDF(sensorSemanticPose);
+        AZ::Transform tf = Utils::GetLocalTransform(sensorSemanticPose);
         auto* transformInterface = entity.FindComponent<AzToolsFramework::Components::TransformComponent>();
         if (transformInterface)
         {

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/ArticulationsMaker.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/ArticulationsMaker.cpp
@@ -52,7 +52,7 @@ namespace ROS2RobotImporter
             const sdf::JointAxis* jointAxis = joint->Axis();
             if (jointAxis != nullptr)
             {
-                jointCoordinateAxis = URDF::TypeConversions::ConvertVector3(jointAxis->Xyz());
+                jointCoordinateAxis = Utils::TypeConversions::ConvertVector3(jointAxis->Xyz());
                 quaternion = jointCoordinateAxis.IsZero()
                     ? AZ::Quaternion::CreateIdentity()
                     : AZ::Quaternion::CreateShortestArc(AZ::Vector3::CreateAxisX(), jointCoordinateAxis);
@@ -98,14 +98,14 @@ namespace ROS2RobotImporter
     ArticulationCfg& AddToArticulationConfig(ArticulationCfg& articulationLinkConfiguration, const gz::math::Inertiald& inertial)
     {
         articulationLinkConfiguration.m_solverPositionIterations =
-            AZStd::max(articulationLinkConfiguration.m_solverPositionIterations, URDF::DefaultNumberPosSolver);
+            AZStd::max(articulationLinkConfiguration.m_solverPositionIterations, Utils::DefaultNumberPosSolver);
         articulationLinkConfiguration.m_solverVelocityIterations =
-            AZStd::max(articulationLinkConfiguration.m_solverVelocityIterations, URDF::DefaultNumberVelSolver);
+            AZStd::max(articulationLinkConfiguration.m_solverVelocityIterations, Utils::DefaultNumberVelSolver);
 
         articulationLinkConfiguration.m_mass = inertial.MassMatrix().Mass();
-        articulationLinkConfiguration.m_centerOfMassOffset = URDF::TypeConversions::ConvertVector3(inertial.Pose().Pos());
+        articulationLinkConfiguration.m_centerOfMassOffset = Utils::TypeConversions::ConvertVector3(inertial.Pose().Pos());
 
-        if (!URDF::TypeConversions::ConvertQuaternion(inertial.Pose().Rot()).IsIdentity())
+        if (!Utils::TypeConversions::ConvertQuaternion(inertial.Pose().Rot()).IsIdentity())
         { // There is a rotation component in URDF that we are not able to apply
             AZ_Warning(
                 "AddArticulationLink", false, "Ignoring URDF/SDF inertial origin rotation (no such field in rigid body configuration)");
@@ -132,7 +132,7 @@ namespace ROS2RobotImporter
         AZStd::string linkName(link->Name().c_str(), link->Name().size());
         for (const sdf::Joint* joint : Utils::GetJointsForChildLink(model, linkName, getNestedModelJoints))
         {
-            const bool isWheelEntity = Utils::IsWheelURDFHeuristics(model, link);
+            const bool isWheelEntity = Utils::IsWheelHeuristics(model, link);
             articulationLinkConfiguration = AddToArticulationConfig(articulationLinkConfiguration, joint, isWheelEntity);
         }
 

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/ArticulationsMaker.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/ArticulationsMaker.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "UrdfParser.h"
+#include "SdfParser.h"
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <PhysX/ArticulationTypes.h>

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/CollidersMaker.cpp
@@ -34,8 +34,8 @@ namespace ROS2RobotImporter
         static const char* CollidersMakerLoggingTag = "CollidersMaker";
     } // namespace Internal
 
-    CollidersMaker::CollidersMaker(const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping)
-        : m_urdfAssetsMapping(urdfAssetsMapping)
+    CollidersMaker::CollidersMaker(const AZStd::shared_ptr<Utils::ReferencedAssetMap>& referencedAssetMap)
+        : m_referencedAssetMap(referencedAssetMap)
     {
     }
 
@@ -67,7 +67,7 @@ namespace ROS2RobotImporter
     void CollidersMaker::AddColliders(const sdf::Model& model, const sdf::Link* link, AZ::EntityId entityId)
     {
         AZStd::string typeString = "collider";
-        const bool isWheelEntity = Utils::IsWheelURDFHeuristics(model, link);
+        const bool isWheelEntity = Utils::IsWheelHeuristics(model, link);
         if (isWheelEntity)
         {
             AZ_Printf(Internal::CollidersMakerLoggingTag, "Due to its name, %s is considered a wheel entity\n", link->Name().c_str());
@@ -129,15 +129,15 @@ namespace ROS2RobotImporter
         Physics::ColliderConfiguration colliderConfig;
 
         colliderConfig.m_materialSlots.SetMaterialAsset(0, materialAsset);
-        colliderConfig.m_position = URDF::TypeConversions::ConvertVector3(collision->RawPose().Pos());
-        colliderConfig.m_rotation = URDF::TypeConversions::ConvertQuaternion(collision->RawPose().Rot());
+        colliderConfig.m_position = Utils::TypeConversions::ConvertVector3(collision->RawPose().Pos());
+        colliderConfig.m_rotation = Utils::TypeConversions::ConvertQuaternion(collision->RawPose().Rot());
         if (!isPrimitiveShape)
         {
             AZ_Printf(Internal::CollidersMakerLoggingTag, "Adding mesh collider to %s\n", entityId.ToString().c_str());
             auto meshGeometry = geometry->MeshShape();
             AZ_Assert(meshGeometry, "geometry is not meshGeometry");
 
-            auto asset = PrefabMakerUtils::GetAssetFromUri(*m_urdfAssetsMapping, modelUri, meshGeometry->Uri());
+            auto asset = PrefabMakerUtils::GetAssetFromUri(*m_referencedAssetMap, modelUri, meshGeometry->Uri());
             if (!asset)
             {
                 return;
@@ -183,7 +183,7 @@ namespace ROS2RobotImporter
             {
                 const auto boxGeometry = geometry->BoxShape();
                 AZ_Assert(boxGeometry, "geometry is not boxGeometry");
-                const Physics::BoxShapeConfiguration cfg{ URDF::TypeConversions::ConvertVector3(boxGeometry->Size()) };
+                const Physics::BoxShapeConfiguration cfg{ Utils::TypeConversions::ConvertVector3(boxGeometry->Size()) };
                 entity->CreateComponent<PhysX::EditorColliderComponent>(colliderConfig, cfg);
             }
             break;

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/CollidersMaker.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/CollidersMaker.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "UrdfParser.h"
+#include "SdfParser.h"
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzCore/std/string/string.h>
@@ -25,7 +25,7 @@ namespace ROS2RobotImporter
     public:
         //! Construct the class based on SDF asset mapping.
         //! @param sdfAssetsMapping a prepared mapping of Assets used by the source URDF/SDF.
-        CollidersMaker(const AZStd::shared_ptr<Utils::UrdfAssetMap>& sdfAssetsMapping);
+        CollidersMaker(const AZStd::shared_ptr<Utils::ReferencedAssetMap>& sdfAssetsMapping);
 
         //! Prevent copying of existing CollidersMaker
         CollidersMaker(const CollidersMaker& other) = delete;
@@ -51,6 +51,6 @@ namespace ROS2RobotImporter
             const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset) const;
 
         AZ::Data::Asset<Physics::MaterialAsset> m_wheelMaterial;
-        AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;
+        AZStd::shared_ptr<Utils::ReferencedAssetMap> m_referencedAssetMap;
     };
 } // namespace ROS2RobotImporter

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/InertialsMaker.cpp
@@ -23,18 +23,18 @@ namespace ROS2RobotImporter
         PhysX::EditorRigidBodyConfiguration rigidBodyConfiguration;
         PhysX::RigidBodyConfiguration physxSpecificConfiguration;
         physxSpecificConfiguration.m_solverPositionIterations =
-            AZStd::max(physxSpecificConfiguration.m_solverPositionIterations, URDF::DefaultNumberPosSolver);
+            AZStd::max(physxSpecificConfiguration.m_solverPositionIterations, Utils::DefaultNumberPosSolver);
         physxSpecificConfiguration.m_solverVelocityIterations =
-            AZStd::max(physxSpecificConfiguration.m_solverVelocityIterations, URDF::DefaultNumberVelSolver);
+            AZStd::max(physxSpecificConfiguration.m_solverVelocityIterations, Utils::DefaultNumberVelSolver);
 
         rigidBodyConfiguration.m_mass = inertial.MassMatrix().Mass();
         rigidBodyConfiguration.m_computeMass = false;
 
-        rigidBodyConfiguration.m_centerOfMassOffset = URDF::TypeConversions::ConvertVector3(inertial.Pose().Pos());
+        rigidBodyConfiguration.m_centerOfMassOffset = Utils::TypeConversions::ConvertVector3(inertial.Pose().Pos());
         rigidBodyConfiguration.m_computeCenterOfMass = false;
 
-        if (!URDF::TypeConversions::ConvertQuaternion(inertial.Pose().Rot()).IsIdentity())
-        { // There is a rotation component in URDF that we are not able to apply
+        if (!Utils::TypeConversions::ConvertQuaternion(inertial.Pose().Rot()).IsIdentity())
+        { // There is a rotation component in the inertial pose that we are not able to apply
             AZ_Warning("AddInertial", false, "Ignoring URDF/SDF inertial origin rotation (no such field in rigid body configuration)");
         }
 

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/InertialsMaker.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/InertialsMaker.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "UrdfParser.h"
+#include "SdfParser.h"
 #include <AzCore/Component/EntityId.h>
 
 namespace ROS2RobotImporter

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/JointsMaker.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/JointsMaker.cpp
@@ -35,7 +35,7 @@ namespace ROS2RobotImporter
         auto quaternion = AZ::Quaternion::CreateIdentity();
         if (jointAxis != nullptr)
         {
-            jointCoordinateAxis = URDF::TypeConversions::ConvertVector3(jointAxis->Xyz());
+            jointCoordinateAxis = Utils::TypeConversions::ConvertVector3(jointAxis->Xyz());
             quaternion = jointCoordinateAxis.IsZero() ? AZ::Quaternion::CreateIdentity()
                                                       : AZ::Quaternion::CreateShortestArc(o3deJointDir, jointCoordinateAxis);
         }

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/JointsMaker.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/JointsMaker.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "UrdfParser.h"
+#include "SdfParser.h"
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Outcome/Outcome.h>

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/PrefabMakerUtils.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/PrefabMakerUtils.cpp
@@ -47,10 +47,10 @@ namespace ROS2RobotImporter::PrefabMakerUtils
 
     void SetEntityTransformLocal(const gz::math::Pose3d& origin, AZ::EntityId entityId)
     {
-        gz::math::Vector3 urdfPosition = origin.Pos();
-        gz::math::Quaternion urdfRotation = origin.Rot();
-        AZ::Quaternion azRotation = URDF::TypeConversions::ConvertQuaternion(urdfRotation);
-        AZ::Vector3 azPosition = URDF::TypeConversions::ConvertVector3(urdfPosition);
+        gz::math::Vector3 sdfPosition = origin.Pos();
+        gz::math::Quaternion sdfRotation = origin.Rot();
+        AZ::Quaternion azRotation = Utils::TypeConversions::ConvertQuaternion(sdfRotation);
+        AZ::Vector3 azPosition = Utils::TypeConversions::ConvertVector3(sdfPosition);
         AZ::Transform tf(azPosition, azRotation, 1.0f);
 
         AZ::Entity* entity = AzToolsFramework::GetEntityById(entityId);
@@ -145,22 +145,22 @@ namespace ROS2RobotImporter::PrefabMakerUtils
     }
 
     AZStd::optional<Utils::AvailableAsset> GetAssetFromUri(
-        const Utils::UrdfAssetMap& urdfAssetsMapping, const AZStd::string& modelUri, const AZStd::string& assetUri)
+        const Utils::ReferencedAssetMap& referencedAssetMap, const AZStd::string& modelUri, const AZStd::string& assetUri)
     {
         const AZStd::string modelAssetUri = (modelUri.empty()) ? assetUri : modelUri + "/" + assetUri;
-        if (!urdfAssetsMapping.contains(modelAssetUri))
+        if (!referencedAssetMap.contains(modelAssetUri))
         {
             AZ_Warning("GetAssetFromUri", false, "there is no asset for mesh %s in model %s", assetUri.c_str(), modelUri.c_str());
             return AZStd::nullopt;
         }
 
-        return urdfAssetsMapping.at(modelAssetUri).m_availableAssetInfo;
+        return referencedAssetMap.at(modelAssetUri).m_availableAssetInfo;
     }
 
     AZStd::optional<Utils::AvailableAsset> GetAssetFromUri(
-        const Utils::UrdfAssetMap& urdfAssetsMapping, const AZStd::string& modelUri, const std::string& assetUri)
+        const Utils::ReferencedAssetMap& referencedAssetMap, const AZStd::string& modelUri, const std::string& assetUri)
     {
-        return GetAssetFromUri(urdfAssetsMapping, modelUri, AZStd::string(assetUri.c_str(), assetUri.size()));
+        return GetAssetFromUri(referencedAssetMap, modelUri, AZStd::string(assetUri.c_str(), assetUri.size()));
     }
 
 } // namespace ROS2RobotImporter::PrefabMakerUtils

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/PrefabMakerUtils.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/PrefabMakerUtils.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "UrdfParser.h"
+#include "SdfParser.h"
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/std/optional.h>
 #include <AzCore/std/string/string.h>
@@ -68,10 +68,10 @@ namespace ROS2RobotImporter::PrefabMakerUtils
     //! @param assetUri a path to the Asset within the model (e.g. mesh, texture) for which the Asset is requested.
     //! @return Asset for the mesh, if found in the mapping.
     AZStd::optional<Utils::AvailableAsset> GetAssetFromUri(
-        const Utils::UrdfAssetMap& sdfAssetsMapping, const AZStd::string& modelUri, const AZStd::string& assetUri);
+        const Utils::ReferencedAssetMap& sdfAssetsMapping, const AZStd::string& modelUri, const AZStd::string& assetUri);
 
     //! Get Asset from path. Version for std::string.
     //! @see GetAssetFromUri.
     AZStd::optional<Utils::AvailableAsset> GetAssetFromUri(
-        const Utils::UrdfAssetMap& sdfAssetsMapping, const AZStd::string& modelUri, const std::string& assetUri);
+        const Utils::ReferencedAssetMap& sdfAssetsMapping, const AZStd::string& modelUri, const std::string& assetUri);
 } // namespace ROS2RobotImporter::PrefabMakerUtils

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/SdfParser.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/SdfParser.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include "UrdfParser.h"
+#include "SdfParser.h"
 
 #include <sstream>
 
@@ -17,7 +17,7 @@
 #include <RobotImporter/Utils/ErrorUtils.h>
 #include <RobotImporter/Utils/FilePath.h>
 
-namespace ROS2RobotImporter::UrdfParser
+namespace ROS2RobotImporter::SdfParser
 {
     class RedirectSDFOutputStream
     {
@@ -122,16 +122,16 @@ namespace ROS2RobotImporter::UrdfParser
         // Store path in a AZ::IO::FixedMaxPath which is stack based structure that provides memory
         // for the path string and is null terminated.
         // It is backed by an AZStd::fixed_string<1024> which is a char buffer of 1025 internally
-        AZ::IO::FixedMaxPath urdfFilePath = filePath.FixedMaxPathString();
-        std::ifstream istream(urdfFilePath.c_str());
+        AZ::IO::FixedMaxPath sourceFilePath = filePath.FixedMaxPathString();
+        std::ifstream istream(sourceFilePath.c_str());
         if (!istream)
         {
-            auto fileNotFoundMessage = AZStd::fixed_string<1024>::format("File %.*s does not exist", AZ_PATH_ARG(urdfFilePath));
+            auto fileNotFoundMessage = AZStd::fixed_string<1024>::format("File %.*s does not exist", AZ_PATH_ARG(sourceFilePath));
             ParseResult fileNotFoundResult;
             fileNotFoundResult.m_sdfErrors.emplace_back(
                 sdf::ErrorCode::FILE_READ,
                 std::string{ fileNotFoundMessage.c_str(), fileNotFoundMessage.size() },
-                std::string{ urdfFilePath.c_str(), urdfFilePath.Native().size() });
+                std::string{ sourceFilePath.c_str(), sourceFilePath.Native().size() });
             return fileNotFoundResult;
         }
 
@@ -149,4 +149,4 @@ namespace ROS2RobotImporter::UrdfParser
         return Parse(xmlStr, parserConfig);
     }
 
-} // namespace ROS2RobotImporter::UrdfParser
+} // namespace ROS2RobotImporter::SdfParser

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/SdfParser.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/SdfParser.h
@@ -24,11 +24,12 @@
 #include <sdf/Root.hh>
 #include <sdf/Visual.hh>
 
-namespace ROS2RobotImporter::UrdfParser
+namespace ROS2RobotImporter::SdfParser
 {
-    //! Functions for parsing URDF/SDF data.
+    //! Functions for parsing robot description data (URDF, SDF, .world) into an sdf::Root object.
+    //! Every supported format is loaded through libsdformat, so the result is always an SDF object tree.
 
-    //! Stores the result of parsing URDF/SDF data
+    //! Stores the result of parsing robot description data
     //! The operator bool returns true if the sdf::Errors vector is empty
     struct ParseResult
     {
@@ -47,7 +48,7 @@ namespace ROS2RobotImporter::UrdfParser
         sdf::Root&& GetRoot() &&;
 
         //! Property getters for retrieving parsing messages
-        //! logged during libsdformat parsing of the URDF content
+        //! logged during libsdformat parsing of the file content
         //! This does not support a non-const lvalue overload
         //! As modification the result structure parser messages
         //! have no need to be modified inplace
@@ -87,7 +88,7 @@ namespace ROS2RobotImporter::UrdfParser
     using RootObjectOutcome = ParseResult;
 
     //! Parse string with URDF/SDF data and generate root SDF object.
-    //! @param xmlString a string that contains URDF data (XML format).
+    //! @param xmlString a string that contains URDF or SDF data (XML format).
     //! @param parserConfig structure that contains configuration options for the SDFormatter parser
     //!        The relevant ParserConfig functions for URDF importing are
     //!        URDFPreserveFixedJoint() function to prevent merging of robot links bound by fixed joint
@@ -96,8 +97,8 @@ namespace ROS2RobotImporter::UrdfParser
     RootObjectOutcome Parse(AZStd::string_view xmlString, const sdf::ParserConfig& parserConfig);
     RootObjectOutcome Parse(const std::string& xmlString, const sdf::ParserConfig& parserConfig);
 
-    //! Parse file with URDF data and generate model.
-    //! @param filePath is a path to file with URDF data that will be loaded and parsed.
+    //! Parse file with URDF/SDF data and generate model.
+    //! @param filePath is a path to a .urdf, .sdf or .world file that will be loaded and parsed.
     //! @param parserConfig structure that contains configuration options for the SDFormater parser
     //!        The relevant ParserConfig functions for URDF importing are
     //!        URDFPreserveFixedJoint() function to prevent merging of robot links bound by fixed joint
@@ -106,4 +107,4 @@ namespace ROS2RobotImporter::UrdfParser
     //! @return SDF root object containing parsed <world> or <model> tags
     RootObjectOutcome ParseFromFile(
         AZ::IO::PathView filePath, const sdf::ParserConfig& parserConfig, const SdfAssetBuilderSettings& settings);
-} // namespace ROS2RobotImporter::UrdfParser
+} // namespace ROS2RobotImporter::SdfParser

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/SdfPrefabMaker.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/SdfPrefabMaker.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include "URDFPrefabMaker.h"
+#include "SdfPrefabMaker.h"
 #include "CollidersMaker.h"
 #include "PrefabMakerUtils.h"
 #include <API/EditorAssetSystemAPI.h>
@@ -31,15 +31,15 @@
 
 namespace ROS2RobotImporter
 {
-    URDFPrefabMaker::URDFPrefabMaker(
+    SdfPrefabMaker::SdfPrefabMaker(
         const sdf::Root* root,
         AZStd::string prefabPath,
-        const AZStd::shared_ptr<Utils::UrdfAssetMap> urdfAssetsMapping,
+        const AZStd::shared_ptr<Utils::ReferencedAssetMap> referencedAssetMap,
         bool useArticulations,
         const AZStd::optional<AZ::Transform> spawnPosition)
         : m_root(root)
-        , m_visualsMaker(urdfAssetsMapping)
-        , m_collidersMaker(urdfAssetsMapping)
+        , m_visualsMaker(referencedAssetMap)
+        , m_collidersMaker(referencedAssetMap)
         , m_prefabPath(AZStd::move(prefabPath))
         , m_spawnPosition(spawnPosition)
         , m_useArticulations(useArticulations)
@@ -48,7 +48,7 @@ namespace ROS2RobotImporter
         AZ_Assert(m_root, "SDF Root is nullptr");
     }
 
-    URDFPrefabMaker::CreatePrefabTemplateResult URDFPrefabMaker::CreatePrefabTemplateFromUrdfOrSdf()
+    SdfPrefabMaker::CreatePrefabTemplateResult SdfPrefabMaker::CreatePrefabTemplateFromUrdfOrSdf()
     {
         {
             AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
@@ -290,7 +290,7 @@ namespace ROS2RobotImporter
                 AZ::EntityId createdEntityId = createLinkEntityResult.GetValue();
                 std::string linkName = linkPtr->Name();
                 const auto linkSemanticPose = linkPtr->SemanticPose();
-                AZ::Transform tf = Utils::GetLocalTransformURDF(linkSemanticPose);
+                AZ::Transform tf = Utils::GetLocalTransform(linkSemanticPose);
                 auto* entity = AzToolsFramework::GetEntityById(createdEntityId);
                 if (entity)
                 {
@@ -561,7 +561,7 @@ namespace ROS2RobotImporter
         return AZ::Success(prefabTemplateId);
     }
 
-    URDFPrefabMaker::CreatePrefabTemplateResult URDFPrefabMaker::CreatePrefabFromUrdfOrSdf()
+    SdfPrefabMaker::CreatePrefabTemplateResult SdfPrefabMaker::CreatePrefabFromUrdfOrSdf()
     {
         // Begin an undo batch for prefab creation process
         AzToolsFramework::UndoSystem::URSequencePoint* currentUndoBatch = nullptr;
@@ -569,7 +569,7 @@ namespace ROS2RobotImporter
             currentUndoBatch, &AzToolsFramework::ToolsApplicationRequests::BeginUndoBatch, "Robot Importer prefab creation");
         if (currentUndoBatch == nullptr)
         {
-            AZ_Warning("URDF Prefab Maker", false, "Unable to start undobatch, EBus might not be listening");
+            AZ_Warning("SdfPrefabMaker", false, "Unable to start undobatch, EBus might not be listening");
         }
 
         auto result = CreatePrefabTemplateFromUrdfOrSdf();
@@ -616,7 +616,7 @@ namespace ROS2RobotImporter
         return result;
     }
 
-    AzToolsFramework::Prefab::PrefabEntityResult URDFPrefabMaker::CreateEntityForModel(const sdf::Model& model)
+    AzToolsFramework::Prefab::PrefabEntityResult SdfPrefabMaker::CreateEntityForModel(const sdf::Model& model)
     {
         auto createEntityResult = PrefabMakerUtils::CreateEntity(AZ::EntityId{}, model.Name().c_str());
         if (!createEntityResult.IsSuccess())
@@ -632,19 +632,19 @@ namespace ROS2RobotImporter
             transformComponent != nullptr)
         {
             gz::math::Pose3d modelPose = model.RawPose();
-            AZ::Transform modelTransform = URDF::TypeConversions::ConvertPose(modelPose);
+            AZ::Transform modelTransform = Utils::TypeConversions::ConvertPose(modelPose);
             // Set the local transform for each model to have it be translated in relation
             // to its parent
             transformComponent->SetLocalTM(AZStd::move(modelTransform));
         }
 
         // Allow the created model entity to persist if there are no errors at ths point
-        entity.release();
+        [[maybe_unused]] auto _ = entity.release();
 
         return entityId;
     }
 
-    AzToolsFramework::Prefab::PrefabEntityResult URDFPrefabMaker::AddEntitiesForLink(
+    AzToolsFramework::Prefab::PrefabEntityResult SdfPrefabMaker::AddEntitiesForLink(
         const sdf::Link& link, const sdf::Model* attachedModel, AZ::EntityId parentEntityId, AZStd::vector<AZ::EntityId>& createdEntities)
     {
         auto createEntityResult = PrefabMakerUtils::CreateEntity(parentEntityId, link.Name().c_str());
@@ -660,7 +660,7 @@ namespace ROS2RobotImporter
         ROS2::ROS2FrameConfiguration frameConfiguration;
         frameConfiguration.m_frameName = AZStd::string(link.Name().c_str());
         auto* ros2interface = ROS2::ROS2EditorInterface::Get();
-        AZ_Assert(ros2interface, "ROS2EditorInterface not available in URDFPrefabMaker::AddEntitiesForLink");
+        AZ_Assert(ros2interface, "ROS2EditorInterface not available in SdfPrefabMaker::AddEntitiesForLink");
         auto* ros2FrameComponent = ros2interface->CreateROS2FrameEditorComponent(*entity, frameConfiguration);
         AZ_Assert(ros2FrameComponent, "ROS2 Frame Component does not exist for %s", entityId.ToString().c_str());
 
@@ -706,17 +706,17 @@ namespace ROS2RobotImporter
         return AZ::Success(entityId);
     }
 
-    const AZStd::string& URDFPrefabMaker::GetPrefabPath() const
+    const AZStd::string& SdfPrefabMaker::GetPrefabPath() const
     {
         return m_prefabPath;
     }
 
-    void URDFPrefabMaker::MoveEntityToDefaultSpawnPoint(
+    void SdfPrefabMaker::MoveEntityToDefaultSpawnPoint(
         const AZ::EntityId& rootEntityId, AZStd::optional<AZ::Transform> spawnPosition = AZStd::nullopt)
     {
         if (!spawnPosition.has_value())
         {
-            AZ_Trace("URDF Importer", "SpawnPosition is null - spawning in Editors default position\n");
+            AZ_Trace("SdfPrefabMaker", "SpawnPosition is null - spawning in Editors default position\n");
             return;
         }
 
@@ -726,15 +726,15 @@ namespace ROS2RobotImporter
 
             if (transformInterface_ == nullptr)
             {
-                AZ_Trace("URDF Importer", "TransformComponent not found in created entity\n") return;
+                AZ_Trace("SdfPrefabMaker", "TransformComponent not found in created entity\n") return;
             }
 
             transformInterface_->SetWorldTM(*spawnPosition);
-            AZ_Trace("URDF Importer", "Successfully set spawn position\n")
+            AZ_Trace("SdfPrefabMaker", "Successfully set spawn position\n")
         }
     }
 
-    AZStd::string URDFPrefabMaker::GetStatus()
+    AZStd::string SdfPrefabMaker::GetStatus()
     {
         AZStd::string report;
         AZStd::lock_guard<AZStd::mutex> lck(m_statusLock);
@@ -774,7 +774,7 @@ namespace ROS2RobotImporter
         return report;
     }
 
-    bool URDFPrefabMaker::ContainsModel() const
+    bool SdfPrefabMaker::ContainsModel() const
     {
         const sdf::Model* sdfModel{};
         auto GetModelAndStopIteration = [&sdfModel](const sdf::Model& model, const Utils::ModelStack&) -> Utils::VisitModelResponse

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/SdfPrefabMaker.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/SdfPrefabMaker.cpp
@@ -639,7 +639,7 @@ namespace ROS2RobotImporter
         }
 
         // Allow the created model entity to persist if there are no errors at ths point
-        [[maybe_unused]] auto _ = entity.release();
+        entity.release();
 
         return entityId;
     }

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/SdfPrefabMaker.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/SdfPrefabMaker.h
@@ -13,8 +13,8 @@
 #include "InertialsMaker.h"
 #include "JointsMaker.h"
 #include "RobotControlMaker.h"
-#include "SensorsMaker.h"
 #include "SdfParser.h"
+#include "SensorsMaker.h"
 #include "VisualsMaker.h"
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Math/Transform.h>

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/SdfPrefabMaker.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/SdfPrefabMaker.h
@@ -14,7 +14,7 @@
 #include "JointsMaker.h"
 #include "RobotControlMaker.h"
 #include "SensorsMaker.h"
-#include "UrdfParser.h"
+#include "SdfParser.h"
 #include "VisualsMaker.h"
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Math/Transform.h>
@@ -30,22 +30,22 @@
 namespace ROS2RobotImporter
 {
     //! Encapsulates constructive mapping of SDF elements to a complete prefab with entities and components
-    class URDFPrefabMaker
+    class SdfPrefabMaker
     {
     public:
         //! Construct PrefabMaker from arguments.
         //! @param root parsed SDF root object.
         //! @param prefabPath path to the prefab which will be created as a result of import.
-        //! @param urdfAssetsMapping prepared mapping of SDF meshes to Assets.
+        //! @param referencedAssetMap prepared mapping of SDF meshes to Assets.
         //! @param useArticulations allows sdfImporter to create PhysXArticulations instead of multiple rigid bodies and joints.
-        URDFPrefabMaker(
+        SdfPrefabMaker(
             const sdf::Root* root,
             AZStd::string prefabPath,
-            const AZStd::shared_ptr<Utils::UrdfAssetMap> sdfAssetsMapping,
+            const AZStd::shared_ptr<Utils::ReferencedAssetMap> sdfAssetsMapping,
             bool useArticulations = false,
             AZStd::optional<AZ::Transform> spawnPosition = AZStd::nullopt);
 
-        ~URDFPrefabMaker() = default;
+        ~SdfPrefabMaker() = default;
 
         //! On prefab creation this will contain a prefab template id when successful,
         //! and an error string on failure.

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/VisualsMaker.cpp
@@ -27,8 +27,8 @@
 namespace ROS2RobotImporter
 {
     VisualsMaker::VisualsMaker() = default;
-    VisualsMaker::VisualsMaker(const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping)
-        : m_urdfAssetsMapping(urdfAssetsMapping)
+    VisualsMaker::VisualsMaker(const AZStd::shared_ptr<Utils::ReferencedAssetMap>& referencedAssetMap)
+        : m_referencedAssetMap(referencedAssetMap)
     {
     }
 
@@ -155,7 +155,7 @@ namespace ROS2RobotImporter
             {
                 auto boxGeometry = geometry->BoxShape();
                 AZ_Assert(boxGeometry, "geometry is not Box");
-                const AZ::Vector3 boxDimensions = URDF::TypeConversions::ConvertVector3(boxGeometry->Size());
+                const AZ::Vector3 boxDimensions = Utils::TypeConversions::ConvertVector3(boxGeometry->Size());
 
                 // The `_box_1x1.fbx.azmodel` is created by Asset Processor based on O3DE `PrimitiveAssets` Gem source.
                 const char* boxAssetRelPath = "objects/_primitives/_box_1x1.fbx.azmodel"; // relative path to cache folder.
@@ -174,10 +174,10 @@ namespace ROS2RobotImporter
             {
                 auto meshGeometry = geometry->MeshShape();
                 AZ_Assert(meshGeometry, "geometry is not Mesh");
-                const AZ::Vector3 scaleVector = URDF::TypeConversions::ConvertVector3(meshGeometry->Scale());
+                const AZ::Vector3 scaleVector = Utils::TypeConversions::ConvertVector3(meshGeometry->Scale());
 
                 const auto asset =
-                    PrefabMakerUtils::GetAssetFromUri(*m_urdfAssetsMapping, modelUri, AZStd::string(meshGeometry->Uri().c_str()));
+                    PrefabMakerUtils::GetAssetFromUri(*m_referencedAssetMap, modelUri, AZStd::string(meshGeometry->Uri().c_str()));
                 AZ_Warning("AddVisual", asset, "There is no source asset for %s.", meshGeometry->Uri().c_str());
 
                 if (asset)
@@ -283,7 +283,7 @@ namespace ROS2RobotImporter
 
     static void OverrideMaterialPbrSettings(
         const sdf::Material* material,
-        const AZStd::shared_ptr<Utils::UrdfAssetMap>& assetMapping,
+        const AZStd::shared_ptr<Utils::ReferencedAssetMap>& assetMapping,
         const AZStd::string& modelUri,
         AZ::Render::MaterialAssignmentMap& overrides)
     {
@@ -408,7 +408,7 @@ namespace ROS2RobotImporter
             // It will likely be too dark, but that's still probably better than not setting the color at all.
             // Convert from gamma to linear to try and account for the different color spaces between phong and PBR rendering.
             const auto materialColor = material->Element()->HasElement("diffuse") ? material->Diffuse() : material->Ambient();
-            const AZ::Color baseColor = URDF::TypeConversions::ConvertColor(materialColor).GammaToLinear();
+            const AZ::Color baseColor = Utils::TypeConversions::ConvertColor(materialColor).GammaToLinear();
 
             for (auto& [id, materialAssignment] : overrides)
             {
@@ -445,7 +445,7 @@ namespace ROS2RobotImporter
             // Get the color and convert from gamma to linear to try and account for the different color spaces between phong and PBR
             // rendering.
             const auto materialColor = material->Emissive();
-            const AZ::Color emissiveColor = URDF::TypeConversions::ConvertColor(materialColor).GammaToLinear();
+            const AZ::Color emissiveColor = Utils::TypeConversions::ConvertColor(materialColor).GammaToLinear();
 
             // It seems to be fairly common to have an emissive entry of black, which isn't emissive at all.
             // Only enable the emissive color if it's a non-black value.
@@ -492,7 +492,7 @@ namespace ROS2RobotImporter
                 // anyways, so it's hard to say what perceptual brightness model would cause any better or worse results here.
                 // Another possibility to consider would be taking the max of the RGB values.
                 const auto materialColor = material->Specular();
-                const AZ::Color specularColor = URDF::TypeConversions::ConvertColor(materialColor);
+                const AZ::Color specularColor = Utils::TypeConversions::ConvertColor(materialColor);
                 const float specularBrightness = (specularColor.GetR() + specularColor.GetG() + specularColor.GetB()) / 3.0f;
                 roughness = 1.0f - specularBrightness;
 
@@ -565,7 +565,7 @@ namespace ROS2RobotImporter
         // Try to override all of the various material settings based on what's contained in the <material> and <visual> elements in the
         // source file.
         OverrideScriptMaterial(material, config.m_materials);
-        OverrideMaterialPbrSettings(material, m_urdfAssetsMapping, modelUri, config.m_materials);
+        OverrideMaterialPbrSettings(material, m_referencedAssetMap, modelUri, config.m_materials);
         OverrideMaterialBaseColor(material, config.m_materials);
         OverrideMaterialTransparency(visual, config.m_materials);
         OverrideMaterialEmissiveSettings(material, config.m_materials);

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/VisualsMaker.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/URDF/VisualsMaker.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "UrdfParser.h"
+#include "SdfParser.h"
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/Math/Vector3.h>
@@ -23,11 +23,11 @@ namespace ROS2RobotImporter
     {
     public:
         VisualsMaker();
-        VisualsMaker(const AZStd::shared_ptr<Utils::UrdfAssetMap>& urdfAssetsMapping);
+        VisualsMaker(const AZStd::shared_ptr<Utils::ReferencedAssetMap>& referencedAssetMap);
 
         //! Add zero, one or many visual elements to a given entity (depending on link content).
         //! Note that a sub-entity will be added to hold each visual (since they can have different transforms).
-        //! @param link A parsed URDF tree link node which could hold information about visuals.
+        //! @param link A parsed SDF link node which could hold information about visuals.
         //! @param modelUri The URI of the model to use for the visual.
         //! @param entityId A non-active entity which will be affected.
         //! @return List containing any entities created.
@@ -41,6 +41,6 @@ namespace ROS2RobotImporter
         void AddMaterialForVisual(
             const sdf::Visual* visual, const AZStd::string& modelUri, AZ::EntityId entityId, const AZ::Data::AssetId& assetId) const;
 
-        AZStd::shared_ptr<Utils::UrdfAssetMap> m_urdfAssetsMapping;
+        AZStd::shared_ptr<Utils::ReferencedAssetMap> m_referencedAssetMap;
     };
 } // namespace ROS2RobotImporter

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/DefaultSolverConfiguration.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/DefaultSolverConfiguration.h
@@ -9,10 +9,10 @@
 
 #include <AzCore/base.h>
 
-namespace ROS2RobotImporter::URDF
+namespace ROS2RobotImporter::Utils
 {
     // Here is the recommended, minimal number of iterations for position and velocity solver.
     // It is needed since currently O3DE default values are optimized for the gaming experience, not a simulation.
     constexpr AZ::u8 DefaultNumberPosSolver = 40;
     constexpr AZ::u8 DefaultNumberVelSolver = 10;
-} // namespace ROS2RobotImporter::URDF
+} // namespace ROS2RobotImporter::Utils

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/ErrorUtils.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/ErrorUtils.h
@@ -15,7 +15,7 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/function/function_template.h>
 #include <AzCore/std/string/string.h>
-#include <RobotImporter/URDF/UrdfParser.h>
+#include <RobotImporter/URDF/SdfParser.h>
 
 #include <sdf/sdf.hh>
 

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -29,7 +29,7 @@ namespace ROS2RobotImporter::Utils
         };
     } // namespace Internal
 
-    bool IsWheelURDFHeuristics(const sdf::Model& model, const sdf::Link* link)
+    bool IsWheelHeuristics(const sdf::Model& model, const sdf::Link* link)
     {
         auto wheelMatcher = [](AZStd::string_view name)
         {
@@ -80,7 +80,7 @@ namespace ROS2RobotImporter::Utils
         return isWheel;
     }
 
-    AZ::Transform GetLocalTransformURDF(const sdf::SemanticPose& semanticPose, AZ::Transform t)
+    AZ::Transform GetLocalTransform(const sdf::SemanticPose& semanticPose, AZ::Transform t)
     {
         // Determine if the pose is relative to another link
         // See doxygen at
@@ -95,7 +95,7 @@ namespace ROS2RobotImporter::Utils
             return {};
         }
 
-        const AZ::Transform localTransform = URDF::TypeConversions::ConvertPose(resolvedPose);
+        const AZ::Transform localTransform = Utils::TypeConversions::ConvertPose(resolvedPose);
         const AZ::Transform resolvedTransform = localTransform * t;
         return resolvedTransform;
     }
@@ -598,13 +598,13 @@ namespace ROS2RobotImporter::Utils
         return resultModel;
     }
 
-    UrdfAssetMap GetReferencedAssetFilenames(const sdf::Root& root)
+    ReferencedAssetMap GetReferencedAssetFilenames(const sdf::Root& root)
     {
-        UrdfAssetMap urdfAssetMap;
-        auto GetAssetsFromModel = [&urdfAssetMap](const sdf::Model& model, const ModelStack&) -> VisitModelResponse
+        ReferencedAssetMap referencedAssetMap;
+        auto GetAssetsFromModel = [&referencedAssetMap](const sdf::Model& model, const ModelStack&) -> VisitModelResponse
         {
             AZStd::string modelUri(model.Uri().c_str(), model.Uri().size());
-            const auto addFilenameFromGeometry = [&urdfAssetMap, &modelUri](const sdf::Geometry* geometry, ReferencedAssetType assetType)
+            const auto addFilenameFromGeometry = [&referencedAssetMap, &modelUri](const sdf::Geometry* geometry, ReferencedAssetType assetType)
             {
                 if (geometry->Type() == sdf::GeometryType::MESH)
                 {
@@ -612,23 +612,23 @@ namespace ROS2RobotImporter::Utils
                     {
                         const AZ::IO::Path assetUri(mesh->Uri().c_str(), mesh->Uri().size());
                         const AZStd::string modelAssetUri = (modelUri.empty()) ? assetUri.String() : modelUri + "/" + assetUri.String();
-                        if (urdfAssetMap.contains(modelAssetUri))
+                        if (referencedAssetMap.contains(modelAssetUri))
                         {
-                            urdfAssetMap[modelAssetUri].m_assetType |= assetType;
+                            referencedAssetMap[modelAssetUri].m_assetType |= assetType;
                         }
                         else
                         {
-                            UrdfAsset asset;
+                            ReferencedAsset asset;
                             asset.m_assetType = assetType;
                             asset.m_modelUri = modelUri;
                             asset.m_assetUri = assetUri;
-                            urdfAssetMap.emplace(modelAssetUri, AZStd::move(asset));
+                            referencedAssetMap.emplace(modelAssetUri, AZStd::move(asset));
                         }
                     }
                 }
             };
 
-            const auto addFilenamesFromMaterial = [&urdfAssetMap, &modelUri](const sdf::Material* material)
+            const auto addFilenamesFromMaterial = [&referencedAssetMap, &modelUri](const sdf::Material* material)
             {
                 // Only PBR entries on a material have filenames that need to be added.
                 if ((!material) || (!material->PbrMaterial()))
@@ -648,16 +648,16 @@ namespace ROS2RobotImporter::Utils
                         }
                     }
 
-                    const auto emplaceTexture = [&urdfAssetMap, &modelUri](const std::string& texturePath)
+                    const auto emplaceTexture = [&referencedAssetMap, &modelUri](const std::string& texturePath)
                     {
-                        UrdfAsset asset;
+                        ReferencedAsset asset;
                         asset.m_assetType = ReferencedAssetType::Texture;
                         asset.m_modelUri = modelUri;
                         asset.m_assetUri = AZ::IO::Path(texturePath.data(), texturePath.size());
 
                         const AZStd::string modelAssetUri =
                             (modelUri.empty()) ? asset.m_assetUri.String() : modelUri + "/" + asset.m_assetUri.String();
-                        urdfAssetMap.emplace(modelAssetUri, AZStd::move(asset));
+                        referencedAssetMap.emplace(modelAssetUri, AZStd::move(asset));
                     };
 
                     if (auto texture = pbrWorkflow->AlbedoMap(); !texture.empty())
@@ -719,7 +719,7 @@ namespace ROS2RobotImporter::Utils
 
         VisitModels(root, GetAssetsFromModel);
 
-        return urdfAssetMap;
+        return referencedAssetMap;
     }
 
     AZ::IO::Path ResolveAmentPrefixPath(AZ::IO::Path unresolvedPath, AZStd::string_view amentPrefixPath, const FileExistsCB& fileExistsCB)
@@ -962,12 +962,12 @@ namespace ROS2RobotImporter::Utils
             {
                 if (getEnvOutcome.GetError().m_errorCode == AZ::Utils::GetEnvErrorCode::EnvNotSet)
                 {
-                    AZ_Error("UrdfAssetMap", false, "AMENT_PREFIX_PATH is not set in the environment.");
+                    AZ_Error("ReferencedAssetMap", false, "AMENT_PREFIX_PATH is not set in the environment.");
                 }
                 else if (getEnvOutcome.GetError().m_errorCode == AZ::Utils::GetEnvErrorCode::BufferTooSmall)
                 {
                     AZ_Error(
-                        "UrdfAssetMap",
+                        "ReferencedAssetMap",
                         false,
                         "AMENT_PREFIX_PATH is too long (%zu), maximum permissible size is %zu ",
                         getEnvOutcome.GetError().m_requiredSize,
@@ -975,7 +975,7 @@ namespace ROS2RobotImporter::Utils
                 }
                 else
                 {
-                    AZ_Error("UrdfAssetMap", false, "AMENT_PREFIX_PATH is not found.");
+                    AZ_Error("ReferencedAssetMap", false, "AMENT_PREFIX_PATH is not found.");
                 }
             }
 

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/RobotImporterUtils.cpp
@@ -604,7 +604,8 @@ namespace ROS2RobotImporter::Utils
         auto GetAssetsFromModel = [&referencedAssetMap](const sdf::Model& model, const ModelStack&) -> VisitModelResponse
         {
             AZStd::string modelUri(model.Uri().c_str(), model.Uri().size());
-            const auto addFilenameFromGeometry = [&referencedAssetMap, &modelUri](const sdf::Geometry* geometry, ReferencedAssetType assetType)
+            const auto addFilenameFromGeometry =
+                [&referencedAssetMap, &modelUri](const sdf::Geometry* geometry, ReferencedAssetType assetType)
             {
                 if (geometry->Type() == sdf::GeometryType::MESH)
                 {

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/RobotImporterUtils.h
@@ -15,7 +15,7 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/function/function_template.h>
 #include <AzCore/std/string/string.h>
-#include <RobotImporter/URDF/UrdfParser.h>
+#include <RobotImporter/URDF/SdfParser.h>
 #include <RobotImporter/Utils/SourceAssetsStorage.h>
 #include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
 
@@ -36,13 +36,13 @@ namespace ROS2RobotImporter::Utils
     //! @param sdfModel Model object which is used to query the joints from SDF format data
     //! @param link the link that will be subjected to the heuristic.
     //! @return true if the link is likely a wheel link.
-    bool IsWheelURDFHeuristics(const sdf::Model& model, const sdf::Link* link);
+    bool IsWheelHeuristics(const sdf::Model& model, const sdf::Link* link);
 
     //! Returns an AZ::Transform converted from the link pose defined relative to another frame.
     //! @param semanticPose pointer to URDF/SDF link
     //! @param t initial transform, multiplied against link transform
     //! @returns Transform of link
-    AZ::Transform GetLocalTransformURDF(const sdf::SemanticPose& semanticPose, AZ::Transform t = AZ::Transform::Identity());
+    AZ::Transform GetLocalTransform(const sdf::SemanticPose& semanticPose, AZ::Transform t = AZ::Transform::Identity());
 
     //! Type Alias representing a "stack" of Model object that were visited on the way to the current Link/Joint Visitor Callback
     using ModelStack = AZStd::deque<AZStd::reference_wrapper<const sdf::Model>>;
@@ -194,7 +194,7 @@ namespace ROS2RobotImporter::Utils
     //! The URIs will still need to get resolved via ResolveAssetPath() to point to a valid file location.
     //! @param root reference to SDF Root object representing the root of the parsed SDF xml document
     //! @returns mapping from asset name (model URI + asset URI) to asset info.
-    UrdfAssetMap GetReferencedAssetFilenames(const sdf::Root& root);
+    ReferencedAssetMap GetReferencedAssetFilenames(const sdf::Root& root);
 
     //! Callback used to check for file exist of a path referenced within a URDF/SDF file
     //! @param path Candidate local filesystem path to check for existence

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -37,7 +37,7 @@ namespace ROS2RobotImporter::Utils
 {
 
     //! A helper class that do no extend PhysX::Pipeline::MeshGroup functionality, but gives necessary setters.
-    class UrdfPhysxMeshGroupHelper : public PhysX::Pipeline::MeshGroup
+    class PhysxMeshGroupHelper : public PhysX::Pipeline::MeshGroup
     {
     public:
         void SetIsDecomposeMeshes(bool decompose)
@@ -285,37 +285,37 @@ namespace ROS2RobotImporter::Utils
     }
 
     void CopyReferencedAssetsAndCreateAssetMap(
-        UrdfAssetMap& urdfAssetMap,
-        const AZ::IO::Path& urdfFilepath,
+        ReferencedAssetMap& referencedAssetMap,
+        const AZ::IO::Path& sourceFilePath,
         const SdfAssetBuilderSettings& sdfBuilderSettings,
         AZStd::string_view outputDirSuffix,
         AZ::IO::FileIOBase* fileIO)
     {
-        ResolveAssetMap(urdfAssetMap, urdfFilepath, sdfBuilderSettings);
-        AZStd::mutex urdfAssetMapMutex;
-        if (urdfAssetMap.empty())
+        ResolveAssetMap(referencedAssetMap, sourceFilePath, sdfBuilderSettings);
+        AZStd::mutex referencedAssetMapMutex;
+        if (referencedAssetMap.empty())
         {
             return;
         }
 
-        auto destDirectory = PrepareImportedAssetsDest(urdfFilepath, outputDirSuffix, fileIO);
+        auto destDirectory = PrepareImportedAssetsDest(sourceFilePath, outputDirSuffix, fileIO);
         if (!destDirectory.IsSuccess())
         {
             return;
         }
 
         AZStd::unordered_map<AZ::IO::Path, unsigned int> duplicatedFilenames;
-        for (auto& [unresolvedFileName, urdfAsset] : urdfAssetMap)
+        for (auto& [unresolvedFileName, referencedAsset] : referencedAssetMap)
         {
-            if (duplicatedFilenames.contains(urdfAsset.m_assetUri))
+            if (duplicatedFilenames.contains(referencedAsset.m_assetUri))
             {
-                duplicatedFilenames[urdfAsset.m_assetUri]++;
+                duplicatedFilenames[referencedAsset.m_assetUri]++;
             }
             else
             {
-                duplicatedFilenames[urdfAsset.m_assetUri] = 0;
+                duplicatedFilenames[referencedAsset.m_assetUri] = 0;
             }
-            CopyReferencedAsset(destDirectory.GetValue(), urdfAsset, duplicatedFilenames[urdfAsset.m_assetUri]);
+            CopyReferencedAsset(destDirectory.GetValue(), referencedAsset, duplicatedFilenames[referencedAsset.m_assetUri]);
         }
         Utils::RemoveTmpDir(destDirectory.GetValue().importDirectoryTmp);
 
@@ -323,7 +323,7 @@ namespace ROS2RobotImporter::Utils
     }
 
     void FindReferencedAssets(
-        UrdfAssetMap& unresolvedAssetMap, const AZ::IO::Path& urdfFilepath, const SdfAssetBuilderSettings& sdfBuilderSettings)
+        ReferencedAssetMap& unresolvedAssetMap, const AZ::IO::Path& sourceFilePath, const SdfAssetBuilderSettings& sdfBuilderSettings)
     {
         if (!unresolvedAssetMap.empty())
         {
@@ -332,8 +332,8 @@ namespace ROS2RobotImporter::Utils
             // Search for suitable mappings by comparing checksum
             for (auto& [unresolvedFileName, asset] : unresolvedAssetMap)
             {
-                asset.m_urdfFileCRC = Utils::GetFileCRC(asset.m_resolvedUrdfPath);
-                auto found_source_asset = availableAssets.find(asset.m_urdfFileCRC);
+                asset.m_resolvedFileCRC = Utils::GetFileCRC(asset.m_resolvedPath);
+                auto found_source_asset = availableAssets.find(asset.m_resolvedFileCRC);
                 if (found_source_asset != availableAssets.end())
                 {
                     asset.m_availableAssetInfo = found_source_asset->second;
@@ -420,7 +420,7 @@ namespace ROS2RobotImporter::Utils
 
         if (collider)
         {
-            AZStd::shared_ptr<UrdfPhysxMeshGroupHelper> physxDataMeshGroup = AZStd::make_shared<UrdfPhysxMeshGroupHelper>();
+            AZStd::shared_ptr<PhysxMeshGroupHelper> physxDataMeshGroup = AZStd::make_shared<PhysxMeshGroupHelper>();
             physxDataMeshGroup->SetIsDecomposeMeshes(true);
             physxDataMeshGroup->SetMeshExportMethod(PhysX::Pipeline::MeshExportMethod::Convex);
 
@@ -457,29 +457,29 @@ namespace ROS2RobotImporter::Utils
     }
 
     void ResolveAssetMap(
-        UrdfAssetMap& unresolvedAssetMap, const AZ::IO::Path& urdfFilepath, const SdfAssetBuilderSettings& sdfBuilderSettings)
+        ReferencedAssetMap& unresolvedAssetMap, const AZ::IO::Path& sourceFilePath, const SdfAssetBuilderSettings& sdfBuilderSettings)
     {
         auto amentPrefixPath = Utils::GetAmentPrefixPath();
 
         for (auto& [unresolvedFileName, asset] : unresolvedAssetMap)
         {
-            asset.m_resolvedUrdfPath = Utils::ResolveAssetPath(unresolvedFileName, urdfFilepath, amentPrefixPath, sdfBuilderSettings);
-            asset.m_urdfFileCRC = AZ::Crc32();
+            asset.m_resolvedPath = Utils::ResolveAssetPath(unresolvedFileName, sourceFilePath, amentPrefixPath, sdfBuilderSettings);
+            asset.m_resolvedFileCRC = AZ::Crc32();
         }
     }
 
     AZ::Outcome<ImportedAssetsDest> PrepareImportedAssetsDest(
-        const AZ::IO::Path& urdfFilepath, AZStd::string_view outputDirSuffix, AZ::IO::FileIOBase* fileIO)
+        const AZ::IO::Path& sourceFilePath, AZStd::string_view outputDirSuffix, AZ::IO::FileIOBase* fileIO)
     {
         AZ_Assert(fileIO, "No FileIO instance");
-        AZ::Crc32 urdfFileCrc;
-        urdfFileCrc.Add(urdfFilepath.c_str(), urdfFilepath.Native().size());
+        AZ::Crc32 sourceFileCrc;
+        sourceFileCrc.Add(sourceFilePath.c_str(), sourceFilePath.Native().size());
 
         // By naming the temp directory '$tmp_*', the default configuration in AssetProcessorPlatformConfig.setreg will
         // exclude these files from processing.
-        const AZStd::string directoryNameTmp = AZStd::string::format("$tmp_%u.tmp", AZ::u32(urdfFileCrc));
+        const AZStd::string directoryNameTmp = AZStd::string::format("$tmp_%u.tmp", AZ::u32(sourceFileCrc));
         const auto directoryNameDst = AZ::IO::FixedMaxPathString::format(
-            "%u_%.*s%.*s", AZ::u32(urdfFileCrc), AZ_PATH_ARG(urdfFilepath.Stem()), AZ_STRING_ARG(outputDirSuffix));
+            "%u_%.*s%.*s", AZ::u32(sourceFileCrc), AZ_PATH_ARG(sourceFilePath.Stem()), AZ_STRING_ARG(outputDirSuffix));
 
         const AZ::IO::Path importDirectoryTmp = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "Importer" / directoryNameTmp;
         const AZ::IO::Path importDirectoryDst = AZ::IO::Path(AZ::Utils::GetProjectPath()) / "Assets" / "Importer" / directoryNameDst;
@@ -487,8 +487,8 @@ namespace ROS2RobotImporter::Utils
         fileIO->DestroyPath(importDirectoryTmp.c_str());
         const auto outcomeCreateDstDir = fileIO->CreatePath(importDirectoryDst.c_str());
         const auto outcomeCreateTmpDir = fileIO->CreatePath(importDirectoryTmp.c_str());
-        AZ_Error("CopyAssetForURDF", outcomeCreateDstDir, "Cannot create destination directory : %s", importDirectoryDst.c_str());
-        AZ_Error("CopyAssetForURDF", outcomeCreateTmpDir, "Cannot create temporary directory : %s", importDirectoryTmp.c_str());
+        AZ_Error("CopyReferencedAsset", outcomeCreateDstDir, "Cannot create destination directory : %s", importDirectoryDst.c_str());
+        AZ_Error("CopyReferencedAsset", outcomeCreateTmpDir, "Cannot create temporary directory : %s", importDirectoryTmp.c_str());
 
         if (!outcomeCreateDstDir || !outcomeCreateTmpDir)
         {
@@ -514,7 +514,7 @@ namespace ROS2RobotImporter::Utils
         const auto outcomeRemoveTmpDir = fileIO->DestroyPath($tmpDir.c_str());
         if (!outcomeRemoveTmpDir)
         {
-            AZ_Error("CopyAssetForURDF", false, "Cannot remove temporary directory : %s", $tmpDir.c_str());
+            AZ_Error("CopyReferencedAsset", false, "Cannot remove temporary directory : %s", $tmpDir.c_str());
             return AZ::Failure();
         }
         return AZ::Success(true);
@@ -522,15 +522,15 @@ namespace ROS2RobotImporter::Utils
 
     CopyStatus CopyReferencedAsset(
         const ImportedAssetsDest& importedAssetsDest,
-        Utils::UrdfAsset& urdfAsset,
+        Utils::ReferencedAsset& referencedAsset,
         unsigned int duplicationCounter,
         AZ::IO::FileIOBase* fileIO)
     {
-        AZStd::string filename = urdfAsset.m_resolvedUrdfPath.Filename().String();
+        AZStd::string filename = referencedAsset.m_resolvedPath.Filename().String();
         if (duplicationCounter > 0)
         {
-            AZStd::string stem = urdfAsset.m_resolvedUrdfPath.Stem().String();
-            AZStd::string extension = urdfAsset.m_resolvedUrdfPath.Extension().String();
+            AZStd::string stem = referencedAsset.m_resolvedPath.Stem().String();
+            AZStd::string extension = referencedAsset.m_resolvedPath.Extension().String();
             filename = AZStd::string::format("%s_%u%s", stem.c_str(), duplicationCounter, extension.c_str());
         }
 
@@ -542,14 +542,14 @@ namespace ROS2RobotImporter::Utils
         bool targetAssetExists = fileIO->Exists(targetPathAssetDst.c_str());
         if (!targetAssetExists)
         {
-            urdfAsset.m_copyStatus = CopyStatus::Copying;
+            referencedAsset.m_copyStatus = CopyStatus::Copying;
 
             // copy mesh file to temporary location ignored by AP
-            const auto outcomeCopyTmp = fileIO->Copy(urdfAsset.m_resolvedUrdfPath.c_str(), targetPathAssetTmp.c_str());
+            const auto outcomeCopyTmp = fileIO->Copy(referencedAsset.m_resolvedPath.c_str(), targetPathAssetTmp.c_str());
             AZ_Printf(
-                "CopyAssetForURDF",
+                "CopyReferencedAsset",
                 "Copy %s to %s, result: %d",
-                urdfAsset.m_resolvedUrdfPath.c_str(),
+                referencedAsset.m_resolvedPath.c_str(),
                 targetPathAssetTmp.c_str(),
                 outcomeCopyTmp.GetResultCode());
 
@@ -558,8 +558,8 @@ namespace ROS2RobotImporter::Utils
                 // call FlushIOOfAsset to ensure the asset processor is aware of the new file
                 FlushIOOfAsset(targetPathAssetTmp);
 
-                const bool needsVisual = (urdfAsset.m_assetType & ReferencedAssetType::VisualMesh) == ReferencedAssetType::VisualMesh;
-                const bool needsCollider = (urdfAsset.m_assetType & ReferencedAssetType::ColliderMesh) == ReferencedAssetType::ColliderMesh;
+                const bool needsVisual = (referencedAsset.m_assetType & ReferencedAssetType::VisualMesh) == ReferencedAssetType::VisualMesh;
+                const bool needsCollider = (referencedAsset.m_assetType & ReferencedAssetType::ColliderMesh) == ReferencedAssetType::ColliderMesh;
                 const bool isMeshFile = (needsVisual || needsCollider);
 
                 // if the asset is a mesh, create asset info at destination location using the temporary mesh file
@@ -578,7 +578,7 @@ namespace ROS2RobotImporter::Utils
                             const AZ::IO::Path assetLocalPath(AZ::IO::Path(AZ::IO::Path(AZ::Utils::GetProjectPath()) / unresolvedAssetPath)
                                                                   .LexicallyRelative(importedAssetsDest.importDirectoryTmp));
 
-                            const AZ::IO::Path assetFullPathSrc(AZ::IO::Path(urdfAsset.m_resolvedUrdfPath.ParentPath()) / assetLocalPath);
+                            const AZ::IO::Path assetFullPathSrc(AZ::IO::Path(referencedAsset.m_resolvedPath.ParentPath()) / assetLocalPath);
                             const AZ::IO::Path assetFullPathDst(importedAssetsDest.importDirectoryDst / assetLocalPath);
 
                             const auto outcomeMkdir = fileIO->CreatePath(AZ::IO::Path(assetFullPathDst.ParentPath()).c_str());
@@ -590,7 +590,7 @@ namespace ROS2RobotImporter::Utils
                             const auto outcomeCopy = fileIO->Copy(assetFullPathSrc.c_str(), assetFullPathDst.c_str());
                             if (!outcomeCopy)
                             {
-                                urdfAsset.m_copyStatus = CopyStatus::Failed;
+                                referencedAsset.m_copyStatus = CopyStatus::Failed;
                             }
                         }
                     }
@@ -598,7 +598,7 @@ namespace ROS2RobotImporter::Utils
                     // move asset file from temporary location to destination location
                     const auto outcomeMoveDst = fileIO->Rename(targetPathAssetTmp.c_str(), targetPathAssetDst.c_str());
                     AZ_Printf(
-                        "CopyAssetForURDF",
+                        "CopyReferencedAsset",
                         "Rename file %s to %s, result: %d",
                         targetPathAssetTmp.c_str(),
                         targetPathAssetDst.c_str(),
@@ -607,27 +607,27 @@ namespace ROS2RobotImporter::Utils
                     // call FlushIOOfAsset to ensure the asset processor is aware of the new file
                     FlushIOOfAsset(targetPathAssetDst);
 
-                    urdfAsset.m_copyStatus = outcomeMoveDst ? CopyStatus::Copied : CopyStatus::Failed;
+                    referencedAsset.m_copyStatus = outcomeMoveDst ? CopyStatus::Copied : CopyStatus::Failed;
                 }
             }
             else
             {
-                urdfAsset.m_copyStatus = CopyStatus::Failed;
+                referencedAsset.m_copyStatus = CopyStatus::Failed;
             }
         }
         else
         {
-            AZ_Printf("CopyAssetForURDF", "File %s already exists, omitting import", targetPathAssetDst.c_str());
-            urdfAsset.m_copyStatus = CopyStatus::Exists;
+            AZ_Printf("CopyReferencedAsset", "File %s already exists, omitting import", targetPathAssetDst.c_str());
+            referencedAsset.m_copyStatus = CopyStatus::Exists;
         }
 
-        if (urdfAsset.m_copyStatus == CopyStatus::Exists || urdfAsset.m_copyStatus == CopyStatus::Copied)
+        if (referencedAsset.m_copyStatus == CopyStatus::Exists || referencedAsset.m_copyStatus == CopyStatus::Copied)
         {
-            urdfAsset.m_availableAssetInfo = Utils::GetAvailableAssetInfo(targetPathAssetDst.String());
+            referencedAsset.m_availableAssetInfo = Utils::GetAvailableAssetInfo(targetPathAssetDst.String());
         }
-        urdfAsset.m_urdfFileCRC = AZ::Crc32();
+        referencedAsset.m_resolvedFileCRC = AZ::Crc32();
 
-        return urdfAsset.m_copyStatus;
+        return referencedAsset.m_copyStatus;
     }
 
     AZStd::unordered_set<AZ::IO::Path> GetMeshTextureAssets(const AZ::IO::Path& sourceMeshAssetPath)
@@ -676,7 +676,7 @@ namespace ROS2RobotImporter::Utils
         AzFramework::AssetSystemRequestBus::BroadcastResult(
             assetStatus, &AzFramework::AssetSystem::AssetSystemRequests::GetAssetStatus_FlushIO, path.c_str());
         AZ_Warning(
-            "CopyAssetForURDF",
+            "CopyReferencedAsset",
             assetStatus != AzFramework::AssetSystem::AssetStatus::AssetStatus_Unknown,
             "Asset processor did not recognize the new file %s.",
             path.c_str());

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/SourceAssetsStorage.cpp
@@ -559,7 +559,8 @@ namespace ROS2RobotImporter::Utils
                 FlushIOOfAsset(targetPathAssetTmp);
 
                 const bool needsVisual = (referencedAsset.m_assetType & ReferencedAssetType::VisualMesh) == ReferencedAssetType::VisualMesh;
-                const bool needsCollider = (referencedAsset.m_assetType & ReferencedAssetType::ColliderMesh) == ReferencedAssetType::ColliderMesh;
+                const bool needsCollider =
+                    (referencedAsset.m_assetType & ReferencedAssetType::ColliderMesh) == ReferencedAssetType::ColliderMesh;
                 const bool isMeshFile = (needsVisual || needsCollider);
 
                 // if the asset is a mesh, create asset info at destination location using the temporary mesh file

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/SourceAssetsStorage.h
@@ -28,7 +28,7 @@ namespace ROS2RobotImporter
 namespace ROS2RobotImporter::Utils
 {
     //! Structure contains essential information about the source and product assets in O3DE.
-    //! It is designed to provide necessary information for other classes in URDF converter, eg CollidersMaker or VisualsMaker.
+    //! It is designed to provide necessary information for other classes of the importer, eg CollidersMaker or VisualsMaker.
     struct AvailableAsset
     {
         //! Relative path to source asset eg `Assets/foo_robot/meshes/bar_link.dae`.
@@ -65,10 +65,10 @@ namespace ROS2RobotImporter::Utils
         Failed, //! Failed
     };
 
-    //! The structure contains a mapping between URDF's path to O3DE asset information.
-    struct UrdfAsset
+    //! The structure contains a mapping between an unresolved URI from the source file and O3DE asset information.
+    struct ReferencedAsset
     {
-        UrdfAsset() = default;
+        ReferencedAsset() = default;
 
         //! The model URI associated with the asset.
         AZStd::string m_modelUri;
@@ -76,11 +76,11 @@ namespace ROS2RobotImporter::Utils
         //! Unresolved path to asset, eg `package://meshes/bar_link.dae`.
         AZ::IO::Path m_assetUri;
 
-        //! Resolved URDF path, points to the valid mesh in the filesystem, eg `/home/user/ros_ws/src/foo_robot/meshes/bar_link.dae'
-        AZ::IO::Path m_resolvedUrdfPath;
+        //! Resolved path, points to the valid mesh in the filesystem, eg `/home/user/ros_ws/src/foo_robot/meshes/bar_link.dae'
+        AZ::IO::Path m_resolvedPath;
 
-        //! Checksum of the file located pointed by `m_resolvedUrdfPath`.
-        AZ::Crc32 m_urdfFileCRC;
+        //! Checksum of the file pointed by `m_resolvedPath`.
+        AZ::Crc32 m_resolvedFileCRC;
 
         //! Status of the copy process.
         CopyStatus m_copyStatus = Waiting;
@@ -103,7 +103,7 @@ namespace ROS2RobotImporter::Utils
     };
 
     /// Type that hold result of mapping from asset name (model URI + asset URI) to asset info
-    using UrdfAssetMap = AZStd::unordered_map<AZ::IO::Path, Utils::UrdfAsset>;
+    using ReferencedAssetMap = AZStd::unordered_map<AZ::IO::Path, Utils::ReferencedAsset>;
 
     //! Function computes CRC32 on first kilobyte of file.
     AZ::Crc32 GetFileCRC(const AZ::IO::Path& filename);
@@ -115,13 +115,13 @@ namespace ROS2RobotImporter::Utils
     //! Discover an association between meshes in input SDF/URDF and O3DE source and product assets.
     //! Steps:
     //! - Function scans all available O3DE assets by calling `GetInterestingSourceAssetsCRC`.
-    //! - Files pointed by resolved URDF paths have their checksum computed `GetFileCRC`.
-    //! - Suitable mapping to the O3DE asset is found by comparing the checksum of the file pointed by the URDF path and source asset.
+    //! - Files pointed by resolved paths have their checksum computed `GetFileCRC`.
+    //! - Suitable mapping to the O3DE asset is found by comparing the checksum of the file pointed by the resolved path and source asset.
     //! @param unresolvedAssetMap - list of the unresolved paths from the SDF/URDF file that are to be found as assets
-    //! @param urdfFilepath - path of URDF file, used for resolving paths of referenced assets
+    //! @param sourceFilePath - path of the SDF/URDF file, used for resolving paths of referenced assets
     //! @param sdfBuilderSettings - the builder settings that should be used to resolve paths
     void FindReferencedAssets(
-        UrdfAssetMap& unresolvedAssetMap, const AZ::IO::Path& urdfFilepath, const SdfAssetBuilderSettings& sdfBuilderSettings);
+        ReferencedAssetMap& unresolvedAssetMap, const AZ::IO::Path& sourceFilePath, const SdfAssetBuilderSettings& sdfBuilderSettings);
 
     //! Helper function that gets all the potential primary product asset paths from the source asset GUID
     //! @param sourceAssetUUID is source asset GUID
@@ -169,45 +169,45 @@ namespace ROS2RobotImporter::Utils
     //! Copies and prepares assets that are referenced in SDF/URDF.
     //! It resolves every asset, creates a directory in Project's Asset directory, copies files, and prepares assets info.
     //! Finally, it assembles its results into mapping that allows mapping the SDF/URDF mesh name to the source asset.
-    //! @param urdfAssetMap - files to copy (as unresolved urdf paths)
-    //! @param urdfFilepath - path to URDF file (as a global path)
+    //! @param referencedAssetMap - files to copy (as unresolved URIs)
+    //! @param sourceFilePath - path to the SDF/URDF file (as a global path)
     //! @param sdfBuilderSettings - the builder settings to use to convert the SDF/URDF files
     //! @param outputDirSuffix - suffix to make output directory unique, if xacro file was used
     //! @param fileIO - instance to fileIO class
     void CopyReferencedAssetsAndCreateAssetMap(
-        UrdfAssetMap& urdfAssetMap,
-        const AZ::IO::Path& urdfFilepath,
+        ReferencedAssetMap& referencedAssetMap,
+        const AZ::IO::Path& sourceFilePath,
         const SdfAssetBuilderSettings& sdfBuilderSettings,
         AZStd::string_view outputDirSuffix = "",
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 
-    //! Creates a mapping from unresolved URDF paths to source asset info.
+    //! Creates a mapping from unresolved URIs to source asset info.
     //! @param unresolvedAssetMap - list of assets discovered in the input SDF/URDF file
-    //! @param urdfFilepath - path to URDF file (as a global path)
+    //! @param sourceFilePath - path to the SDF/URDF file (as a global path)
     //! @param sdfBuilderSettings - the builder settings to use to convert the SDF/URDF files
     void ResolveAssetMap(
-        UrdfAssetMap& unresolvedAssetMap, const AZ::IO::Path& urdfFilepath, const SdfAssetBuilderSettings& sdfBuilderSettings);
+        ReferencedAssetMap& unresolvedAssetMap, const AZ::IO::Path& sourceFilePath, const SdfAssetBuilderSettings& sdfBuilderSettings);
 
     //! Copies and prepares asset that is referenced in SDF/URDF.
-    //! Modifies urdfAsset in place.
+    //! Modifies referencedAsset in place.
     //! @param importedAssetsDest - destination ImportedAssetsDest for imported assets.
-    //! @param urdfAsset - asset info. Will be modified.
+    //! @param referencedAsset - asset info. Will be modified.
     //! @param duplicationCounter - number indication the number of times the asset has been duplicated
     //! @param fileIO - instance to fileIO class
     //! @returns status of the copy process
     CopyStatus CopyReferencedAsset(
         const ImportedAssetsDest& importedAssetsDest,
-        Utils::UrdfAsset& urdfAsset,
+        Utils::ReferencedAsset& referencedAsset,
         unsigned int duplicationCounter,
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 
     //! Prepares temporary and final directory for imported assets.
-    //! @param urdfFilepath - path to URDF file (as a global path)
+    //! @param sourceFilePath - path to the SDF/URDF file (as a global path)
     //! @param outputDirSuffix - name of the output directory
     //! @param fileIO - instance to fileIO class
     //! @returns structure containing paths to temporary and final directory for imported assets, or failure if failed to create.
     AZ::Outcome<ImportedAssetsDest> PrepareImportedAssetsDest(
-        const AZ::IO::Path& urdfFilepath,
+        const AZ::IO::Path& sourceFilePath,
         AZStd::string_view outputDirSuffix = "",
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/TypeConversions.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/TypeConversions.cpp
@@ -8,16 +8,16 @@
 
 #include "TypeConversions.h"
 
-namespace ROS2RobotImporter::URDF
+namespace ROS2RobotImporter::Utils
 {
-    AZ::Vector3 TypeConversions::ConvertVector3(const gz::math::Vector3d& urdfVector)
+    AZ::Vector3 TypeConversions::ConvertVector3(const gz::math::Vector3d& gzVector)
     {
-        return AZ::Vector3(urdfVector.X(), urdfVector.Y(), urdfVector.Z());
+        return AZ::Vector3(gzVector.X(), gzVector.Y(), gzVector.Z());
     }
 
-    AZ::Quaternion TypeConversions::ConvertQuaternion(const gz::math::Quaterniond& urdfQuaternion)
+    AZ::Quaternion TypeConversions::ConvertQuaternion(const gz::math::Quaterniond& gzQuaternion)
     {
-        return AZ::Quaternion(urdfQuaternion.X(), urdfQuaternion.Y(), urdfQuaternion.Z(), urdfQuaternion.W());
+        return AZ::Quaternion(gzQuaternion.X(), gzQuaternion.Y(), gzQuaternion.Z(), gzQuaternion.W());
     }
 
     AZ::Color TypeConversions::ConvertColor(const gz::math::Color& color)
@@ -27,9 +27,9 @@ namespace ROS2RobotImporter::URDF
 
     AZ::Transform TypeConversions::ConvertPose(const gz::math::Pose3d& pose)
     {
-        AZ::Quaternion azRotation = URDF::TypeConversions::ConvertQuaternion(pose.Rot());
-        AZ::Vector3 azPosition = URDF::TypeConversions::ConvertVector3(pose.Pos());
+        AZ::Quaternion azRotation = Utils::TypeConversions::ConvertQuaternion(pose.Rot());
+        AZ::Vector3 azPosition = Utils::TypeConversions::ConvertVector3(pose.Pos());
         return AZ::Transform(azPosition, azRotation, 1.0f);
     }
 
-} // namespace ROS2RobotImporter::URDF
+} // namespace ROS2RobotImporter::Utils

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/TypeConversions.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Utils/TypeConversions.h
@@ -12,16 +12,16 @@
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
-#include <RobotImporter/URDF/UrdfParser.h>
+#include <RobotImporter/URDF/SdfParser.h>
 
-namespace ROS2RobotImporter::URDF
+namespace ROS2RobotImporter::Utils
 {
-    //! Common types conversion between urdf and AZ formats
+    //! Common types conversion between gz::math (libsdformat) and AZ formats
     namespace TypeConversions
     {
-        AZ::Vector3 ConvertVector3(const gz::math::Vector3d& urdfVector);
-        AZ::Quaternion ConvertQuaternion(const gz::math::Quaterniond& urdfQuaternion);
+        AZ::Vector3 ConvertVector3(const gz::math::Vector3d& gzVector);
+        AZ::Quaternion ConvertQuaternion(const gz::math::Quaterniond& gzQuaternion);
         AZ::Color ConvertColor(const gz::math::Color& color);
         AZ::Transform ConvertPose(const gz::math::Pose3d& pose);
     }; // namespace TypeConversions
-} // namespace ROS2RobotImporter::URDF
+} // namespace ROS2RobotImporter::Utils

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/xacro/XacroUtils.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/xacro/XacroUtils.cpp
@@ -93,14 +93,14 @@ namespace ROS2RobotImporter::Utils::xacro
             {
                 // modify in memory URDF result
                 auto [modifiedXmlStr, modifiedElements] = (Utils::ModifyURDFInMemory(output));
-                outcome.m_urdfHandle = UrdfParser::Parse(modifiedXmlStr, parserConfig);
-                outcome.m_urdfHandle.m_modifiedURDFContent = AZStd::move(modifiedXmlStr);
-                outcome.m_urdfHandle.m_urdfModifications = AZStd::move(modifiedElements);
+                outcome.m_parseResult = SdfParser::Parse(modifiedXmlStr, parserConfig);
+                outcome.m_parseResult.m_modifiedURDFContent = AZStd::move(modifiedXmlStr);
+                outcome.m_parseResult.m_urdfModifications = AZStd::move(modifiedElements);
                 outcome.m_succeed = true;
             }
             else
             {
-                outcome.m_urdfHandle = UrdfParser::Parse(output, parserConfig);
+                outcome.m_parseResult = SdfParser::Parse(output, parserConfig);
                 outcome.m_succeed = true;
             }
         }

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/xacro/XacroUtils.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/xacro/XacroUtils.h
@@ -10,7 +10,7 @@
 
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/string/string.h>
-#include <RobotImporter/URDF/UrdfParser.h>
+#include <RobotImporter/URDF/SdfParser.h>
 
 namespace ROS2RobotImporter::Utils::xacro
 {
@@ -20,8 +20,8 @@ namespace ROS2RobotImporter::Utils::xacro
     //! Structure that keeps all artifacts of xacro execution
     struct ExecutionOutcome
     {
-        //! Parsed URDF from successful xacro's output
-        UrdfParser::RootObjectOutcome m_urdfHandle;
+        //! Result of parsing the URDF that xacro generated on its standard output
+        SdfParser::RootObjectOutcome m_parseResult;
         //! Return code of 'xacro' program
         bool m_succeed{ false };
         //! Called program name
@@ -34,7 +34,7 @@ namespace ROS2RobotImporter::Utils::xacro
         //! Gets if execution was a success
         explicit operator bool() const
         {
-            return m_succeed && m_urdfHandle;
+            return m_succeed && m_parseResult;
         }
     };
 

--- a/Gems/ROS2RobotImporter/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
@@ -22,8 +22,8 @@
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 #include <AssetBuilderSDK/SerializationDependencies.h>
 
-#include <RobotImporter/URDF/URDFPrefabMaker.h>
-#include <RobotImporter/URDF/UrdfParser.h>
+#include <RobotImporter/URDF/SdfPrefabMaker.h>
+#include <RobotImporter/URDF/SdfParser.h>
 #include <RobotImporter/Utils/ErrorUtils.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
 #include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
@@ -83,12 +83,12 @@ namespace ROS2RobotImporter
         // The AssetBuilderSDK doesn't support deregistration, so there's nothing more to do here.
     }
 
-    Utils::UrdfAssetMap SdfAssetBuilder::FindAssets(const sdf::Root& root, const AZStd::string& sourceFilename) const
+    Utils::ReferencedAssetMap SdfAssetBuilder::FindAssets(const sdf::Root& root, const AZStd::string& sourceFilename) const
     {
         AZ_Info(SdfAssetBuilderName, "Parsing mesh and collider names");
 
-        Utils::UrdfAssetMap allReferencedAssets = Utils::GetReferencedAssetFilenames(root);
-        Utils::UrdfAssetMap existingReferencedAssets;
+        Utils::ReferencedAssetMap allReferencedAssets = Utils::GetReferencedAssetFilenames(root);
+        Utils::ReferencedAssetMap existingReferencedAssets;
 
         using AssetSysReqBus = AzToolsFramework::AssetSystemRequestBus;
 
@@ -96,12 +96,12 @@ namespace ROS2RobotImporter
 
         for (const auto& [unresolvedUri, assetReferenceType] : allReferencedAssets)
         {
-            Utils::UrdfAsset asset;
+            Utils::ReferencedAsset asset;
 
             // Attempt to find the absolute path for the raw uri reference, which might look something like "model://meshes/model.dae"
-            asset.m_resolvedUrdfPath =
+            asset.m_resolvedPath =
                 Utils::ResolveAssetPath(unresolvedUri, AZ::IO::PathView(sourceFilename), amentPrefixPath, m_globalSettings);
-            if (asset.m_resolvedUrdfPath.empty())
+            if (asset.m_resolvedPath.empty())
             {
                 AZ_Warning(
                     SdfAssetBuilderName,
@@ -114,7 +114,7 @@ namespace ROS2RobotImporter
             // Get a checksum on the resolved file that we'll use to ensure we've matched with the correct relative
             // source asset. Ideally we'll be able to remove this check since it's not a very robust safety check and
             // adds some amount of overhead to the processing.
-            asset.m_urdfFileCRC = Utils::GetFileCRC(asset.m_resolvedUrdfPath);
+            asset.m_resolvedFileCRC = Utils::GetFileCRC(asset.m_resolvedPath);
 
             // Given the absolute path to the asset, try to get the source asset info from the AssetProcessor.
             bool sourceAssetFound{ false };
@@ -123,14 +123,14 @@ namespace ROS2RobotImporter
             AssetSysReqBus::BroadcastResult(
                 sourceAssetFound,
                 &AssetSysReqBus::Events::GetSourceInfoBySourcePath,
-                asset.m_resolvedUrdfPath.c_str(),
+                asset.m_resolvedPath.c_str(),
                 assetInfo,
                 watchFolder);
 
             if (!sourceAssetFound)
             {
                 AZ_Warning(
-                    SdfAssetBuilderName, false, "Cannot find source asset info for '%s', skipping.", asset.m_resolvedUrdfPath.c_str());
+                    SdfAssetBuilderName, false, "Cannot find source asset info for '%s', skipping.", asset.m_resolvedPath.c_str());
                 continue;
             }
 
@@ -144,7 +144,7 @@ namespace ROS2RobotImporter
             // We should determine if this CRC check is actually necessary for resolving URI references.
             // Ideally, the additional overhead should be removed and the asset reference result should be trusted.
             AZ::Crc32 crc = Utils::GetFileCRC(asset.m_availableAssetInfo.m_sourceAssetGlobalPath);
-            if (crc == asset.m_urdfFileCRC)
+            if (crc == asset.m_resolvedFileCRC)
             {
                 AZ_Info(
                     SdfAssetBuilderName,
@@ -198,11 +198,11 @@ namespace ROS2RobotImporter
 
         const auto fullSourcePath = AZ::IO::Path(request.m_watchFolder) / AZ::IO::Path(request.m_sourceFile);
 
-        // Set the parser config settings for parsing URDF content through the libsdformat parser
+        // Set the parser config settings for parsing the source file content through the libsdformat parser
         sdf::ParserConfig parserConfig = Utils::SDFormat::CreateSdfParserConfigFromSettings(m_globalSettings, fullSourcePath);
 
         AZ_Info(SdfAssetBuilderName, "Parsing source file: %s", fullSourcePath.c_str());
-        auto parsedSdfRootOutcome = UrdfParser::ParseFromFile(fullSourcePath, parserConfig, m_globalSettings);
+        auto parsedSdfRootOutcome = SdfParser::ParseFromFile(fullSourcePath, parserConfig, m_globalSettings);
         if (!parsedSdfRootOutcome)
         {
             const AZStd::string sdfParseErrors = Utils::JoinSdfErrorsToString(parsedSdfRootOutcome.GetSdfErrors());
@@ -261,13 +261,13 @@ namespace ROS2RobotImporter
         auto tempAssetOutputPath = AZ::IO::Path(request.m_tempDirPath) / request.m_sourceFile;
         tempAssetOutputPath.ReplaceExtension("procprefab");
 
-        // Set the parser config settings for parsing URDF content through the libsdformat parser
+        // Set the parser config settings for parsing the source file content through the libsdformat parser
         sdf::ParserConfig parserConfig =
             Utils::SDFormat::CreateSdfParserConfigFromSettings(m_globalSettings, AZ::IO::PathView(request.m_sourceFile));
 
         // Read in and parse the source SDF file.
         AZ_Info(SdfAssetBuilderName, "Parsing source file: %s", request.m_fullPath.c_str());
-        auto parsedSdfRootOutcome = UrdfParser::ParseFromFile(AZ::IO::PathView(request.m_fullPath), parserConfig, m_globalSettings);
+        auto parsedSdfRootOutcome = SdfParser::ParseFromFile(AZ::IO::PathView(request.m_fullPath), parserConfig, m_globalSettings);
         if (!parsedSdfRootOutcome)
         {
             const AZStd::string sdfParseErrors = Utils::JoinSdfErrorsToString(parsedSdfRootOutcome.GetSdfErrors());
@@ -285,11 +285,11 @@ namespace ROS2RobotImporter
 
         // Resolve all the URI references into source asset GUIDs.
         AZ_Info(SdfAssetBuilderName, "Finding asset IDs for all mesh and collider assets.");
-        auto assetMap = AZStd::make_shared<Utils::UrdfAssetMap>(FindAssets(sdfRoot, request.m_fullPath));
+        auto assetMap = AZStd::make_shared<Utils::ReferencedAssetMap>(FindAssets(sdfRoot, request.m_fullPath));
 
         // Given the parsed source file and asset mappings, generate an in-memory prefab.
         AZ_Info(SdfAssetBuilderName, "Creating prefab from source file.");
-        auto prefabMaker = AZStd::make_unique<URDFPrefabMaker>(&sdfRoot, tempAssetOutputPath.String(), assetMap, useArticulation);
+        auto prefabMaker = AZStd::make_unique<SdfPrefabMaker>(&sdfRoot, tempAssetOutputPath.String(), assetMap, useArticulation);
         auto prefabResult = prefabMaker->CreatePrefabTemplateFromUrdfOrSdf();
         if (!prefabResult.IsSuccess())
         {

--- a/Gems/ROS2RobotImporter/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
@@ -22,8 +22,8 @@
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 #include <AssetBuilderSDK/SerializationDependencies.h>
 
-#include <RobotImporter/URDF/SdfPrefabMaker.h>
 #include <RobotImporter/URDF/SdfParser.h>
+#include <RobotImporter/URDF/SdfPrefabMaker.h>
 #include <RobotImporter/Utils/ErrorUtils.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
 #include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
@@ -121,16 +121,11 @@ namespace ROS2RobotImporter
             AZ::Data::AssetInfo assetInfo;
             AZStd::string watchFolder;
             AssetSysReqBus::BroadcastResult(
-                sourceAssetFound,
-                &AssetSysReqBus::Events::GetSourceInfoBySourcePath,
-                asset.m_resolvedPath.c_str(),
-                assetInfo,
-                watchFolder);
+                sourceAssetFound, &AssetSysReqBus::Events::GetSourceInfoBySourcePath, asset.m_resolvedPath.c_str(), assetInfo, watchFolder);
 
             if (!sourceAssetFound)
             {
-                AZ_Warning(
-                    SdfAssetBuilderName, false, "Cannot find source asset info for '%s', skipping.", asset.m_resolvedPath.c_str());
+                AZ_Warning(SdfAssetBuilderName, false, "Cannot find source asset info for '%s', skipping.", asset.m_resolvedPath.c_str());
                 continue;
             }
 

--- a/Gems/ROS2RobotImporter/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
+++ b/Gems/ROS2RobotImporter/Code/Source/SdfAssetBuilder/SdfAssetBuilder.h
@@ -11,7 +11,7 @@
 #include <AssetBuilderSDK/AssetBuilderBusses.h>
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 
-#include <RobotImporter/URDF/UrdfParser.h>
+#include <RobotImporter/URDF/SdfParser.h>
 #include <RobotImporter/Utils/SourceAssetsStorage.h>
 #include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
 
@@ -46,7 +46,7 @@ namespace ROS2RobotImporter
         AZStd::string GetFingerprint() const;
 
         //! Create a mapping of all the asset references in the source file.
-        Utils::UrdfAssetMap FindAssets(const sdf::Root& root, const AZStd::string& sourceFilename) const;
+        Utils::ReferencedAssetMap FindAssets(const sdf::Root& root, const AZStd::string& sourceFilename) const;
 
         SdfAssetBuilderSettings m_globalSettings;
         AZStd::string m_fingerprint;

--- a/Gems/ROS2RobotImporter/Code/Source/Tools/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/Tools/ROS2RobotImporterEditorSystemComponent.cpp
@@ -18,7 +18,7 @@
 #include <RobotImporter/RobotImporterWidget.h>
 #include <RobotImporter/SDFormat/ROS2ModelPluginHooks.h>
 #include <RobotImporter/SDFormat/ROS2SensorHooks.h>
-#include <RobotImporter/URDF/UrdfParser.h>
+#include <RobotImporter/URDF/SdfParser.h>
 #include <RobotImporter/Utils/ErrorUtils.h>
 #include <RobotImporter/Utils/FilePath.h>
 #include <SdfAssetBuilder/SdfAssetBuilderSettings.h>
@@ -44,6 +44,8 @@ namespace ROS2RobotImporter
                 ->Attribute(AZ::Script::Attributes::Category, "Robotics")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
                 ->Attribute(AZ::Script::Attributes::Module, "ROS2")
+                // The "ImportURDF" event name is kept for backwards compatibility with existing Python scripts,
+                // even though the importer accepts URDF, SDF and .world files.
                 ->Event("ImportURDF", &RobotImporterRequestBus::Events::GeneratePrefabFromFile);
         }
     }
@@ -114,7 +116,7 @@ namespace ROS2RobotImporter
     }
 
     bool ROS2RobotImporterEditorSystemComponent::GeneratePrefabFromFile(
-        const AZStd::string_view filePath, bool importAssetWithUrdf, bool useArticulation)
+        const AZStd::string_view filePath, bool importAssetWithFile, bool useArticulation)
     {
         if (filePath.empty())
         {
@@ -130,10 +132,10 @@ namespace ROS2RobotImporter
         // Read the SDF Settings from the Settings Registry into a local struct
         SdfAssetBuilderSettings sdfBuilderSettings;
         sdfBuilderSettings.LoadSettings();
-        // Set the parser config settings for URDF content
+        // Set the parser config settings for the source file content
         sdf::ParserConfig parserConfig = Utils::SDFormat::CreateSdfParserConfigFromSettings(sdfBuilderSettings, filePath);
 
-        auto parsedSdfOutcome = UrdfParser::ParseFromFile(filePath, parserConfig, sdfBuilderSettings);
+        auto parsedSdfOutcome = SdfParser::ParseFromFile(filePath, parserConfig, sdfBuilderSettings);
         if (!parsedSdfOutcome)
         {
             const AZStd::string log = Utils::JoinSdfErrorsToString(parsedSdfOutcome.GetSdfErrors());
@@ -142,13 +144,13 @@ namespace ROS2RobotImporter
             return false;
         }
 
-        // Urdf Root has been parsed successfully retrieve it from the Outcome
+        // SDF Root has been parsed successfully retrieve it from the Outcome
         const sdf::Root& parsedSdfRoot = parsedSdfOutcome.GetRoot();
 
-        auto urdfAssetsMapping = Utils::GetReferencedAssetFilenames(parsedSdfRoot);
-        if (importAssetWithUrdf)
+        auto referencedAssetMap = Utils::GetReferencedAssetFilenames(parsedSdfRoot);
+        if (importAssetWithFile)
         {
-            Utils::CopyReferencedAssetsAndCreateAssetMap(urdfAssetsMapping, filePath, sdfBuilderSettings);
+            Utils::CopyReferencedAssetsAndCreateAssetMap(referencedAssetMap, filePath, sdfBuilderSettings);
         }
         bool allAssetProcessed = false;
         bool assetProcessorFailed = false;
@@ -156,7 +158,7 @@ namespace ROS2RobotImporter
         auto loopStartTime = AZStd::chrono::system_clock::now();
 
         /* This loop waits until all of the assets are processed.
-           The urdf prefab cannot be created before all assets are processed.
+           The prefab cannot be created before all assets are processed.
            There are three stop conditions: allAssetProcessed, assetProcessorFailed and a timeout.
            After all asset are processed the allAssetProcessed will be set to true.
            assetProcessorFailed will be set to true if the asset processor does not respond.
@@ -172,7 +174,7 @@ namespace ROS2RobotImporter
             }
 
             allAssetProcessed = true;
-            for (const auto& [name, asset] : urdfAssetsMapping)
+            for (const auto& [name, asset] : referencedAssetMap)
             {
                 auto sourceAssetFullPath = asset.m_availableAssetInfo.m_sourceAssetGlobalPath;
                 if (sourceAssetFullPath.empty())
@@ -231,8 +233,8 @@ namespace ROS2RobotImporter
 
         const AZ::IO::Path prefabPathRelative(AZ::IO::Path("Assets") / "Importer" / prefabName);
         const AZ::IO::Path prefabPath(AZ::IO::Path(AZ::Utils::GetProjectPath()) / prefabPathRelative);
-        AZStd::unique_ptr<URDFPrefabMaker> prefabMaker = AZStd::make_unique<URDFPrefabMaker>(
-            &parsedSdfRoot, prefabPath.String(), AZStd::make_shared<Utils::UrdfAssetMap>(urdfAssetsMapping), useArticulation);
+        AZStd::unique_ptr<SdfPrefabMaker> prefabMaker = AZStd::make_unique<SdfPrefabMaker>(
+            &parsedSdfRoot, prefabPath.String(), AZStd::make_shared<Utils::ReferencedAssetMap>(referencedAssetMap), useArticulation);
 
         auto prefabOutcome = prefabMaker->CreatePrefabFromUrdfOrSdf();
 

--- a/Gems/ROS2RobotImporter/Code/Source/Tools/ROS2RobotImporterEditorSystemComponent.h
+++ b/Gems/ROS2RobotImporter/Code/Source/Tools/ROS2RobotImporterEditorSystemComponent.h
@@ -43,7 +43,7 @@ namespace ROS2RobotImporter
         void NotifyRegisterViews() override;
 
         // RobotImporterRequestsBus::Handler overrides ..
-        bool GeneratePrefabFromFile(const AZStd::string_view filePath, bool importAssetWithUrdf, bool useArticulation) override;
+        bool GeneratePrefabFromFile(const AZStd::string_view filePath, bool importAssetWithFile, bool useArticulation) override;
         const SDFormat::SensorImporterHooksStorage& GetSensorHooks() const override;
         const SDFormat::ModelPluginImporterHooksStorage& GetModelPluginHooks() const override;
 

--- a/Gems/ROS2RobotImporter/Code/Tests/SdfParserTest.cpp
+++ b/Gems/ROS2RobotImporter/Code/Tests/SdfParserTest.cpp
@@ -11,7 +11,7 @@
 #include <AzTest/AzTest.h>
 #include <AzTest/Utils.h>
 #include <RobotImporter/SDFormat/ROS2SensorHooks.h>
-#include <RobotImporter/URDF/UrdfParser.h>
+#include <RobotImporter/URDF/SdfParser.h>
 #include <RobotImporter/Utils/ErrorUtils.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
 
@@ -233,7 +233,7 @@ namespace UnitTest
     TEST_F(SdfParserTest, SdfWithDuplicateModelNames_ResultsInError)
     {
         const auto xmlStr = GetSdfWithDuplicateModelName();
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, {});
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, {});
         ASSERT_FALSE(sdfRootOutcome);
         const auto& sdfErrors = sdfRootOutcome.GetSdfErrors();
         EXPECT_FALSE(sdfErrors.empty());
@@ -244,7 +244,7 @@ namespace UnitTest
     TEST_F(SdfParserTest, SdfWithModelsOnRootAndWorld_ParsesSuccessfully)
     {
         const auto xmlStr = GetSdfWithWorldThatHasMultipleModels();
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, {});
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, {});
         ASSERT_TRUE(sdfRootOutcome);
         const auto& sdfRoot = sdfRootOutcome.GetRoot();
         // This SDF should have a model on the root that points to root model
@@ -328,7 +328,7 @@ namespace UnitTest
     TEST_F(SdfParserTest, VisitingSdfWithMultipleModelsWithSameLinkName_VisitsAllLinks)
     {
         const auto xmlStr = GetSdfWithMultipleModelsThatHaveLinksWithTheSameName();
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, {});
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, {});
         ASSERT_TRUE(sdfRootOutcome);
         const auto& sdfRoot = sdfRootOutcome.GetRoot();
         // The SDF should also have a single world
@@ -389,7 +389,7 @@ namespace UnitTest
 
         sdfConfig.SetFindCallback(AZStd::move(SdfFindCallback));
 
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, sdfConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, sdfConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const auto& sdfRoot = sdfRootOutcome.GetRoot();
         // The SDF should also have a single world
@@ -424,7 +424,7 @@ namespace UnitTest
     {
         {
             const auto xmlStr = GetSdfWithTwoSensors();
-            const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, {});
+            const auto sdfRootOutcome = SdfParser::Parse(xmlStr, {});
             ASSERT_TRUE(sdfRootOutcome);
             const auto& sdfRoot = sdfRootOutcome.GetRoot();
             const auto* sdfModel = sdfRoot.Model();
@@ -474,7 +474,7 @@ namespace UnitTest
 
         {
             const auto xmlStr = GetSdfWithImuSensor();
-            const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, {});
+            const auto sdfRootOutcome = SdfParser::Parse(xmlStr, {});
             ASSERT_TRUE(sdfRootOutcome);
             const auto& sdfRoot = sdfRootOutcome.GetRoot();
             const auto* sdfModel = sdfRoot.Model();
@@ -546,7 +546,7 @@ namespace UnitTest
         };
 
         const auto xmlStr = GetSdfWithTwoSensors();
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, {});
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, {});
         ASSERT_TRUE(sdfRootOutcome);
         const auto& sdfRoot = sdfRootOutcome.GetRoot();
         const auto* sdfModel = sdfRoot.Model();
@@ -614,7 +614,7 @@ namespace UnitTest
     {
         {
             const auto xmlStr = GetSdfWithTwoSensors();
-            const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, {});
+            const auto sdfRootOutcome = SdfParser::Parse(xmlStr, {});
             ASSERT_TRUE(sdfRootOutcome);
             const auto& sdfRoot = sdfRootOutcome.GetRoot();
             const auto* sdfModel = sdfRoot.Model();
@@ -659,7 +659,7 @@ namespace UnitTest
         }
         {
             const auto xmlStr = GetSdfWithImuSensor();
-            const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, {});
+            const auto sdfRootOutcome = SdfParser::Parse(xmlStr, {});
             ASSERT_TRUE(sdfRootOutcome);
             const auto& sdfRoot = sdfRootOutcome.GetRoot();
             const auto* sdfModel = sdfRoot.Model();

--- a/Gems/ROS2RobotImporter/Code/Tests/UrdfParserTest.cpp
+++ b/Gems/ROS2RobotImporter/Code/Tests/UrdfParserTest.cpp
@@ -10,7 +10,7 @@
 #include <AzCore/std/ranges/ranges_algorithm.h>
 #include <AzCore/std/string/string.h>
 #include <AzTest/AzTest.h>
-#include <RobotImporter/URDF/UrdfParser.h>
+#include <RobotImporter/URDF/SdfParser.h>
 #include <RobotImporter/Utils/ErrorUtils.h>
 #include <RobotImporter/Utils/RobotImporterUtils.h>
 #include <RobotImporter/xacro/XacroUtils.h>
@@ -326,7 +326,7 @@ namespace UnitTest
     {
         const auto xmlStr = GetUrdfWithOneLink();
         sdf::ParserConfig parserConfig;
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
@@ -376,7 +376,7 @@ namespace UnitTest
     {
         const auto xmlStr = GetUrdfWithTwoLinksAndJoint();
         sdf::ParserConfig parserConfig;
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
@@ -407,7 +407,7 @@ namespace UnitTest
         const auto xmlStr = GetUrdfWithTwoLinksAndJoint();
         sdf::ParserConfig parserConfig;
         parserConfig.URDFSetPreserveFixedJoint(true);
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
@@ -457,7 +457,7 @@ namespace UnitTest
     {
         const auto xmlStr = GetUrdfWithTwoLinksAndJoint("continuous");
         sdf::ParserConfig parserConfig;
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
@@ -510,7 +510,7 @@ namespace UnitTest
         const auto xmlStr = GetURDFWithTwoLinksAndBaseLinkNoInertia();
         sdf::ParserConfig parserConfig;
         parserConfig.URDFSetPreserveFixedJoint(true);
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_FALSE(sdfRootOutcome);
         AZStd::string errorString = Utils::JoinSdfErrorsToString(sdfRootOutcome.GetSdfErrors());
         printf("URDF with single link and no inertia: %s\n", errorString.c_str());
@@ -521,7 +521,7 @@ namespace UnitTest
         const auto xmlStr = GetURDFWithTwoLinksAndBaseLinkNoInertia();
         sdf::ParserConfig parserConfig;
         parserConfig.URDFSetPreserveFixedJoint(false);
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
@@ -554,7 +554,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         // Make sure joint reduction occurs
         parserConfig.URDFSetPreserveFixedJoint(false);
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
@@ -599,7 +599,7 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         // Make sure joint reduction occurs
         parserConfig.URDFSetPreserveFixedJoint(false);
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
 
@@ -642,25 +642,25 @@ namespace UnitTest
         sdf::ParserConfig parserConfig;
         const AZStd::string_view wheelName("wheel_left_link");
         const auto xmlStr = GetURDFWithWheel(wheelName, "continuous");
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         auto wheelCandidate = model->LinkByName(std::string(wheelName.data(), wheelName.size()));
         ASSERT_NE(nullptr, wheelCandidate);
-        EXPECT_TRUE(Utils::IsWheelURDFHeuristics(*model, wheelCandidate));
+        EXPECT_TRUE(Utils::IsWheelHeuristics(*model, wheelCandidate));
 
         const AZStd::string_view wheelNameSuffix("left_link_wheel");
         const auto xmlStr2 = GetURDFWithWheel(wheelNameSuffix, "continuous");
-        const auto sdfRootOutcome2 = UrdfParser::Parse(xmlStr2, parserConfig);
+        const auto sdfRootOutcome2 = SdfParser::Parse(xmlStr2, parserConfig);
         ASSERT_TRUE(sdfRootOutcome2);
         const sdf::Root& sdfRoot2 = sdfRootOutcome2.GetRoot();
         const sdf::Model* model2 = sdfRoot2.Model();
         ASSERT_NE(nullptr, model2);
         auto wheelCandidate2 = model2->LinkByName(std::string(wheelNameSuffix.data(), wheelNameSuffix.size()));
         ASSERT_NE(nullptr, wheelCandidate2);
-        EXPECT_TRUE(Utils::IsWheelURDFHeuristics(*model2, wheelCandidate2));
+        EXPECT_TRUE(Utils::IsWheelHeuristics(*model2, wheelCandidate2));
     }
 
     TEST_F(UrdfParserTest, WheelHeuristicNameNotValid1)
@@ -668,14 +668,14 @@ namespace UnitTest
         const AZStd::string wheelName("whe3l_left_link");
         const auto xmlStr = GetURDFWithWheel(wheelName, "continuous");
         sdf::ParserConfig parserConfig;
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         auto wheelCandidate = model->LinkByName(std::string(wheelName.data(), wheelName.size()));
         ASSERT_NE(nullptr, wheelCandidate);
-        EXPECT_FALSE(Utils::IsWheelURDFHeuristics(*model, wheelCandidate));
+        EXPECT_FALSE(Utils::IsWheelHeuristics(*model, wheelCandidate));
     }
 
     TEST_F(UrdfParserTest, WheelHeuristicJointNotValid)
@@ -683,7 +683,7 @@ namespace UnitTest
         const AZStd::string wheelName("wheel_left_link");
         const auto xmlStr = GetURDFWithWheel(wheelName, "fixed");
         sdf::ParserConfig parserConfig;
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
@@ -698,7 +698,7 @@ namespace UnitTest
 
         EXPECT_TRUE(model->FrameNameExists(std::string{ wheelName.c_str(), wheelName.size() }));
         EXPECT_TRUE(model->FrameNameExists("joint0"));
-        EXPECT_FALSE(Utils::IsWheelURDFHeuristics(*model, wheelCandidate));
+        EXPECT_FALSE(Utils::IsWheelHeuristics(*model, wheelCandidate));
     }
 
     TEST_F(UrdfParserTest, WheelHeuristicJointVisualNotValid)
@@ -706,14 +706,14 @@ namespace UnitTest
         const AZStd::string wheelName("wheel_left_link");
         const auto xmlStr = GetURDFWithWheel(wheelName, "continuous", false, true);
         sdf::ParserConfig parserConfig;
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         auto wheelCandidate = model->LinkByName(std::string(wheelName.c_str(), wheelName.size()));
         ASSERT_NE(nullptr, wheelCandidate);
-        EXPECT_FALSE(Utils::IsWheelURDFHeuristics(*model, wheelCandidate));
+        EXPECT_FALSE(Utils::IsWheelHeuristics(*model, wheelCandidate));
     }
 
     TEST_F(UrdfParserTest, WheelHeuristicJointColliderNotValid)
@@ -721,21 +721,21 @@ namespace UnitTest
         const AZStd::string wheelName("wheel_left_link");
         const auto xmlStr = GetURDFWithWheel(wheelName, "continuous", true, false);
         sdf::ParserConfig parserConfig;
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
         ASSERT_NE(nullptr, model);
         auto wheelCandidate = model->LinkByName(std::string(wheelName.c_str(), wheelName.size()));
         ASSERT_NE(nullptr, wheelCandidate);
-        EXPECT_FALSE(Utils::IsWheelURDFHeuristics(*model, wheelCandidate));
+        EXPECT_FALSE(Utils::IsWheelHeuristics(*model, wheelCandidate));
     }
 
     TEST_F(UrdfParserTest, TestLinkListing)
     {
         const auto xmlStr = GetURDFWithTransforms();
         sdf::ParserConfig parserConfig;
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
@@ -762,7 +762,7 @@ namespace UnitTest
     {
         const auto xmlStr = GetURDFWithTransforms();
         sdf::ParserConfig parserConfig;
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
@@ -777,7 +777,7 @@ namespace UnitTest
     {
         const auto xmlStr = GetURDFWithTransforms();
         sdf::ParserConfig parserConfig;
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
@@ -799,19 +799,19 @@ namespace UnitTest
         const AZ::Vector3 expected_translation_link3{ -2.4000000953674316, 0.0, 0.0 };
 
         const auto base_link_pose = base_link_ptr->SemanticPose();
-        const AZ::Transform transform_from_urdf_link1 = Utils::GetLocalTransformURDF(base_link_pose);
+        const AZ::Transform transform_from_urdf_link1 = Utils::GetLocalTransform(base_link_pose);
         EXPECT_NEAR(expected_translation_link1.GetX(), transform_from_urdf_link1.GetTranslation().GetX(), 1e-5);
         EXPECT_NEAR(expected_translation_link1.GetY(), transform_from_urdf_link1.GetTranslation().GetY(), 1e-5);
         EXPECT_NEAR(expected_translation_link1.GetZ(), transform_from_urdf_link1.GetTranslation().GetZ(), 1e-5);
 
         const auto link2_pose = link2_ptr->SemanticPose();
-        const AZ::Transform transform_from_urdf_link2 = Utils::GetLocalTransformURDF(link2_pose);
+        const AZ::Transform transform_from_urdf_link2 = Utils::GetLocalTransform(link2_pose);
         EXPECT_NEAR(expected_translation_link2.GetX(), transform_from_urdf_link2.GetTranslation().GetX(), 1e-5);
         EXPECT_NEAR(expected_translation_link2.GetY(), transform_from_urdf_link2.GetTranslation().GetY(), 1e-5);
         EXPECT_NEAR(expected_translation_link2.GetZ(), transform_from_urdf_link2.GetTranslation().GetZ(), 1e-5);
 
         const auto link3_pose = link3_ptr->SemanticPose();
-        const AZ::Transform transform_from_urdf_link3 = Utils::GetLocalTransformURDF(link3_pose);
+        const AZ::Transform transform_from_urdf_link3 = Utils::GetLocalTransform(link3_pose);
         EXPECT_NEAR(expected_translation_link3.GetX(), transform_from_urdf_link3.GetTranslation().GetX(), 1e-5);
         EXPECT_NEAR(expected_translation_link3.GetY(), transform_from_urdf_link3.GetTranslation().GetY(), 1e-5);
         EXPECT_NEAR(expected_translation_link3.GetZ(), transform_from_urdf_link3.GetTranslation().GetZ(), 1e-5);
@@ -821,7 +821,7 @@ namespace UnitTest
     {
         const auto xmlStr = GetURDFWithTransforms();
         sdf::ParserConfig parserConfig;
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();
@@ -846,7 +846,7 @@ namespace UnitTest
     {
         const auto xmlStr = GetURDFWithTransforms();
         sdf::ParserConfig parserConfig;
-        const auto sdfRootOutcome = UrdfParser::Parse(xmlStr, parserConfig);
+        const auto sdfRootOutcome = SdfParser::Parse(xmlStr, parserConfig);
         ASSERT_TRUE(sdfRootOutcome);
         const sdf::Root& sdfRoot = sdfRootOutcome.GetRoot();
         const sdf::Model* model = sdfRoot.Model();

--- a/Gems/ROS2RobotImporter/Code/ros2robotimporter_editor_private_files.cmake
+++ b/Gems/ROS2RobotImporter/Code/ros2robotimporter_editor_private_files.cmake
@@ -55,10 +55,10 @@ set(FILES
     Source/RobotImporter/URDF/RobotControlMaker.h
     Source/RobotImporter/URDF/SensorsMaker.cpp
     Source/RobotImporter/URDF/SensorsMaker.h
-    Source/RobotImporter/URDF/UrdfParser.cpp
-    Source/RobotImporter/URDF/UrdfParser.h
-    Source/RobotImporter/URDF/URDFPrefabMaker.cpp
-    Source/RobotImporter/URDF/URDFPrefabMaker.h
+    Source/RobotImporter/URDF/SdfParser.cpp
+    Source/RobotImporter/URDF/SdfParser.h
+    Source/RobotImporter/URDF/SdfPrefabMaker.cpp
+    Source/RobotImporter/URDF/SdfPrefabMaker.h
     Source/RobotImporter/URDF/VisualsMaker.cpp
     Source/RobotImporter/URDF/VisualsMaker.h
     Source/RobotImporter/xacro/XacroUtils.cpp


### PR DESCRIPTION
## What does this PR do?

Renaming certain files and functions to correct misleading names, resulting from the gem's expansion and the switch of the parsing module from URDF to SDF.

## How was this PR tested?

Build and launch project with gem.  Several robots were imported into the project.