### PR TITLE
Fix build after o3de#19951

### DIFF
--- a/Gems/LevelGeoreferencing/Code/CMakeLists.txt
+++ b/Gems/LevelGeoreferencing/Code/CMakeLists.txt
@@ -240,7 +240,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                         AZ::AzTestShared
                         AZ::AzToolsFramework
                         Legacy::CryCommon
-                        Legacy::EditorCommon
+                        Legacy::EditorCore
                         Legacy::Editor.Headers
                         AZ::AzManipulatorTestFramework.Static
                         Gem::${gem_name}.API

--- a/Gems/SimulationInterfaces/Code/CMakeLists.txt
+++ b/Gems/SimulationInterfaces/Code/CMakeLists.txt
@@ -274,7 +274,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                         AZ::AzTestShared
                         AZ::AzToolsFramework
                         Legacy::CryCommon
-                        Legacy::EditorCommon
+                        Legacy::EditorCore
                         Legacy::Editor.Headers
                         AZ::AzManipulatorTestFramework.Static
                         Gem::${gem_name}.API


### PR DESCRIPTION
## What does this PR do?

The O3DE engine update https://github.com/o3de/o3de/pull/19951 ("Remove support for CryEngine IPlugins"), deleted `Legacy::EditorCommon` target and moved all the leftover code to `Legacy::EditorCore` target. This triggers a problem in _extras_:

```
[build]   Target "LevelGeoreferencing.Editor.Tests" links to:
[build]     Legacy::EditorCommon
[build]   but the target was not found.
[build]   Target "SimulationInterfaces.Editor.Tests" links to:
[build]     Legacy::EditorCommon
[build]   but the target was not found.
```

This PR fixes dependencies.

## How was this PR tested?

The code builds correctly with the change.
