### PR TITLE
[Simulation Interfaces] Add notifications for SpawnEntity and SpawnEntities services

### DIFF
--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
@@ -245,7 +245,7 @@ namespace SimulationInterfaces
         //////////////////////////////////////////////////////////////////////////
     };
 
-    using SimulationEntitiesManagerNotificationBus =
+    using SimulationEntitiesManagerNotificationsBus =
         AZ::EBus<SimulationEntitiesManagerNotifications, SimulationEntitiesManagerNotificationsBusTraits>;
 
 } // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
@@ -216,4 +216,36 @@ namespace SimulationInterfaces
     using SimulationEntityManagerRequestBus = AZ::EBus<SimulationEntityManagerRequests, SimulationInterfacesBusTraits>;
     using SimulationEntityManagerInterface = AZ::Interface<SimulationEntityManagerRequests>;
 
+    //! Notifications about entities spawned through SimulationEntityManagerRequests::SpawnEntity / SpawnEntities.
+    class SimulationEntitiesManagerNotifications
+    {
+    public:
+        AZ_RTTI(SimulationEntitiesManagerNotifications, SimulationEntitiesManagerNotificationsTypeId);
+        virtual ~SimulationEntitiesManagerNotifications() = default;
+
+        //! Called once the spawned entities exist but are not yet inserted/activated into the world.
+        //! @param proposedName the name requested for the entity, not yet the final registered simulation entity name
+        virtual void OnEntityPreInsertion(const AZStd::string& proposedName, AzFramework::SpawnableEntityContainerView view)
+        {
+        }
+
+        //! Called after the entity has been registered with the simulation interfaces registry under its final, unique name.
+        virtual void OnEntitySpawned(const AZStd::string& simulationEntityName, AzFramework::SpawnableConstEntityContainerView view)
+        {
+        }
+    };
+
+    class SimulationEntitiesManagerNotificationsBusTraits : public AZ::EBusTraits
+    {
+    public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        //////////////////////////////////////////////////////////////////////////
+    };
+
+    using SimulationEntitiesManagerNotificationBus =
+        AZ::EBus<SimulationEntitiesManagerNotifications, SimulationEntitiesManagerNotificationsBusTraits>;
+
 } // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationInterfacesTypeIds.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationInterfacesTypeIds.h
@@ -37,6 +37,7 @@ namespace SimulationInterfaces
     inline constexpr const char* SimulationManagerRequestsTypeId = "{056477BA-8153-4901-9401-0146A5E3E9ED}";
     inline constexpr const char* SimulationFeaturesAggregatorRequestsTypeId = "{099FD08B-B0E2-4705-9C35-CC09C8E45076}";
     inline constexpr const char* SimulationManagerNotificationsTypeId = "{0201067B-9D52-4AB7-9A45-284287F53B00}";
+    inline constexpr const char* SimulationEntitiesManagerNotificationsTypeId = "{3A7DD6BB-B7B0-4758-AEBC-88BF531EB9B4}";
     inline constexpr const char* NamedPoseManagerRequestsTypeId = "{705280D6-7AB4-4586-A0A4-25AD71268279}";
     inline constexpr const char* NamedPoseComponentRequestsTypeId = "{9C2FEA33-90CE-4577-AB32-F7963852DC81}";
 

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -847,6 +847,8 @@ namespace SimulationInterfaces
             // run preinsertion Callback if exists
             if (spawnData != m_spawnCompletedCallbacks.end())
             {
+                SimulationEntitiesManagerNotificationBus::Broadcast(
+                    &SimulationEntitiesManagerNotifications::OnEntityPreInsertion, spawnData->second.m_userProposedName, view);
                 spawnData->second.m_preInsertionCb(AZ::Success(view));
             }
         };
@@ -886,6 +888,8 @@ namespace SimulationInterfaces
                 if (finalNameOutcome.IsSuccess())
                 {
                     m_simulatedEntityToPrefabRoot[finalNameOutcome.GetValue()] = root->GetId();
+                    SimulationEntitiesManagerNotificationBus::Broadcast(
+                        &SimulationEntitiesManagerNotifications::OnEntitySpawned, finalNameOutcome.GetValue(), view);
                     spawnData->second.m_completedCb(AZ::Success(finalNameOutcome.GetValue()));
                 }
                 else

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -847,7 +847,7 @@ namespace SimulationInterfaces
             // run preinsertion Callback if exists
             if (spawnData != m_spawnCompletedCallbacks.end())
             {
-                SimulationEntitiesManagerNotificationBus::Broadcast(
+                SimulationEntitiesManagerNotificationsBus::Broadcast(
                     &SimulationEntitiesManagerNotifications::OnEntityPreInsertion, spawnData->second.m_userProposedName, view);
                 spawnData->second.m_preInsertionCb(AZ::Success(view));
             }
@@ -888,7 +888,7 @@ namespace SimulationInterfaces
                 if (finalNameOutcome.IsSuccess())
                 {
                     m_simulatedEntityToPrefabRoot[finalNameOutcome.GetValue()] = root->GetId();
-                    SimulationEntitiesManagerNotificationBus::Broadcast(
+                    SimulationEntitiesManagerNotificationsBus::Broadcast(
                         &SimulationEntitiesManagerNotifications::OnEntitySpawned, finalNameOutcome.GetValue(), view);
                     spawnData->second.m_completedCb(AZ::Success(finalNameOutcome.GetValue()));
                 }


### PR DESCRIPTION
## What does this PR do?

This PR creates a notifications bus that is called when an entity is spawned using Simulation Interfaces API. This is useful for example when needing to register additional child entities into simulation interfaces when an entity is spawned through one of the ROS2 services. Previously the only way to do it was to completely replace the spawn service handler with a custom one, just to connect to the spawn completion callback, which resulted in unnecessary code duplication.

## How was this PR tested?

Tested by registering a handler for the bus in an empty project and spawning a prefab consisting of multiple children using the /spawn_entity service. With a few lines of code I was able to register the children of the prefab to the simulation interfaces API.
