### PR TITLE
Fix deprecated gmock Invoke() usage in SimulationInterfaces tests

### DIFF
--- a/Gems/SimulationInterfaces/Code/Tests/Clients/InterfacesTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Clients/InterfacesTest.cpp
@@ -202,12 +202,12 @@ namespace UnitTest
         const AZStd::string entityName = AZStd::string(TestEntityName);
 
         EXPECT_CALL(*mock, DeleteEntity(entityName, _))
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 [](const AZStd::string& name, SimulationInterfaces::DeletionCompletedCb completedCb)
                 {
                     EXPECT_EQ(name, "test_entity");
                     completedCb(AZ::Success());
-                }));
+                });
 
         auto future = client->async_send_request(request);
         SpinAppUntilFuture(future);
@@ -230,7 +230,7 @@ namespace UnitTest
         const AZStd::string entityName = AZStd::string(TestEntityName);
 
         EXPECT_CALL(mock, DeleteEntity(entityName, _))
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 [](const AZStd::string& name, SimulationInterfaces::DeletionCompletedCb completedCb)
                 {
                     EXPECT_EQ(name, "test_entity");
@@ -238,7 +238,7 @@ namespace UnitTest
                     failedResult.m_errorCode = simulation_interfaces::msg::Result::RESULT_NOT_FOUND,
                     failedResult.m_errorString = "FooBar not found.";
                     completedCb(AZ::Failure(failedResult));
-                }));
+                });
 
         auto future = client->async_send_request(request);
         SpinAppUntilFuture(future);
@@ -267,7 +267,7 @@ namespace UnitTest
         request->filters.filter = "FooBarFilter";
 
         EXPECT_CALL(mock, GetEntities(_))
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 [=](const EntityFilters& filter)
                 {
                     EXPECT_NE(filter.m_boundsShape, nullptr);
@@ -286,7 +286,7 @@ namespace UnitTest
 
                     EXPECT_EQ(filter.m_nameFilter, "FooBarFilter");
                     return AZ::Success(EntityNameList{ "FooBar" });
-                }));
+                });
 
         auto future = client->async_send_request(request);
         SpinAppUntilFuture(future);
@@ -339,7 +339,7 @@ namespace UnitTest
         request->filters.bounds.type = simulation_interfaces::msg::Bounds::TYPE_BOX;
 
         EXPECT_CALL(mock, GetEntities(_))
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 [=](const EntityFilters& filter)
                 {
                     EXPECT_NE(filter.m_boundsShape, nullptr);
@@ -355,7 +355,7 @@ namespace UnitTest
                     auto loc = filter.m_boundsPose.GetTranslation();
                     EXPECT_EQ(loc, AZ::Vector3::CreateZero());
                     return AZ::Success(EntityNameList{ "FooBar" });
-                }));
+                });
 
         auto future = client->async_send_request(request);
         SpinAppUntilFuture(future);
@@ -422,11 +422,11 @@ namespace UnitTest
             static_cast<SimulationFeatureType>(0xFF), // invalid feature, should be ignored
         };
         EXPECT_CALL(mockAggregator, GetSimulationFeatures())
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 [&](void)
                 {
                     return features;
-                }));
+                });
 
         auto client = node->create_client<simulation_interfaces::srv::GetSimulatorFeatures>("/get_simulator_features");
         auto request = std::make_shared<simulation_interfaces::srv::GetSimulatorFeatures::Request>();
@@ -459,7 +459,7 @@ namespace UnitTest
 
         auto future = client->async_send_request(request);
         EXPECT_CALL(mock, SpawnEntity(_, _, _, _, _, _, _))
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 [](const AZStd::string& name,
                    const AZStd::string& uri,
                    const AZStd::string& entityNamespace,
@@ -473,7 +473,7 @@ namespace UnitTest
                     EXPECT_EQ(entityNamespace, "test_namespace");
                     EXPECT_TRUE(allowRename);
                     completedCb(AZ::Success("valid_name"));
-                }));
+                });
         SpinAppUntilFuture(future);
 
         ASSERT_TRUE(future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) << "Service call timed out.";
@@ -546,20 +546,20 @@ namespace UnitTest
         ASSERT_TRUE(client->wait_for_action_server(std::chrono::seconds(0)) == true) << "Action server is unavailable";
 
         EXPECT_CALL(mock, IsSimulationPaused())
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 []()
                 {
                     return true;
-                }));
+                });
 
         EXPECT_CALL(mock, StepSimulation(steps));
 
         EXPECT_CALL(mock, IsSimulationStepsActive())
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 []()
                 {
                     return false;
-                }));
+                });
 
         auto future = client->async_send_goal(*goal);
         SpinAppUntilFuture(future);
@@ -584,11 +584,11 @@ namespace UnitTest
         ASSERT_TRUE(client->wait_for_action_server(std::chrono::seconds(0)) == true) << "Action server is unavailable";
 
         EXPECT_CALL(mock, IsSimulationPaused())
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 []()
                 {
                     return false;
-                }));
+                });
 
         auto future = client->async_send_goal(*goal);
         SpinAppUntilFuture(future);
@@ -614,20 +614,20 @@ namespace UnitTest
         ASSERT_TRUE(client->wait_for_action_server(std::chrono::seconds(0)) == true) << "Action server is unavailable";
 
         EXPECT_CALL(mock, IsSimulationPaused())
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 []()
                 {
                     return true;
-                }));
+                });
 
         EXPECT_CALL(mock, StepSimulation(steps));
 
         EXPECT_CALL(mock, IsSimulationStepsActive())
-            .WillRepeatedly(::testing::Invoke(
+            .WillRepeatedly(
                 []()
                 {
                     return true;
-                }));
+                });
 
         EXPECT_CALL(mock, CancelStepSimulation());
 


### PR DESCRIPTION
Replace deprecated `::testing::Invoke(...)` wrappers with direct callables in `InterfacesTest.cpp`. Actions can now be constructed directly from a callable, so the wrapper is unnecessary and newer googletest/gmock flags it as an error under `-Werror -Wdeprecated-declarations`.

This fix was required after engine updates in https://github.com/o3de/o3de/pull/20003

Before:
```
/__w/o3de-ros2-gem-testing/o3de-ros2-gem-testing/engine/o3de-extras/Gems/SimulationInterfaces/Code/Tests/Clients/InterfacesTest.cpp:205:34: error: 'Invoke<(lambda at /__w/o3de-ros2-gem-testing/o3de-ros2-gem-testing/engine/o3de-extras/Gems/SimulationInterfaces/Code/Tests/Clients/InterfacesTest.cpp:206:17)>' is deprecated: Actions can now be implicitly constructed from callables. No need to create wrapper objects using Invoke(). [-Werror,-Wdeprecated-declarations]
  205 |             .WillOnce(::testing::Invoke(
      |                                  ^
_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:2039:1: note: 'Invoke<(lambda at /__w/o3de-ros2-gem-testing/o3de-ros2-gem-testing/engine/o3de-extras/Gems/SimulationInterfaces/Code/Tests/Clients/InterfacesTest.cpp:206:17)>' has been explicitly marked deprecated here
 2039 | GTEST_INTERNAL_DEPRECATE_AND_INLINE(
      | ^
_deps/googletest-src/googletest/include/gtest/internal/gtest-port.h:2383:5: note: expanded from macro 'GTEST_INTERNAL_DEPRECATE_AND_INLINE'
 2383 |   [[deprecated(msg), clang::annotate("inline-me")]]
      | 
```

After:
```
    Start 136: Gem::LevelGeoreferencing.Tests.main::TEST_RUN
1/9 Test #136: Gem::LevelGeoreferencing.Tests.main::TEST_RUN ...........   Passed    0.01 sec
    Start 137: Gem::LevelGeoreferencing.Editor.Tests.main::TEST_RUN
2/9 Test #137: Gem::LevelGeoreferencing.Editor.Tests.main::TEST_RUN ....   Passed    0.44 sec
    Start 138: Gem::ROS2.Editor.Tests.main::TEST_RUN
3/9 Test #138: Gem::ROS2.Editor.Tests.main::TEST_RUN ...................   Passed    0.52 sec
    Start 139: Gem::ROS2Controllers.Tests.main::TEST_RUN
4/9 Test #139: Gem::ROS2Controllers.Tests.main::TEST_RUN ...............   Passed    0.07 sec
    Start 140: Gem::ROS2Controllers.Editor.Tests.main::TEST_RUN
5/9 Test #140: Gem::ROS2Controllers.Editor.Tests.main::TEST_RUN ........   Passed    0.60 sec
    Start 141: Gem::ROS2RobotImporter.Editor.Tests.main::TEST_RUN
6/9 Test #141: Gem::ROS2RobotImporter.Editor.Tests.main::TEST_RUN ......   Passed    0.96 sec
    Start 142: Gem::SimulationInterfaces.Tests.main::TEST_RUN
7/9 Test #142: Gem::SimulationInterfaces.Tests.main::TEST_RUN ..........   Passed    0.54 sec
    Start 143: Gem::SimulationInterfaces.Editor.Tests.main::TEST_RUN
8/9 Test #143: Gem::SimulationInterfaces.Editor.Tests.main::TEST_RUN ...   Passed    0.96 sec
    Start 144: Gem::SimulationInterfaces.ROS2Tests.main::TEST_RUN
9/9 Test #144: Gem::SimulationInterfaces.ROS2Tests.main::TEST_RUN ......   Passed    0.45 sec

100% tests passed, 0 tests failed out of 9

Label Time Summary:
FRAMEWORK_googletest    =   4.56 sec*proc (9 tests)
SUITE_main              =   4.56 sec*proc (9 tests)

Total Test time (real) =   4.57 sec

```