### PR TITLE
Fix ResetSimulationService handler: bits not ints

### DIFF
--- a/Gems/SimulationInterfaces/Code/Source/Services/ResetSimulationServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/ResetSimulationServiceHandler.cpp
@@ -33,72 +33,8 @@ namespace ROS2SimulationInterfaces
     AZStd::optional<ResetSimulationServiceHandler::Response> ResetSimulationServiceHandler::HandleServiceRequest(
         const std::shared_ptr<rmw_request_id_t> header, const Request& request)
     {
-        if (request.scope == Request::SCOPE_STATE)
-        {
-            Response response;
-            AZ::Outcome<void, SimulationInterfaces::FailedResult> resetingOutcome;
-            SimulationInterfaces::SimulationEntityManagerRequestBus::BroadcastResult(
-                resetingOutcome, &SimulationInterfaces::SimulationEntityManagerRequests::ResetAllEntitiesToInitialState);
-            if (resetingOutcome.IsSuccess())
-            {
-                response.result.result = simulation_interfaces::msg::Result::RESULT_OK;
-            }
-            else
-            {
-                response.result.result = resetingOutcome.GetError().m_errorCode;
-                response.result.error_message = resetingOutcome.GetError().m_errorString.c_str();
-            }
-            return response;
-        }
-
-        if (request.scope == Request::SCOPE_SPAWNED)
-        {
-            auto deletionCompletedCb = [this](const AZ::Outcome<void, SimulationInterfaces::FailedResult>& outcome)
-            {
-                Response response;
-                if (outcome.IsSuccess())
-                {
-                    response.result.result = simulation_interfaces::msg::Result::RESULT_OK;
-                }
-                else
-                {
-                    const auto& failedResult = outcome.GetError();
-                    response.result.result = failedResult.m_errorCode;
-                    response.result.error_message = failedResult.m_errorString.c_str();
-                }
-                SendResponse(response);
-            };
-            SimulationInterfaces::SimulationEntityManagerRequestBus::Broadcast(
-                &SimulationInterfaces::SimulationEntityManagerRequests::DeleteAllEntities, deletionCompletedCb);
-            return AZStd::nullopt;
-        }
-
-        if (request.scope == Request::SCOPE_TIME)
-        {
-            auto* interface = ROS2::ROS2ClockInterface::Get();
-            AZ_Assert(interface, "ROS2ClockInterface is not available");
-
-            builtin_interfaces::msg::Time time;
-            time.sec = 0;
-            time.nanosec = 0;
-            auto results = interface->AdjustTime(time);
-
-            if (results.IsSuccess())
-            {
-                Response response;
-                response.result.result = simulation_interfaces::msg::Result::RESULT_OK;
-                return response;
-            }
-            else
-            {
-                Response response;
-                response.result.result = simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED;
-                const auto& errorMessage = results.GetError();
-                response.result.error_message = std::string(errorMessage.c_str(), errorMessage.size());
-                return response;
-            }
-        }
-
+        // SCOPE_ALL and SCOPE_DEFAULT (0) are not part of the SCOPE_TIME / SCOPE_STATE / SCOPE_SPAWNED bit field;
+        // they request a full simulation restart (level reload) instead of resetting individual aspects.
         if (request.scope == Request::SCOPE_ALL || request.scope == Request::SCOPE_DEFAULT)
         {
             // check if we are in GameLauncher
@@ -132,10 +68,76 @@ namespace ROS2SimulationInterfaces
             return AZStd::nullopt;
         }
 
-        // no case matched, return response that request was invalid
-        Response invalidResponse;
-        invalidResponse.result.result = simulation_interfaces::msg::Result::RESULT_NOT_FOUND;
-        invalidResponse.result.error_message = "Passed unknown scope";
-        return invalidResponse;
+        // SCOPE_TIME, SCOPE_STATE and SCOPE_SPAWNED form a bit field and may be requested in any combination,
+        // e.g. scope = SCOPE_STATE | SCOPE_SPAWNED.
+        constexpr uint8_t KnownScopeMask = Request::SCOPE_TIME | Request::SCOPE_STATE | Request::SCOPE_SPAWNED;
+        if ((request.scope & ~KnownScopeMask) != 0)
+        {
+            // no known scope bit matched, return response that request was invalid
+            Response invalidResponse;
+            invalidResponse.result.result = simulation_interfaces::msg::Result::RESULT_NOT_FOUND;
+            invalidResponse.result.error_message = "Passed unknown scope";
+            return invalidResponse;
+        }
+
+        if (request.scope & Request::SCOPE_STATE)
+        {
+            AZ::Outcome<void, SimulationInterfaces::FailedResult> resetingOutcome;
+            SimulationInterfaces::SimulationEntityManagerRequestBus::BroadcastResult(
+                resetingOutcome, &SimulationInterfaces::SimulationEntityManagerRequests::ResetAllEntitiesToInitialState);
+            if (!resetingOutcome.IsSuccess())
+            {
+                Response response;
+                response.result.result = resetingOutcome.GetError().m_errorCode;
+                response.result.error_message = resetingOutcome.GetError().m_errorString.c_str();
+                return response;
+            }
+        }
+
+        if (request.scope & Request::SCOPE_TIME)
+        {
+            auto* interface = ROS2::ROS2ClockInterface::Get();
+            AZ_Assert(interface, "ROS2ClockInterface is not available");
+
+            builtin_interfaces::msg::Time time;
+            time.sec = 0;
+            time.nanosec = 0;
+            auto results = interface->AdjustTime(time);
+
+            if (!results.IsSuccess())
+            {
+                Response response;
+                response.result.result = simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED;
+                const auto& errorMessage = results.GetError();
+                response.result.error_message = std::string(errorMessage.c_str(), errorMessage.size());
+                return response;
+            }
+        }
+
+        if (request.scope & Request::SCOPE_SPAWNED)
+        {
+            auto deletionCompletedCb = [this](const AZ::Outcome<void, SimulationInterfaces::FailedResult>& outcome)
+            {
+                Response response;
+                if (outcome.IsSuccess())
+                {
+                    response.result.result = simulation_interfaces::msg::Result::RESULT_OK;
+                }
+                else
+                {
+                    const auto& failedResult = outcome.GetError();
+                    response.result.result = failedResult.m_errorCode;
+                    response.result.error_message = failedResult.m_errorString.c_str();
+                }
+                SendResponse(response);
+            };
+            SimulationInterfaces::SimulationEntityManagerRequestBus::Broadcast(
+                &SimulationInterfaces::SimulationEntityManagerRequests::DeleteAllEntities, deletionCompletedCb);
+            return AZStd::nullopt;
+        }
+
+        Response response;
+        response.result.result = simulation_interfaces::msg::Result::RESULT_OK;
+        return response;
     }
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Tests/Clients/InterfacesTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Clients/InterfacesTest.cpp
@@ -217,6 +217,62 @@ namespace UnitTest
         EXPECT_EQ(response->result.result, simulation_interfaces::msg::Result::RESULT_OK);
     }
 
+    //! Reset scope is a bit field. Passing a combination of scopes (SCOPE_STATE | SCOPE_SPAWNED) should trigger
+    //! both the corresponding reset actions instead of being rejected as an unknown scope.
+    TEST_F(SimulationInterfaceROS2TestFixture, ResetSimulationBitfieldScopeStateAndSpawned)
+    {
+        using ::testing::_;
+        auto node = GetRos2Node();
+        SimulationEntityManagerMockedHandler mock;
+        auto client = node->create_client<simulation_interfaces::srv::ResetSimulation>("/reset_simulation");
+        auto request = std::make_shared<simulation_interfaces::srv::ResetSimulation::Request>();
+        request->scope = simulation_interfaces::srv::ResetSimulation::Request::SCOPE_STATE |
+            simulation_interfaces::srv::ResetSimulation::Request::SCOPE_SPAWNED;
+
+        EXPECT_CALL(mock, ResetAllEntitiesToInitialState())
+            .WillOnce(
+                []()
+                {
+                    return AZ::Success();
+                });
+
+        EXPECT_CALL(mock, DeleteAllEntities(_))
+            .WillOnce(
+                [](SimulationInterfaces::DeletionCompletedCb completedCb)
+                {
+                    completedCb(AZ::Success());
+                });
+
+        auto future = client->async_send_request(request);
+        SpinAppUntilFuture(future);
+
+        ASSERT_TRUE(future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) << "Service call timed out.";
+        auto response = future.get();
+        EXPECT_EQ(response->result.result, simulation_interfaces::msg::Result::RESULT_OK);
+    }
+
+    //! A scope value with a bit outside of SCOPE_TIME | SCOPE_STATE | SCOPE_SPAWNED (and not SCOPE_ALL/SCOPE_DEFAULT)
+    //! is not a known scope and should be rejected without triggering any reset action.
+    TEST_F(SimulationInterfaceROS2TestFixture, ResetSimulationUnknownScopeBitReturnsError)
+    {
+        using ::testing::_;
+        auto node = GetRos2Node();
+        SimulationEntityManagerMockedHandler mock;
+        auto client = node->create_client<simulation_interfaces::srv::ResetSimulation>("/reset_simulation");
+        auto request = std::make_shared<simulation_interfaces::srv::ResetSimulation::Request>();
+        request->scope = 0x08; // not a defined scope bit
+
+        EXPECT_CALL(mock, ResetAllEntitiesToInitialState()).Times(0);
+        EXPECT_CALL(mock, DeleteAllEntities(_)).Times(0);
+
+        auto future = client->async_send_request(request);
+        SpinAppUntilFuture(future);
+
+        ASSERT_TRUE(future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) << "Service call timed out.";
+        auto response = future.get();
+        EXPECT_EQ(response->result.result, simulation_interfaces::msg::Result::RESULT_NOT_FOUND);
+    }
+
     //! Test if the service call fails when the entity is not found
     TEST_F(SimulationInterfaceROS2TestFixture, TestDeleteEntity_02)
     {


### PR DESCRIPTION
Close #1077

## What does this PR do?

Following the issue, the input scope is used as a bitmask. This required to change the order of execution of different scopes.

Tests were added.

## How was this PR tested?

Built the code, spawned object, moved object
- checked reset `SCOPE_STATE` in different bit combinations (2, 4, 5, 6)
- checked reset `SCOPE_SPAWNED`  in different bit combinations (2, 4, 5, 6)
