### PR TITLE
Refactor of RobotImporter asset detection and copying - deduplication across diffrent import method.

### DIFF
--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetImporter.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetImporter.cpp
@@ -16,29 +16,29 @@
 
 namespace ROS2RobotImporter::Assets
 {
-    void CopyReferencedAssetsAndCreateAssetMap(
+    bool CopyReferencedAssets(
         ReferencedAssetMap& referencedAssetMap,
         const AZ::IO::Path& sourceFilePath,
-        const SdfAssetBuilderSettings& sdfBuilderSettings,
+        CopyAssetsStatusCallback statusCallback,
         AZStd::string_view outputDirSuffix,
         AZ::IO::FileIOBase* fileIO)
     {
-        ResolveAssetMap(referencedAssetMap, sourceFilePath, sdfBuilderSettings);
-        AZStd::mutex referencedAssetMapMutex;
         if (referencedAssetMap.empty())
         {
-            return;
+            return false;
         }
 
         auto destDirectory = PrepareImportedAssetsDest(sourceFilePath, outputDirSuffix, fileIO);
         if (!destDirectory.IsSuccess())
         {
-            return;
+            AZ_Error("CopyReferencedAsset", false, "Failed to create destination folder for imported assets");
+            return false;
         }
 
         AZStd::unordered_map<AZ::IO::Path, unsigned int> duplicatedFilenames;
         for (auto& [unresolvedFileName, referencedAsset] : referencedAssetMap)
         {
+            auto copyStatus = CopyStatus::Copying;
             if (duplicatedFilenames.contains(referencedAsset.m_assetUri))
             {
                 duplicatedFilenames[referencedAsset.m_assetUri]++;
@@ -47,11 +47,28 @@ namespace ROS2RobotImporter::Assets
             {
                 duplicatedFilenames[referencedAsset.m_assetUri] = 0;
             }
-            CopyReferencedAsset(destDirectory.GetValue(), referencedAsset, duplicatedFilenames[referencedAsset.m_assetUri]);
+            if (statusCallback)
+            {
+                statusCallback(copyStatus, unresolvedFileName, referencedAsset);
+            }
+            copyStatus = CopyStatus::Unresolvable;
+            if (referencedAsset.m_resolvedPath.empty())
+            {
+                AZ_Warning("CopyReferencedAsset", false, "There is no resolved path for %s", unresolvedFileName.c_str());
+            }
+            else
+            {
+                copyStatus =
+                    CopyReferencedAsset(destDirectory.GetValue(), referencedAsset, duplicatedFilenames[referencedAsset.m_assetUri]);
+            }
+            if (statusCallback)
+            {
+                statusCallback(copyStatus, unresolvedFileName, referencedAsset);
+            }
         }
-        Assets::RemoveTmpDir(destDirectory.GetValue().importDirectoryTmp);
+        RemoveTmpDir(destDirectory.GetValue().importDirectoryTmp);
 
-        return;
+        return true;
     }
 
     AZ::Outcome<ImportedAssetsDest> PrepareImportedAssetsDest(

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetImporter.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetImporter.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <RobotImporter/Assets/AssetImporter.h>
+#include "AssetImporter.h"
 
 #include <AzCore/Math/Crc.h>
 #include <AzCore/Utils/Utils.h>

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetImporter.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetImporter.cpp
@@ -25,7 +25,7 @@ namespace ROS2RobotImporter::Assets
     {
         if (referencedAssetMap.empty())
         {
-            return false;
+            return true;
         }
 
         auto destDirectory = PrepareImportedAssetsDest(sourceFilePath, outputDirSuffix, fileIO);

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetImporter.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetImporter.h
@@ -21,7 +21,8 @@ namespace ROS2RobotImporter
 namespace ROS2RobotImporter::Assets
 {
 
-    using CopyAssetsStatusCallback = AZStd::function<void(Assets::CopyStatus copyStatus, AZ::IO::Path filename, ReferencedAsset asset)>;
+    using CopyAssetsStatusCallback =
+        AZStd::function<void(Assets::CopyStatus copyStatus, const AZ::IO::Path& filename, const ReferencedAsset& asset)>;
 
     //! Copies and prepares assets that are referenced in SDF/URDF.
     //! It resolves every asset, creates a directory in Project's Asset directory, copies files, and prepares assets info.

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetImporter.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetImporter.h
@@ -20,18 +20,20 @@ namespace ROS2RobotImporter
 
 namespace ROS2RobotImporter::Assets
 {
+
+    using CopyAssetsStatusCallback = AZStd::function<void(Assets::CopyStatus copyStatus, AZ::IO::Path filename, ReferencedAsset asset)>;
+
     //! Copies and prepares assets that are referenced in SDF/URDF.
     //! It resolves every asset, creates a directory in Project's Asset directory, copies files, and prepares assets info.
     //! Finally, it assembles its results into mapping that allows mapping the SDF/URDF mesh name to the source asset.
     //! @param referencedAssetMap - files to copy (as unresolved URIs)
     //! @param sourceFilePath - path to the SDF/URDF file (as a global path)
-    //! @param sdfBuilderSettings - the builder settings to use to convert the SDF/URDF files
     //! @param outputDirSuffix - suffix to make output directory unique, if xacro file was used
     //! @param fileIO - instance to fileIO class
-    void CopyReferencedAssetsAndCreateAssetMap(
+    bool CopyReferencedAssets(
         ReferencedAssetMap& referencedAssetMap,
         const AZ::IO::Path& sourceFilePath,
-        const SdfAssetBuilderSettings& sdfBuilderSettings,
+        CopyAssetsStatusCallback statusCallback = {},
         AZStd::string_view outputDirSuffix = "",
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance());
 

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetLookup.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetLookup.cpp
@@ -190,10 +190,9 @@ namespace ROS2RobotImporter::Assets
         // Search for suitable mappings by comparing checksum
         for (auto& unmatchedAsset : unmatchedAssets)
         {
-            auto found_source_asset = availableAssets.find(unmatchedAsset->m_resolvedFileCRC);
-            if (found_source_asset != availableAssets.end())
+            if (auto foundSourceAsset = availableAssets.find(unmatchedAsset->m_resolvedFileCRC); foundSourceAsset != availableAssets.end())
             {
-                unmatchedAsset->m_availableAssetInfo = found_source_asset->second;
+                unmatchedAsset->m_availableAssetInfo = foundSourceAsset->second;
             }
         }
     }

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetLookup.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetLookup.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/std/algorithm.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <PhysX/MeshAsset.h>
 #include <RobotImporter/Assets/AssetPathResolver.h>
@@ -155,24 +156,81 @@ namespace ROS2RobotImporter::Assets
         return availableAssets;
     }
 
-    void FindReferencedAssets(
-        ReferencedAssetMap& unresolvedAssetMap, const AZ::IO::Path& sourceFilePath, const SdfAssetBuilderSettings& sdfBuilderSettings)
+    void FindReferencedAssets(ReferencedAssetMap& referencedAssetMap)
     {
-        if (!unresolvedAssetMap.empty())
+        if (referencedAssetMap.empty())
         {
-            AZStd::unordered_map<AZ::Crc32, AvailableAsset> availableAssets = Assets::GetInterestingSourceAssetsCRC();
+            return;
+        }
 
-            // Search for suitable mappings by comparing checksum
-            for (auto& [unresolvedFileName, asset] : unresolvedAssetMap)
+        // Try to match assets by exact path first. For unmatched assets look for a copy with the same content.
+        AZStd::vector<ReferencedAsset*> unmatchedAssets;
+        for (auto& [unresolvedFileName, asset] : referencedAssetMap)
+        {
+            if (asset.m_resolvedPath.empty())
             {
-                asset.m_resolvedFileCRC = Assets::GetFileCRC(asset.m_resolvedPath);
-                auto found_source_asset = availableAssets.find(asset.m_resolvedFileCRC);
-                if (found_source_asset != availableAssets.end())
-                {
-                    asset.m_availableAssetInfo = found_source_asset->second;
-                }
+                continue;
+            }
+
+            asset.m_resolvedFileCRC = Assets::GetFileCRC(asset.m_resolvedPath);
+            asset.m_availableAssetInfo = Assets::GetAvailableAssetInfo(asset.m_resolvedPath);
+            if (asset.m_availableAssetInfo.m_sourceGuid.IsNull())
+            {
+                unmatchedAssets.emplace_back(&asset);
             }
         }
+
+        if (unmatchedAssets.empty())
+        {
+            return;
+        }
+
+        AZStd::unordered_map<AZ::Crc32, AvailableAsset> availableAssets = Assets::GetInterestingSourceAssetsCRC();
+
+        // Search for suitable mappings by comparing checksum
+        for (auto& unmatchedAsset : unmatchedAssets)
+        {
+            auto found_source_asset = availableAssets.find(unmatchedAsset->m_resolvedFileCRC);
+            if (found_source_asset != availableAssets.end())
+            {
+                unmatchedAsset->m_availableAssetInfo = found_source_asset->second;
+            }
+        }
+    }
+
+    AvailableAsset GetAvailableAssetInfo(const AZ::IO::Path& globalSourceAssetPath)
+    {
+        using AssetSysReqBus = AzToolsFramework::AssetSystemRequestBus;
+
+        bool sourceAssetFound{ false };
+        AZ::Data::AssetInfo assetInfo;
+        AZStd::string watchFolder;
+        AvailableAsset foundAsset;
+
+        // get source asset info
+        AssetSysReqBus::BroadcastResult(
+            sourceAssetFound, &AssetSysReqBus::Events::GetSourceInfoBySourcePath, globalSourceAssetPath.c_str(), assetInfo, watchFolder);
+
+        if (!sourceAssetFound)
+        {
+            // Not an error on its own - the file may be outside every scan folder, or not scanned yet.
+            AZ_Trace("GetAvailableAssetInfo", "Cannot find source asset info for %s\n", globalSourceAssetPath.c_str());
+            return foundAsset;
+        }
+
+        const auto fullSourcePath = AZ::IO::Path(watchFolder) / AZ::IO::Path(assetInfo.m_relativePath);
+        foundAsset.m_sourceAssetRelativePath = assetInfo.m_relativePath;
+        foundAsset.m_sourceAssetGlobalPath = fullSourcePath.String();
+        foundAsset.m_sourceGuid = assetInfo.m_assetId.m_guid;
+
+        AZ::Crc32 crc = Assets::GetFileCRC(foundAsset.m_sourceAssetGlobalPath);
+        if (crc == AZ::Crc32(0))
+        {
+            AZ_Warning("GetInterestingSourceAssetsCRC", false, "Zero CRC for source asset %s", foundAsset.m_sourceAssetGlobalPath.c_str());
+            return foundAsset;
+        }
+
+        return foundAsset;
     }
 
     void ResolveAssetMap(

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetLookup.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetLookup.cpp
@@ -218,16 +218,31 @@ namespace ROS2RobotImporter::Assets
         }
 
         const auto fullSourcePath = AZ::IO::Path(watchFolder) / AZ::IO::Path(assetInfo.m_relativePath);
+
+        // Due to the fact that the source name is stored by the asset processor as case-insensitive text,
+        // collisions may occur in the case of files whose path differs only in letter case.
+        const AZ::Crc32 requestedFileCRC = Assets::GetFileCRC(globalSourceAssetPath);
+        const AZ::Crc32 foundFileCRC = Assets::GetFileCRC(fullSourcePath);
+        if (requestedFileCRC != foundFileCRC)
+        {
+            AZ_Warning(
+                "GetAvailableAssetInfo",
+                false,
+                "Source asset found by the Asset Processor for '%s' does not match by content ('%s'), skipping.",
+                globalSourceAssetPath.c_str(),
+                fullSourcePath.c_str());
+            return foundAsset;
+        }
+
+        if (foundFileCRC == AZ::Crc32(0))
+        {
+            AZ_Warning("GetAvailableAssetInfo", false, "Zero CRC for source asset %s", fullSourcePath.c_str());
+            return foundAsset;
+        }
+
         foundAsset.m_sourceAssetRelativePath = assetInfo.m_relativePath;
         foundAsset.m_sourceAssetGlobalPath = fullSourcePath.String();
         foundAsset.m_sourceGuid = assetInfo.m_assetId.m_guid;
-
-        AZ::Crc32 crc = Assets::GetFileCRC(foundAsset.m_sourceAssetGlobalPath);
-        if (crc == AZ::Crc32(0))
-        {
-            AZ_Warning("GetInterestingSourceAssetsCRC", false, "Zero CRC for source asset %s", foundAsset.m_sourceAssetGlobalPath.c_str());
-            return foundAsset;
-        }
 
         return foundAsset;
     }

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetLookup.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetLookup.h
@@ -31,15 +31,13 @@ namespace ROS2RobotImporter::Assets
     AZStd::unordered_map<AZ::Crc32, AvailableAsset> GetInterestingSourceAssetsCRC();
 
     //! Discover an association between meshes in input SDF/URDF and O3DE source and product assets.
+    //! Requires the resolved paths to be filled in beforehand by `ResolveAssetMap`.
     //! Steps:
-    //! - Function scans all available O3DE assets by calling `GetInterestingSourceAssetsCRC`.
-    //! - Files pointed by resolved paths have their checksum computed `GetFileCRC`.
-    //! - Suitable mapping to the O3DE asset is found by comparing the checksum of the file pointed by the resolved path and source asset.
-    //! @param unresolvedAssetMap - list of the unresolved paths from the SDF/URDF file that are to be found as assets
-    //! @param sourceFilePath - path of the SDF/URDF file, used for resolving paths of referenced assets
-    //! @param sdfBuilderSettings - the builder settings that should be used to resolve paths
-    void FindReferencedAssets(
-        ReferencedAssetMap& unresolvedAssetMap, const AZ::IO::Path& sourceFilePath, const SdfAssetBuilderSettings& sdfBuilderSettings);
+    //! - Assets resolved to a path inside an Asset Processor scan folder are looked up by that path `LookupSourceAssetByPath`.
+    //! - Files pointed by the remaining resolved paths have their checksum computed `GetFileCRC`.
+    //! - Suitable mapping to the O3DE asset is found by comparing the checksum of the file pointed by the resolved path and source asset
+    //! @param referencedAssetMap - list of the assets from the SDF/URDF file that are to be found as O3DE assets
+    void FindReferencedAssets(ReferencedAssetMap& referencedAssetMap);
 
     //! Creates a mapping from unresolved URIs to source asset info.
     //! @param unresolvedAssetMap - list of assets discovered in the input SDF/URDF file
@@ -78,5 +76,10 @@ namespace ROS2RobotImporter::Assets
     //! @param sourceMeshAssetPath - global path to source asset used to find scene
     //! @returns list of file paths referenced in the scene
     AZStd::unordered_set<AZ::IO::Path> GetMeshTextureAssets(const AZ::IO::Path& sourceMeshAssetPath);
+
+    //! Retrieves the O3DE source asset info for an already existing source asset.
+    //! @param globalSourceAssetPath - global path to the source asset
+    //! @returns found asset info, or a default constructed one when the source asset is not known to the Asset Processor
+    AvailableAsset GetAvailableAssetInfo(const AZ::IO::Path& sourceAssetGlobalPath);
 
 } // namespace ROS2RobotImporter::Assets

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetLookup.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetLookup.h
@@ -33,7 +33,7 @@ namespace ROS2RobotImporter::Assets
     //! Discover an association between meshes in input SDF/URDF and O3DE source and product assets.
     //! Requires the resolved paths to be filled in beforehand by `ResolveAssetMap`.
     //! Steps:
-    //! - Assets resolved to a path inside an Asset Processor scan folder are looked up by that path `LookupSourceAssetByPath`.
+    //! - Assets resolved to a path inside an Asset Processor scan folder are looked up by that path `GetAvailableAssetInfo`.
     //! - Files pointed by the remaining resolved paths have their checksum computed `GetFileCRC`.
     //! - Suitable mapping to the O3DE asset is found by comparing the checksum of the file pointed by the resolved path and source asset
     //! @param referencedAssetMap - list of the assets from the SDF/URDF file that are to be found as O3DE assets

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/SceneManifestBuilder.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/SceneManifestBuilder.cpp
@@ -36,44 +36,6 @@ namespace ROS2RobotImporter::Assets
         }
     };
 
-    AvailableAsset GetAvailableAssetInfo(const AZStd::string& globalSourceAssetPath)
-    {
-        using AssetSysReqBus = AzToolsFramework::AssetSystemRequestBus;
-        AvailableAsset foundAsset;
-
-        // get source asset info
-        bool sourceAssetFound{ false };
-        AZ::Data::AssetInfo assetInfo;
-        AZStd::string watchFolder;
-        AssetSysReqBus::BroadcastResult(
-            sourceAssetFound, &AssetSysReqBus::Events::GetSourceInfoBySourcePath, globalSourceAssetPath.c_str(), assetInfo, watchFolder);
-        if (!sourceAssetFound)
-        {
-            AZ_Trace("GetAvailableAssetInfo", "Source asset info not found for: %s", globalSourceAssetPath.c_str());
-            return foundAsset;
-        }
-
-        foundAsset.m_sourceGuid = assetInfo.m_assetId.m_guid;
-
-        foundAsset.m_sourceAssetRelativePath = assetInfo.m_relativePath;
-        foundAsset.m_sourceAssetGlobalPath = globalSourceAssetPath;
-
-        AZ::Crc32 crc = Assets::GetFileCRC(foundAsset.m_sourceAssetGlobalPath);
-        if (crc == AZ::Crc32(0))
-        {
-            AZ_Warning("GetInterestingSourceAssetsCRC", false, "Zero CRC for source asset %s", foundAsset.m_sourceAssetGlobalPath.c_str());
-            return foundAsset;
-        }
-
-        AZ_Printf("GetAvailableAssetInfo", "Found asset:");
-        AZ_Printf("GetAvailableAssetInfo", "\tm_sourceAssetRelativePath  : %s", foundAsset.m_sourceAssetRelativePath.c_str());
-        AZ_Printf("GetAvailableAssetInfo", "\tm_sourceAssetGlobalPath    : %s", foundAsset.m_sourceAssetGlobalPath.c_str());
-        AZ_Printf("GetAvailableAssetInfo", "\tm_productAssetRelativePath : %s", foundAsset.m_productAssetRelativePath.c_str());
-        AZ_Printf("GetAvailableAssetInfo", "\tm_sourceGuid               : %s", foundAsset.m_sourceGuid.ToString<AZStd::string>().c_str());
-
-        return foundAsset;
-    }
-
     bool CreateSceneManifest(const AZ::IO::Path& sourceAssetPath, const AZ::IO::Path& assetInfoFile, const bool collider, const bool visual)
     {
         // Start with a default set of import settings.

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/SceneManifestBuilder.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/SceneManifestBuilder.cpp
@@ -8,7 +8,6 @@
 
 #include "SceneManifestBuilder.h"
 #include <AzCore/Settings/SettingsRegistry.h>
-#include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <RobotImporter/Assets/AssetLookup.h>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
 #include <SceneAPI/SceneCore/Events/AssetImportRequest.h>

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/SceneManifestBuilder.h
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/SceneManifestBuilder.h
@@ -14,11 +14,6 @@
 
 namespace ROS2RobotImporter::Assets
 {
-    //! Retrieves the O3DE source asset info for an already existing source asset.
-    //! @param globalSourceAssetPath - global path to the source asset
-    //! @returns found asset info, or a default constructed one when the source asset is not known to the Asset Processor
-    AvailableAsset GetAvailableAssetInfo(const AZStd::string& globalSourceAssetPath);
-
     //! Creates side-car file (.assetinfo) that configures the imported scene (e.g. DAE file).
     //! The .assetinfo will be create next to scene's file.
     //! @param sourceAssetPath - global path to source asset

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -393,8 +393,10 @@ namespace ROS2RobotImporter
                 m_copyReferencedAssetsThread = AZStd::make_shared<AZStd::thread>(
                     [this, dirSuffix]()
                     {
-                        Assets::CopyAssetsStatusCallback statusCallback =
-                            [this](Assets::CopyStatus copyStatus, AZ::IO::Path unresolvedFileName, Assets::ReferencedAsset referencedAsset)
+                        Assets::CopyAssetsStatusCallback statusCallback = [this](
+                                                                              Assets::CopyStatus copyStatus,
+                                                                              const AZ::IO::Path& unresolvedFileName,
+                                                                              const Assets::ReferencedAsset& referencedAsset)
                         {
                             if (copyStatus != Assets::CopyStatus::Copying || referencedAsset.m_copyStatus == Assets::CopyStatus::Waiting)
                             {

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -345,7 +345,7 @@ namespace ROS2RobotImporter
             Assets::ResolveAssetMap(m_referencedAssetMap, m_sourceFilePath, sdfBuilderSettings);
             if (!m_copyReferencedAssets)
             {
-                Assets::FindReferencedAssets(m_referencedAssetMap, m_sourceFilePath, sdfBuilderSettings);
+                Assets::FindReferencedAssets(m_referencedAssetMap);
                 for (const auto& [_, asset] : m_referencedAssetMap)
                 {
                     const bool visual =

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/RobotImporterWidget.cpp
@@ -393,55 +393,33 @@ namespace ROS2RobotImporter
                 m_copyReferencedAssetsThread = AZStd::make_shared<AZStd::thread>(
                     [this, dirSuffix]()
                     {
-                        auto destStatus = Assets::PrepareImportedAssetsDest(m_sourceFilePath.String(), dirSuffix);
-                        if (!destStatus.IsSuccess())
+                        Assets::CopyAssetsStatusCallback statusCallback =
+                            [this](Assets::CopyStatus copyStatus, AZ::IO::Path unresolvedFileName, Assets::ReferencedAsset referencedAsset)
                         {
-                            AZ_Error("RobotImporterWidget", false, "Failed to create destination folder for imported assets");
-                            QWizard::button(QWizard::NextButton)->setDisabled(false);
-                            return;
-                        }
-                        AZStd::unordered_map<AZ::IO::Path, unsigned int> duplicatedFilenames;
-                        for (auto& [unresolvedFileName, referencedAsset] : m_referencedAssetMap)
-                        {
-                            if (duplicatedFilenames.contains(referencedAsset.m_assetUri))
-                            {
-                                duplicatedFilenames[referencedAsset.m_assetUri]++;
-                            }
-                            else
-                            {
-                                duplicatedFilenames[referencedAsset.m_assetUri] = 0;
-                            }
-                            if (referencedAsset.m_copyStatus == Assets::CopyStatus::Waiting)
+                            if (copyStatus != Assets::CopyStatus::Copying || referencedAsset.m_copyStatus == Assets::CopyStatus::Waiting)
                             {
                                 m_assetPage->OnAssetCopyStatusChanged(
-                                    Assets::CopyStatus::Copying, AZStd::string(unresolvedFileName.c_str()), "");
+                                    copyStatus,
+                                    AZStd::string(unresolvedFileName.c_str()),
+                                    AZStd::string(referencedAsset.m_availableAssetInfo.m_sourceAssetRelativePath.c_str()));
                             }
-
-                            auto copyStatus = Assets::CopyStatus::Unresolvable;
-                            if (referencedAsset.m_resolvedPath.empty())
-                            {
-                                AZ_Warning("CopyReferencedAsset", false, "There is no resolved path for %s", unresolvedFileName.c_str());
-                            }
-                            else
-                            {
-                                copyStatus = Assets::CopyReferencedAsset(
-                                    destStatus.GetValue(), referencedAsset, duplicatedFilenames[referencedAsset.m_assetUri]);
-                            }
-
-                            m_assetPage->OnAssetCopyStatusChanged(
-                                copyStatus,
-                                AZStd::string(unresolvedFileName.c_str()),
-                                AZStd::string(referencedAsset.m_availableAssetInfo.m_sourceAssetRelativePath.c_str()));
-
                             if (copyStatus == Assets::CopyStatus::Copied || copyStatus == Assets::CopyStatus::Exists)
                             {
                                 m_toProcessAssets.insert(unresolvedFileName);
                             }
+                            if (copyStatus != Assets::CopyStatus::Copying)
+                            {
+                                // Check all assets that are ready to be processed
+                                CheckToProcessAssets();
+                            }
+                        };
+                        bool copyResultOk = Assets::CopyReferencedAssets(m_referencedAssetMap, m_sourceFilePath.String(), statusCallback);
 
-                            // Check all assets that are ready to be processed
-                            CheckToProcessAssets();
+                        if (!copyResultOk)
+                        {
+                            QWizard::button(QWizard::NextButton)->setDisabled(false);
+                            return;
                         }
-                        Assets::RemoveTmpDir(destStatus.GetValue().importDirectoryTmp);
 
                         if (!m_toProcessAssets.empty())
                         {

--- a/Gems/ROS2RobotImporter/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
@@ -92,17 +92,11 @@ namespace ROS2RobotImporter
         Assets::ReferencedAssetMap allReferencedAssets = Assets::GetReferencedAssetFilenames(root);
         Assets::ReferencedAssetMap existingReferencedAssets;
 
-        using AssetSysReqBus = AzToolsFramework::AssetSystemRequestBus;
+        // Attempt to find the absolute path for the raw uri reference, which might look something like "model://meshes/model.dae"
+        Assets::ResolveAssetMap(allReferencedAssets, AZ::IO::Path(sourceFilename), m_globalSettings);
 
-        auto amentPrefixPath = Assets::GetAmentPrefixPath();
-
-        for (const auto& [unresolvedUri, assetReferenceType] : allReferencedAssets)
+        for (auto& [unresolvedUri, asset] : allReferencedAssets)
         {
-            Assets::ReferencedAsset asset;
-
-            // Attempt to find the absolute path for the raw uri reference, which might look something like "model://meshes/model.dae"
-            asset.m_resolvedPath =
-                Assets::ResolveAssetPath(unresolvedUri, AZ::IO::PathView(sourceFilename), amentPrefixPath, m_globalSettings);
             if (asset.m_resolvedPath.empty())
             {
                 AZ_Warning(
@@ -113,51 +107,22 @@ namespace ROS2RobotImporter
                 continue;
             }
 
-            // Get a checksum on the resolved file that we'll use to ensure we've matched with the correct relative
-            // source asset. Ideally we'll be able to remove this check since it's not a very robust safety check and
-            // adds some amount of overhead to the processing.
-            asset.m_resolvedFileCRC = Assets::GetFileCRC(asset.m_resolvedPath);
-
-            // Given the absolute path to the asset, try to get the source asset info from the AssetProcessor.
-            bool sourceAssetFound{ false };
-            AZ::Data::AssetInfo assetInfo;
-            AZStd::string watchFolder;
-            AssetSysReqBus::BroadcastResult(
-                sourceAssetFound, &AssetSysReqBus::Events::GetSourceInfoBySourcePath, asset.m_resolvedPath.c_str(), assetInfo, watchFolder);
-
-            if (!sourceAssetFound)
+            // If the source asset has been found by the Asset Processor, save the mapping between raw uri
+            // reference and Asset Processor source asset information.
+            auto assetInfo = Assets::GetAvailableAssetInfo(asset.m_resolvedPath);
+            if (assetInfo.m_sourceGuid.IsNull())
             {
                 AZ_Warning(SdfAssetBuilderName, false, "Cannot find source asset info for '%s', skipping.", asset.m_resolvedPath.c_str());
                 continue;
             }
+            asset.m_availableAssetInfo = assetInfo;
 
-            // If the source asset has been found by the Asset Processor, save the mapping between raw uri
-            // reference and Asset Processor source asset information.
-            const auto fullSourcePath = AZ::IO::Path(watchFolder) / AZ::IO::Path(assetInfo.m_relativePath);
-            asset.m_availableAssetInfo.m_sourceAssetRelativePath = assetInfo.m_relativePath;
-            asset.m_availableAssetInfo.m_sourceAssetGlobalPath = fullSourcePath.String();
-            asset.m_availableAssetInfo.m_sourceGuid = assetInfo.m_assetId.m_guid;
-
-            // We should determine if this CRC check is actually necessary for resolving URI references.
-            // Ideally, the additional overhead should be removed and the asset reference result should be trusted.
-            AZ::Crc32 crc = Assets::GetFileCRC(asset.m_availableAssetInfo.m_sourceAssetGlobalPath);
-            if (crc == asset.m_resolvedFileCRC)
-            {
-                AZ_Info(
-                    SdfAssetBuilderName,
-                    "Resolved uri '%s' to source asset '%s'.",
-                    unresolvedUri.c_str(),
-                    assetInfo.m_relativePath.c_str());
-                existingReferencedAssets.emplace(unresolvedUri, AZStd::move(asset));
-            }
-            else
-            {
-                AZ_Warning(
-                    SdfAssetBuilderName,
-                    false,
-                    "Resolved to source asset '%s' which has incorrect CRC, skipping.",
-                    assetInfo.m_relativePath.c_str());
-            }
+            AZ_Info(
+                SdfAssetBuilderName,
+                "Resolved uri '%s' to source asset '%s'.",
+                unresolvedUri.c_str(),
+                asset.m_availableAssetInfo.m_sourceAssetRelativePath.c_str());
+            existingReferencedAssets.emplace(unresolvedUri, AZStd::move(asset));
         }
 
         return existingReferencedAssets;

--- a/Gems/ROS2RobotImporter/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/SdfAssetBuilder/SdfAssetBuilder.cpp
@@ -115,7 +115,7 @@ namespace ROS2RobotImporter
                 AZ_Warning(SdfAssetBuilderName, false, "Cannot find source asset info for '%s', skipping.", asset.m_resolvedPath.c_str());
                 continue;
             }
-            asset.m_availableAssetInfo = assetInfo;
+            asset.m_availableAssetInfo = AZStd::move(assetInfo);
 
             AZ_Info(
                 SdfAssetBuilderName,

--- a/Gems/ROS2RobotImporter/Code/Source/Tools/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/Tools/ROS2RobotImporterEditorSystemComponent.cpp
@@ -157,10 +157,7 @@ namespace ROS2RobotImporter
         {
             Assets::ResolveAssetMap(referencedAssetMap, filePath, sdfBuilderSettings);
             bool copyResultOk = Assets::CopyReferencedAssets(referencedAssetMap, filePath);
-            if (!copyResultOk)
-            {
-                AZ_Warning("ROS2RobotImporterEditorSystemComponent", false, "Copying assets failed");
-            }
+            AZ_Warning("ROS2RobotImporterEditorSystemComponent", copyResultOk, "Copying assets failed");
         }
         bool allAssetProcessed = false;
         bool assetProcessorFailed = false;

--- a/Gems/ROS2RobotImporter/Code/Source/Tools/ROS2RobotImporterEditorSystemComponent.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/Tools/ROS2RobotImporterEditorSystemComponent.cpp
@@ -16,6 +16,7 @@
 #include <AzToolsFramework/API/ViewPaneOptions.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <RobotImporter/Assets/AssetImporter.h>
+#include <RobotImporter/Assets/AssetLookup.h>
 #include <RobotImporter/Assets/AssetPathResolver.h>
 #include <RobotImporter/Building/SdfPrefabMaker.h>
 #include <RobotImporter/Parsing/SdfParser.h>
@@ -154,7 +155,12 @@ namespace ROS2RobotImporter
         auto referencedAssetMap = Assets::GetReferencedAssetFilenames(parsedSdfRoot);
         if (importAssetWithFile)
         {
-            Assets::CopyReferencedAssetsAndCreateAssetMap(referencedAssetMap, filePath, sdfBuilderSettings);
+            Assets::ResolveAssetMap(referencedAssetMap, filePath, sdfBuilderSettings);
+            bool copyResultOk = Assets::CopyReferencedAssets(referencedAssetMap, filePath);
+            if (!copyResultOk)
+            {
+                AZ_Warning("ROS2RobotImporterEditorSystemComponent", false, "Copying assets failed");
+            }
         }
         bool allAssetProcessed = false;
         bool assetProcessorFailed = false;


### PR DESCRIPTION
## What does this PR do?

Extraction of duplicated code parts between different import processes. 
Extraction of a duplicated function for finding an asset via the Asset Processor for a resolved path. Added a check in the wizard's asset search for whether the source asset file is not already in the project, before searching through all files to find one with the same content. 
Extraction of duplicated logic for copying assets via the widget and EBus.

PR requires prior merger of changes from PR [RobotImporter Gem - passing referenced assets and import status through EBuses.](https://github.com/o3de/o3de-extras/pull/1075)

## How was this PR tested?

A sample project featuring a new robot model. An xacro file for the "mini_pupper" robot has been loaded using Python code and the wizard.