### PR TITLE
Fix incorrect AZ::IO::Path constructor

### DIFF
--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetPathResolver.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Assets/AssetPathResolver.cpp
@@ -38,7 +38,7 @@ namespace ROS2RobotImporter::Assets
                 {
                     if (auto mesh = geometry->MeshShape(); mesh)
                     {
-                        const AZ::IO::Path assetUri(mesh->Uri().c_str(), mesh->Uri().size());
+                        const AZ::IO::Path assetUri(mesh->Uri().c_str());
                         const AZStd::string modelAssetUri = (modelUri.empty()) ? assetUri.String() : modelUri + "/" + assetUri.String();
                         if (referencedAssetMap.contains(modelAssetUri))
                         {
@@ -81,7 +81,7 @@ namespace ROS2RobotImporter::Assets
                         ReferencedAsset asset;
                         asset.m_assetType = ReferencedAssetType::Texture;
                         asset.m_modelUri = modelUri;
-                        asset.m_assetUri = AZ::IO::Path(texturePath.data(), texturePath.size());
+                        asset.m_assetUri = AZ::IO::Path(texturePath.c_str());
 
                         const AZStd::string modelAssetUri =
                             (modelUri.empty()) ? asset.m_assetUri.String() : modelUri + "/" + asset.m_assetUri.String();

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Building/Makers/CollidersMaker.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Building/Makers/CollidersMaker.cpp
@@ -143,7 +143,7 @@ namespace ROS2RobotImporter
                 m_sessionId,
                 &ReferencedAssetsRequests::FindReferencedAssets,
                 modelUri,
-                AZ::IO::Path(meshGeometry->Uri().c_str(), meshGeometry->Uri().size()));
+                AZ::IO::Path(meshGeometry->Uri().c_str()));
             if (!referencedAsset)
             {
                 AZ_Warning(

--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Building/Makers/VisualsMaker.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Building/Makers/VisualsMaker.cpp
@@ -179,7 +179,7 @@ namespace ROS2RobotImporter
                     m_sessionId,
                     &ReferencedAssetsRequests::FindReferencedAssets,
                     modelUri,
-                    AZ::IO::Path(meshGeometry->Uri().c_str(), meshGeometry->Uri().size()));
+                    AZ::IO::Path(meshGeometry->Uri().c_str()));
                 AZ_Warning("AddVisual", referencedAsset, "There is no source asset for %s.", meshGeometry->Uri().c_str());
 
                 if (referencedAsset)
@@ -322,7 +322,7 @@ namespace ROS2RobotImporter
                         sessionId,
                         &ReferencedAssetsRequests::FindReferencedAssets,
                         modelUri,
-                        AZ::IO::Path(uri.c_str(), uri.size()));
+                        AZ::IO::Path(uri.c_str()));
                     AZ_Warning("AddVisual", referencedAsset, "There is no source image asset for %s.", uri.c_str());
 
                     if (referencedAsset)


### PR DESCRIPTION
## What does this PR do?

The same incorrect  `AZ::IO::Path` construction pattern - previously found in `AssetPathResolver.cpp` - also appeared in the code responsible for asset lookups (`VisualsMaker.cpp`, `CollidersMaker.cpp`). 
There is no `AZ::IO::Path` constructor that accepts a size as the second parameter. Constructor call is incorrectly mapped to `BasicPath(const value_type* pathString, const char preferredSeparator)`. 
In `AssetPathResolver.cpp`, this had no impact because the resulting object was immediately converted to a standard string before being used as a map key. However, in `VisualsMaker.cpp` and `CollidersMaker.cpp`, this same pattern was used directly as a lookup key for the `ReferencedAssetsRequestBus`. This can alter the path's hash, potentially causing an existing asset to go undetected.

## How was this PR tested?

The project was built using RobotImporter Gem, and the robot, that previously was loaded incorrectly, was loaded. Xarco files of robot was loaded using wizard, and urdf files using python console.
