### PR TITLE
Add inertia tensor extraction to AddToArticulationConfig

### DIFF
--- a/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Building/Makers/ArticulationsMaker.cpp
+++ b/Gems/ROS2RobotImporter/Code/Source/RobotImporter/Building/Makers/ArticulationsMaker.cpp
@@ -110,6 +110,16 @@ namespace ROS2RobotImporter
             AZ_Warning(
                 "AddArticulationLink", false, "Ignoring URDF/SDF inertial origin rotation (no such field in rigid body configuration)");
         }
+
+        // Inertia tensor is symmetrical
+        auto moi = inertial.Moi();
+        auto inertiaMatrix = AZ::Matrix3x3::CreateFromRows(
+            AZ::Vector3(moi(0, 0), moi(0, 1), moi(0, 2)),
+            AZ::Vector3(moi(0, 1), moi(1, 1), moi(1, 2)),
+            AZ::Vector3(moi(0, 2), moi(1, 2), moi(2, 2)));
+        articulationLinkConfiguration.m_inertiaTensor = inertiaMatrix;
+        articulationLinkConfiguration.m_computeInertiaTensor = false;
+
         return articulationLinkConfiguration;
     }
 


### PR DESCRIPTION
**need** : https://github.com/o3de/o3de/pull/20053

bugfix : Bug Report-ArticulationLink lacks Inertia Tensor configuration and auto-compute, causing PhysX simulation mismatch with Isaac Sim
 #20016

What does this PR do?

Old behavior:
The AddToArticulationConfig function in ArticulationsMaker was only setting mass and center of mass offset from URDF/SDF inertial properties. The inertia tensor was not being extracted from the inertial data, causing the articulation links to use computed inertia values instead of the actual values specified in the robot description.

New behavior:
The function now extracts the inertia tensor (Moment of Inertia) from the gz::math::Inertiald object and applies it to the articulationLinkConfiguration. The inertia tensor is symmetric, so the matrix is constructed with proper symmetry:
- Ixy = Iyx, Ixz = Izx, Iyz = Izy

The changes:
- Extract the inertia tensor using inertial.Moi()
- Construct a symmetric AZ::Matrix3x3 from the inertia components
- Set m_inertiaTensor with the constructed matrix
- Set m_computeInertiaTensor = false to use the provided values instead of auto-computing

This ensures that articulation links use the exact inertial properties specified in the URDF/SDF robot description, improving simulation accuracy.

How was this PR tested?

The implementation was tested by:
1. Importing URDF/SDF robot models with defined inertial properties
2. Verifying that the inertia tensor values are correctly extracted and applied to articulation links
3. Confirming that the resulting articulation configurations match the expected inertial properties from the source robot descriptions

The code follows the existing pattern in ArticulationsMaker.cpp and properly handles the symmetric nature of inertia tensors.
