### PR TITLE
Upgrade Tracy profiler to 1.14.1, also mark the tracy frame end to RHI OnFrameEnd.

### DIFF
--- a/Gems/ExternalProfilers/TracyProfiler/Code/CMakeLists.txt
+++ b/Gems/ExternalProfilers/TracyProfiler/Code/CMakeLists.txt
@@ -11,16 +11,15 @@ include(FetchContent)
 FetchContent_Declare(
     Tracy
     GIT_REPOSITORY "https://github.com/wolfpld/tracy.git"
-    GIT_TAG "05cceee0df3b8d7c6fa87e9638af311dbabc63cb" # version 0.13.1
+    GIT_TAG "30997d5ca6bb632cc10807a1da8a6d3de0aeeb3c" # version 0.14.1
 )
 
 set(TRACY_ENABLE ON)
-set(TRACY_CALLSTACK ON)
 set(TRACY_ON_DEMAND ON)
 
 FetchContent_MakeAvailable(Tracy)
 
-message(STATUS "TracyProfiler gem uses https://github.com/wolfpld/tracy version 0.13.1 (License: BSD-3-Clause)")
+message(STATUS "TracyProfiler gem uses https://github.com/wolfpld/tracy version 0.14.1 (License: BSD-3-Clause)")
 
 target_compile_options(TracyClient ${O3DE_COMPILE_OPTION_DISABLE_WARNINGS})
 
@@ -51,6 +50,7 @@ ly_add_target(
         PUBLIC
             AZ::AzCore
             AZ::AzFramework
+            Gem::Atom_RHI.Public
             TracyClient
 )
 

--- a/Gems/ExternalProfilers/TracyProfiler/Code/Source/TracyProfilerEventForwarder.cpp
+++ b/Gems/ExternalProfilers/TracyProfiler/Code/Source/TracyProfilerEventForwarder.cpp
@@ -18,7 +18,7 @@ namespace TracyProfiler
     void TracyProfilerEventForwarder::Init()
     {
         AZ::Interface<AZ::Debug::Profiler>::Register(this);
-        AZ::TickBus::Handler::BusConnect();
+        AZ::RHI::RHISystemNotificationBus::Handler::BusConnect();
         m_initialized = true;
     }
 
@@ -34,8 +34,8 @@ namespace TracyProfiler
 
         // Wait for the remaining threads that might still be processing its profiling calls
         AZStd::unique_lock<AZStd::shared_mutex> shutdownLock(m_shutdownMutex);
-
-        AZ::TickBus::Handler::BusDisconnect();
+        AZ::RHI::FrameEventBus::Handler::BusDisconnect();
+        AZ::RHI::RHISystemNotificationBus::Handler::BusDisconnect();
     }
 
     void TracyProfilerEventForwarder::BeginRegion(const AZ::Debug::Budget* budget, const char* eventName, ...)
@@ -69,15 +69,15 @@ namespace TracyProfiler
         }
     }
 
-    int TracyProfilerEventForwarder::GetTickOrder()
+    void TracyProfilerEventForwarder::OnFrameEnd()
     {
-        return AZ::ComponentTickBus::TICK_LAST;
+        TracyCFrameMark;
     }
 
-    void TracyProfilerEventForwarder::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint timePoint)
+    void TracyProfilerEventForwarder::OnRHISystemInitialized()
     {
-        // From Tracy documentation about FrameMark : "Ideally, that would be right after the swap buffers command"
-        TracyCFrameMark;
+        AZ::RHI::Device* device = AZ::RHI::RHISystemInterface::Get()->GetDevice(AZ::RHI::MultiDevice::DefaultDeviceIndex);
+        AZ::RHI::FrameEventBus::Handler::BusConnect(device);
     }
 
 } // namespace TracyProfiler

--- a/Gems/ExternalProfilers/TracyProfiler/Code/Source/TracyProfilerEventForwarder.h
+++ b/Gems/ExternalProfilers/TracyProfiler/Code/Source/TracyProfilerEventForwarder.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <AzCore/Component/TickBus.h>
 #include <AzCore/Debug/Profiler.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Name/Name.h>
@@ -16,6 +15,8 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/parallel/mutex.h>
 #include <AzCore/std/parallel/shared_mutex.h>
+#include <Atom/RHI/FrameEventBus.h>
+#include <Atom/RHI/RHISystemInterface.h>
 #include <tracy/TracyC.h>
 
 namespace TracyProfiler
@@ -23,7 +24,8 @@ namespace TracyProfiler
     //! Listen to 03DE frame/profiling events and forward them to the Tracy profiling library
     class TracyProfilerEventForwarder final
         : public AZ::Debug::Profiler
-        , public AZ::TickBus::Handler
+        , public AZ::RHI::FrameEventBus::Handler
+        , public AZ::RHI::RHISystemNotificationBus::Handler
     {
     public:
         AZ_RTTI(TracyProfilerEventForwarder, "{9467E3F6-0581-4E46-A98A-F3C249FD7B24}", AZ::Debug::Profiler);
@@ -40,10 +42,11 @@ namespace TracyProfiler
         void BeginRegion(const AZ::Debug::Budget* budget, const char* eventName, ...) final override;
         void EndRegion(const AZ::Debug::Budget* budget) final override;
 
-        //! AZ::TickBus::Handler overrides
-        int GetTickOrder() override;
-        void OnTick(float deltaTime, AZ::ScriptTimePoint timePoint) override;
+        //! AZ::RHI::FrameEventInterface
+        void OnFrameEnd() override;
 
+        //! AZ::RHI::RHISystemNotificiationInterface
+        void OnRHISystemInitialized() override;
     private:
         using EventIdStack = AZStd::vector<TracyCZoneCtx>;
         static thread_local EventIdStack ms_threadLocalStorage;


### PR DESCRIPTION
## What does this PR do?

This PR bumped tracy version to 1.14.1. Also it now marks the frame at RHI::FrameEventBus::OnFrameEnd to make frame time more accurate.

## How was this PR tested?

Tested on cachyos
