### PR TITLE
Fix 1079: read PID joint state

### DIFF
--- a/Gems/ROS2Controllers/Code/Include/ROS2Controllers/Controllers/PidConfiguration.h
+++ b/Gems/ROS2Controllers/Code/Include/ROS2Controllers/Controllers/PidConfiguration.h
@@ -56,7 +56,17 @@ namespace ROS2Controllers
         //! @returns Value of computed command.
         double ComputeCommand(double error, uint64_t deltaTimeNanoseconds);
 
+        //! Compute the value of PID command using a directly-measured rate for the derivative
+        //! term instead of numerically differencing successive error values.
+        //! @param error Value of difference between target and state since last call.
+        //! @param measuredRate Directly-measured rate of change of the process variable.
+        //! @param deltaTimeNanoseconds change in time since last call (nanoseconds).
+        //! @returns Value of computed command.
+        double ComputeCommandWithMeasuredRate(double error, double measuredRate, uint64_t deltaTimeNanoseconds);
+
     private:
+        double ComputeCommandInternal(double error, double dt, double derivativeTerm);
+
         double m_p = 1.0; //!< proportional gain.
         double m_i = 0.0; //!< integral gain.
         double m_d = 0.0; //!< derivative gain.

--- a/Gems/ROS2Controllers/Code/Source/Utilities/Controllers/PidConfiguration.cpp
+++ b/Gems/ROS2Controllers/Code/Source/Utilities/Controllers/PidConfiguration.cpp
@@ -80,6 +80,35 @@ namespace ROS2Controllers
             return 0.0;
         }
 
+        const double derivative = (error - m_previousError) / dt;
+        const double output = ComputeCommandInternal(error, dt, m_d * derivative);
+        m_previousError = error;
+        return output;
+    }
+
+    double PidConfiguration::ComputeCommandWithMeasuredRate(double error, double measuredRate, uint64_t deltaTimeNanoseconds)
+    {
+        const double dt = aznumeric_cast<double>(deltaTimeNanoseconds) / 1.e9;
+
+        if (!m_initialized)
+        {
+            AZ_Error("PidConfiguration", false, "PID not initialized, ignoring.");
+            return 0.0;
+        }
+
+        if (dt <= 0.0 || !azisfinite(error) || !azisfinite(measuredRate))
+        {
+            AZ_Warning("PidConfiguration", false, "Invalid PID conditions.");
+            return 0.0;
+        }
+
+        // Derivative-on-measurement: damp against the process variable's own measured rate of
+        // change rather than differencing successive error values.
+        return ComputeCommandInternal(error, dt, -m_d * measuredRate);
+    }
+
+    double PidConfiguration::ComputeCommandInternal(double error, double dt, double derivativeTerm)
+    {
         const double proportionalTerm = m_p * error;
 
         m_integral += error * dt;
@@ -96,11 +125,6 @@ namespace ROS2Controllers
         {
             integralTerm = AZStd::clamp<double>(integralTerm, m_iMin, m_iMax);
         }
-
-        const double derivative = (error - m_previousError) / dt;
-        const double derivativeTerm = m_d * derivative;
-
-        m_previousError = error;
 
         double output = proportionalTerm + integralTerm + derivativeTerm;
 

--- a/Gems/ROS2Controllers/Code/Source/VehicleDynamics/DriveModels/AckermannDriveModel.cpp
+++ b/Gems/ROS2Controllers/Code/Source/VehicleDynamics/DriveModels/AckermannDriveModel.cpp
@@ -88,8 +88,10 @@ namespace ROS2Controllers::VehicleDynamics
                 steeringEntity,
                 [&](PhysX::ArticulationJointRequests* joint)
                 {
-                    double currentSteeringAngle = joint->GetJointPosition(wheelData.m_axis);
-                    const double pidCommand = m_steeringPid.ComputeCommand(scaledSteering - currentSteeringAngle, deltaTimeNs);
+                    const double currentSteeringAngle = joint->GetJointPosition(wheelData.m_axis);
+                    const double currentSteeringVelocity = joint->GetJointVelocity(wheelData.m_axis);
+                    const double pidCommand = m_steeringPid.ComputeCommandWithMeasuredRate(
+                        scaledSteering - currentSteeringAngle, currentSteeringVelocity, deltaTimeNs);
                     joint->SetDriveTargetVelocity(wheelData.m_axis, pidCommand);
                 });
         }
@@ -99,8 +101,10 @@ namespace ROS2Controllers::VehicleDynamics
                 id,
                 [&](PhysX::JointRequests* joint)
                 {
-                    double currentSteeringAngle = joint->GetPosition();
-                    const double pidCommand = m_steeringPid.ComputeCommand(scaledSteering - currentSteeringAngle, deltaTimeNs);
+                    const double currentSteeringAngle = joint->GetPosition();
+                    const double currentSteeringVelocity = joint->GetVelocity();
+                    const double pidCommand = m_steeringPid.ComputeCommandWithMeasuredRate(
+                        scaledSteering - currentSteeringAngle, currentSteeringVelocity, deltaTimeNs);
                     joint->SetVelocity(pidCommand);
                 });
         }

--- a/Gems/ROS2Controllers/Code/Tests/PIDTest.cpp
+++ b/Gems/ROS2Controllers/Code/Tests/PIDTest.cpp
@@ -9,6 +9,8 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzTest/AzTest.h>
 
+#include <limits>
+
 #include <ROS2Controllers/Controllers/PidConfiguration.h>
 
 namespace UnitTest
@@ -191,5 +193,46 @@ namespace UnitTest
 
         output = pid.ComputeCommand(-1.0, 1 * secToNanosec);
         EXPECT_EQ(-3.5, output);
+    }
+
+    TEST_F(PIDTest, measuredRateDOnly)
+    {
+        ROS2Controllers::PidConfiguration pid(0.0, 0.0, 1.0, 0.0, 0.0, false, 0.0);
+        pid.InitializePid();
+
+        double output = 0.0;
+
+        // Derivative-on-measurement uses -m_d * measuredRate directly, independent of error history.
+        output = pid.ComputeCommandWithMeasuredRate(-0.5, 2.0, 1 * secToNanosec);
+        EXPECT_EQ(-2.0, output);
+
+        output = pid.ComputeCommandWithMeasuredRate(-0.5, -3.0, 1 * secToNanosec);
+        EXPECT_EQ(3.0, output);
+
+        output = pid.ComputeCommandWithMeasuredRate(-0.5, 0.0, 1 * secToNanosec);
+        EXPECT_EQ(0.0, output);
+    }
+
+    TEST_F(PIDTest, measuredRateCompletePID)
+    {
+        ROS2Controllers::PidConfiguration pid(1.0, 1.0, 1.0, 5.0, -5.0, false, 0.0);
+        pid.InitializePid();
+
+        double output = 0.0;
+
+        // proportional(-0.5) + integral(-0.5) + derivative(-1.0 * 2.0)
+        output = pid.ComputeCommandWithMeasuredRate(-0.5, 2.0, 1 * secToNanosec);
+        EXPECT_EQ(-3.0, output);
+    }
+
+    TEST_F(PIDTest, measuredRateInvalidConditions)
+    {
+        ROS2Controllers::PidConfiguration pid(1.0, 0.0, 1.0, 0.0, 0.0, false, 0.0);
+        pid.InitializePid();
+
+        const double nan = std::numeric_limits<double>::quiet_NaN();
+        EXPECT_EQ(0.0, pid.ComputeCommandWithMeasuredRate(-0.5, nan, 1 * secToNanosec));
+        EXPECT_EQ(0.0, pid.ComputeCommandWithMeasuredRate(nan, 1.0, 1 * secToNanosec));
+        EXPECT_EQ(0.0, pid.ComputeCommandWithMeasuredRate(-0.5, 1.0, 0 * secToNanosec));
     }
 } // namespace UnitTest


### PR DESCRIPTION
## What does this PR do?

Adds `PidConfiguration::ComputeCommandWithMeasuredRate`, a derivative-on-measurement variant of the PID controller that damps against a directly-measured process-variable rate instead of numerically differencing successive error values.

`AckermannDriveModel`'s steering PID now reads the joint's actual velocity (`GetJointVelocity`/`GetVelocity`) and calls this new method, instead of differencing position error across ticks. This avoids amplifying noise/discontinuities in the position signal and removes derivative kick from setpoint changes.

Fixes #1079.

## How was this PR tested?

Added tests, tried repro from #1079
