### PR TITLE
Development -> Stabilization cherries: SimulationInterfaces Gem

### DIFF
--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationEntityManagerRequestBus.h
@@ -216,4 +216,36 @@ namespace SimulationInterfaces
     using SimulationEntityManagerRequestBus = AZ::EBus<SimulationEntityManagerRequests, SimulationInterfacesBusTraits>;
     using SimulationEntityManagerInterface = AZ::Interface<SimulationEntityManagerRequests>;
 
+    //! Notifications about entities spawned through SimulationEntityManagerRequests::SpawnEntity / SpawnEntities.
+    class SimulationEntitiesManagerNotifications
+    {
+    public:
+        AZ_RTTI(SimulationEntitiesManagerNotifications, SimulationEntitiesManagerNotificationsTypeId);
+        virtual ~SimulationEntitiesManagerNotifications() = default;
+
+        //! Called once the spawned entities exist but are not yet inserted/activated into the world.
+        //! @param proposedName the name requested for the entity, not yet the final registered simulation entity name
+        virtual void OnEntityPreInsertion(const AZStd::string& proposedName, AzFramework::SpawnableEntityContainerView view)
+        {
+        }
+
+        //! Called after the entity has been registered with the simulation interfaces registry under its final, unique name.
+        virtual void OnEntitySpawned(const AZStd::string& simulationEntityName, AzFramework::SpawnableConstEntityContainerView view)
+        {
+        }
+    };
+
+    class SimulationEntitiesManagerNotificationsBusTraits : public AZ::EBusTraits
+    {
+    public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        //////////////////////////////////////////////////////////////////////////
+    };
+
+    using SimulationEntitiesManagerNotificationsBus =
+        AZ::EBus<SimulationEntitiesManagerNotifications, SimulationEntitiesManagerNotificationsBusTraits>;
+
 } // namespace SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationInterfacesTypeIds.h
+++ b/Gems/SimulationInterfaces/Code/Include/SimulationInterfaces/SimulationInterfacesTypeIds.h
@@ -37,6 +37,7 @@ namespace SimulationInterfaces
     inline constexpr const char* SimulationManagerRequestsTypeId = "{056477BA-8153-4901-9401-0146A5E3E9ED}";
     inline constexpr const char* SimulationFeaturesAggregatorRequestsTypeId = "{099FD08B-B0E2-4705-9C35-CC09C8E45076}";
     inline constexpr const char* SimulationManagerNotificationsTypeId = "{0201067B-9D52-4AB7-9A45-284287F53B00}";
+    inline constexpr const char* SimulationEntitiesManagerNotificationsTypeId = "{3A7DD6BB-B7B0-4758-AEBC-88BF531EB9B4}";
     inline constexpr const char* NamedPoseManagerRequestsTypeId = "{705280D6-7AB4-4586-A0A4-25AD71268279}";
     inline constexpr const char* NamedPoseComponentRequestsTypeId = "{9C2FEA33-90CE-4577-AB32-F7963852DC81}";
 

--- a/Gems/SimulationInterfaces/Code/Source/Clients/LevelManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/LevelManager.cpp
@@ -19,6 +19,7 @@
 #include <AzCore/std/string/conversions.h>
 #include <AzCore/std/string/string.h>
 #include <AzFramework/API/ApplicationAPI.h>
+#include <AzFramework/Spawnable/RootSpawnableInterface.h>
 #include <SimulationInterfaces/LevelManagerRequestBus.h>
 #include <SimulationInterfaces/Resource.h>
 #include <SimulationInterfaces/Result.h>
@@ -244,10 +245,10 @@ namespace SimulationInterfaces
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, errorMsg));
         }
 
-        // unload level if needed
+        // remove all entities and unload level if needed. unload world removes entities as one of its steps
         if (GetCurrentWorld().IsSuccess())
         {
-            levelSystem->UnloadLevel();
+            UnloadWorld();
         }
         // notify state machine
         SimulationManagerRequestBus::Broadcast(
@@ -299,8 +300,33 @@ namespace SimulationInterfaces
             m_actionRequestedFromSimInterfaces = false;
             return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, errorMsg));
         }
+        AZStd::atomic<bool> entitiesRemoved = false;
+        DeletionCompletedCb deleteAllCompletion = [&entitiesRemoved](const AZ::Outcome<void, FailedResult>& result)
+        {
+            entitiesRemoved = result.IsSuccess();
+        };
+
+        SimulationEntityManagerRequestBus::Broadcast(&SimulationEntityManagerRequests::DeleteAllEntities, deleteAllCompletion);
+
+        // DeleteAllEntities removes spawn tickets and process despawning in async way. UnloadWorld must be blocking operation, hence we
+        // need to wait till all spawnable tasks are finished
+        if (auto* rootSpawnable = AzFramework::RootSpawnableInterface::Get())
+        {
+            rootSpawnable->ProcessSpawnableQueueUntilEmpty();
+        }
+
+        if (!entitiesRemoved)
+        {
+            constexpr const char* errorMsg = "Failed to remove all entities before unloading level";
+            AZ_Warning("SimulationInterfaces", false, errorMsg);
+            m_actionRequestedFromSimInterfaces = false;
+            return AZ::Failure(FailedResult(simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED, errorMsg));
+        }
 
         levelSystem->UnloadLevel();
+        // clean up all left over assets event, especially un-/loading level spawnable
+        AZ::Data::AssetBus::ExecuteQueuedEvents();
+
         SimulationManagerRequestBus::Broadcast(
             &SimulationManagerRequests::SetSimulationState, simulation_interfaces::msg::SimulationState::STATE_NO_WORLD);
         m_actionRequestedFromSimInterfaces = false;

--- a/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Clients/SimulationEntitiesManager.cpp
@@ -847,6 +847,8 @@ namespace SimulationInterfaces
             // run preinsertion Callback if exists
             if (spawnData != m_spawnCompletedCallbacks.end())
             {
+                SimulationEntitiesManagerNotificationsBus::Broadcast(
+                    &SimulationEntitiesManagerNotifications::OnEntityPreInsertion, spawnData->second.m_userProposedName, view);
                 spawnData->second.m_preInsertionCb(AZ::Success(view));
             }
         };
@@ -886,6 +888,8 @@ namespace SimulationInterfaces
                 if (finalNameOutcome.IsSuccess())
                 {
                     m_simulatedEntityToPrefabRoot[finalNameOutcome.GetValue()] = root->GetId();
+                    SimulationEntitiesManagerNotificationsBus::Broadcast(
+                        &SimulationEntitiesManagerNotifications::OnEntitySpawned, finalNameOutcome.GetValue(), view);
                     spawnData->second.m_completedCb(AZ::Success(finalNameOutcome.GetValue()));
                 }
                 else

--- a/Gems/SimulationInterfaces/Code/Source/Services/ResetSimulationServiceHandler.cpp
+++ b/Gems/SimulationInterfaces/Code/Source/Services/ResetSimulationServiceHandler.cpp
@@ -33,72 +33,8 @@ namespace ROS2SimulationInterfaces
     AZStd::optional<ResetSimulationServiceHandler::Response> ResetSimulationServiceHandler::HandleServiceRequest(
         const std::shared_ptr<rmw_request_id_t> header, const Request& request)
     {
-        if (request.scope == Request::SCOPE_STATE)
-        {
-            Response response;
-            AZ::Outcome<void, SimulationInterfaces::FailedResult> resetingOutcome;
-            SimulationInterfaces::SimulationEntityManagerRequestBus::BroadcastResult(
-                resetingOutcome, &SimulationInterfaces::SimulationEntityManagerRequests::ResetAllEntitiesToInitialState);
-            if (resetingOutcome.IsSuccess())
-            {
-                response.result.result = simulation_interfaces::msg::Result::RESULT_OK;
-            }
-            else
-            {
-                response.result.result = resetingOutcome.GetError().m_errorCode;
-                response.result.error_message = resetingOutcome.GetError().m_errorString.c_str();
-            }
-            return response;
-        }
-
-        if (request.scope == Request::SCOPE_SPAWNED)
-        {
-            auto deletionCompletedCb = [this](const AZ::Outcome<void, SimulationInterfaces::FailedResult>& outcome)
-            {
-                Response response;
-                if (outcome.IsSuccess())
-                {
-                    response.result.result = simulation_interfaces::msg::Result::RESULT_OK;
-                }
-                else
-                {
-                    const auto& failedResult = outcome.GetError();
-                    response.result.result = failedResult.m_errorCode;
-                    response.result.error_message = failedResult.m_errorString.c_str();
-                }
-                SendResponse(response);
-            };
-            SimulationInterfaces::SimulationEntityManagerRequestBus::Broadcast(
-                &SimulationInterfaces::SimulationEntityManagerRequests::DeleteAllEntities, deletionCompletedCb);
-            return AZStd::nullopt;
-        }
-
-        if (request.scope == Request::SCOPE_TIME)
-        {
-            auto* interface = ROS2::ROS2ClockInterface::Get();
-            AZ_Assert(interface, "ROS2ClockInterface is not available");
-
-            builtin_interfaces::msg::Time time;
-            time.sec = 0;
-            time.nanosec = 0;
-            auto results = interface->AdjustTime(time);
-
-            if (results.IsSuccess())
-            {
-                Response response;
-                response.result.result = simulation_interfaces::msg::Result::RESULT_OK;
-                return response;
-            }
-            else
-            {
-                Response response;
-                response.result.result = simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED;
-                const auto& errorMessage = results.GetError();
-                response.result.error_message = std::string(errorMessage.c_str(), errorMessage.size());
-                return response;
-            }
-        }
-
+        // SCOPE_ALL and SCOPE_DEFAULT (0) are not part of the SCOPE_TIME / SCOPE_STATE / SCOPE_SPAWNED bit field;
+        // they request a full simulation restart (level reload) instead of resetting individual aspects.
         if (request.scope == Request::SCOPE_ALL || request.scope == Request::SCOPE_DEFAULT)
         {
             // check if we are in GameLauncher
@@ -132,10 +68,76 @@ namespace ROS2SimulationInterfaces
             return AZStd::nullopt;
         }
 
-        // no case matched, return response that request was invalid
-        Response invalidResponse;
-        invalidResponse.result.result = simulation_interfaces::msg::Result::RESULT_NOT_FOUND;
-        invalidResponse.result.error_message = "Passed unknown scope";
-        return invalidResponse;
+        // SCOPE_TIME, SCOPE_STATE and SCOPE_SPAWNED form a bit field and may be requested in any combination,
+        // e.g. scope = SCOPE_STATE | SCOPE_SPAWNED.
+        constexpr uint8_t KnownScopeMask = Request::SCOPE_TIME | Request::SCOPE_STATE | Request::SCOPE_SPAWNED;
+        if ((request.scope & ~KnownScopeMask) != 0)
+        {
+            // no known scope bit matched, return response that request was invalid
+            Response invalidResponse;
+            invalidResponse.result.result = simulation_interfaces::msg::Result::RESULT_NOT_FOUND;
+            invalidResponse.result.error_message = "Passed unknown scope";
+            return invalidResponse;
+        }
+
+        if (request.scope & Request::SCOPE_STATE)
+        {
+            AZ::Outcome<void, SimulationInterfaces::FailedResult> resetingOutcome;
+            SimulationInterfaces::SimulationEntityManagerRequestBus::BroadcastResult(
+                resetingOutcome, &SimulationInterfaces::SimulationEntityManagerRequests::ResetAllEntitiesToInitialState);
+            if (!resetingOutcome.IsSuccess())
+            {
+                Response response;
+                response.result.result = resetingOutcome.GetError().m_errorCode;
+                response.result.error_message = resetingOutcome.GetError().m_errorString.c_str();
+                return response;
+            }
+        }
+
+        if (request.scope & Request::SCOPE_TIME)
+        {
+            auto* interface = ROS2::ROS2ClockInterface::Get();
+            AZ_Assert(interface, "ROS2ClockInterface is not available");
+
+            builtin_interfaces::msg::Time time;
+            time.sec = 0;
+            time.nanosec = 0;
+            auto results = interface->AdjustTime(time);
+
+            if (!results.IsSuccess())
+            {
+                Response response;
+                response.result.result = simulation_interfaces::msg::Result::RESULT_OPERATION_FAILED;
+                const auto& errorMessage = results.GetError();
+                response.result.error_message = std::string(errorMessage.c_str(), errorMessage.size());
+                return response;
+            }
+        }
+
+        if (request.scope & Request::SCOPE_SPAWNED)
+        {
+            auto deletionCompletedCb = [this](const AZ::Outcome<void, SimulationInterfaces::FailedResult>& outcome)
+            {
+                Response response;
+                if (outcome.IsSuccess())
+                {
+                    response.result.result = simulation_interfaces::msg::Result::RESULT_OK;
+                }
+                else
+                {
+                    const auto& failedResult = outcome.GetError();
+                    response.result.result = failedResult.m_errorCode;
+                    response.result.error_message = failedResult.m_errorString.c_str();
+                }
+                SendResponse(response);
+            };
+            SimulationInterfaces::SimulationEntityManagerRequestBus::Broadcast(
+                &SimulationInterfaces::SimulationEntityManagerRequests::DeleteAllEntities, deletionCompletedCb);
+            return AZStd::nullopt;
+        }
+
+        Response response;
+        response.result.result = simulation_interfaces::msg::Result::RESULT_OK;
+        return response;
     }
 } // namespace ROS2SimulationInterfaces

--- a/Gems/SimulationInterfaces/Code/Tests/Clients/InterfacesTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Clients/InterfacesTest.cpp
@@ -217,6 +217,62 @@ namespace UnitTest
         EXPECT_EQ(response->result.result, simulation_interfaces::msg::Result::RESULT_OK);
     }
 
+    //! Reset scope is a bit field. Passing a combination of scopes (SCOPE_STATE | SCOPE_SPAWNED) should trigger
+    //! both the corresponding reset actions instead of being rejected as an unknown scope.
+    TEST_F(SimulationInterfaceROS2TestFixture, ResetSimulationBitfieldScopeStateAndSpawned)
+    {
+        using ::testing::_;
+        auto node = GetRos2Node();
+        SimulationEntityManagerMockedHandler mock;
+        auto client = node->create_client<simulation_interfaces::srv::ResetSimulation>("/reset_simulation");
+        auto request = std::make_shared<simulation_interfaces::srv::ResetSimulation::Request>();
+        request->scope = simulation_interfaces::srv::ResetSimulation::Request::SCOPE_STATE |
+            simulation_interfaces::srv::ResetSimulation::Request::SCOPE_SPAWNED;
+
+        EXPECT_CALL(mock, ResetAllEntitiesToInitialState())
+            .WillOnce(
+                []()
+                {
+                    return AZ::Success();
+                });
+
+        EXPECT_CALL(mock, DeleteAllEntities(_))
+            .WillOnce(
+                [](SimulationInterfaces::DeletionCompletedCb completedCb)
+                {
+                    completedCb(AZ::Success());
+                });
+
+        auto future = client->async_send_request(request);
+        SpinAppUntilFuture(future);
+
+        ASSERT_TRUE(future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) << "Service call timed out.";
+        auto response = future.get();
+        EXPECT_EQ(response->result.result, simulation_interfaces::msg::Result::RESULT_OK);
+    }
+
+    //! A scope value with a bit outside of SCOPE_TIME | SCOPE_STATE | SCOPE_SPAWNED (and not SCOPE_ALL/SCOPE_DEFAULT)
+    //! is not a known scope and should be rejected without triggering any reset action.
+    TEST_F(SimulationInterfaceROS2TestFixture, ResetSimulationUnknownScopeBitReturnsError)
+    {
+        using ::testing::_;
+        auto node = GetRos2Node();
+        SimulationEntityManagerMockedHandler mock;
+        auto client = node->create_client<simulation_interfaces::srv::ResetSimulation>("/reset_simulation");
+        auto request = std::make_shared<simulation_interfaces::srv::ResetSimulation::Request>();
+        request->scope = 0x08; // not a defined scope bit
+
+        EXPECT_CALL(mock, ResetAllEntitiesToInitialState()).Times(0);
+        EXPECT_CALL(mock, DeleteAllEntities(_)).Times(0);
+
+        auto future = client->async_send_request(request);
+        SpinAppUntilFuture(future);
+
+        ASSERT_TRUE(future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) << "Service call timed out.";
+        auto response = future.get();
+        EXPECT_EQ(response->result.result, simulation_interfaces::msg::Result::RESULT_NOT_FOUND);
+    }
+
     //! Test if the service call fails when the entity is not found
     TEST_F(SimulationInterfaceROS2TestFixture, TestDeleteEntity_02)
     {

--- a/Gems/SimulationInterfaces/Code/Tests/Clients/InterfacesTest.cpp
+++ b/Gems/SimulationInterfaces/Code/Tests/Clients/InterfacesTest.cpp
@@ -202,12 +202,12 @@ namespace UnitTest
         const AZStd::string entityName = AZStd::string(TestEntityName);
 
         EXPECT_CALL(*mock, DeleteEntity(entityName, _))
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 [](const AZStd::string& name, SimulationInterfaces::DeletionCompletedCb completedCb)
                 {
                     EXPECT_EQ(name, "test_entity");
                     completedCb(AZ::Success());
-                }));
+                });
 
         auto future = client->async_send_request(request);
         SpinAppUntilFuture(future);
@@ -230,7 +230,7 @@ namespace UnitTest
         const AZStd::string entityName = AZStd::string(TestEntityName);
 
         EXPECT_CALL(mock, DeleteEntity(entityName, _))
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 [](const AZStd::string& name, SimulationInterfaces::DeletionCompletedCb completedCb)
                 {
                     EXPECT_EQ(name, "test_entity");
@@ -238,7 +238,7 @@ namespace UnitTest
                     failedResult.m_errorCode = simulation_interfaces::msg::Result::RESULT_NOT_FOUND,
                     failedResult.m_errorString = "FooBar not found.";
                     completedCb(AZ::Failure(failedResult));
-                }));
+                });
 
         auto future = client->async_send_request(request);
         SpinAppUntilFuture(future);
@@ -267,7 +267,7 @@ namespace UnitTest
         request->filters.filter = "FooBarFilter";
 
         EXPECT_CALL(mock, GetEntities(_))
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 [=](const EntityFilters& filter)
                 {
                     EXPECT_NE(filter.m_boundsShape, nullptr);
@@ -286,7 +286,7 @@ namespace UnitTest
 
                     EXPECT_EQ(filter.m_nameFilter, "FooBarFilter");
                     return AZ::Success(EntityNameList{ "FooBar" });
-                }));
+                });
 
         auto future = client->async_send_request(request);
         SpinAppUntilFuture(future);
@@ -339,7 +339,7 @@ namespace UnitTest
         request->filters.bounds.type = simulation_interfaces::msg::Bounds::TYPE_BOX;
 
         EXPECT_CALL(mock, GetEntities(_))
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 [=](const EntityFilters& filter)
                 {
                     EXPECT_NE(filter.m_boundsShape, nullptr);
@@ -355,7 +355,7 @@ namespace UnitTest
                     auto loc = filter.m_boundsPose.GetTranslation();
                     EXPECT_EQ(loc, AZ::Vector3::CreateZero());
                     return AZ::Success(EntityNameList{ "FooBar" });
-                }));
+                });
 
         auto future = client->async_send_request(request);
         SpinAppUntilFuture(future);
@@ -422,11 +422,11 @@ namespace UnitTest
             static_cast<SimulationFeatureType>(0xFF), // invalid feature, should be ignored
         };
         EXPECT_CALL(mockAggregator, GetSimulationFeatures())
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 [&](void)
                 {
                     return features;
-                }));
+                });
 
         auto client = node->create_client<simulation_interfaces::srv::GetSimulatorFeatures>("/get_simulator_features");
         auto request = std::make_shared<simulation_interfaces::srv::GetSimulatorFeatures::Request>();
@@ -459,7 +459,7 @@ namespace UnitTest
 
         auto future = client->async_send_request(request);
         EXPECT_CALL(mock, SpawnEntity(_, _, _, _, _, _, _))
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 [](const AZStd::string& name,
                    const AZStd::string& uri,
                    const AZStd::string& entityNamespace,
@@ -473,7 +473,7 @@ namespace UnitTest
                     EXPECT_EQ(entityNamespace, "test_namespace");
                     EXPECT_TRUE(allowRename);
                     completedCb(AZ::Success("valid_name"));
-                }));
+                });
         SpinAppUntilFuture(future);
 
         ASSERT_TRUE(future.wait_for(std::chrono::seconds(0)) == std::future_status::ready) << "Service call timed out.";
@@ -546,20 +546,20 @@ namespace UnitTest
         ASSERT_TRUE(client->wait_for_action_server(std::chrono::seconds(0)) == true) << "Action server is unavailable";
 
         EXPECT_CALL(mock, IsSimulationPaused())
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 []()
                 {
                     return true;
-                }));
+                });
 
         EXPECT_CALL(mock, StepSimulation(steps));
 
         EXPECT_CALL(mock, IsSimulationStepsActive())
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 []()
                 {
                     return false;
-                }));
+                });
 
         auto future = client->async_send_goal(*goal);
         SpinAppUntilFuture(future);
@@ -584,11 +584,11 @@ namespace UnitTest
         ASSERT_TRUE(client->wait_for_action_server(std::chrono::seconds(0)) == true) << "Action server is unavailable";
 
         EXPECT_CALL(mock, IsSimulationPaused())
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 []()
                 {
                     return false;
-                }));
+                });
 
         auto future = client->async_send_goal(*goal);
         SpinAppUntilFuture(future);
@@ -614,20 +614,20 @@ namespace UnitTest
         ASSERT_TRUE(client->wait_for_action_server(std::chrono::seconds(0)) == true) << "Action server is unavailable";
 
         EXPECT_CALL(mock, IsSimulationPaused())
-            .WillOnce(::testing::Invoke(
+            .WillOnce(
                 []()
                 {
                     return true;
-                }));
+                });
 
         EXPECT_CALL(mock, StepSimulation(steps));
 
         EXPECT_CALL(mock, IsSimulationStepsActive())
-            .WillRepeatedly(::testing::Invoke(
+            .WillRepeatedly(
                 []()
                 {
                     return true;
-                }));
+                });
 
         EXPECT_CALL(mock, CancelStepSimulation());
 


### PR DESCRIPTION
## What does this PR do?

This is a collection of PRs that were pushed to the `development` branch, but should be a part of the release 2610. All but #1071 are bugfixes. #1071 is a small feature that enables post-spawn modifications. Small, well tested code.

The cherry-picked changes:
- #1074
- #1076 
- #1071 
- #1078

## How was this PR tested?

The code builds, the tests run. The code was reviewed in the respective PRs.
